### PR TITLE
Update Valkey GLIDE dependency to Uber Jar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,6 @@ Spring Data Valkey is a Spring Data module providing first-class Valkey/Redis in
 
 **Driver Notes:**
 
-- Valkey GLIDE requires `${os.detected.classifier}` (platform-specific JAR) and the `os-maven-plugin` build extension
 - Sentinel support is available in Lettuce and Jedis only — GLIDE does not support Sentinel at this time
 
 ## Architecture Quick Facts

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -32,23 +32,8 @@ Update your `pom.xml`:
 <dependency>
     <groupId>io.valkey</groupId>
     <artifactId>valkey-glide</artifactId>
-    <classifier>${os.detected.classifier}</classifier>
     <version>${version}</version>
 </dependency>
-```
-
-Valkey GLIDE requires platform-specific native libraries. Add the os-maven-plugin to resolve `${os.detected.classifier}`:
-
-```xml
-<build>
-    <extensions>
-        <extension>
-            <groupId>kr.motd.maven</groupId>
-            <artifactId>os-maven-plugin</artifactId>
-            <version>1.7.1</version>
-        </extension>
-    </extensions>
-</build>
 ```
 
 Note: You can continue using Lettuce or Jedis if preferred by setting `spring.data.valkey.client-type=lettuce` or `spring.data.valkey.client-type=jedis`.
@@ -63,15 +48,7 @@ implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 // After
 implementation 'io.valkey.springframework.boot:spring-boot-starter-data-valkey:${version}'
-implementation "io.valkey:valkey-glide:${version}:${osdetector.classifier}"
-```
-
-Add the osdetector plugin to resolve `${osdetector.classifier}`:
-
-```groovy
-plugins {
-    id 'com.google.osdetector' version '1.7.3'
-}
+implementation 'io.valkey:valkey-glide:${version}'
 ```
 
 ### Vanilla Spring
@@ -97,7 +74,6 @@ Update your `pom.xml`:
 <dependency>
     <groupId>io.valkey</groupId>
     <artifactId>valkey-glide</artifactId>
-    <classifier>${os.detected.classifier}</classifier>
     <version>${version}</version>
 </dependency>
 ```
@@ -112,7 +88,7 @@ implementation 'org.springframework.data:spring-data-redis:${version}'
 
 // After
 implementation 'io.valkey.springframework.data:spring-data-valkey:${version}'
-implementation "io.valkey:valkey-glide:${version}:${osdetector.classifier}"
+implementation 'io.valkey:valkey-glide:${version}'
 ```
 
 ## Package Name Changes

--- a/docs/src/content/docs/valkey/drivers.md
+++ b/docs/src/content/docs/valkey/drivers.md
@@ -74,7 +74,7 @@ The following overview explains features that are supported by the individual Va
     <groupId>io.valkey</groupId>
     <artifactId>valkey-glide</artifactId>
     <version>2.4.0</version>
-
+  </dependency>
 </dependencies>
 ```
 

--- a/docs/src/content/docs/valkey/drivers.md
+++ b/docs/src/content/docs/valkey/drivers.md
@@ -73,9 +73,7 @@ The following overview explains features that are supported by the individual Va
   <dependency>
     <groupId>io.valkey</groupId>
     <artifactId>valkey-glide</artifactId>
-    <version>2.3.0</version>
-    <classifier>linux-x86_64</classifier>
-  </dependency>
+    <version>2.4.0</version>
 
 </dependencies>
 ```

--- a/examples/boot-iam-auth/pom.xml
+++ b/examples/boot-iam-auth/pom.xml
@@ -29,13 +29,6 @@
 	</dependencies>
 
 	<build>
-		<extensions>
-			<extension>
-				<groupId>kr.motd.maven</groupId>
-				<artifactId>os-maven-plugin</artifactId>
-				<version>1.7.1</version>
-			</extension>
-		</extensions>
 		<plugins>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>

