### PR TITLE
Add benchmark CI and orchestrator script

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,15 +3,35 @@ name: Benchmark
 on:
   workflow_dispatch:
     inputs:
-      driver:
-        description: "Driver config (default: spring-data-valkey with valkey-glide)"
+      primary_driver:
+        description: "Primary driver (for details, see resp-bench repo)"
         required: true
-        type: string
-        default: "example-spring-data-valkey-glide-standalone"
+        type: choice
+        options:
+          - spring-data-valkey
+          - spring-data-redis
+          - valkey-glide
+          - jedis
+          - lettuce
+          - redisson
+        default: "spring-data-valkey"
+      secondary_driver:
+        description: "Secondary driver (for spring-data-* only, ignored for others)"
+        required: false
+        type: choice
+        options:
+          - valkey-glide
+          - jedis
+          - lettuce
+          - none
+        default: "valkey-glide"
       workload:
-        description: "Workload config (default: example-workload)"
+        description: "Workload config (for details, see resp-bench repo)"
         required: true
-        type: string
+        type: choice
+        options:
+          - example-workload
+          - example-workload-single-client
         default: "example-workload"
       primary_version:
         description: "Primary driver version. Leave empty for spring-data-valkey (uses branch HEAD)."
@@ -34,7 +54,8 @@ on:
       - add-benchmark-ci
 
 env:
-  DEFAULT_DRIVER: "example-spring-data-valkey-glide-standalone"
+  DEFAULT_PRIMARY_DRIVER: "spring-data-valkey"
+  DEFAULT_SECONDARY_DRIVER: "valkey-glide"
   DEFAULT_WORKLOAD: "example-workload"
   DEFAULT_PRIMARY_VERSION: ""
   DEFAULT_SECONDARY_VERSION: ""
@@ -68,29 +89,33 @@ jobs:
       - name: Resolve inputs
         id: inputs
         run: |
-          # TODO: this is for testing only. Remove once possible 
+          # TODO: this is for testing only. Remove once possible
           if [ "${{ github.event_name }}" = "push" ]; then
-            DRIVER="${{ env.DEFAULT_DRIVER }}"
+            PRIMARY_DRIVER="${{ env.DEFAULT_PRIMARY_DRIVER }}"
+            SECONDARY_DRIVER="${{ env.DEFAULT_SECONDARY_DRIVER }}"
             WORKLOAD="${{ env.DEFAULT_WORKLOAD }}"
             PRIMARY_VERSION="${{ env.DEFAULT_PRIMARY_VERSION }}"
             SECONDARY_VERSION="${{ env.DEFAULT_SECONDARY_VERSION }}"
             JOB_ID_PREFIX="${{ env.DEFAULT_JOB_ID_PREFIX }}"
           else
-            DRIVER="${{ github.event.inputs.driver }}"
+            PRIMARY_DRIVER="${{ github.event.inputs.primary_driver }}"
+            SECONDARY_DRIVER="${{ github.event.inputs.secondary_driver }}"
             WORKLOAD="${{ github.event.inputs.workload }}"
             PRIMARY_VERSION="${{ github.event.inputs.primary_version }}"
             SECONDARY_VERSION="${{ github.event.inputs.secondary_version }}"
             JOB_ID_PREFIX="${{ github.event.inputs.job_id_prefix }}"
           fi
 
-          echo "driver=$DRIVER" >> $GITHUB_OUTPUT
+          echo "primary_driver=$PRIMARY_DRIVER" >> $GITHUB_OUTPUT
+          echo "secondary_driver=$SECONDARY_DRIVER" >> $GITHUB_OUTPUT
           echo "workload=$WORKLOAD" >> $GITHUB_OUTPUT
           echo "primary_version=$PRIMARY_VERSION" >> $GITHUB_OUTPUT
           echo "secondary_version=$SECONDARY_VERSION" >> $GITHUB_OUTPUT
           echo "job_id_prefix=$JOB_ID_PREFIX" >> $GITHUB_OUTPUT
 
           echo "========================================"
-          echo "Driver:            $DRIVER"
+          echo "Primary driver:    $PRIMARY_DRIVER"
+          echo "Secondary driver:  $SECONDARY_DRIVER"
           echo "Workload:          $WORKLOAD"
           echo "Primary version:   '${PRIMARY_VERSION}'"
           echo "Secondary version: '${SECONDARY_VERSION}'"
