### PR TITLE
Optimize valkey-glide driver

### DIFF
--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/AbstractValkeyConnection.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/AbstractValkeyConnection.java
@@ -35,7 +35,7 @@ import org.springframework.util.Assert;
  */
 public abstract class AbstractValkeyConnection implements ValkeyConnection {
 
-	private final Log LOGGER = LogFactory.getLog(getClass());
+	private final static Log LOGGER = LogFactory.getLog(AbstractValkeyConnection.class);
 
 	private @Nullable ValkeySentinelConfiguration sentinelConfiguration;
 	private final Map<ValkeyNode, ValkeySentinelConnection> connectionCache = new ConcurrentHashMap<>();

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ClusterGlideClientAdapter.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ClusterGlideClientAdapter.java
@@ -15,6 +15,7 @@
  */
 package io.valkey.springframework.data.valkey.connection.valkeyglide;
 
+import java.time.Duration;
 import java.util.AbstractMap;
 import java.util.AbstractSet;
 import java.util.Iterator;
@@ -22,13 +23,23 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
+import glide.api.models.configuration.AdvancedGlideClusterClientConfiguration;
+import glide.api.models.configuration.BackoffStrategy;
+import glide.api.models.configuration.ClusterSubscriptionConfiguration;
+import glide.api.models.configuration.GlideClusterClientConfiguration;
+import glide.api.models.configuration.NodeAddress;
+import glide.api.models.configuration.ReadFrom;
 import glide.api.models.configuration.RequestRoutingConfiguration.ByAddressRoute;
 import glide.api.models.configuration.RequestRoutingConfiguration.Route;
 import glide.api.models.configuration.RequestRoutingConfiguration.SimpleMultiNodeRoute;
 import glide.api.models.ClusterValue;
 import glide.api.models.GlideString;
-import io.micrometer.common.lang.Nullable;
+import org.springframework.lang.Nullable;
+import org.springframework.util.StringUtils;
+
+import io.valkey.springframework.data.valkey.connection.ValkeyClusterConfiguration;
 import io.valkey.springframework.data.valkey.connection.ValkeyClusterNode;
+import io.valkey.springframework.data.valkey.connection.ValkeyPassword;
 import glide.api.GlideClusterClient;
 
 /**
@@ -41,10 +52,112 @@ import glide.api.GlideClusterClient;
 class ClusterGlideClientAdapter implements UnifiedGlideClient {
 
     private final GlideClusterClient glideClusterClient;
+    private final @Nullable DelegatingPubSubListener listener;
     @Nullable private Route nextCommandRoute = null;
 
-    ClusterGlideClientAdapter(GlideClusterClient glideClusterClient) {
-        this.glideClusterClient = glideClusterClient;
+    ClusterGlideClientAdapter(ValkeyClusterConfiguration clusterConfig, ValkeyGlideClientConfiguration valkeyGlideConfiguration) {
+        // Build GlideClusterClientConfiguration using Glide's API
+        var configBuilder = 
+            GlideClusterClientConfiguration.builder();
+        
+        // CONNECTION PROPERTIES from driver-agnostic configuration
+        // Add all cluster nodes
+        clusterConfig.getClusterNodes().forEach(node -> {
+            configBuilder.address(NodeAddress.builder()
+                .host(node.getHost())
+                .port(node.getPort())
+                .build());
+        });
+        
+        // Set credentials from driver-agnostic configuration
+        ValkeyPassword password = clusterConfig.getPassword();
+        if (!password.equals(ValkeyPassword.none())) {
+            String username = clusterConfig.getUsername();
+            
+            if (StringUtils.hasText(username)) {
+                configBuilder.credentials(
+                    glide.api.models.configuration.ServerCredentials.builder()
+                        .username(username)
+                        .password(String.valueOf(password.get()))
+                        .build());
+            } else {
+                configBuilder.credentials(
+                    glide.api.models.configuration.ServerCredentials.builder()
+                        .password(String.valueOf(password.get()))
+                        .build());
+            }
+        }
+        
+        // DRIVER-SPECIFIC PROPERTIES from ValkeyGlideClientConfiguration
+        
+        // Request timeout
+        Duration commandTimeout = valkeyGlideConfiguration.getCommandTimeout();
+        if (commandTimeout != null) {
+            configBuilder.requestTimeout((int) commandTimeout.toMillis());
+        }
+
+        // Connection timeout
+        Duration connectionTimeout = valkeyGlideConfiguration.getConnectionTimeout();
+        if (connectionTimeout != null) {
+            var advancedConfigBuilder = AdvancedGlideClusterClientConfiguration.builder();
+            advancedConfigBuilder.connectionTimeout((int) connectionTimeout.toMillis());
+            configBuilder.advancedConfiguration(advancedConfigBuilder.build());
+        }
+
+        // SSL/TLS
+        if (valkeyGlideConfiguration.isUseSsl()) {
+            configBuilder.useTLS(true);
+        }
+        
+        // Read from strategy
+        ReadFrom readFrom = valkeyGlideConfiguration.getReadFrom();
+        if (readFrom != null) {
+            configBuilder.readFrom(readFrom);
+        }
+        
+        // Inflight requests limit
+        Integer inflightRequestsLimit = valkeyGlideConfiguration.getInflightRequestsLimit();
+        if (inflightRequestsLimit != null) {
+            configBuilder.inflightRequestsLimit(inflightRequestsLimit);
+        }
+        
+        // Client AZ
+        String clientAZ = valkeyGlideConfiguration.getClientAZ();
+        if (clientAZ != null) {
+            configBuilder.clientAZ(clientAZ);
+        }
+        
+        // Reconnect strategy
+        BackoffStrategy reconnectStrategy = valkeyGlideConfiguration.getReconnectStrategy();
+        if (reconnectStrategy != null) {
+            configBuilder.reconnectStrategy(reconnectStrategy);
+        }
+
+        this.listener = new DelegatingPubSubListener();
+
+        // Configure pub/sub with callback for event-driven message delivery
+        var subConfigBuilder = ClusterSubscriptionConfiguration.builder();
+        
+        // Set callback that delegates to our listener holder
+        subConfigBuilder.callback((msg, context) -> this.listener.onMessage(msg, context));
+        configBuilder.subscriptionConfiguration(subConfigBuilder.build());
+
+        // Build and create cluster client
+        GlideClusterClientConfiguration config = configBuilder.build();
+        try {
+            this.glideClusterClient = GlideClusterClient.createClient(config).get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted creating GlideClusterClient", e);
+        } catch (ExecutionException e) {
+            throw new IllegalStateException("Failed creating GlideClusterClient", e);
+        }
+    }
+
+    @Override
+    @Nullable
+    public DelegatingPubSubListener getDelegatingListener() {
+        return listener;
     }
 
     /**
@@ -320,6 +433,14 @@ class ClusterGlideClientAdapter implements UnifiedGlideClient {
     @Override
     public void discardBatch() {
         throw new IllegalStateException("Transactions and pipelines are not supported in cluster mode");
+    }
+
+    @Override
+    public void reset() {
+        nextCommandRoute = null;
+        if (getDelegatingListener() != null) {
+            getDelegatingListener().clearListener();
+        }
     }
 
     public void setOneShotRouteForNextCommand(Route glideRoute) {

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/StandaloneGlideClientAdapter.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/StandaloneGlideClientAdapter.java
@@ -15,10 +15,21 @@
  */
 package io.valkey.springframework.data.valkey.connection.valkeyglide;
 
+import java.time.Duration;
 import java.util.concurrent.ExecutionException;
 import glide.api.models.GlideString;
+import glide.api.models.configuration.AdvancedGlideClientConfiguration;
+import glide.api.models.configuration.BackoffStrategy;
+import glide.api.models.configuration.GlideClientConfiguration;
+import glide.api.models.configuration.NodeAddress;
+import glide.api.models.configuration.ReadFrom;
+import glide.api.models.configuration.StandaloneSubscriptionConfiguration;
+import io.valkey.springframework.data.valkey.connection.ValkeyPassword;
+import io.valkey.springframework.data.valkey.connection.ValkeyStandaloneConfiguration;
 import glide.api.GlideClient;
 import glide.api.models.Batch;
+import org.springframework.lang.Nullable;
+import org.springframework.util.StringUtils;
 
 /**
  * 
@@ -28,11 +39,118 @@ import glide.api.models.Batch;
 class StandaloneGlideClientAdapter implements UnifiedGlideClient {
 
     private final GlideClient glideClient;
+    private final @Nullable DelegatingPubSubListener listener;
     private Batch currentBatch;
     private BatchStatus batchStatus = BatchStatus.None;
 
-    StandaloneGlideClientAdapter(GlideClient glideClient) {
-        this.glideClient = glideClient;
+    StandaloneGlideClientAdapter(ValkeyStandaloneConfiguration standaloneConfig, ValkeyGlideClientConfiguration valkeyGlideConfiguration) {
+        // Build GlideClientConfiguration using Glide's API
+        var configBuilder = GlideClientConfiguration.builder();
+        
+        // CONNECTION PROPERTIES from driver-agnostic configuration
+        configBuilder.address(NodeAddress.builder()
+            .host(standaloneConfig.getHostName())
+            .port(standaloneConfig.getPort())
+            .build());
+        
+        // Set credentials from driver-agnostic configuration
+        ValkeyPassword password = standaloneConfig.getPassword();
+        if (!password.equals(ValkeyPassword.none())) {
+            String username = standaloneConfig.getUsername();
+            
+            if (StringUtils.hasText(username)) {
+                // Username + password authentication
+                configBuilder.credentials(
+                    glide.api.models.configuration.ServerCredentials.builder()
+                        .username(username)
+                        .password(String.valueOf(password.get()))
+                        .build());
+            } else {
+                // Password-only authentication
+                configBuilder.credentials(
+                    glide.api.models.configuration.ServerCredentials.builder()
+                        .password(String.valueOf(password.get()))
+                        .build());
+            }
+        }
+        
+        // Set database from driver-agnostic configuration
+        int database = standaloneConfig.getDatabase();
+        if (database != 0) {
+            configBuilder.databaseId(database);
+        }
+        
+        // DRIVER-SPECIFIC PROPERTIES from ValkeyGlideClientConfiguration
+        
+        // Request timeout
+        Duration commandTimeout = valkeyGlideConfiguration.getCommandTimeout();
+        if (commandTimeout != null) {
+            configBuilder.requestTimeout((int) commandTimeout.toMillis());
+        }
+
+        // Connection timeout
+        Duration connectionTimeout = valkeyGlideConfiguration.getConnectionTimeout();
+        if (connectionTimeout != null) {
+            var advancedConfigBuilder = AdvancedGlideClientConfiguration.builder();
+            advancedConfigBuilder.connectionTimeout((int) connectionTimeout.toMillis());
+            configBuilder.advancedConfiguration(advancedConfigBuilder.build());
+        }
+        
+        // SSL/TLS
+        if (valkeyGlideConfiguration.isUseSsl()) {
+            configBuilder.useTLS(true);
+        }
+        
+        // Read from strategy
+        ReadFrom readFrom = valkeyGlideConfiguration.getReadFrom();
+        if (readFrom != null) {
+            configBuilder.readFrom(readFrom);
+        }
+        
+        // Inflight requests limit
+        Integer inflightRequestsLimit = valkeyGlideConfiguration.getInflightRequestsLimit();
+        if (inflightRequestsLimit != null) {
+            configBuilder.inflightRequestsLimit(inflightRequestsLimit);
+        }
+        
+        // Client AZ
+        String clientAZ = valkeyGlideConfiguration.getClientAZ();
+        if (clientAZ != null) {
+            configBuilder.clientAZ(clientAZ);
+        }
+        
+        // Reconnect strategy
+        BackoffStrategy reconnectStrategy = valkeyGlideConfiguration.getReconnectStrategy();
+        if (reconnectStrategy != null) {
+            configBuilder.reconnectStrategy(reconnectStrategy);
+        }
+
+        // Pubsub listener 
+        this.listener = new DelegatingPubSubListener();
+
+        // Configure pub/sub with callback for event-driven message delivery
+        var subConfigBuilder = StandaloneSubscriptionConfiguration.builder();
+        
+        // Set callback that delegates to our listener holder
+        subConfigBuilder.callback((msg, context) -> this.listener.onMessage(msg, context));
+        configBuilder.subscriptionConfiguration(subConfigBuilder.build());
+
+        // Build and create client
+        GlideClientConfiguration config = configBuilder.build();
+        try {
+            this.glideClient = GlideClient.createClient(config).get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted creating GlideClient", e);
+        } catch (ExecutionException e) {
+            throw new IllegalStateException("Failed creating GlideClient", e);
+        }
+    }
+
+    @Override
+    @Nullable
+    public DelegatingPubSubListener getDelegatingListener() {
+        return listener;
     }
 
     @Override
@@ -85,6 +203,15 @@ class StandaloneGlideClientAdapter implements UnifiedGlideClient {
     public void discardBatch() {
         currentBatch = null;
         batchStatus = BatchStatus.None;
+    }
+
+    @Override
+    public void reset() {
+        currentBatch = null;
+        batchStatus = BatchStatus.None;
+        if (getDelegatingListener() != null) {
+            getDelegatingListener().clearListener();
+        }
     }
 
 }

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/UnifiedGlideClient.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/UnifiedGlideClient.java
@@ -18,6 +18,7 @@ package io.valkey.springframework.data.valkey.connection.valkeyglide;
 import java.util.concurrent.ExecutionException;
 
 import glide.api.models.GlideString;
+import org.springframework.lang.Nullable;
 
 /**
  * Unified interface that abstracts both GlideClient and GlideClusterClient
@@ -40,4 +41,19 @@ interface UnifiedGlideClient extends AutoCloseable {
     void discardBatch();
     Object customCommand(GlideString[] args) throws InterruptedException, ExecutionException;
     Object getNativeClient();
+
+    /**
+     * Resets the adapter's mutable state so it can be safely reused from the pool.
+     * Must be called before returning the adapter to the pool.
+     */
+    void reset();
+    
+    /**
+     * Returns the {@link DelegatingPubSubListener} associated with this client.
+     * The listener is pre-associated at creation time to avoid per-command map lookups.
+     *
+     * @return the delegating pub/sub listener, or {@literal null} if pub/sub is not configured
+     */
+    @Nullable
+    DelegatingPubSubListener getDelegatingListener();
 }

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideClusterConnection.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideClusterConnection.java
@@ -25,8 +25,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.lang.Nullable;
@@ -40,7 +40,6 @@ import glide.api.models.GlideString;
 import glide.api.models.configuration.RequestRoutingConfiguration.Route;
 import glide.api.models.configuration.RequestRoutingConfiguration.ByAddressRoute;
 import glide.api.models.configuration.RequestRoutingConfiguration.SimpleMultiNodeRoute;