--- a/examples/boot-telemetry/pom.xml
+++ b/examples/boot-telemetry/pom.xml
@@ -33,13 +33,6 @@
 	</dependencies>
 
 	<build>
-		<extensions>
-			<extension>
-				<groupId>kr.motd.maven</groupId>
-				<artifactId>os-maven-plugin</artifactId>
-				<version>1.7.1</version>
-			</extension>
-		</extensions>
 		<plugins>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -54,19 +54,11 @@
 		<dependency>
 			<groupId>io.valkey</groupId>
 			<artifactId>valkey-glide</artifactId>
-			<classifier>${os.detected.classifier}</classifier>
 			<version>${valkey-glide.version}</version>
 		</dependency>
 	</dependencies>
 
 	<build>
-		<extensions>
-			<extension>
-				<groupId>kr.motd.maven</groupId>
-				<artifactId>os-maven-plugin</artifactId>
-				<version>1.7.1</version>
-			</extension>
-		</extensions>
 		<pluginManagement>
 			<plugins>
 				<plugin>

--- a/examples/spring-boot/pom.xml
+++ b/examples/spring-boot/pom.xml
@@ -29,13 +29,6 @@
 	</dependencies>
 
 	<build>
-		<extensions>
-			<extension>
-				<groupId>kr.motd.maven</groupId>
-				<artifactId>os-maven-plugin</artifactId>
-				<version>1.7.1</version>
-			</extension>
-		</extensions>
 		<plugins>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>

--- a/performance/pom.xml
+++ b/performance/pom.xml
@@ -31,7 +31,6 @@
 		<dependency>
 			<groupId>io.valkey</groupId>
 			<artifactId>valkey-glide</artifactId>
-			<classifier>${os.detected.classifier}</classifier>
 			<version>${valkey-glide.version}</version>
 		</dependency>
 		<dependency>
@@ -52,13 +51,6 @@
 	</dependencies>
 
 	<build>
-		<extensions>
-			<extension>
-				<groupId>kr.motd.maven</groupId>
-				<artifactId>os-maven-plugin</artifactId>
-				<version>1.7.1</version>
-			</extension>
-		</extensions>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 		<springdata.parent.version>3.5.1</springdata.parent.version>
 
 		<!-- Valkey/Redis client versions -->
-		<valkey-glide.version>2.3.0-rc2</valkey-glide.version>
+		<valkey-glide.version>2.4.0</valkey-glide.version>
 		<lettuce.version>6.6.0.RELEASE</lettuce.version>
 		<jedis.version>6.0.0</jedis.version>
 		<pool.version>2.11.1</pool.version>

--- a/spring-boot-starter-data-valkey/README.md
+++ b/spring-boot-starter-data-valkey/README.md
@@ -37,40 +37,23 @@ Add the starter and Valkey GLIDE dependencies:
     <dependency>
         <groupId>io.valkey</groupId>
         <artifactId>valkey-glide</artifactId>
-        <classifier>${os.detected.classifier}</classifier>
         <version>${version}</version>
     </dependency>
 </dependencies>
 ```
 
-Add the os-maven-plugin for platform-specific GLIDE libraries:
-
-```xml
-<build>
-    <extensions>
-        <extension>
-            <groupId>kr.motd.maven</groupId>
-            <artifactId>os-maven-plugin</artifactId>
-            <version>1.7.1</version>
-        </extension>
-    </extensions>
-</build>
-```
-
 Or to your `build.gradle`:
 
 ```gradle
