### PR TITLE
Set client lib-name to GlideSpringDataValkey

### DIFF
--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ClusterGlideClientAdapter.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ClusterGlideClientAdapter.java
@@ -171,6 +171,9 @@ class ClusterGlideClientAdapter implements UnifiedGlideClient {
         subConfigBuilder.callback((msg, context) -> this.listener.onMessage(msg, context));
         configBuilder.subscriptionConfiguration(subConfigBuilder.build());
 
+        // Set library name for server-side client identification
+        configBuilder.libName("GlideSpringDataValkey");
+
         // Build and create cluster client
         GlideClusterClientConfiguration config = configBuilder.build();
         try {

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/StandaloneGlideClientAdapter.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/StandaloneGlideClientAdapter.java
@@ -164,6 +164,9 @@ class StandaloneGlideClientAdapter implements UnifiedGlideClient {
         subConfigBuilder.callback((msg, context) -> this.listener.onMessage(msg, context));
         configBuilder.subscriptionConfiguration(subConfigBuilder.build());
 
+        // Set library name for server-side client identification
+        configBuilder.libName("GlideSpringDataValkey");
+
         // Build and create client
         GlideClientConfiguration config = configBuilder.build();
         try {

--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionClusterServerCommandsIntegrationTests.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionClusterServerCommandsIntegrationTests.java
@@ -31,6 +31,7 @@ import io.valkey.springframework.data.valkey.connection.ValkeyClusterServerComma
 import io.valkey.springframework.data.valkey.connection.ValkeyServerCommands.FlushOption;
 import io.valkey.springframework.data.valkey.core.types.ValkeyClientInfo;
 import io.valkey.springframework.data.valkey.test.condition.EnabledOnValkeyClusterAvailable;
+import io.valkey.springframework.data.valkey.test.condition.EnabledOnValkeyVersion;
 
 /**
  * Comprehensive low-level integration tests for {@link ValkeyGlideClusterConnection} 
@@ -464,6 +465,7 @@ public class ValkeyGlideConnectionClusterServerCommandsIntegrationTests extends 
     }
 
     @Test
+    @EnabledOnValkeyVersion("7.2")
     void testClientLibNameReported() {
         List<ValkeyClientInfo> clientList = clusterConnection.serverCommands().getClientList();
         assertThat(clientList).anyMatch(client -> "GlideSpringDataValkey".equals(client.get("lib-name")));

--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionClusterServerCommandsIntegrationTests.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionClusterServerCommandsIntegrationTests.java
@@ -463,6 +463,12 @@ public class ValkeyGlideConnectionClusterServerCommandsIntegrationTests extends 
         }
     }
 
+    @Test
+    void testClientLibNameReported() {
+        List<ValkeyClientInfo> clientList = clusterConnection.serverCommands().getClientList();
+        assertThat(clientList).anyMatch(client -> "GlideSpringDataValkey".equals(client.get("lib-name")));
+    }
+
     // ==================== Cluster-Wide Routing and Aggregation Verification ====================
 
     @Test

--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionServerCommandsIntegrationTests.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionServerCommandsIntegrationTests.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
 import io.valkey.springframework.data.valkey.connection.ValkeyNode;
+import io.valkey.springframework.data.valkey.test.condition.EnabledOnValkeyVersion;
 import io.valkey.springframework.data.valkey.connection.ValkeyServerCommands;
 import io.valkey.springframework.data.valkey.connection.ValkeyServerCommands.FlushOption;
 import io.valkey.springframework.data.valkey.connection.ValkeyServerCommands.MigrateOption;
@@ -454,6 +455,7 @@ public class ValkeyGlideConnectionServerCommandsIntegrationTests extends Abstrac
     }
 
     @Test
+    @EnabledOnValkeyVersion("7.2")
     void testClientLibNameReported() {
         List<ValkeyClientInfo> clientList = connection.serverCommands().getClientList();
         assertThat(clientList).anyMatch(client -> "GlideSpringDataValkey".equals(client.get("lib-name")));

--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionServerCommandsIntegrationTests.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionServerCommandsIntegrationTests.java
@@ -454,6 +454,12 @@ public class ValkeyGlideConnectionServerCommandsIntegrationTests extends Abstrac
     }
 
     @Test
+    void testClientLibNameReported() {
+        List<ValkeyClientInfo> clientList = connection.serverCommands().getClientList();
+        assertThat(clientList).anyMatch(client -> "GlideSpringDataValkey".equals(client.get("lib-name")));
+    }
+
+    @Test
     void testKillClient() {
         // Test killing a client
         // This is tricky to test safely, so we test with a non-existent client


### PR DESCRIPTION
## Overivew

This PR set the reported `lib-name` to GlideSpringDataValkey. 

Two small sanity tests were added.

## Related Issues

#81 