### PR TITLE
Implemented option C from the doc

### DIFF
--- a/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideClientConfiguration.java
+++ b/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideClientConfiguration.java
@@ -22,6 +22,11 @@ import glide.api.models.configuration.BackoffStrategy;
 import glide.api.models.configuration.ReadFrom;
 import org.springframework.lang.Nullable;
 
+import glide.api.OpenTelemetry;
+import glide.api.OpenTelemetry.MetricsConfig;
+import glide.api.OpenTelemetry.OpenTelemetryConfig;
+import glide.api.OpenTelemetry.TracesConfig;
+
 /**
  * Configuration interface for Valkey-Glide client settings.
  *
@@ -209,7 +214,52 @@ public interface ValkeyGlideClientConfiguration {
             this.reconnectStrategy = reconnectStrategy;
             return this;
         }
-        
+
+        /**
+         * Initialize GLIDE OpenTelemetry with OTLP endpoints.
+         *
+         * If at least one endpoint (traces or metrics) is provided, this will initialize
+         * OpenTelemetry once per JVM.
+         */
+        public ValkeyGlideClientConfigurationBuilder useOpenTelemetry(
+        @Nullable String tracesEndpoint,
+        @Nullable String metricsEndpoint,
+        @Nullable Integer samplePercentage,
+        @Nullable Long flushIntervalMs
+        ) {
+            boolean hasTraces = tracesEndpoint != null && !tracesEndpoint.isBlank();
+            boolean hasMetrics = metricsEndpoint != null && !metricsEndpoint.isBlank();
+
+            // Initialize if AT LEAST ONE endpoint is provided
+            if (hasTraces || hasMetrics) {
+
+                OpenTelemetryConfig.Builder otelBuilder = OpenTelemetryConfig.builder();
+
+                if (hasTraces) {
+                    TracesConfig.Builder tracesBuilder =
+                            TracesConfig.builder().endpoint(tracesEndpoint);
+
+                    if (samplePercentage != null) {
+                        tracesBuilder.samplePercentage(samplePercentage);
+                    }
+
+                    otelBuilder.traces(tracesBuilder.build());
+                }
+                if (hasMetrics) {
+                    otelBuilder.metrics(
+                            MetricsConfig.builder()
+                                    .endpoint(metricsEndpoint)
+                                    .build()
+                    );
+                }
+                if (flushIntervalMs != null) {
+                    otelBuilder.flushIntervalMs(flushIntervalMs);
+                }
+                OpenTelemetry.init(otelBuilder.build());
+            }
+            return this;
+        }
+
         /**
          * Set the maximum pool size for client pooling.
          * 


### PR DESCRIPTION
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->
Example of usage in this option:

```
package com.example.demo;

import io.valkey.springframework.data.valkey.connection.ValkeyClusterConfiguration;
import io.valkey.springframework.data.valkey.connection.ValkeyConnectionFactory;
import io.valkey.springframework.data.valkey.connection.valkeyglide.ValkeyGlideClientConfiguration;
import io.valkey.springframework.data.valkey.connection.valkeyglide.ValkeyGlideConnectionFactory;
import io.valkey.springframework.data.valkey.core.StringValkeyTemplate;

import java.util.List;

import org.springframework.context.annotation.Bean;
import org.springframework.context.annotation.Configuration;

@Configuration
public class ValkeyConfig {

    @Bean
    public ValkeyConnectionFactory valkeyConnectionFactory() {
        // Opentelemetry setup for Glide
        String tracesEndpoint = "http://localhost:4318/v1/traces";
        String metricsEndpoint = "http://localhost:4318/v1/metrics";
        int samplePercentage = 10;
        long flushIntervalMs = 100L;
        
        // Valkey glide client
        String hostAndPort = "clustercfg.disney-test-valkey-7-r5.nra7gl.use1.cache.amazonaws.com:6379";

        ValkeyClusterConfiguration valkeyConfig = new ValkeyClusterConfiguration(List.of(hostAndPort));

        ValkeyGlideClientConfiguration clientConfig =
            ValkeyGlideClientConfiguration
                .builder()
                .useOpenTelemetry(
                    tracesEndpoint,
                    metricsEndpoint,
                    samplePercentage,     // (optional)
                    flushIntervalMs            //  (optional)
                )
                .useSsl() // keep only if TLS is enabled
                .build();

        return new ValkeyGlideConnectionFactory(valkeyConfig, clientConfig);
    }

    @Bean
    public StringValkeyTemplate valkeyTemplate(ValkeyConnectionFactory factory) {
        // Spring will call afterPropertiesSet() automatically as part of bean lifecycle
        return new StringValkeyTemplate(factory);
    }
}
```