-import org.springframework.dao.DataAccessException;
 import io.valkey.springframework.data.valkey.connection.ClusterInfo;
 import io.valkey.springframework.data.valkey.connection.ClusterTopology;
 import io.valkey.springframework.data.valkey.connection.ClusterTopologyProvider;
@@ -76,47 +75,29 @@ public class ValkeyGlideClusterConnection extends ValkeyGlideConnection implemen
     
     // Cache of cluster nodes for backward compatibility
     private final Map<String, ValkeyClusterNode> knownNodes = new ConcurrentHashMap<>();
-    private final ValkeyGlideClusterServerCommands clusterServerCommands;
-    private final ValkeyGlideClusterListCommands clusterListCommands;
-    private final ValkeyGlideClusterKeyCommands clusterKeyCommands;
-    private final ValkeyGlideClusterStringCommands clusterStringCommands;
-    private final ValkeyGlideClusterSetCommands clusterSetCommands;
+    private ValkeyGlideClusterServerCommands clusterServerCommands = null;
+    private ValkeyGlideClusterListCommands clusterListCommands = null;
+    private ValkeyGlideClusterKeyCommands clusterKeyCommands = null;
+    private ValkeyGlideClusterStringCommands clusterStringCommands = null;
+    private ValkeyGlideClusterSetCommands clusterSetCommands = null;
 
     public ValkeyGlideClusterConnection(ClusterGlideClientAdapter clusterAdapter) {
-        this(clusterAdapter, null, Duration.ofMillis(100), null);
+        this(clusterAdapter, null, Duration.ofMillis(100));
     }
 
     public ValkeyGlideClusterConnection(ClusterGlideClientAdapter clusterAdapter, 
             @Nullable ValkeyGlideConnectionFactory factory) {
-        this(clusterAdapter, factory, Duration.ofMillis(100), null);
+        this(clusterAdapter, factory, Duration.ofMillis(100));
     }
 
     public ValkeyGlideClusterConnection(ClusterGlideClientAdapter clusterAdapter, 
             @Nullable ValkeyGlideConnectionFactory factory,
-            @Nullable DelegatingPubSubListener pubSubListener) {
-        this(clusterAdapter, factory, Duration.ofMillis(100), pubSubListener);
-    }
-
-    public ValkeyGlideClusterConnection(ClusterGlideClientAdapter clusterAdapter, 
-            @Nullable ValkeyGlideConnectionFactory factory, 
             Duration cacheTimeout) {
-        this(clusterAdapter, factory, cacheTimeout, null);
-    }
-
-    public ValkeyGlideClusterConnection(ClusterGlideClientAdapter clusterAdapter, 
-            @Nullable ValkeyGlideConnectionFactory factory,
-            Duration cacheTimeout,
-            @Nullable DelegatingPubSubListener pubSubListener) {
-        super(clusterAdapter, factory, pubSubListener);
+        super(clusterAdapter, factory);
         Assert.notNull(cacheTimeout, "CacheTimeout must not be null!");
         
         this.clusterAdapter = clusterAdapter;
         this.cacheTimeoutMs = cacheTimeout.toMillis();
-        this.clusterServerCommands = new ValkeyGlideClusterServerCommands(this);
-        this.clusterListCommands = new ValkeyGlideClusterListCommands(this);
-        this.clusterKeyCommands = new ValkeyGlideClusterKeyCommands(this);
-        this.clusterStringCommands = new ValkeyGlideClusterStringCommands(this);
-        this.clusterSetCommands = new ValkeyGlideClusterSetCommands(this);
     }
 
     public ClusterGlideClientAdapter getClusterAdapter() {
@@ -124,36 +105,31 @@ public class ValkeyGlideClusterConnection extends ValkeyGlideConnection implemen
     }
 
     /**
-     * Cleans up server-side connection state before returning client to pool.
-     * This ensures the next connection gets a clean client without stale state.
+     * Sends an UNWATCH command to ALL_NODES in cluster mode.
+     * Overrides the standalone implementation which sends to a single node.
      */
     @Override
