### PR TITLE
Optimization: Async cleanup of connections before pooling

### DIFF
--- a/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ClusterGlideClientAdapter.java
+++ b/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ClusterGlideClientAdapter.java
@@ -293,7 +293,7 @@ class ClusterGlideClientAdapter implements UnifiedGlideClient {
     }
 
     @Override
-    public Object getNativeClient() {
+    public GlideClusterClient getNativeClient() {
         return glideClusterClient;
     }
 

--- a/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/StandaloneGlideClientAdapter.java
+++ b/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/StandaloneGlideClientAdapter.java
@@ -53,7 +53,7 @@ class StandaloneGlideClientAdapter implements UnifiedGlideClient {
     }
 
     @Override
-    public Object getNativeClient() {
+    public GlideClient getNativeClient() {
         return glideClient;
     }
 

--- a/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/UnifiedGlideClient.java
+++ b/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/UnifiedGlideClient.java
@@ -17,6 +17,7 @@ package io.valkey.springframework.data.valkey.connection.valkeyglide;
 
 import java.util.concurrent.ExecutionException;
 
+import glide.api.BaseClient;
 import glide.api.models.GlideString;
 
 /**
@@ -39,5 +40,5 @@ interface UnifiedGlideClient extends AutoCloseable {
     Object[] execBatch() throws InterruptedException, ExecutionException;
     void discardBatch();
     Object customCommand(GlideString[] args) throws InterruptedException, ExecutionException;
-    Object getNativeClient();
+    BaseClient getNativeClient();
 }

--- a/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnection.java
+++ b/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnection.java
@@ -191,8 +191,6 @@ public class ValkeyGlideConnection extends AbstractValkeyConnection {
                     subscription.close();
                     subscription = null;
                 }
-                // Reset closed flag so connection can be reused
-                closed.set(false);
             }
         } catch (Exception ex) {
             throw new ValkeyGlideExceptionConverter().convert(ex);

--- a/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnection.java
+++ b/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnection.java
@@ -66,7 +66,7 @@ public class ValkeyGlideConnection extends AbstractValkeyConnection {
     private final AtomicBoolean closed = new AtomicBoolean(false);
 
     private final List<ResultMapper<?, ?>> batchCommandsConverters = new ArrayList<>();
-    protected final Set<byte[]> watchedKeys = new HashSet<>();
+    private final Set<byte[]> watchedKeys = new HashSet<>();
     private @Nullable Subscription subscription;
 
     // Command interfaces

--- a/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionFactory.java
+++ b/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionFactory.java
@@ -18,6 +18,7 @@ package io.valkey.springframework.data.valkey.connection.valkeyglide;
 import java.time.Duration;
 import java.util.concurrent.ExecutionException;
 
+import glide.api.BaseClient;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.SmartLifecycle;
@@ -81,7 +82,7 @@ public class ValkeyGlideConnectionFactory
     private final ValkeyConfiguration configuration;
     
     // Connection pools for client reuse
-    private final BlockingQueue<Object> clientPool;
+    private final BlockingQueue<BaseClient> clientPool;
     
     private @Nullable AsyncTaskExecutor executor;
     
@@ -272,7 +273,7 @@ public class ValkeyGlideConnectionFactory
      * 
      * @param client the client to release
      */
-    void releaseClient(Object client) {
+    void releaseClient(BaseClient client) {
         clientPool.offer(client);
     }
 


### PR DESCRIPTION
Rework the connection state clean-up to happen asynchronously instead of blocking the application thread.
This provides similar performance benefits to skipping the UNWATCH entirely, but is safer due to not
changing the semantics and also more applicable to scenarios where there actually are WATCHed keys.

- [ ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
