### PR TITLE
Increased tests parameters to reduce flakiness

### DIFF
--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionKeyCommandsIntegrationTests.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionKeyCommandsIntegrationTests.java
@@ -1719,7 +1719,7 @@ public class ValkeyGlideConnectionKeyCommandsIntegrationTests extends AbstractVa
             // Verify conversion relationships
             if (actualPTtlHours != null && actualPTtlHours > 0) {
                 double hoursToMillisecondsRatio = (double) actualPTtlMilliseconds / actualPTtlHours;
-                assertThat(hoursToMillisecondsRatio).isBetween(3500000.0, 3700000.0); // ~3600000 ms per hour
+                assertThat(hoursToMillisecondsRatio).isBetween(3500000.0, 3800000.0); // ~3600000 ms per hour
             }
             
         } finally {

--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionListCommandsIntegrationTests.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionListCommandsIntegrationTests.java
@@ -497,7 +497,7 @@ public class ValkeyGlideConnectionListCommandsIntegrationTests extends AbstractV
             
             assertThat(timeoutResult).isNull();
             // Verify timeout occurred (allow some margin for execution time)
-            assertThat(endTime - startTime).isGreaterThanOrEqualTo(90L).isLessThan(200L);
+            assertThat(endTime - startTime).isGreaterThanOrEqualTo(90L).isLessThan(300L);
         } finally {
             cleanupKey(sourceKey);
             cleanupKey(destKey);


### PR DESCRIPTION
This PR attempts to fix the following flaky tests:
- Increased the timeout check for `testBLMove` to fix the flakiness noticed in this failed [run](https://github.com/valkey-io/spring-data-valkey/actions/runs/26782443557/job/78950011462?pr=86#logs).
- Increased the accepted range in `testPTtlTimeUnitConversionTransaction` ratio check to fix flakiness saw in this [run](https://github.com/valkey-io/spring-data-valkey/actions/runs/26766335204/job/78953866370?pr=89).