### PR TITLE
Benchmark: Allow for SDV commit-id input, add network emulation inputs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -58,6 +58,26 @@ on:
         required: false
         type: string
         default: ""
+      network_delay:
+        description: "Network delay with unit, e.g. '1ms' or '500us' (tc netem). Leave empty to disable."
+        required: false
+        type: string
+        default: ""
+      network_jitter:
+        description: "Network jitter with unit, e.g. '1ms' or '100us' (tc netem). Requires network_delay."
+        required: false
+        type: string
+        default: ""
+      network_delay_distribution:
+        description: "Jitter distribution (tc netem). Requires jitter. Options: normal, pareto, paretonormal."
+        required: false
+        type: choice
+        options:
+          - ""
+          - normal
+          - pareto
+          - paretonormal
+        default: ""
 
 env:
   RESP_BENCH_REPO: "https://github.com/ikolomi/resp-bench.git"
@@ -95,6 +115,26 @@ jobs:
           PRIMARY_VERSION="${{ github.event.inputs.primary_version }}"
           SECONDARY_VERSION="${{ github.event.inputs.secondary_version }}"
           JOB_ID_PREFIX="${{ github.event.inputs.job_id_prefix }}"
+          NETWORK_DELAY="${{ github.event.inputs.network_delay }}"
+          NETWORK_JITTER="${{ github.event.inputs.network_jitter }}"
+          NETWORK_DELAY_DISTRIBUTION="${{ github.event.inputs.network_delay_distribution }}"
+
+          # Validate tc netem input combinations
+          if [ -n "$NETWORK_DELAY_DISTRIBUTION" ] && [ -z "$NETWORK_JITTER" ]; then
+            echo "ERROR: network_delay_distribution requires network_jitter"
+            exit 1
+          fi
+          if [ -n "$NETWORK_JITTER" ] && [ -z "$NETWORK_DELAY" ]; then
+            echo "ERROR: network_jitter requires network_delay"
+            exit 1
+          fi
+          # Validate unit format (number followed by ms or us)
+          for val in "$NETWORK_DELAY" "$NETWORK_JITTER"; do
+            if [ -n "$val" ] && ! [[ "$val" =~ ^[0-9]+(ms|us)$ ]]; then
+              echo "ERROR: invalid tc netem value '$val' — expected format: <number>ms or <number>us"
+              exit 1
+            fi
+          done
 
           echo "primary_driver=$PRIMARY_DRIVER" >> $GITHUB_OUTPUT
           echo "secondary_driver=$SECONDARY_DRIVER" >> $GITHUB_OUTPUT
@@ -102,6 +142,9 @@ jobs:
           echo "primary_version=$PRIMARY_VERSION" >> $GITHUB_OUTPUT
           echo "secondary_version=$SECONDARY_VERSION" >> $GITHUB_OUTPUT
           echo "job_id_prefix=$JOB_ID_PREFIX" >> $GITHUB_OUTPUT
+          echo "network_delay=$NETWORK_DELAY" >> $GITHUB_OUTPUT
+          echo "network_jitter=$NETWORK_JITTER" >> $GITHUB_OUTPUT
+          echo "network_delay_distribution=$NETWORK_DELAY_DISTRIBUTION" >> $GITHUB_OUTPUT
 
           echo "========================================"
           echo "Primary driver:    $PRIMARY_DRIVER"
@@ -110,6 +153,7 @@ jobs:
           echo "Primary version:   '${PRIMARY_VERSION}'"
           echo "Secondary version: '${SECONDARY_VERSION}'"
           echo "Job ID prefix:     '${JOB_ID_PREFIX}'"
+          echo "Network delay:     '${NETWORK_DELAY}' jitter='${NETWORK_JITTER}' distribution='${NETWORK_DELAY_DISTRIBUTION}'"
           echo "========================================"
 
       - name: Validate configs exist
@@ -452,6 +496,15 @@ jobs:
           PREFIX_ARG=""
           [ -n "$JOB_ID_PREFIX" ] && PREFIX_ARG="--job-id-prefix $JOB_ID_PREFIX"
 
