### PR TITLE
Fix Flaky Cluster Test

### DIFF
--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionClusterServerCommandsIntegrationTests.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionClusterServerCommandsIntegrationTests.java
@@ -607,7 +607,7 @@ public class ValkeyGlideConnectionClusterServerCommandsIntegrationTests extends 
     @Test
     void testGetClientListClusterWideAggregation() throws InterruptedException {
         // Wait for cluster nodes to stabilize client connections
-        Thread.sleep(1000);
+        Thread.sleep(3000);
         
         // Get cluster-wide client list (should combine lists from all primaries)
         List<ValkeyClientInfo> clusterClientList = clusterConnection.serverCommands().getClientList();


### PR DESCRIPTION
## Summary

As a follow-up to #28, added a wait for `testGetClientListClusterWideAggregation` so that client connections are settled before asserting.  This follows what was done for `testClusterGetClusterInfo` before.

Note that `testGetClientListClusterWideAggregation` only recently started failing a week or so ago, and it fails regularly now, for whatever reason it taking a bit longer for the cluster connections to stabilize.  Ran CI for this branch multiple times and have not seen the error since.