### PR TITLE
Change cluster client aggregation to test minimum clients

### DIFF
--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionClusterServerCommandsIntegrationTests.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionClusterServerCommandsIntegrationTests.java
@@ -605,25 +605,22 @@ public class ValkeyGlideConnectionClusterServerCommandsIntegrationTests extends 
     }
 
     @Test
-    void testGetClientListClusterWideAggregation() throws InterruptedException {
-        // Wait for cluster nodes to stabilize client connections
-        Thread.sleep(3000);
-        
+    void testGetClientListClusterWideAggregation() {
         // Get cluster-wide client list (should combine lists from all primaries)
         List<ValkeyClientInfo> clusterClientList = clusterConnection.serverCommands().getClientList();
         
         assertThat(clusterClientList).isNotNull();
         assertThat(clusterClientList).isNotEmpty();
         
-        // Verify it's actually combining clients from all nodes
-        int individualClientCounts = 0;
+        // Verify cluster-wide count is at least the sum from each node
+        // (>= instead of == to avoid race condition where connections are created between measurements)
+        int minExpectedClients = 0;
         for (ValkeyClusterNode node : allPrimaries) {
             List<ValkeyClientInfo> nodeClients = clusterConnection.serverCommands().getClientList(node);
-            individualClientCounts += nodeClients.size();
+            minExpectedClients += nodeClients.size();
         }
         
-        // Cluster-wide list should contain all clients from all nodes
-        assertThat(clusterClientList.size()).isEqualTo(individualClientCounts);
+        assertThat(clusterClientList.size()).isGreaterThanOrEqualTo(minExpectedClients);
     }
 
     @Test


### PR DESCRIPTION
## Summary

This test frequently fails due to a race condition between measuring the cluster-wide client count and summing individual node counts as connections can be created/destroyed between the two measurements.  Instead of verifying an exact count, verify the cluster-wide count is at least the minimum expected from individual nodes.

## Testing

Ran CI tests a few times in a row without a single failure.