+          NETWORK_DELAY="${{ steps.inputs.outputs.network_delay }}"
+          NETWORK_JITTER="${{ steps.inputs.outputs.network_jitter }}"
+          NETWORK_DELAY_DISTRIBUTION="${{ steps.inputs.outputs.network_delay_distribution }}"
+
+          TC_ARGS=""
+          [ -n "$NETWORK_DELAY" ] && TC_ARGS="$TC_ARGS --network-delay $NETWORK_DELAY"
+          [ -n "$NETWORK_JITTER" ] && TC_ARGS="$TC_ARGS --network-jitter $NETWORK_JITTER"
+          [ -n "$NETWORK_DELAY_DISTRIBUTION" ] && TC_ARGS="$TC_ARGS --network-delay-distribution $NETWORK_DELAY_DISTRIBUTION"
+
           python3 -u .github/workflows/benchmark_orchestrator.py \
             --output "benchmark_results_${DRIVER}_${WORKLOAD}.json" \
             --workload-config "$WORKLOAD_CONFIG" \
@@ -461,7 +514,7 @@ jobs:
             --s3-bucket "${{ secrets.BENCHMARK_S3_BUCKET }}" \
             --pg-host "${{ secrets.BENCHMARK_PG_HOST }}" \
             --pg-secret-name "${{ secrets.BENCHMARK_PG_SECRET_NAME }}" \
-            $PREFIX_ARG
+            $PREFIX_ARG $TC_ARGS
 
       - name: Display results summary
         if: always()
@@ -540,7 +593,9 @@ jobs:
           driver = data["config"]["driver"]["driver_id"]
           workload_profile = data["config"]["workload"]["benchmark_profile"]["name"]
           elapsed = data["results"]["elapsed_ms"]
-          network_delay = data["results"].get("network_delay_ms", 1)
+          network_delay = data["results"].get("network_delay", "")
+          network_jitter = data["results"].get("network_jitter", "")
+          network_distribution = data["results"].get("network_delay_distribution", "")
           pv = versions.get("primary_driver_version") or "N/A"
           sv = versions.get("secondary_driver_version")
           sid = versions.get("secondary_driver_id")
@@ -555,7 +610,12 @@ jobs:
               print(f"**resp-bench:** \`{commit_id}\`")
           print(f"**Workload config:** \`${WORKLOAD}\` ({workload_profile})")
           print(f"**Driver config:** \`${DRIVER}\`")
-          print(f"**Simulated network delay:** {network_delay}ms")
+          delay_str = network_delay or "disabled"
+          if network_jitter:
+              delay_str += f" jitter {network_jitter}"
+              if network_distribution:
+                  delay_str += f" distribution {network_distribution}"
+          print(f"**Simulated network delay:** {delay_str}")
           print(f"**Elapsed:** {elapsed}ms")
           print()
 

--- a/.github/workflows/benchmark_orchestrator.py
+++ b/.github/workflows/benchmark_orchestrator.py
@@ -202,11 +202,13 @@ class VarianceControl:
         self.nmi_watchdog_original = None
         self.smt_original = None
 
-    def setup(self, network_delay_ms: int = 1):
+    def setup(self, network_delay: str = "", network_jitter: str = "",
+              network_delay_distribution: str = ""):
         print("Setting up variance control...")
         self._disable_smt()
         self._disable_turbo_boost()
-        self._setup_network_delay(network_delay_ms)
+        self._setup_network_delay(network_delay, network_jitter,
+                                  network_delay_distribution)
         self._disable_nmi_watchdog()
         self._set_perf_permissions()
         print("Variance control setup complete")
@@ -279,17 +281,28 @@ class VarianceControl:
             except Exception as e:
                 print(f"  ⚠ Could not restore SMT: {e}")
 
-    def _setup_network_delay(self, delay_ms: int):
+    def _setup_network_delay(self, delay: str, jitter: str = "",
+                             distribution: str = ""):
+        if not delay:
+            return
         try:
             subprocess.run(["sudo", "tc", "qdisc", "del", "dev", "lo", "root"],
                            capture_output=True)
-            result = subprocess.run(
-                ["sudo", "tc", "qdisc", "add", "dev", "lo", "root", "netem",
-                 "delay", f"{delay_ms}ms"],
-                capture_output=True, text=True)
+            cmd = ["sudo", "tc", "qdisc", "add", "dev", "lo", "root", "netem",
+                   "delay", delay]
+            if jitter:
+                cmd.append(jitter)
+                if distribution:
+                    cmd.extend(["distribution", distribution])
+            desc = delay
+            if jitter:
+                desc += f" jitter {jitter}"
+                if distribution:
+                    desc += f" distribution {distribution}"
+            result = subprocess.run(cmd, capture_output=True, text=True)
             if result.returncode == 0:
                 self.tc_configured = True