@@ -98,9 +123,37 @@ jobs:
           echo "========================================"
 
       - name: Validate configs exist
+        id: validate
         run: |
-          DRIVER="${{ steps.inputs.outputs.driver }}"
+          PRIMARY_DRIVER="${{ steps.inputs.outputs.primary_driver }}"
+          SECONDARY_DRIVER="${{ steps.inputs.outputs.secondary_driver }}"
           WORKLOAD="${{ steps.inputs.outputs.workload }}"
+
+          # Resolve driver config filename based on primary and secondary driver
+          if [[ "$PRIMARY_DRIVER" == spring-data-* ]]; then
+            # spring-data-* drivers require a secondary driver
+            if [ "$SECONDARY_DRIVER" = "none" ] || [ -z "$SECONDARY_DRIVER" ]; then
+              echo "ERROR: $PRIMARY_DRIVER requires a secondary driver (valkey-glide, jedis, or lettuce)"
+              exit 1
+            fi
+            # spring-data-redis cannot use valkey-glide
+            if [ "$PRIMARY_DRIVER" = "spring-data-redis" ] && [ "$SECONDARY_DRIVER" = "valkey-glide" ]; then
+              echo "ERROR: spring-data-redis does not support valkey-glide. Use jedis or lettuce instead."
+              exit 1
+            fi
+            # Map secondary driver name to filename convention (valkey-glide -> glide)
+            SECONDARY_IN_FILENAME="$SECONDARY_DRIVER"
+            if [ "$SECONDARY_DRIVER" = "valkey-glide" ]; then
+              SECONDARY_IN_FILENAME="glide"
+            fi
+            DRIVER="example-${PRIMARY_DRIVER}-${SECONDARY_IN_FILENAME}-standalone"
+          else
+            # Standalone drivers (valkey-glide, jedis, lettuce, redisson)
+            DRIVER="example-${PRIMARY_DRIVER}-standalone"
+            if [ "$SECONDARY_DRIVER" != "none" ] && [ -n "$SECONDARY_DRIVER" ]; then
+              echo "Note: secondary_driver '$SECONDARY_DRIVER' ignored for standalone driver '$PRIMARY_DRIVER'"
+            fi
+          fi
 
           DRIVER_CONFIG="resp-bench/configs/drivers/${DRIVER}.json"
           WORKLOAD_CONFIG="resp-bench/configs/workloads/${WORKLOAD}.json"
@@ -121,6 +174,8 @@ jobs:
           fi
           echo "✓ Workload config: $WORKLOAD_CONFIG"
 
+          echo "driver=$DRIVER" >> $GITHUB_OUTPUT
+
           echo "Driver config contents:"
           cat "$DRIVER_CONFIG" | jq .
 
@@ -130,7 +185,7 @@ jobs:
       - name: Analyze driver requirements
         id: driver-info
         run: |
-          DRIVER="${{ steps.inputs.outputs.driver }}"
+          DRIVER="${{ steps.validate.outputs.driver }}"
           SECONDARY_VERSION="${{ steps.inputs.outputs.secondary_version }}"
           DRIVER_CONFIG="resp-bench/configs/drivers/${DRIVER}.json"
 
@@ -348,7 +403,7 @@ jobs:
 
       - name: Run benchmark and publish results to DB
         run: |
-          DRIVER="${{ steps.inputs.outputs.driver }}"
+          DRIVER="${{ steps.validate.outputs.driver }}"
           WORKLOAD="${{ steps.inputs.outputs.workload }}"
           JOB_ID_PREFIX="${{ steps.inputs.outputs.job_id_prefix }}"
 
@@ -369,7 +424,7 @@ jobs:
       - name: Display results summary
         if: always()
         run: |
-          DRIVER="${{ steps.inputs.outputs.driver }}"
+          DRIVER="${{ steps.validate.outputs.driver }}"
           WORKLOAD="${{ steps.inputs.outputs.workload }}"
           RESULT_FILE="benchmark_results_${DRIVER}_${WORKLOAD}.json"
 
@@ -425,7 +480,7 @@ jobs:
       - name: Generate summary report
         if: always()
         run: |