-    protected void cleanupConnectionState() {
-        // Dont use RESET - we will destroy the configured state
-        // Use valkey-glide native pipe to selectively clear the state on the backends,
-        // adapter and connection object do not matter - they are being destroyed
-        // some state cannot be cleared (like stats) but this is acceptable if pooling to be used
-
+    protected void sendUnwatch() {
         GlideClusterClient nativeClient = (GlideClusterClient) unifiedClient.getNativeClient();
 
-        @SuppressWarnings("unchecked")
-        Callable<Void>[] actions = new Callable[] {
-                () -> nativeClient.customCommand(new String[]{"UNWATCH"}, SimpleMultiNodeRoute.ALL_NODES).get(),
-            };
-
-        for (Callable<Void> action : actions) {
-            try {
-                action.call();
-            } catch (InterruptedException ie) {
-                Thread.currentThread().interrupt();
-            } catch (Exception e) {
-            }
+        try {
+            nativeClient.customCommand(new String[]{"UNWATCH"}, SimpleMultiNodeRoute.ALL_NODES).get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted UNWATCH command during connection cleanup", e);
+        } catch (ExecutionException e) {
+            throw new IllegalStateException("Failed to send UNWATCH command during connection cleanup", e);
         }
     }
 
     @Override
     public ValkeyClusterServerCommands serverCommands() {
-        return this.clusterServerCommands;
+        ValkeyGlideClusterServerCommands cmds = this.clusterServerCommands;
+        if (cmds == null) {
+            cmds = new ValkeyGlideClusterServerCommands(this);
+            this.clusterServerCommands = cmds;
+        }
+        return cmds;
     }
 
     @Override
@@ -163,22 +139,42 @@ public class ValkeyGlideClusterConnection extends ValkeyGlideConnection implemen
 
     @Override
     public ValkeyGlideClusterListCommands listCommands() {
-        return this.clusterListCommands;
+        ValkeyGlideClusterListCommands cmds = this.clusterListCommands;
+        if (cmds == null) {
+            cmds = new ValkeyGlideClusterListCommands(this);
+            this.clusterListCommands = cmds;
+        }
+        return cmds;
     }
 
     @Override
     public ValkeyGlideClusterKeyCommands keyCommands() {
-        return this.clusterKeyCommands;
+        ValkeyGlideClusterKeyCommands cmds = this.clusterKeyCommands;
+        if (cmds == null) {
+            cmds = new ValkeyGlideClusterKeyCommands(this);
+            this.clusterKeyCommands = cmds;
+        }
+        return cmds;
     }
 
     @Override
     public ValkeyGlideClusterStringCommands stringCommands() {
-        return this.clusterStringCommands;
+        ValkeyGlideClusterStringCommands cmds = this.clusterStringCommands;
+        if (cmds == null) {
+            cmds = new ValkeyGlideClusterStringCommands(this);
+            this.clusterStringCommands = cmds;
+        }
+        return cmds;
     }
 
     @Override
     public ValkeyGlideClusterSetCommands setCommands() {
-        return this.clusterSetCommands;
+        ValkeyGlideClusterSetCommands cmds = this.clusterSetCommands;
+        if (cmds == null) {
+            cmds = new ValkeyGlideClusterSetCommands(this);
+            this.clusterSetCommands = cmds;
+        }
+        return cmds;
     }
 
 	@Override

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnection.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnection.java
@@ -46,7 +46,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 // Imports from valkey-glide library
@@ -63,30 +63,26 @@ public class ValkeyGlideConnection extends AbstractValkeyConnection {
 
     protected final UnifiedGlideClient unifiedClient;
     protected final @Nullable ValkeyGlideConnectionFactory factory;
-    /**
-     * Bridges Glide's callback mechanism (configured at client creation) with Spring's
-     * {@link MessageListener} (provided at subscribe time). The user's listener is set
-     * on this delegate when {@code subscribe()} is called, and cleared on connection close.
-     */
-    protected final @Nullable DelegatingPubSubListener delegatingListener;
     private final AtomicBoolean closed = new AtomicBoolean(false);
 
     private final List<ResultMapper<?, ?>> batchCommandsConverters = new ArrayList<>();
     private final Set<byte[]> watchedKeys = new HashSet<>();
+    /** Tracks whether a WATCH command was issued via execute() directly, bypassing the watch() API */
+    private boolean watchCommandIssued = false;
     private volatile @Nullable ValkeyGlideSubscription subscription;
 
     // Command interfaces
-    private final ValkeyGlideKeyCommands keyCommands;
-    private final ValkeyGlideStringCommands stringCommands;
-    private final ValkeyGlideListCommands listCommands;
-    private final ValkeyGlideSetCommands setCommands;
-    private final ValkeyGlideZSetCommands zSetCommands;
-    private final ValkeyGlideHashCommands hashCommands;
-    private final ValkeyGlideGeoCommands geoCommands;
-    private final ValkeyGlideHyperLogLogCommands hyperLogLogCommands;
-    private final ValkeyGlideScriptingCommands scriptingCommands;
-    private final ValkeyGlideServerCommands serverCommands;
-    private final ValkeyGlideStreamCommands streamCommands;
+    private ValkeyGlideKeyCommands keyCommands = null;
+    private ValkeyGlideStringCommands stringCommands = null;
+    private ValkeyGlideListCommands listCommands = null;
+    private ValkeyGlideSetCommands setCommands = null;
+    private ValkeyGlideZSetCommands zSetCommands = null;
+    private ValkeyGlideHashCommands hashCommands = null;
+    private ValkeyGlideGeoCommands geoCommands = null;
+    private ValkeyGlideHyperLogLogCommands hyperLogLogCommands = null;
+    private ValkeyGlideScriptingCommands scriptingCommands = null;
+    private ValkeyGlideServerCommands serverCommands = null;
+    private ValkeyGlideStreamCommands streamCommands = null;
 
     /**
      * Creates a new {@link ValkeyGlideConnection} with a unified client adapter.
@@ -96,37 +92,10 @@ public class ValkeyGlideConnection extends AbstractValkeyConnection {
      * @param factory the connection factory (optional, for pooling support)
      */
     public ValkeyGlideConnection(UnifiedGlideClient unifiedClient, @Nullable ValkeyGlideConnectionFactory factory) {
-        this(unifiedClient, factory, null);
-    }
-
-    /**
-     * Creates a new {@link ValkeyGlideConnection} with a unified client adapter and delegating pub/sub listener.
-     *
-     * @param unifiedClient unified client adapter (standalone or cluster)
-     * @param factory the connection factory (optional, for pooling support)
-     * @param delegatingListener the delegating pub/sub listener for callback-based message delivery
-     */
-    public ValkeyGlideConnection(UnifiedGlideClient unifiedClient, 
-            @Nullable ValkeyGlideConnectionFactory factory,
-            @Nullable DelegatingPubSubListener delegatingListener) {
         Assert.notNull(unifiedClient, "UnifiedClient must not be null");
         
         this.unifiedClient = unifiedClient;
         this.factory = factory;
-        this.delegatingListener = delegatingListener;
-        
-        // Initialize command interfaces
-        this.keyCommands = new ValkeyGlideKeyCommands(this);
-        this.stringCommands = new ValkeyGlideStringCommands(this);
-        this.listCommands = new ValkeyGlideListCommands(this);
-        this.setCommands = new ValkeyGlideSetCommands(this);
-        this.zSetCommands = new ValkeyGlideZSetCommands(this);
-        this.hashCommands = new ValkeyGlideHashCommands(this);
-        this.geoCommands = new ValkeyGlideGeoCommands(this);
-        this.hyperLogLogCommands = new ValkeyGlideHyperLogLogCommands(this);
-        this.scriptingCommands = new ValkeyGlideScriptingCommands(this);
-        this.serverCommands = new ValkeyGlideServerCommands(this);
-        this.streamCommands = new ValkeyGlideStreamCommands(this);
     }
 
     /**
@@ -142,57 +111,112 @@ public class ValkeyGlideConnection extends AbstractValkeyConnection {
 
     @Override
     public ValkeyGeoCommands geoCommands() {
-        return this.geoCommands;
+        ValkeyGlideGeoCommands cmds = this.geoCommands;
+        if (cmds == null) {
+            cmds = new ValkeyGlideGeoCommands(this);
+            this.geoCommands = cmds;
+        }
+        return cmds;
     }
 
     @Override
     public ValkeyHashCommands hashCommands() {
-        return this.hashCommands;
+        ValkeyGlideHashCommands cmds = this.hashCommands;
+        if (cmds == null) {
+            cmds = new ValkeyGlideHashCommands(this);
+            this.hashCommands = cmds;
+        }
+        return cmds;
     }
 
     @Override
     public ValkeyHyperLogLogCommands hyperLogLogCommands() {
-        return this.hyperLogLogCommands;
+        ValkeyGlideHyperLogLogCommands cmds = this.hyperLogLogCommands;
+        if (cmds == null) {
+            cmds = new ValkeyGlideHyperLogLogCommands(this);
+            this.hyperLogLogCommands = cmds;
+        }
+        return cmds;
     }
 
     @Override
     public ValkeyKeyCommands keyCommands() {
-        return this.keyCommands;
+        ValkeyGlideKeyCommands cmds = this.keyCommands;
+        if (cmds == null) {
+            cmds = new ValkeyGlideKeyCommands(this);
+            this.keyCommands = cmds;
+        }
+        return cmds;
     }
 
     @Override
     public ValkeyListCommands listCommands() {
-        return this.listCommands;
+        ValkeyGlideListCommands cmds = this.listCommands;
+        if (cmds == null) {
+            cmds = new ValkeyGlideListCommands(this);
+            this.listCommands = cmds;
+        }
+        return cmds;
     }
 
     @Override
     public ValkeySetCommands setCommands() {
-        return this.setCommands;
+        ValkeyGlideSetCommands cmds = this.setCommands;
+        if (cmds == null) {
+            cmds = new ValkeyGlideSetCommands(this);
+            this.setCommands = cmds;
+        }
+        return cmds;
     }
 
     @Override
     public ValkeyScriptingCommands scriptingCommands() {
-        return this.scriptingCommands;
+        ValkeyGlideScriptingCommands cmds = this.scriptingCommands;
+        if (cmds == null) {
+            cmds = new ValkeyGlideScriptingCommands(this);
+            this.scriptingCommands = cmds;
+        }
+        return cmds;
     }
 
     @Override
     public ValkeyServerCommands serverCommands() {
-        return this.serverCommands;
+        ValkeyGlideServerCommands cmds = this.serverCommands;
+        if (cmds == null) {
+            cmds = new ValkeyGlideServerCommands(this);
+            this.serverCommands = cmds;
+        }
+        return cmds;
     }
 
     @Override
     public ValkeyStreamCommands streamCommands() {
-        return this.streamCommands;
+        ValkeyGlideStreamCommands cmds = this.streamCommands;
+        if (cmds == null) {
+            cmds = new ValkeyGlideStreamCommands(this);
+            this.streamCommands = cmds;
+        }
+        return cmds;
     }
 
     @Override
     public ValkeyStringCommands stringCommands() {
-        return this.stringCommands;
+        ValkeyGlideStringCommands cmds = this.stringCommands;
+        if (cmds == null) {
+            cmds = new ValkeyGlideStringCommands(this);
+            this.stringCommands = cmds;
+        }
+        return cmds;
     }
 
     @Override
     public ValkeyZSetCommands zSetCommands() {
-        return this.zSetCommands;
+        ValkeyGlideZSetCommands cmds = this.zSetCommands;
+        if (cmds == null) {
+            cmds = new ValkeyGlideZSetCommands(this);
+            this.zSetCommands = cmds;
+        }
+        return cmds;
     }
 
     @Override
@@ -210,48 +234,34 @@ public class ValkeyGlideConnection extends AbstractValkeyConnection {
                     sub.close();
                     this.subscription = null;
                 }
-                
-                cleanupConnectionState();
 
-                if (delegatingListener != null) {
-                    delegatingListener.clearListener();
+                if (!watchedKeys.isEmpty() || watchCommandIssued) {
+                    sendUnwatch();
+                    watchedKeys.clear();
+                    watchCommandIssued = false;
                 }
-                
-                // Return client to pool
+
+                // Reset adapter state and return to pool
                 if (factory != null) {
-                    factory.releaseClient(unifiedClient.getNativeClient());
+                    unifiedClient.reset();
+                    factory.releaseAdapter(unifiedClient);
                 }
             }
         } catch (Exception ex) {
             throw new ValkeyGlideExceptionConverter().convert(ex);
         }
     }
-    
-    /**
-     * Cleans up server-side connection state before returning client to pool.
-     * This ensures the next connection gets a clean client without stale state.
-     */
-    protected void cleanupConnectionState() {
-        // Dont use RESET - we will destroy the configured state
-        // Use valkey-glide native pipe to selectively clear the state on the backends,
-        // adapter and connection object do not matter - they are being destroyed
-        // some state cannot be cleared (like stats) but this is acceptable if pooling to be used
 
-        // GlideClient nativeClient = (GlideClient) unifiedClient.getNativeClient();
-
-        // @SuppressWarnings("unchecked")
-        // Callable<Void>[] actions = new Callable[] {
-        //         () -> nativeClient.customCommand(new String[]{"UNWATCH"}).get(),
-        //     };
-
-        // for (Callable<Void> action : actions) {
-        //     try {
-        //         action.call();
-        //     } catch (InterruptedException ie) {
-        //         Thread.currentThread().interrupt();
-        //     } catch (Exception e) {
-        //     }
-        // }
+    protected void sendUnwatch() {
+        GlideClient nativeClient = (GlideClient) unifiedClient.getNativeClient();
+        try {
+            nativeClient.customCommand(new String[]{"UNWATCH"}).get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted UNWATCH command during connection cleanup", e);
+        } catch (ExecutionException e) {
+            throw new IllegalStateException("Failed to send UNWATCH command during connection cleanup", e);
+        }
     }
 
     @Override
@@ -379,8 +389,9 @@ public class ValkeyGlideConnection extends AbstractValkeyConnection {
             // Clean up transaction state
             unifiedClient.discardBatch();
             batchCommandsConverters.clear();
-            // Watches are automatically cleared after EXEC
+            // Watches are automatically cleared by the server after EXEC
             watchedKeys.clear();
+            watchCommandIssued = false;
         }
     }
 
@@ -398,7 +409,7 @@ public class ValkeyGlideConnection extends AbstractValkeyConnection {
     @Override
     public void unwatch() {
         try {
-            if (watchedKeys.isEmpty()) {
+            if (watchedKeys.isEmpty() || !watchCommandIssued) {
                 return; // No keys to unwatch
             }
             execute("UNWATCH");
@@ -457,22 +468,22 @@ public class ValkeyGlideConnection extends AbstractValkeyConnection {
 			throw new InvalidDataAccessApiUsageException("Cannot subscribe in pipeline / transaction mode");
 		}
 
-        if (delegatingListener == null) {
+        if (unifiedClient.getDelegatingListener() == null) {
             throw new InvalidDataAccessApiUsageException(
                     "Pub/Sub not configured. Ensure the connection factory was created with pub/sub callback support.");
         }
 
         try {
-            delegatingListener.setListener(listener);
+            unifiedClient.getDelegatingListener().setListener(listener);
             
             ValkeyGlideSubscription glideSubscription = new ValkeyGlideSubscription(
-                    listener, unifiedClient, delegatingListener);
+                    listener, unifiedClient, unifiedClient.getDelegatingListener());
             this.subscription = glideSubscription;
             glideSubscription.subscribe(channels);
             
         } catch (Exception ex) {
-            if (delegatingListener != null) {
-                delegatingListener.clearListener();
+            if (unifiedClient.getDelegatingListener() != null) {
+                unifiedClient.getDelegatingListener().clearListener();
             }
             this.subscription = null;
             throw new ValkeyGlideExceptionConverter().convert(ex);
@@ -494,22 +505,22 @@ public class ValkeyGlideConnection extends AbstractValkeyConnection {
 			throw new InvalidDataAccessApiUsageException("Cannot subscribe in pipeline / transaction mode");
 		}
         
-        if (delegatingListener == null) {
+        if (unifiedClient.getDelegatingListener() == null) {
             throw new InvalidDataAccessApiUsageException(
                     "Pub/Sub not configured. Ensure the connection factory was created with pub/sub callback support.");
         }
 
         try {
-            delegatingListener.setListener(listener);
+            unifiedClient.getDelegatingListener().setListener(listener);
             
             ValkeyGlideSubscription glideSubscription = new ValkeyGlideSubscription(
-                    listener, unifiedClient, delegatingListener);
+                    listener, unifiedClient, unifiedClient.getDelegatingListener());
             this.subscription = glideSubscription;
             glideSubscription.pSubscribe(patterns);
             
         } catch (Exception ex) {
-            if (delegatingListener != null) {
-                delegatingListener.clearListener();
+            if (unifiedClient.getDelegatingListener() != null) {
+                unifiedClient.getDelegatingListener().clearListener();
             }
             this.subscription = null;
             throw new ValkeyGlideExceptionConverter().convert(ex);
@@ -571,6 +582,12 @@ public class ValkeyGlideConnection extends AbstractValkeyConnection {
         Assert.notNull(mapper, "ResultMapper must not be null");
 
         verifyConnectionOpen();
+
+        // Track WATCH commands issued directly via execute() to ensure UNWATCH on close
+        if ("WATCH".equalsIgnoreCase(command)) {
+            watchCommandIssued = true;
+        }
+
         try {
             // Convert arguments to appropriate format for Glide
             GlideString[] glideArgs = new GlideString[args.length + 1];

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionFactory.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionFactory.java
@@ -39,33 +39,10 @@ import io.valkey.springframework.data.valkey.connection.valkeyglide.ValkeyGlideC
 import io.valkey.springframework.data.valkey.connection.ValkeySentinelConnection;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
-
-// Imports needed for working with valkey-glide
-// Imports for valkey-glide library
-import glide.api.GlideClient;
-import glide.api.GlideClusterClient;
-import glide.api.models.GlideString;
-import glide.api.models.configuration.AdvancedGlideClientConfiguration;
-import glide.api.models.configuration.AdvancedGlideClusterClientConfiguration;
-import glide.api.models.configuration.BackoffStrategy;
-import glide.api.models.configuration.GlideClientConfiguration;
-import glide.api.models.configuration.GlideClusterClientConfiguration;
-import glide.api.models.configuration.NodeAddress;
-import glide.api.models.configuration.ReadFrom;
 import glide.api.OpenTelemetry;
 import glide.api.OpenTelemetry.MetricsConfig;
 import glide.api.OpenTelemetry.OpenTelemetryConfig;
 import glide.api.OpenTelemetry.TracesConfig;
-import glide.api.models.configuration.StandaloneSubscriptionConfiguration;
-import glide.api.models.configuration.ClusterSubscriptionConfiguration;
-
-import java.util.Map;
-import java.util.Set;
-import java.util.LinkedList;
-import java.util.Queue;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -97,8 +74,8 @@ public class ValkeyGlideConnectionFactory
     private final @Nullable ValkeyGlideClientConfiguration valkeyGlideConfiguration;
     private final ValkeyConfiguration configuration;
     
-    // Connection pools for client reuse
-    private final BlockingQueue<Object> clientPool;
+    // Bounded pool of pre-created adapters (with listeners pre-associated).
+    private final LinkedBlockingQueue<UnifiedGlideClient> adapterPool;
     
     private @Nullable AsyncTaskExecutor executor;
     
@@ -111,22 +88,6 @@ public class ValkeyGlideConnectionFactory
     private static @Nullable OpenTelemetryForGlide OTEL_INITIALIZED_CONFIG;
     private static final Object OTEL_LOCK = new Object();
 
-    /**
-     * Maps native Glide clients ({@link GlideClient} or {@link GlideClusterClient}) to their
-     * associated {@link DelegatingPubSubListener}.
-     * 
-     * <p>This mapping is necessary because Glide requires pub/sub callbacks to be configured
-     * at client creation time, before any subscriptions exist. When a client is created and
-     * added to the pool, we also create a {@link DelegatingPubSubListener} and register it
-     * as the client's pub/sub callback. The actual {@link MessageListener} is set on the
-     * {@link DelegatingPubSubListener} later when {@code subscribe()} is called.
-     * 
-     * <p>When a connection is obtained from the pool, we look up the corresponding
-     * {@link DelegatingPubSubListener} for that client and pass it to the
-     * {@link ValkeyGlideConnection}, which can then configure it with the user's
-     * {@link MessageListener} during subscription.
-     */
-    private final Map<Object, DelegatingPubSubListener> clientListenerMap = new ConcurrentHashMap<>();
 
     /**
      * Constructs a new {@link ValkeyGlideConnectionFactory} instance with default settings.
@@ -155,7 +116,7 @@ public class ValkeyGlideConnectionFactory
         
         this.configuration = standaloneConfiguration;
         this.valkeyGlideConfiguration = valkeyGlideConfiguration;
-        this.clientPool = new LinkedBlockingQueue<>(valkeyGlideConfiguration.getMaxPoolSize());
+        this.adapterPool = new LinkedBlockingQueue<>(valkeyGlideConfiguration.getMaxPoolSize());
     }
 
     /**
@@ -184,7 +145,7 @@ public class ValkeyGlideConnectionFactory
         
         this.configuration = clusterConfiguration;
         this.valkeyGlideConfiguration = valkeyGlideConfiguration;
-        this.clientPool = new LinkedBlockingQueue<>(valkeyGlideConfiguration.getMaxPoolSize());
+        this.adapterPool = new LinkedBlockingQueue<>(valkeyGlideConfiguration.getMaxPoolSize());
     }
 
     /**
@@ -225,7 +186,7 @@ public class ValkeyGlideConnectionFactory
         
         this.configuration = new ValkeyStandaloneConfiguration();
         this.valkeyGlideConfiguration = valkeyGlideConfiguration;
-        this.clientPool = new LinkedBlockingQueue<>(valkeyGlideConfiguration.getMaxPoolSize());
+        this.adapterPool = new LinkedBlockingQueue<>(valkeyGlideConfiguration.getMaxPoolSize());
     }
 
     /**
@@ -243,14 +204,22 @@ public class ValkeyGlideConnectionFactory
             return;
         }
         
-        // Pre-create pool of clients based on configuration mode
+        // Initialize OpenTelemetry before creating any clients
+        if (valkeyGlideConfiguration != null) {
+            OpenTelemetryForGlide openTelemetryForGlide = valkeyGlideConfiguration.getOpenTelemetryForGlide();
+            if (openTelemetryForGlide != null) {
+                useOpenTelemetry(openTelemetryForGlide);
+            }
+        }
+
+        // Pre-create pool of adapters based on configuration mode
         if (isClusterAware()) {
             for (int i = 0; i < valkeyGlideConfiguration.getMaxPoolSize(); i++) {
-                clientPool.offer(createGlideClusterClient());
+                adapterPool.offer(new ClusterGlideClientAdapter((ValkeyClusterConfiguration) configuration, valkeyGlideConfiguration));
             }
         } else {
             for (int i = 0; i < valkeyGlideConfiguration.getMaxPoolSize(); i++) {
-                clientPool.offer(createGlideClient());
+                adapterPool.offer(new StandaloneGlideClientAdapter((ValkeyStandaloneConfiguration) configuration, valkeyGlideConfiguration));
             }
         }
         
@@ -266,17 +235,15 @@ public class ValkeyGlideConnectionFactory
             return getClusterConnection();
         }
         
-        // Get client from pool (or create new if pool is empty)
-        GlideClient client = (GlideClient) clientPool.poll();
-        if (client == null) {
-            client = createGlideClient();
+        // Get adapter from lock-free pool (or create new if pool is empty)
+        UnifiedGlideClient adapter = adapterPool.poll();
+        if (adapter == null) {
+            if (ValkeyConfiguration.isClusterConfiguration(configuration)) {
+                throw new IllegalStateException("Cannot create StandaloneGlideClientAdapter in cluster mode");
+            }
+            adapter = new StandaloneGlideClientAdapter((ValkeyStandaloneConfiguration) configuration, valkeyGlideConfiguration);
         }
-
-        // Get the listener associated with this client
-        DelegatingPubSubListener listener = clientListenerMap.get(client);
-
-        // Return a new connection wrapper around the pooled client
-        return new ValkeyGlideConnection(new StandaloneGlideClientAdapter(client), this, listener);
+        return new ValkeyGlideConnection(adapter, this);
     }
 
     @Override
@@ -287,17 +254,15 @@ public class ValkeyGlideConnectionFactory
             throw new InvalidDataAccessResourceUsageException("Cluster mode is not configured!");
         }
 
-        // Get cluster client from pool (or create new if pool is empty)
-        GlideClusterClient client = (GlideClusterClient) clientPool.poll();
-        if (client == null) {
-            client = createGlideClusterClient();
+        // Get adapter from lock-free pool (or create new if pool is empty)
+        UnifiedGlideClient adapter = adapterPool.poll();
+        if (adapter == null) {
+            if (!ValkeyConfiguration.isClusterConfiguration(configuration)) {
+                throw new IllegalStateException("Cannot create ClusterGlideClientAdapter in non-cluster mode");
+            }
+            adapter = new ClusterGlideClientAdapter((ValkeyClusterConfiguration) configuration, valkeyGlideConfiguration);
         }
-        
-        // Get the listener associated with this client
-        DelegatingPubSubListener listener = clientListenerMap.get(client);
-        
-        // Return a new connection wrapper around the pooled cluster client
-        return new ValkeyGlideClusterConnection(new ClusterGlideClientAdapter(client), this, listener);
+        return new ValkeyGlideClusterConnection((ClusterGlideClientAdapter) adapter, this);
     }
 
     @Override
@@ -311,12 +276,13 @@ public class ValkeyGlideConnectionFactory
     }
 
     /**
-     * Release a standalone client back to the pool.
+     * Release an adapter back to the bounded pool.
+     * If the pool is full, the adapter is discarded (will be GC'd).
      * 
-     * @param client the client to release
+     * @param adapter the adapter to release
      */
-    void releaseClient(Object client) {
-        clientPool.offer(client);
+    void releaseAdapter(UnifiedGlideClient adapter) {
+        adapterPool.offer(adapter);
     }
 
     /**
@@ -404,248 +370,6 @@ public class ValkeyGlideConnectionFactory
 
             OTEL_INITIALIZED_CONFIG = openTelemetryForGlide;
             OpenTelemetry.init(otelBuilder.build());
-        }
-    }
-
-    /**
-     * Creates a GlideClient instance for each connection.
-     */
-    private GlideClient createGlideClient() {
-        try {
-            if (ValkeyConfiguration.isClusterConfiguration(configuration)) {
-                throw new IllegalStateException("Cannot create GlideClient in cluster mode");
-            }
-            // Cast to standalone configuration
-            ValkeyStandaloneConfiguration standaloneConfig = 
-                (ValkeyStandaloneConfiguration) configuration;
-            
-            // Build GlideClientConfiguration using Glide's API
-            var configBuilder = GlideClientConfiguration.builder();
-            
-            // CONNECTION PROPERTIES from driver-agnostic configuration
-            configBuilder.address(NodeAddress.builder()
-                .host(standaloneConfig.getHostName())
-                .port(standaloneConfig.getPort())
-                .build());
-            
-            // Set credentials from driver-agnostic configuration
-            ValkeyPassword password = standaloneConfig.getPassword();
-            if (!password.equals(ValkeyPassword.none())) {
-                String username = standaloneConfig.getUsername();
-                
-                if (StringUtils.hasText(username)) {
-                    // Username + password authentication
-                    configBuilder.credentials(
-                        glide.api.models.configuration.ServerCredentials.builder()
-                            .username(username)
-                            .password(String.valueOf(password.get()))
-                            .build());
-                } else {
-                    // Password-only authentication
-                    configBuilder.credentials(
-                        glide.api.models.configuration.ServerCredentials.builder()
-                            .password(String.valueOf(password.get()))
-                            .build());
-                }
-            }
-            
-            // Set database from driver-agnostic configuration
-            int database = standaloneConfig.getDatabase();
-            if (database != 0) {
-                configBuilder.databaseId(database);
-            }
-            
-            // DRIVER-SPECIFIC PROPERTIES from ValkeyGlideClientConfiguration
-            
-            // Request timeout
-            Duration commandTimeout = valkeyGlideConfiguration.getCommandTimeout();
-            if (commandTimeout != null) {
-                configBuilder.requestTimeout((int) commandTimeout.toMillis());
-            }
-
-            // Connection timeout
-            Duration connectionTimeout = valkeyGlideConfiguration.getConnectionTimeout();
-            if (connectionTimeout != null) {
-                var advancedConfigBuilder = AdvancedGlideClientConfiguration.builder();
-                advancedConfigBuilder.connectionTimeout((int) connectionTimeout.toMillis());
-                configBuilder.advancedConfiguration(advancedConfigBuilder.build());
-            }
-            
-            // SSL/TLS
-            if (valkeyGlideConfiguration.isUseSsl()) {
-                configBuilder.useTLS(true);
-            }
-            
-            // Read from strategy
-            ReadFrom readFrom = valkeyGlideConfiguration.getReadFrom();
-            if (readFrom != null) {
-                configBuilder.readFrom(readFrom);
-            }
-            
-            // Inflight requests limit
-            Integer inflightRequestsLimit = valkeyGlideConfiguration.getInflightRequestsLimit();
-            if (inflightRequestsLimit != null) {
-                configBuilder.inflightRequestsLimit(inflightRequestsLimit);
-            }
-            
-            // Client AZ
-            String clientAZ = valkeyGlideConfiguration.getClientAZ();
-            if (clientAZ != null) {
-                configBuilder.clientAZ(clientAZ);
-            }
-            
-            // Reconnect strategy
-            BackoffStrategy reconnectStrategy = valkeyGlideConfiguration.getReconnectStrategy();
-            if (reconnectStrategy != null) {
-                configBuilder.reconnectStrategy(reconnectStrategy);
-            }
-
-            // OpenTelemetry
-            OpenTelemetryForGlide openTelemetryForGlide = valkeyGlideConfiguration.getOpenTelemetryForGlide();
-            if (openTelemetryForGlide != null){
-                this.useOpenTelemetry(openTelemetryForGlide);
-            }
-
-            // Pubsub listener 
-            DelegatingPubSubListener clientListener = new DelegatingPubSubListener();
-
-            
-            // Configure pub/sub with callback for event-driven message delivery
-            var subConfigBuilder = StandaloneSubscriptionConfiguration.builder();            
-            
-            // Set callback that delegates to our listener holder
-            subConfigBuilder.callback((msg, context) -> clientListener.onMessage(msg, context));
-            configBuilder.subscriptionConfiguration(subConfigBuilder.build());
-
-            // Build and create client
-            GlideClientConfiguration config = configBuilder.build();
-            GlideClient client = GlideClient.createClient(config).get();
-
-            // Save the mapping of this client to its DelegatingListener
-            clientListenerMap.put(client, clientListener);
-
-            return client;
-        } catch (Exception e) {
-            throw new IllegalStateException("Failed to create GlideClient: " + e.getMessage(), e);
-        }
-    }
-
-    /**
-     * Creates a GlideClusterClient instance for each connection.
-     */
-    private GlideClusterClient createGlideClusterClient() {
-        try {
-            if (!ValkeyConfiguration.isClusterConfiguration(configuration)) {
-                throw new IllegalStateException("Cannot create GlideClusterClient in non-cluster mode");
-            }
-            
-            // Cast to cluster configuration
-            ValkeyClusterConfiguration clusterConfig = 
-                (ValkeyClusterConfiguration) configuration;
-            
-            // Build GlideClusterClientConfiguration using Glide's API
-            var configBuilder = 
-                GlideClusterClientConfiguration.builder();
-            
-            // CONNECTION PROPERTIES from driver-agnostic configuration
-            // Add all cluster nodes
-            clusterConfig.getClusterNodes().forEach(node -> {
-                configBuilder.address(NodeAddress.builder()
-                    .host(node.getHost())
-                    .port(node.getPort())
-                    .build());
-            });
-            
-            // Set credentials from driver-agnostic configuration
-            ValkeyPassword password = clusterConfig.getPassword();
-            if (!password.equals(ValkeyPassword.none())) {
-                String username = clusterConfig.getUsername();
-                
-                if (StringUtils.hasText(username)) {
-                    configBuilder.credentials(
-                        glide.api.models.configuration.ServerCredentials.builder()
-                            .username(username)
-                            .password(String.valueOf(password.get()))
-                            .build());
-                } else {
-                    configBuilder.credentials(
-                        glide.api.models.configuration.ServerCredentials.builder()
-                            .password(String.valueOf(password.get()))
-                            .build());
-                }
-            }
-            
-            // DRIVER-SPECIFIC PROPERTIES from ValkeyGlideClientConfiguration
-            
-            // Request timeout
-            Duration commandTimeout = valkeyGlideConfiguration.getCommandTimeout();
-            if (commandTimeout != null) {
-                configBuilder.requestTimeout((int) commandTimeout.toMillis());
-            }
-
-            // Connection timeout
-            Duration connectionTimeout = valkeyGlideConfiguration.getConnectionTimeout();
-            if (connectionTimeout != null) {
-                var advancedConfigBuilder = AdvancedGlideClusterClientConfiguration.builder();
-                advancedConfigBuilder.connectionTimeout((int) connectionTimeout.toMillis());
-                configBuilder.advancedConfiguration(advancedConfigBuilder.build());
-            }
-
-            // SSL/TLS
-            if (valkeyGlideConfiguration.isUseSsl()) {
-                configBuilder.useTLS(true);
-            }
-            
-            // Read from strategy
-            ReadFrom readFrom = valkeyGlideConfiguration.getReadFrom();
-            if (readFrom != null) {
-                configBuilder.readFrom(readFrom);
-            }
-            
-            // Inflight requests limit
-            Integer inflightRequestsLimit = valkeyGlideConfiguration.getInflightRequestsLimit();
-            if (inflightRequestsLimit != null) {
-                configBuilder.inflightRequestsLimit(inflightRequestsLimit);
-            }
-            
-            // Client AZ
-            String clientAZ = valkeyGlideConfiguration.getClientAZ();
-            if (clientAZ != null) {
-                configBuilder.clientAZ(clientAZ);
-            }
-            
-            // Reconnect strategy
-            BackoffStrategy reconnectStrategy = valkeyGlideConfiguration.getReconnectStrategy();
-            if (reconnectStrategy != null) {
-                configBuilder.reconnectStrategy(reconnectStrategy);
-            }
-
-           // OpenTelemetry
-            OpenTelemetryForGlide openTelemetryForGlide = valkeyGlideConfiguration.getOpenTelemetryForGlide();
-            if (openTelemetryForGlide != null){
-                this.useOpenTelemetry(openTelemetryForGlide);
-            }
-            
-
-            DelegatingPubSubListener clientListener = new DelegatingPubSubListener();
-
-            // Configure pub/sub with callback for event-driven message delivery
-            var subConfigBuilder = ClusterSubscriptionConfiguration.builder();
-            
-            // Set callback that delegates to our listener holder
-            subConfigBuilder.callback((msg, context) -> clientListener.onMessage(msg, context));
-            configBuilder.subscriptionConfiguration(subConfigBuilder.build());
-
-            
-            // Build and create cluster client
-            GlideClusterClientConfiguration config = configBuilder.build();
-            GlideClusterClient client = GlideClusterClient.createClient(config).get();
-
-            clientListenerMap.put(client, clientListener);
-            
-            return client;
-        } catch (InterruptedException | ExecutionException e) {
-            throw new IllegalStateException("Failed to create GlideClusterClient: " + e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
Major performance optimizations to improve latency for valkey-glide when using ValkeyTemplate.

1. Pool adapters instead of raw clients
   - Replace BlockingQueue<Object> + ConcurrentHashMap<Object, DelegatingPubSubListener> with LinkedBlockingQueue<UnifiedGlideClient>
   - Pre-associate DelegatingPubSubListener inside adapters at creation time
   - Eliminate ConcurrentHashMap.get() lookup on every getConnection() call

2. Move client construction into adapter constructors
   - StandaloneGlideClientAdapter and ClusterGlideClientAdapter now own their GlideClient/GlideClusterClient lifecycle and configuration
   - Remove ~250 lines of createGlideClient()/createGlideClusterClient() from factory

3. Lazy-initialize command interfaces
   - Defer creation of 11 command objects (KeyCommands, StringCommands, etc.) from constructor time to first-use, reducing per-connection allocation

4. Conditional UNWATCH on connection close
   - Track WATCH usage via watchedKeys set and watchCommandIssued flag
   - Only send synchronous UNWATCH when WATCH was actually used
   - Zero overhead for the common GET/SET datapath (~99% of operations)
   - Cluster mode overrides sendUnwatch() to route to ALL_NODES

5. Make AbstractValkeyConnection.LOGGER static
   - Avoid per-instance LogFactory.getLog(getClass()) reflective call