-plugins {
-    id 'com.google.osdetector' version '1.7.3'
-}
-
 dependencies {
     implementation 'io.valkey.springframework.boot:spring-boot-starter-data-valkey:${version}'
-    implementation 'io.valkey:valkey-glide:${version}:${osdetector.classifier}'
+    implementation 'io.valkey:valkey-glide:${version}'
 }
 ```
 
-Note: The Valkey GLIDE dependency must also be explicitly added due to the OS classifier (platform-specific JAR).  To use the Lettuce or Jedis driver instead, add their dependencies and set `spring.data.valkey.client-type` accordingly.
+To use platform specific Valkey GLIDE dependency and reduce the Jar size, see Valkey GLIDE installation [guide](https://glide.valkey.io/how-to/installation?lang=java).
+
+To use the Lettuce or Jedis driver instead, add their dependencies and set `spring.data.valkey.client-type` accordingly.
 
 ## Getting Started
 

--- a/spring-boot-starter-data-valkey/pom.xml
+++ b/spring-boot-starter-data-valkey/pom.xml
@@ -83,7 +83,6 @@
 		<dependency>
 			<groupId>io.valkey</groupId>
 			<artifactId>valkey-glide</artifactId>
-			<classifier>${os.detected.classifier}</classifier>
 			<version>${valkey-glide.version}</version>
 		</dependency>
 
@@ -262,13 +261,6 @@
 	</dependencies>
 
 	<build>
-		<extensions>
-			<extension>
-				<groupId>kr.motd.maven</groupId>
-				<artifactId>os-maven-plugin</artifactId>
-				<version>1.7.1</version>
-			</extension>
-		</extensions>
 		<plugins>
 			<!-- Flatten plugin for Maven Central deployment -->
 			<plugin>

--- a/spring-data-valkey/README.md
+++ b/spring-data-valkey/README.md
@@ -31,23 +31,8 @@ Add the Spring Data Valkey and Valkey GLIDE dependencies:
 <dependency>
     <groupId>io.valkey</groupId>
     <artifactId>valkey-glide</artifactId>
-    <classifier>${os.detected.classifier}</classifier>
     <version>${version}</version>
 </dependency>
-```
-
-Add the os-maven-plugin for platform-specific GLIDE libraries:
-
-```xml
-<build>
-    <extensions>
-        <extension>
-            <groupId>kr.motd.maven</groupId>
-            <artifactId>os-maven-plugin</artifactId>
-            <version>1.7.1</version>
-        </extension>
-    </extensions>
-</build>
 ```
 
 ## Getting Started

--- a/spring-data-valkey/pom.xml
+++ b/spring-data-valkey/pom.xml
@@ -123,7 +123,6 @@
 		<dependency>
 			<groupId>io.valkey</groupId>
 			<artifactId>valkey-glide</artifactId>
-			<classifier>${os.detected.classifier}</classifier>
 			<version>${valkey-glide.version}</version>
 			<optional>true</optional>
 		</dependency>
@@ -325,13 +324,6 @@
 	</dependencies>
 
 	<build>
-		<extensions>
-			<extension>
-				<groupId>kr.motd.maven</groupId>
-				<artifactId>os-maven-plugin</artifactId>
-				<version>1.7.1</version>
-			</extension>
-		</extensions>
 		<plugins>
 
 			<plugin>