-          DRIVER="${{ steps.inputs.outputs.driver }}"
+          DRIVER="${{ steps.validate.outputs.driver }}"
           WORKLOAD="${{ steps.inputs.outputs.workload }}"
           RESULT_FILE="benchmark_results_${DRIVER}_${WORKLOAD}.json"
 
@@ -487,8 +542,8 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: benchmark-results-${{ steps.inputs.outputs.driver }}-${{ steps.inputs.outputs.workload }}
+          name: benchmark-results-${{ steps.validate.outputs.driver }}-${{ steps.inputs.outputs.workload }}
           path: |
-            benchmark_results_${{ steps.inputs.outputs.driver }}_${{ steps.inputs.outputs.workload }}.json
-            benchmark_results_${{ steps.inputs.outputs.driver }}_${{ steps.inputs.outputs.workload }}.ndjson
-            benchmark_results_${{ steps.inputs.outputs.driver }}_${{ steps.inputs.outputs.workload }}_collapsed.txt
+            benchmark_results_${{ steps.validate.outputs.driver }}_${{ steps.inputs.outputs.workload }}.json
+            benchmark_results_${{ steps.validate.outputs.driver }}_${{ steps.inputs.outputs.workload }}.ndjson
+            benchmark_results_${{ steps.validate.outputs.driver }}_${{ steps.inputs.outputs.workload }}_collapsed.txt

--- a/.github/workflows/benchmark_orchestrator.py
+++ b/.github/workflows/benchmark_orchestrator.py
@@ -1253,7 +1253,7 @@ def main():
     parser.add_argument("--resp-bench-commit", type=str, required=True,
                         help="Git commit ID of the resp-bench repository")
     parser.add_argument("--skip-infra", action="store_true")
-    parser.add_argument("--network-delay-ms", type=int, default=1)
+    parser.add_argument("--network-delay-ms", type=int, default=0)
     parser.add_argument("--job-id-prefix", type=str, default="",
                         help="Optional prefix for the job ID "
                              "(e.g., 'regression', 'nightly', 'pr-123')")


### PR DESCRIPTION
This PR adds a benchmark CI workflow for performance testing.

### Benchmark Orchestrator (benchmark_orchestrator.py)

- Orchestrates end-to-end benchmark runs using https://github.com/ikolomi/resp-bench
- Starts Valkey infrastructure (standalone or cluster mode)
- Runs Java benchmarks with CPU core pinning for isolation
- Collects system metrics:
  - perf stat
  - CPU (mpstat)
  - Disk I/O (iostat)
  - Network (sar)
- Generates flame graphs using async-profiler
- Publishes results to PostgreSQL and uploads artifacts to S3
- Writes monitoring files to /dev/shm (RAM) to eliminate disk I/O interference

### Variance Control for Consistent Results

- Disables SMT (hyperthreading)
- Disables CPU turbo boost
- Configures simulated network delay on loopback
- Sets perf permissions for hardware counters

### Workflow (benchmark.yml)

- Runs on ephemeral bare-metal EC2 instances  
  ([self-hosted, Linux, x86, ephemeral, metal])  
  Runner labels trigger automatic instance provisioning
- workflow_dispatch trigger with configurable inputs:
  - Driver config (e.g., example-spring-data-valkey-glide-standalone)
  - Workload config
  - Optional primary driver version  
    (leave empty for spring-data-valkey to use branch HEAD)
  - Optional secondary driver version  
    (e.g., specific valkey-glide commit)
  - Optional job ID prefix for categorization
- Builds spring-data-valkey from the current branch with commit ID embedded in version
- Optionally builds valkey-glide from source  
  (with debug symbols for flamegraph visibility)
- Generates a GitHub Actions summary with benchmark results
- Uploads artifacts:
  - JSON results
  - NDJSON metrics
  - Collapsed stack file

### Required Secrets

Before using this workflow, add these GitHub secrets:

- BENCHMARK_S3_BUCKET - S3 bucket for artifact storage
- BENCHMARK_PG_HOST - PostgreSQL host for results storage
- BENCHMARK_PG_SECRET_NAME - AWS Secrets Manager secret name for DB credentials

The push trigger on the add-benchmark-ci branch is temporary and for testing only.  
GitHub does not allow workflow_dispatch for workflows that are not already on the default branch.  
Once this PR is apprived, the push trigger will be removed before merging. 
