### PR TITLE
Implement connection pooling for Valkey-Glide.

### DIFF
--- a/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ClusterGlideClientAdapter.java
+++ b/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ClusterGlideClientAdapter.java
@@ -299,7 +299,7 @@ class ClusterGlideClientAdapter implements UnifiedGlideClient {
 
     @Override
     public void close() throws ExecutionException {
-        glideClusterClient.close();
+        // The native client might be pooled - dont close
     }
 
     @Override

--- a/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/DefaultValkeyGlideClientConfiguration.java
+++ b/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/DefaultValkeyGlideClientConfiguration.java
@@ -36,9 +36,10 @@ public class DefaultValkeyGlideClientConfiguration implements ValkeyGlideClientC
     private final @Nullable Integer inflightRequestsLimit;
     private final @Nullable String clientAZ;
     private final @Nullable BackoffStrategy reconnectStrategy;
+    private final int maxPoolSize;
 
     DefaultValkeyGlideClientConfiguration() {
-        this(null, false, null, null, null, null, null);
+        this(null, false, null, null, null, null, null, 8);
     }
 
     public DefaultValkeyGlideClientConfiguration(
@@ -48,7 +49,8 @@ public class DefaultValkeyGlideClientConfiguration implements ValkeyGlideClientC
             @Nullable ReadFrom readFrom,
             @Nullable Integer inflightRequestsLimit,
             @Nullable String clientAZ,
-            @Nullable BackoffStrategy reconnectStrategy) {
+            @Nullable BackoffStrategy reconnectStrategy,
+            int maxPoolSize) {
         this.commandTimeout = commandTimeout;
         this.useSsl = useSsl;
         this.connectionTimeout = connectionTimeout;
@@ -56,6 +58,7 @@ public class DefaultValkeyGlideClientConfiguration implements ValkeyGlideClientC
         this.inflightRequestsLimit = inflightRequestsLimit;
         this.clientAZ = clientAZ;
         this.reconnectStrategy = reconnectStrategy;
+        this.maxPoolSize = maxPoolSize;
     }
 
     @Nullable
@@ -97,6 +100,11 @@ public class DefaultValkeyGlideClientConfiguration implements ValkeyGlideClientC
     @Override
     public BackoffStrategy getReconnectStrategy() {
         return reconnectStrategy;
+    }
+
+    @Override
+    public int getMaxPoolSize() {
+        return maxPoolSize;
     }
 
     @Override

--- a/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/StandaloneGlideClientAdapter.java
+++ b/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/StandaloneGlideClientAdapter.java
@@ -59,7 +59,7 @@ class StandaloneGlideClientAdapter implements UnifiedGlideClient {
 
     @Override
     public void close() throws ExecutionException {
-        glideClient.close();
+        // The native client might be pooled - dont close
     }
 
     @Override

--- a/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideClientConfiguration.java
+++ b/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideClientConfiguration.java
@@ -104,6 +104,13 @@ public interface ValkeyGlideClientConfiguration {
     BackoffStrategy getReconnectStrategy();
 
     /**
+     * Get the maximum pool size for client pooling.
+     * 
+     * @return The maximum pool size. Default is 8.
+     */
+    int getMaxPoolSize();
+
+    /**
      * Get client options for mode-specific configurations.
      * Placeholder for future mode-specific extensions.
      * 
@@ -123,6 +130,7 @@ public interface ValkeyGlideClientConfiguration {
         private @Nullable Integer inflightRequestsLimit;
         private @Nullable String clientAZ;
         private @Nullable BackoffStrategy reconnectStrategy;
+        private int maxPoolSize = 8; // Default pool size
         
         ValkeyGlideClientConfigurationBuilder() {}
         
@@ -203,6 +211,17 @@ public interface ValkeyGlideClientConfiguration {
         }
         
         /**
+         * Set the maximum pool size for client pooling.
+         * 
+         * @param maxPoolSize the maximum number of clients in the pool.
+         * @return {@literal this} builder.
+         */
+        public ValkeyGlideClientConfigurationBuilder maxPoolSize(int maxPoolSize) {
+            this.maxPoolSize = maxPoolSize;
+            return this;
+        }
+        
+        /**
          * Build the {@link ValkeyGlideClientConfiguration}.
          * 
          * @return a new {@link ValkeyGlideClientConfiguration} instance.
@@ -215,7 +234,8 @@ public interface ValkeyGlideClientConfiguration {
                 readFrom,
                 inflightRequestsLimit,
                 clientAZ,
-                reconnectStrategy
+                reconnectStrategy,
+                maxPoolSize
             );
         }
     }


### PR DESCRIPTION
Native Valkey-Glide connection objects will now be stored in ValkeyGlideConnectionFactory for reuse, allowing ValkeyTemplate logic to quickly get connetions from the factory. The default pool size is 8 and cab be configured via ValkeyGlideClientConfiguration.maxPoolSize().