-                print(f"  ✓ Network delay configured: {delay_ms}ms on loopback")
+                print(f"  ✓ Network delay configured: {desc} on loopback")
             else:
                 print(f"  ⚠ Could not configure network delay: {result.stderr}")
         except Exception as e:
@@ -891,7 +904,8 @@ class BenchmarkOrchestrator:
                  workload_config_path: Path, driver_config_path: Path,
                  s3_bucket: str,
                  job_id_prefix: str = "",
-                 skip_infra: bool = False, network_delay_ms: int = 1,
+                 skip_infra: bool = False, network_delay: str = "",
+                 network_jitter: str = "", network_delay_distribution: str = "",
                  publish_to_db: bool = True, pg_host: str = None,
                  pg_port: int = 5432, pg_database: str = "postgres",
                  pg_secret_name: str = None):
@@ -903,7 +917,9 @@ class BenchmarkOrchestrator:
         self.workload_config = load_json_config(workload_config_path)
         self.driver_config = load_json_config(driver_config_path)
         self.skip_infra = skip_infra
-        self.network_delay_ms = network_delay_ms
+        self.network_delay = network_delay
+        self.network_jitter = network_jitter
+        self.network_delay_distribution = network_delay_distribution
         self.publish_to_db = publish_to_db
         self.job_id = generate_job_id(prefix=job_id_prefix)
         self.timestamp = get_timestamp()
@@ -916,7 +932,10 @@ class BenchmarkOrchestrator:
 
         # Apply variance control
         self.variance_control = VarianceControl()
-        self.variance_control.setup(network_delay_ms=network_delay_ms)
+        self.variance_control.setup(
+            network_delay=network_delay,
+            network_jitter=network_jitter,
+            network_delay_distribution=network_delay_distribution)
 
         # Detect NUMA topology and allocate cores accordingly
         self._setup_numa_aware_cores()
@@ -1295,7 +1314,9 @@ class BenchmarkOrchestrator:
 
                 results = {
                     "elapsed_ms": elapsed_ms,
-                    "network_delay_ms": self.network_delay_ms,
+                    "network_delay": self.network_delay,
+                    "network_jitter": self.network_jitter,
+                    "network_delay_distribution": self.network_delay_distribution,
                     "phases": all_phases,
                     "perf": {
                         "counters": perf_counters,
@@ -1342,7 +1363,12 @@ def main():
     parser.add_argument("--resp-bench-commit", type=str, required=True,
                         help="Git commit ID of the resp-bench repository")
     parser.add_argument("--skip-infra", action="store_true")
-    parser.add_argument("--network-delay-ms", type=int, default=0)
+    parser.add_argument("--network-delay", type=str, default="",
+                        help="Network delay with unit, e.g. '1ms' or '500us'")
+    parser.add_argument("--network-jitter", type=str, default="",
+                        help="Network jitter with unit, e.g. '1ms' or '100us'")
+    parser.add_argument("--network-delay-distribution", type=str, default="",
+                        choices=["", "normal", "pareto", "paretonormal"])
     parser.add_argument("--job-id-prefix", type=str, default="",
                         help="Optional prefix for the job ID "
                              "(e.g., 'regression', 'nightly', 'pr-123')")
@@ -1376,7 +1402,9 @@ def main():
         s3_bucket=args.s3_bucket,
         job_id_prefix=args.job_id_prefix,
         skip_infra=args.skip_infra,
-        network_delay_ms=args.network_delay_ms,
+        network_delay=args.network_delay,
+        network_jitter=args.network_jitter,
+        network_delay_distribution=args.network_delay_distribution,
         publish_to_db=not args.no_publish,
         pg_host=args.pg_host,
         pg_port=args.pg_port,


### PR DESCRIPTION
This PR - 
1. Updates the SDV build flow to match Glide’s. It uses the `resp-bench`'s default version of SDV by default (the SDV version already configured in `resp-bench/pom.xml`), while still allowing an override through workflow inputs when a specific commit-id or version is provided. If a commit-id is supplied, SDV is cloned at that exact commit and built from source. Cloning is used instead of checking out within the existing repo so that commits older than the benchmarking infrastructure can be tested. This fully decouples the benchmark orchestration from the SDV build process.

2. Adds support for network emulation by introducing three new workflow inputs:
   - Delay  
   - Jitter  
   - Jitter distribution