### PR TITLE
Optimization: Change clean-up of pooled connections to be conditional

### DIFF
--- a/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnection.java
+++ b/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnection.java
@@ -191,8 +191,6 @@ public class ValkeyGlideConnection extends AbstractValkeyConnection {
                     subscription.close();
                     subscription = null;
                 }
-                // Reset closed flag so connection can be reused
-                closed.set(false);
             }
         } catch (Exception ex) {
             throw new ValkeyGlideExceptionConverter().convert(ex);


### PR DESCRIPTION
Only send UNWATCH requests when returning a connection to the pool if there have actually been watched keys.
This increases the performance by avoiding a network roundtrip when executing a non-batched operation (for scalar operations this halves the number of roundtrips).

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
