### PR TITLE
Add missing actuator config

### DIFF
--- a/spring-boot-starter-data-valkey/README.md
+++ b/spring-boot-starter-data-valkey/README.md
@@ -228,6 +228,7 @@ Configure health endpoints in `application.properties`:
 
 ```properties
 management.endpoints.web.exposure.include=health,metrics
+management.endpoint.health.show-components=always
 management.health.valkey.enabled=true
 ```
 


### PR DESCRIPTION
## Summary

Add missing `management.endpoint.health.show-components=always` to the actuator health example config in the starter README. Without this property `/actuator/health/valkey` returns 404.

Closes #77