--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideZSetOrderingIntegrationTests.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideZSetOrderingIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideZSetOrderingIntegrationTests.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideZSetOrderingIntegrationTests.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.valkey.springframework.data.valkey.connection.valkeyglide;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import io.valkey.springframework.data.valkey.connection.valkeyglide.extension.ValkeyGlideConnectionFactoryExtension;
+import io.valkey.springframework.data.valkey.core.StringValkeyTemplate;
+import io.valkey.springframework.data.valkey.core.ZSetOperations;
+import io.valkey.springframework.data.valkey.test.condition.EnabledOnValkeyClusterAvailable;
+import io.valkey.springframework.data.valkey.test.extension.ValkeyCluster;
+import io.valkey.springframework.data.valkey.test.extension.ValkeyStanalone;
+
+/**
+ * Integration tests verifying that ZSet rangeWithScores operations maintain
+ * score-based ordering for both standalone and cluster connections.
+ *
+ * @see <a href="https://github.com/valkey-io/spring-data-valkey/issues/36">Issue #36</a>
+ * @see <a href="https://github.com/valkey-io/valkey-glide/issues/4963">Glide #4963</a>
+ */
+class ValkeyGlideZSetOrderingIntegrationTests {
+
+	@Test
+	void rangeWithScoresStandaloneOrder() {
+		StringValkeyTemplate template = new StringValkeyTemplate(
+				ValkeyGlideConnectionFactoryExtension.getConnectionFactory(ValkeyStanalone.class));
+		try {
+			ZSetOperations<String, String> opsForZSet = template.opsForZSet();
+
+			opsForZSet.add("testKey", "value1", 2.0);
+			opsForZSet.add("testKey", "value2", 1.0);
+			opsForZSet.add("testKey", "value3", 4.0);
+			opsForZSet.add("testKey", "value4", 3.0);
+
+			Set<String> rangeResult = opsForZSet.range("testKey", 0, 3);
+			String[] rangeArray = rangeResult.toArray(new String[0]);
+			assertThat(rangeArray[0]).isEqualTo("value2");
+			assertThat(rangeArray[1]).isEqualTo("value1");
+			assertThat(rangeArray[2]).isEqualTo("value4");
+			assertThat(rangeArray[3]).isEqualTo("value3");
+
+			Set<ZSetOperations.TypedTuple<String>> rangeWithScoresResult = opsForZSet.rangeWithScores("testKey", 0, 3);
+			ZSetOperations.TypedTuple<String>[] tuplesArray = rangeWithScoresResult.toArray(new ZSetOperations.TypedTuple[0]);
+			assertThat(tuplesArray[0].getValue()).isEqualTo("value2");
+			assertThat(tuplesArray[1].getValue()).isEqualTo("value1");
+			assertThat(tuplesArray[2].getValue()).isEqualTo("value4");
+			assertThat(tuplesArray[3].getValue()).isEqualTo("value3");
+		} finally {
+			template.delete("testKey");
+		}
+	}
+
+	@Test
+	@EnabledOnValkeyClusterAvailable
+	void rangeWithScoresClusterOrder() {
+		StringValkeyTemplate template = new StringValkeyTemplate(
+				ValkeyGlideConnectionFactoryExtension.getConnectionFactory(ValkeyCluster.class));
+		try {
+			ZSetOperations<String, String> opsForZSet = template.opsForZSet();
+
+			opsForZSet.add("testKey", "value1", 2.0);
+			opsForZSet.add("testKey", "value2", 1.0);
+			opsForZSet.add("testKey", "value3", 4.0);
+			opsForZSet.add("testKey", "value4", 3.0);
+
+			Set<String> rangeResult = opsForZSet.range("testKey", 0, 3);
+			String[] rangeArray = rangeResult.toArray(new String[0]);
+			assertThat(rangeArray[0]).isEqualTo("value2");
+			assertThat(rangeArray[1]).isEqualTo("value1");
+			assertThat(rangeArray[2]).isEqualTo("value4");
+			assertThat(rangeArray[3]).isEqualTo("value3");
+
+			Set<ZSetOperations.TypedTuple<String>> rangeWithScoresResult = opsForZSet.rangeWithScores("testKey", 0, 3);
+			ZSetOperations.TypedTuple<String>[] tuplesArray = rangeWithScoresResult.toArray(new ZSetOperations.TypedTuple[0]);
+			assertThat(tuplesArray[0].getValue()).isEqualTo("value2");
+			assertThat(tuplesArray[1].getValue()).isEqualTo("value1");
+			assertThat(tuplesArray[2].getValue()).isEqualTo("value4");
+			assertThat(tuplesArray[3].getValue()).isEqualTo("value3");
+		} finally {
+			template.delete("testKey");
+		}
+	}
+}


### PR DESCRIPTION
## Overview

- Updated the GLIDE dependency to using the uber jar. Related documentations has been updated.
- Also verified that the zset ordering issue noted in #36 has been fixed. Regression tests were added. 

## Related Issues

Closes #36 
Related #81 

## Checklist
- [ ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
