### PR TITLE
Add Docs Deployment Workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,79 @@
+name: Docs
+
+on:
+  workflow_dispatch:
+  # Uncomment to automatically push doc changes on merge to main
+  # push:
+  #   branches: [main]
+  #   paths:
+  #     - 'docs/**'
+  #     - 'spring-data-valkey/src/main/resources/io/valkey/springframework/data/valkey/config/spring-valkey-1.0.xsd'
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: docs/package-lock.json
+
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: ./docs
+
+      - name: Generate JavaDocs
+        run: |
+          ./mvnw javadoc:javadoc -pl spring-data-valkey -DskipTests
+          mkdir -p docs/dist/api/java
+          cp -r spring-data-valkey/target/site/apidocs/* docs/dist/api/java/
+
+      - name: Copy Schema
+        run: |
+          mkdir -p docs/dist/schema/valkey
+          cp spring-data-valkey/src/main/resources/io/valkey/springframework/data/valkey/config/spring-valkey-1.0.xsd docs/dist/schema/valkey/
+
+      - name: Build docs
+        run: npm run build
+        working-directory: ./docs
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./docs/dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Add a GitHub workflow to deploy docs to GitHub pages.  This is needed before #58 in order to configure GitHub pages to use this workflow.