### PR TITLE
Implemented pipelining for cluster mode

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -36,6 +36,7 @@ Replace `quickstart` with any example name below. To run from project root, use 
 | **serialization** | Different serialization strategies (String, JSON, JDK) for storing objects |
 | **transactions** | MULTI/EXEC transactions with WATCH for optimistic locking |
 | **pipeline** | Pipelining multiple commands for improved performance |
+| **cluster-pipeline** | Pipelining multiple commands in cluster mode for improved performance |
 | **streams** | Valkey Streams for event sourcing and message queues (XADD, XREAD, consumer groups) |
 | **collections** | Valkey-backed Java collections (ValkeyList, ValkeySet, ValkeyMap) and atomic counters |
 | **scripting** | Lua script execution (EVAL, EVALSHA) for atomic operations |

--- a/examples/cluster-pipeline/pom.xml
+++ b/examples/cluster-pipeline/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>io.valkey.springframework</groupId>
+		<artifactId>spring-data-valkey-examples</artifactId>
+		<version>1.0.0</version>
+	</parent>
+
+	<artifactId>spring-data-valkey-example-cluster-pipeline</artifactId>
+	<name>Spring Data Valkey - Cluster Pipeline Example</name>
+
+	<properties>
+		<exec.mainClass>example.clusterpipeline.ClusterPipelineExample</exec.mainClass>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<configuration>
+					<mainClass>example.clusterpipeline.ClusterPipelineExample</mainClass>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/examples/cluster-pipeline/src/main/java/example/clusterpipeline/ClusterPipelineExample.java
+++ b/examples/cluster-pipeline/src/main/java/example/clusterpipeline/ClusterPipelineExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/cluster-pipeline/src/main/java/example/clusterpipeline/ClusterPipelineExample.java
+++ b/examples/cluster-pipeline/src/main/java/example/clusterpipeline/ClusterPipelineExample.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.clusterpipeline;
+
+import io.valkey.springframework.data.valkey.connection.ValkeyClusterConfiguration;
+import io.valkey.springframework.data.valkey.connection.ValkeyNode;
+import io.valkey.springframework.data.valkey.connection.valkeyglide.ValkeyGlideClientConfiguration;
+import io.valkey.springframework.data.valkey.connection.valkeyglide.ValkeyGlideConnectionFactory;
+import io.valkey.springframework.data.valkey.core.ValkeyCallback;
+import io.valkey.springframework.data.valkey.core.ValkeyTemplate;
+import io.valkey.springframework.data.valkey.serializer.StringValkeySerializer;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Example demonstrating pipelining in Valkey Cluster mode.
+ *
+ * <p>Cluster pipelining supports both same-slot and cross-slot keys.
+ * The Valkey GLIDE driver routes each command in the batch to the
+ * correct cluster node transparently.
+ */
+public class ClusterPipelineExample {
+
+	public static void main(String[] args) {
+
+		ValkeyClusterConfiguration clusterConfig = new ValkeyClusterConfiguration();
+		clusterConfig.setClusterNodes(Arrays.asList(
+				new ValkeyNode("127.0.0.1", 7379),
+				new ValkeyNode("127.0.0.1", 7380),
+				new ValkeyNode("127.0.0.1", 7381)
+		));
+
+		ValkeyGlideConnectionFactory connectionFactory = new ValkeyGlideConnectionFactory(
+				clusterConfig, ValkeyGlideClientConfiguration.defaultConfiguration());
+		connectionFactory.afterPropertiesSet();
+
+		try {
+			ValkeyTemplate<String, String> template = new ValkeyTemplate<>();
+			template.setConnectionFactory(connectionFactory);
+			template.setDefaultSerializer(StringValkeySerializer.UTF_8);
+			template.afterPropertiesSet();
+
+			System.out.println("=== Cluster Pipeline Example ===\n");
+
+			// 1. Same-slot pipeline using hash tags
+			sameSlotPipeline(template);
+
+			// 2. Cross-slot pipeline (keys on different nodes)
+			crossSlotPipeline(template);
+
+			// 3. Performance comparison
+			performanceComparison(template);
+
+		} finally {
+			connectionFactory.destroy();
+		}
+	}
+
+	private static void sameSlotPipeline(ValkeyTemplate<String, String> template) {
+		System.out.println("--- Same-slot pipeline (hash tags) ---");
+
+		List<Object> results = template.executePipelined((ValkeyCallback<Object>) connection -> {
+			byte[] key1 = "{user:1}:name".getBytes();
+			byte[] key2 = "{user:1}:email".getBytes();
+			byte[] key3 = "{user:1}:role".getBytes();
+
+			connection.stringCommands().set(key1, "Alice".getBytes());
+			connection.stringCommands().set(key2, "alice@example.com".getBytes());
+			connection.stringCommands().set(key3, "admin".getBytes());
+			connection.stringCommands().get(key1);
+			connection.stringCommands().get(key2);
+			connection.stringCommands().get(key3);
+			return null;
+		});
+
+		System.out.println("SET results: " + results.subList(0, 3));
+		System.out.println("GET results: " + results.subList(3, 6));
+
+		template.delete(Arrays.asList("{user:1}:name", "{user:1}:email", "{user:1}:role"));
+		System.out.println();
+	}
+
+	private static void crossSlotPipeline(ValkeyTemplate<String, String> template) {
+		System.out.println("--- Cross-slot pipeline (different nodes) ---");
+
+		List<Object> results = template.executePipelined((ValkeyCallback<Object>) connection -> {
+			// These keys will hash to different slots and be routed to different nodes
+			connection.stringCommands().set("orders:1001".getBytes(), "pending".getBytes());
+			connection.stringCommands().set("inventory:sku-42".getBytes(), "150".getBytes());
+			connection.stringCommands().set("sessions:abc123".getBytes(), "active".getBytes());
+			connection.hashCommands().hSet("metrics:daily".getBytes(), "requests".getBytes(), "5000".getBytes());
+
+			connection.stringCommands().get("orders:1001".getBytes());
+			connection.stringCommands().get("inventory:sku-42".getBytes());
+			connection.stringCommands().get("sessions:abc123".getBytes());
+			connection.hashCommands().hGet("metrics:daily".getBytes(), "requests".getBytes());
+			return null;
+		});
+
+		System.out.println("Pipeline executed across multiple cluster nodes");
+		System.out.println("Results: " + results);
+
+		template.delete(Arrays.asList("orders:1001", "inventory:sku-42", "sessions:abc123", "metrics:daily"));
+		System.out.println();
+	}
+
+	private static void performanceComparison(ValkeyTemplate<String, String> template) {
+		System.out.println("--- Performance: pipeline vs sequential ---");
+		int count = 500;
+
+		// Sequential
+		long start = System.currentTimeMillis();
+		for (int i = 0; i < count; i++) {
+			template.opsForValue().set("bench:" + i, "val:" + i);
+		}
+		long sequentialTime = System.currentTimeMillis() - start;
+		System.out.println("Sequential " + count + " SETs: " + sequentialTime + "ms");
+
+		// Pipelined
+		start = System.currentTimeMillis();
+		template.executePipelined((ValkeyCallback<Object>) connection -> {
+			for (int i = 0; i < count; i++) {
+				connection.stringCommands().set(("bench:" + i).getBytes(), ("val:" + i).getBytes());
+			}
+			return null;
+		});
+		long pipelineTime = System.currentTimeMillis() - start;
+		System.out.println("Pipelined  " + count + " SETs: " + pipelineTime + "ms");
+
+		if (sequentialTime > 0) {
+			System.out.println("Speedup: " + String.format("%.1fx", (double) sequentialTime / pipelineTime));
+		}
+
+		// Cleanup
+		List<String> keys = new ArrayList<>(count);
+		for (int i = 0; i < count; i++) {
+			keys.add("bench:" + i);
+		}
+		template.delete(keys);
+	}
+}

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -22,6 +22,7 @@
 		<module>boot-telemetry</module>
 		<module>cache</module>
 		<module>cluster</module>
+		<module>cluster-pipeline</module>
 		<module>collections</module>
 		<module>operations</module>
 		<module>pipeline</module>

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ClusterGlideClientAdapter.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ClusterGlideClientAdapter.java
@@ -45,6 +45,7 @@ import io.valkey.springframework.data.valkey.connection.ValkeyPassword;
 import io.valkey.springframework.data.valkey.connection.valkeyglide.ValkeyGlideClientConfiguration.AwsServiceType;
 import io.valkey.springframework.data.valkey.connection.valkeyglide.ValkeyGlideClientConfiguration.IamAuthenticationForGlide;
 import glide.api.GlideClusterClient;
+import glide.api.models.ClusterBatch;
 
 /**
  * Unified interface that abstracts both GlideClient and GlideClusterClient
@@ -58,6 +59,8 @@ class ClusterGlideClientAdapter implements UnifiedGlideClient {
     private final GlideClusterClient glideClusterClient;
     private final @Nullable DelegatingPubSubListener listener;
     @Nullable private Route nextCommandRoute = null;
+    private ClusterBatch currentBatch;
+    private BatchStatus batchStatus = BatchStatus.None;
 
     ClusterGlideClientAdapter(ValkeyClusterConfiguration clusterConfig, ValkeyGlideClientConfiguration valkeyGlideConfiguration) {
         // Build GlideClusterClientConfiguration using Glide's API
@@ -382,6 +385,10 @@ class ClusterGlideClientAdapter implements UnifiedGlideClient {
 
     @Override
     public Object customCommand(GlideString[] args) throws InterruptedException, ExecutionException {
+        if (currentBatch != null) {
+            currentBatch.customCommand(args);
+            return null;
+        }
         try {
             ClusterValue<?> clusterValue = nextCommandRoute == null
                 ? glideClusterClient.customCommand(args).get()
@@ -434,7 +441,10 @@ class ClusterGlideClientAdapter implements UnifiedGlideClient {
 
     @Override
     public Object[] execBatch() throws InterruptedException, ExecutionException {
-        throw new IllegalStateException("Transactions and pipelines are not supported in cluster mode");
+        if (currentBatch == null) {
+            throw new IllegalStateException("No batch in progress");
+        }
+        return glideClusterClient.exec(currentBatch, false).get();
     }
 
     @Override
@@ -449,27 +459,34 @@ class ClusterGlideClientAdapter implements UnifiedGlideClient {
 
     @Override
     public BatchStatus getBatchStatus() {
-        return BatchStatus.None;
+        return batchStatus;
     }
 
     @Override
     public int getBatchCount() {
-        throw new IllegalStateException("No batch in progress");
+        if (currentBatch == null) {
+            throw new IllegalStateException("No batch in progress");
+        }
+        return currentBatch.getProtobufBatch().getCommandsCount();
     }
 
     @Override
     public void startNewBatch(boolean atomic) {
-        throw new IllegalStateException("Transactions and pipelines are not supported in cluster mode");
+        currentBatch = new ClusterBatch(atomic).withBinaryOutput();
+        batchStatus = atomic ? BatchStatus.Transaction : BatchStatus.Pipeline;
     }
 
     @Override
     public void discardBatch() {
-        throw new IllegalStateException("Transactions and pipelines are not supported in cluster mode");
+        currentBatch = null;
+        batchStatus = BatchStatus.None;
     }
 
     @Override
     public void reset() {
         nextCommandRoute = null;
+        currentBatch = null;
+        batchStatus = BatchStatus.None;
         if (getDelegatingListener() != null) {
             getDelegatingListener().clearListener();
         }

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideClusterConnection.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideClusterConnection.java
@@ -50,7 +50,6 @@ import io.valkey.springframework.data.valkey.connection.ValkeyClusterNode.LinkSt
 import io.valkey.springframework.data.valkey.connection.ValkeyClusterNode.SlotRange;
 import io.valkey.springframework.data.valkey.connection.ValkeyClusterServerCommands;
 import io.valkey.springframework.data.valkey.connection.ValkeyNode.NodeType;
-import io.valkey.springframework.data.valkey.connection.ValkeyPipelineException;
 import io.valkey.springframework.data.valkey.connection.ValkeySentinelConnection;
 import io.valkey.springframework.data.valkey.core.Cursor;
 import io.valkey.springframework.data.valkey.core.ScanOptions;
@@ -202,20 +201,6 @@ public class ValkeyGlideClusterConnection extends ValkeyGlideConnection implemen
 		throw new InvalidDataAccessApiUsageException("UNWATCH is currently not supported in cluster mode");
 	}
 
-	@Override
-	public boolean isPipelined() {
-		return false;
-	}
-
-	@Override
-	public void openPipeline() {
-		throw new InvalidDataAccessApiUsageException("Pipeline is not supported in cluster mode");
-	}
-
-	@Override
-	public List<Object> closePipeline() throws ValkeyPipelineException {
-		throw new InvalidDataAccessApiUsageException("Pipeline is not supported in cluster mode");
-	}
 
 	@Override
 	public ValkeySentinelConnection getSentinelConnection() {

--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideClusterConnectionFactoryIntegrationTests.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideClusterConnectionFactoryIntegrationTests.java
@@ -50,7 +50,7 @@ import io.valkey.springframework.data.valkey.test.condition.EnabledOnValkeyClust
  *   <li>All test keys use hash tags (e.g., {@code {test}:key}) to ensure multi-key operations
  *       work correctly in cluster mode by routing to the same slot.</li>
  *   <li>Transactions ({@code MULTI/EXEC}) are not supported in cluster mode and are omitted.</li>
- *   <li>Pipeline operations have limited support in cluster mode and are omitted.</li>
+ *   <li>Pipeline operations are supported in cluster mode via {@code ClusterBatch}.</li>
  * </ul>
  * 
  * @author Ilia Kolominsky
@@ -949,6 +949,114 @@ public class ValkeyGlideClusterConnectionFactoryIntegrationTests {
      * This test is intentionally omitted as cluster mode does not support transactions
      * that span multiple keys, and even single-key transactions have limited support.
      */
+
+    // ==================== Pipeline Tests ====================
+
+    @Test
+    void testBasicPipelineFlow() {
+        String key1 = "{pipe}:basic:key1";
+        String key2 = "{pipe}:basic:key2";
+
+        try {
+            template.execute((ValkeyCallback<Object>) connection -> {
+                assertThat(connection.isPipelined()).isFalse();
+
+                connection.openPipeline();
+                assertThat(connection.isPipelined()).isTrue();
+
+                connection.stringCommands().set(key1.getBytes(), "value1".getBytes());
+                connection.stringCommands().set(key2.getBytes(), "value2".getBytes());
+                connection.stringCommands().get(key1.getBytes());
+                connection.stringCommands().get(key2.getBytes());
+
+                List<Object> results = connection.closePipeline();
+
+                assertThat(connection.isPipelined()).isFalse();
+                assertThat(results).hasSize(4);
+                assertThat(results.get(0)).isEqualTo(true);
+                assertThat(results.get(1)).isEqualTo(true);
+                assertThat(results.get(2)).isEqualTo("value1".getBytes());
+                assertThat(results.get(3)).isEqualTo("value2".getBytes());
+                return null;
+            });
+        } finally {
+            template.delete(key1);
+            template.delete(key2);
+        }
+    }
+
+    @Test
+    void testEmptyPipeline() {
+        template.execute((ValkeyCallback<Object>) connection -> {
+            connection.openPipeline();
+            assertThat(connection.isPipelined()).isTrue();
+
+            List<Object> results = connection.closePipeline();
+
+            assertThat(connection.isPipelined()).isFalse();
+            assertThat(results).isNotNull();
+            assertThat(results).isEmpty();
+            return null;
+        });
+    }
+
+    @Test
+    void testMultipleConsecutivePipelines() {
+        String key1 = "{pipe}:consecutive:key1";
+        String key2 = "{pipe}:consecutive:key2";
+
+        try {
+            template.execute((ValkeyCallback<Object>) connection -> {
+                connection.openPipeline();
+                connection.stringCommands().set(key1.getBytes(), "pipe1_value".getBytes());
+                List<Object> results1 = connection.closePipeline();
+
+                assertThat(results1).hasSize(1);
+                assertThat(results1.get(0)).isEqualTo(true);
+
+                connection.openPipeline();
+                connection.stringCommands().set(key2.getBytes(), "pipe2_value".getBytes());
+                connection.stringCommands().get(key1.getBytes());
+                List<Object> results2 = connection.closePipeline();
+
+                assertThat(results2).hasSize(2);
+                assertThat(results2.get(0)).isEqualTo(true);
+                assertThat(results2.get(1)).isEqualTo("pipe1_value".getBytes());
+                return null;
+            });
+        } finally {
+            template.delete(key1);
+            template.delete(key2);
+        }
+    }
+
+    @Test
+    void testPipelineWithCrossSlotKeys() {
+        String key1 = "pipe:cross:key1";
+        String key2 = "pipe:cross:key2";
+
+        try {
+            template.execute((ValkeyCallback<Object>) connection -> {
+                connection.openPipeline();
+                connection.stringCommands().set(key1.getBytes(), "cross1".getBytes());
+                connection.stringCommands().set(key2.getBytes(), "cross2".getBytes());
+                connection.stringCommands().get(key1.getBytes());
+                connection.stringCommands().get(key2.getBytes());
+
+                List<Object> results = connection.closePipeline();
+
+                assertThat(results).hasSize(4);
+                assertThat(results.get(0)).isEqualTo(true);
+                assertThat(results.get(1)).isEqualTo(true);
+                assertThat(results.get(2)).isEqualTo("cross1".getBytes());
+                assertThat(results.get(3)).isEqualTo("cross2".getBytes());
+                return null;
+            });
+        } finally {
+            template.delete(key1);
+            template.delete(key2);
+        }
+    }
 
     /**
      * Checks if the server version is at least the specified major.minor version.

--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideClusterConnectionFactoryIntegrationTests.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideClusterConnectionFactoryIntegrationTests.java
@@ -16,12 +16,17 @@
 package io.valkey.springframework.data.valkey.connection.valkeyglide;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -29,8 +34,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+import org.springframework.dao.InvalidDataAccessApiUsageException;
 import io.valkey.springframework.data.valkey.connection.ClusterTestVariables;
 import io.valkey.springframework.data.valkey.connection.ValkeyClusterConnection;
+import io.valkey.springframework.data.valkey.connection.ValkeyConnection;
 import io.valkey.springframework.data.valkey.connection.ValkeyStringCommands;
 import io.valkey.springframework.data.valkey.connection.ValkeyListCommands;
 import io.valkey.springframework.data.valkey.connection.ValkeyClusterConfiguration;
@@ -1056,6 +1063,469 @@ public class ValkeyGlideClusterConnectionFactoryIntegrationTests {
             template.delete(key1);
             template.delete(key2);
         }
+    }
+
+    // ==================== Pipeline: Mixed Command Type Tests ====================
+
+    @Test
+    void testPipelineWithMixedCommandTypes() {
+        String stringKey = "{pipe}:mixed:string";
+        String hashKey = "{pipe}:mixed:hash";
+        String listKey = "{pipe}:mixed:list";
+        String setKey = "{pipe}:mixed:set";
+        String zsetKey = "{pipe}:mixed:zset";
+
+        try {
+            template.execute((ValkeyCallback<Object>) connection -> {
+                connection.openPipeline();
+
+                connection.stringCommands().set(stringKey.getBytes(), "string_value".getBytes());
+                connection.stringCommands().get(stringKey.getBytes());
+
+                connection.hashCommands().hSet(hashKey.getBytes(), "field1".getBytes(), "hash_value".getBytes());
+                connection.hashCommands().hGet(hashKey.getBytes(), "field1".getBytes());
+
+                connection.listCommands().lPush(listKey.getBytes(), "list_item".getBytes());
+                connection.listCommands().lLen(listKey.getBytes());
+
+                connection.setCommands().sAdd(setKey.getBytes(), "set_member".getBytes());
+                connection.setCommands().sCard(setKey.getBytes());
+
+                connection.zSetCommands().zAdd(zsetKey.getBytes(), 1.0, "zset_member".getBytes());
+                connection.zSetCommands().zCard(zsetKey.getBytes());
+
+                List<Object> results = connection.closePipeline();
+
+                assertThat(results).hasSize(10);
+
+                assertThat(results.get(0)).isEqualTo(true);
+                assertThat(results.get(2)).isEqualTo(true);
+                assertThat(results.get(4)).isEqualTo(1L);
+                assertThat(results.get(6)).isEqualTo(1L);
+                assertThat(results.get(8)).isEqualTo(true);
+
+                assertThat(results.get(1)).isEqualTo("string_value".getBytes());
+                assertThat(results.get(3)).isEqualTo("hash_value".getBytes());
+                assertThat(results.get(5)).isEqualTo(1L);
+                assertThat(results.get(7)).isEqualTo(1L);
+                assertThat(results.get(9)).isEqualTo(1L);
+                return null;
+            });
+        } finally {
+            template.delete(stringKey);
+            template.delete(hashKey);
+            template.delete(listKey);
+            template.delete(setKey);
+            template.delete(zsetKey);
+        }
+    }
+
+    @Test
+    void testPipelineWithMixedCommandTypesCrossSlot() {
+        String stringKey = "pipe:mixed:cs:string";
+        String hashKey = "pipe:mixed:cs:hash";
+        String listKey = "pipe:mixed:cs:list";
+        String setKey = "pipe:mixed:cs:set";
+
+        try {
+            template.execute((ValkeyCallback<Object>) connection -> {
+                connection.openPipeline();
+
+                connection.stringCommands().set(stringKey.getBytes(), "str_val".getBytes());
+                connection.hashCommands().hSet(hashKey.getBytes(), "f1".getBytes(), "h_val".getBytes());
+                connection.listCommands().lPush(listKey.getBytes(), "l_item".getBytes());
+                connection.setCommands().sAdd(setKey.getBytes(), "s_member".getBytes());
+
+                connection.stringCommands().get(stringKey.getBytes());
+                connection.hashCommands().hGet(hashKey.getBytes(), "f1".getBytes());
+                connection.listCommands().lLen(listKey.getBytes());
+                connection.setCommands().sCard(setKey.getBytes());
+
+                List<Object> results = connection.closePipeline();
+
+                assertThat(results).hasSize(8);
+                assertThat(results.get(0)).isEqualTo(true);
+                assertThat(results.get(1)).isEqualTo(true);
+                assertThat(results.get(2)).isEqualTo(1L);
+                assertThat(results.get(3)).isEqualTo(1L);
+                assertThat(results.get(4)).isEqualTo("str_val".getBytes());
+                assertThat(results.get(5)).isEqualTo("h_val".getBytes());
+                assertThat(results.get(6)).isEqualTo(1L);
+                assertThat(results.get(7)).isEqualTo(1L);
+                return null;
+            });
+        } finally {
+            template.delete(stringKey);
+            template.delete(hashKey);
+            template.delete(listKey);
+            template.delete(setKey);
+        }
+    }
+
+    // ==================== Pipeline: State Management Tests ====================
+
+    @Test
+    void testIsPipelinedState() {
+        template.execute((ValkeyCallback<Object>) connection -> {
+            assertThat(connection.isPipelined()).isFalse();
+
+            connection.openPipeline();
+            assertThat(connection.isPipelined()).isTrue();
+
+            connection.closePipeline();
+            assertThat(connection.isPipelined()).isFalse();
+            return null;
+        });
+    }
+
+    @Test
+    void testPipelineTransactionIsolation() {
+        template.execute((ValkeyCallback<Object>) connection -> {
+            connection.openPipeline();
+
+            // In cluster mode, multi() is blocked entirely (not just during pipeline)
+            assertThatThrownBy(() -> connection.multi())
+                .isInstanceOf(InvalidDataAccessApiUsageException.class);
+
+            connection.closePipeline();
+            return null;
+        });
+    }
+
+    // ==================== Pipeline: Edge Cases and Error Handling ====================
+
+    @Test
+    void testClosePipelineWithoutOpen() {
+        template.execute((ValkeyCallback<Object>) connection -> {
+            assertThat(connection.isPipelined()).isFalse();
+
+            List<Object> results = connection.closePipeline();
+
+            assertThat(results).isNotNull();
+            assertThat(results).isEmpty();
+            assertThat(connection.isPipelined()).isFalse();
+            return null;
+        });
+    }
+
+    @Test
+    void testNestedOpenPipelineCalls() {
+        String key = "{pipe}:nested:key";
+
+        try {
+            template.execute((ValkeyCallback<Object>) connection -> {
+                connection.openPipeline();
+                assertThat(connection.isPipelined()).isTrue();
+
+                connection.openPipeline();
+                assertThat(connection.isPipelined()).isTrue();
+
+                connection.stringCommands().set(key.getBytes(), "nested_value".getBytes());
+
+                List<Object> results = connection.closePipeline();
+
+                assertThat(connection.isPipelined()).isFalse();
+                assertThat(results).hasSize(1);
+                assertThat(results.get(0)).isEqualTo(true);
+                return null;
+            });
+        } finally {
+            template.delete(key);
+        }
+    }
+
+    @Test
+    void testPipelineWithNonExistentKeys() {
+        String nonExistentKey1 = "{pipe}:nonexist:key1";
+        String nonExistentKey2 = "{pipe}:nonexist:key2";
+
+        template.execute((ValkeyCallback<Object>) connection -> {
+            connection.openPipeline();
+
+            connection.stringCommands().get(nonExistentKey1.getBytes());
+            connection.stringCommands().get(nonExistentKey2.getBytes());
+            connection.listCommands().lLen("{pipe}:nonexist:list".getBytes());
+            connection.setCommands().sCard("{pipe}:nonexist:set".getBytes());
+
+            List<Object> results = connection.closePipeline();
+
+            assertThat(results).hasSize(4);
+            assertThat(results.get(0)).isNull();
+            assertThat(results.get(1)).isNull();
+            assertThat(results.get(2)).isEqualTo(0L);
+            assertThat(results.get(3)).isEqualTo(0L);
+            return null;
+        });
+    }
+
+    @Test
+    void testPipelineWithEmptyValues() {
+        String key = "{pipe}:empty:key";
+
+        try {
+            template.execute((ValkeyCallback<Object>) connection -> {
+                connection.openPipeline();
+
+                connection.stringCommands().set(key.getBytes(), new byte[0]);
+                connection.stringCommands().get(key.getBytes());
+                connection.stringCommands().strLen(key.getBytes());
+
+                List<Object> results = connection.closePipeline();
+
+                assertThat(results).hasSize(3);
+                assertThat(results.get(0)).isEqualTo(true);
+                assertThat(results.get(1)).isEqualTo(new byte[0]);
+                assertThat(results.get(2)).isEqualTo(0L);
+                return null;
+            });
+        } finally {
+            template.delete(key);
+        }
+    }
+
+    // ==================== Pipeline: Large Pipeline Tests ====================
+
+    @Test
+    void testLargePipeline() {
+        String keyPrefix = "{pipe}:large:key";
+        int commandCount = 100;
+
+        try {
+            template.execute((ValkeyCallback<Object>) connection -> {
+                connection.openPipeline();
+
+                for (int i = 0; i < commandCount; i++) {
+                    String key = keyPrefix + ":" + i;
+                    connection.stringCommands().set(key.getBytes(), ("value" + i).getBytes());
+                }
+
+                List<Object> results = connection.closePipeline();
+
+                assertThat(results).hasSize(commandCount);
+                for (int i = 0; i < commandCount; i++) {
+                    assertThat(results.get(i)).isEqualTo(true);
+                }
+                return null;
+            });
+
+            // Verify values were set
+            template.execute((ValkeyCallback<Object>) connection -> {
+                assertThat(connection.stringCommands().get((keyPrefix + ":0").getBytes()))
+                    .isEqualTo("value0".getBytes());
+                assertThat(connection.stringCommands().get((keyPrefix + ":50").getBytes()))
+                    .isEqualTo("value50".getBytes());
+                assertThat(connection.stringCommands().get((keyPrefix + ":99").getBytes()))
+                    .isEqualTo("value99".getBytes());
+                return null;
+            });
+        } finally {
+            for (int i = 0; i < commandCount; i++) {
+                template.delete(keyPrefix + ":" + i);
+            }
+        }
+    }
+
+    @Test
+    void testLargePipelineCrossSlot() {
+        String keyPrefix = "pipe:largecs:key";
+        int commandCount = 100;
+
+        try {
+            template.execute((ValkeyCallback<Object>) connection -> {
+                connection.openPipeline();
+
+                for (int i = 0; i < commandCount; i++) {
+                    String key = keyPrefix + ":" + i;
+                    connection.stringCommands().set(key.getBytes(), ("value" + i).getBytes());
+                }
+
+                List<Object> results = connection.closePipeline();
+
+                assertThat(results).hasSize(commandCount);
+                for (int i = 0; i < commandCount; i++) {
+                    assertThat(results.get(i)).isEqualTo(true);
+                }
+                return null;
+            });
+
+            // Verify a few values
+            template.execute((ValkeyCallback<Object>) connection -> {
+                assertThat(connection.stringCommands().get((keyPrefix + ":0").getBytes()))
+                    .isEqualTo("value0".getBytes());
+                assertThat(connection.stringCommands().get((keyPrefix + ":99").getBytes()))
+                    .isEqualTo("value99".getBytes());
+                return null;
+            });
+        } finally {
+            for (int i = 0; i < commandCount; i++) {
+                template.delete(keyPrefix + ":" + i);
+            }
+        }
+    }
+
+    @Test
+    void testPipelinePerformance() {
+        String keyPrefix = "{pipe}:perf:key";
+        int commandCount = 200;
+
+        try {
+            template.execute((ValkeyCallback<Object>) connection -> {
+                long startTime = System.currentTimeMillis();
+
+                connection.openPipeline();
+
+                for (int i = 0; i < commandCount; i++) {
+                    String key = keyPrefix + ":" + i;
+                    connection.stringCommands().set(key.getBytes(), ("value" + i).getBytes());
+                    connection.stringCommands().get(key.getBytes());
+                }
+
+                List<Object> results = connection.closePipeline();
+
+                long duration = System.currentTimeMillis() - startTime;
+
+                assertThat(results).hasSize(commandCount * 2);
+                assertThat(duration).isLessThan(10000);
+
+                for (int i = 0; i < commandCount; i += 10) {
+                    assertThat(results.get(i * 2)).isEqualTo(true);
+                    assertThat(results.get(i * 2 + 1)).isEqualTo(("value" + i).getBytes());
+                }
+                return null;
+            });
+        } finally {
+            for (int i = 0; i < commandCount; i++) {
+                template.delete(keyPrefix + ":" + i);
+            }
+        }
+    }
+
+    // ==================== Pipeline: Concurrent Tests ====================
+
+    @Test
+    void testConcurrentPipelines() throws Exception {
+        String sharedKey = "{pipe}:concurrent:shared";
+        String keyPrefix = "{pipe}:concurrent:key";
+        ExecutorService executor = Executors.newFixedThreadPool(5);
+
+        try {
+            template.opsForValue().set(sharedKey, "shared_value");
+
+            CompletableFuture<?>[] futures = new CompletableFuture[5];
+
+            for (int i = 0; i < 5; i++) {
+                final int threadId = i;
+                futures[i] = CompletableFuture.runAsync(() -> {
+                    try (ValkeyConnection conn = connectionFactory.getClusterConnection()) {
+                        conn.openPipeline();
+                        conn.stringCommands().set((keyPrefix + ":" + threadId).getBytes(),
+                            ("thread" + threadId).getBytes());
+                        conn.stringCommands().get(sharedKey.getBytes());
+                        List<Object> results = conn.closePipeline();
+
+                        assertThat(results).hasSize(2);
+                        assertThat(results.get(0)).isEqualTo(true);
+                        assertThat(results.get(1)).isEqualTo("shared_value".getBytes());
+                    }
+                }, executor);
+            }
+
+            CompletableFuture.allOf(futures).get(10, TimeUnit.SECONDS);
+
+            // Verify all threads succeeded
+            for (int i = 0; i < 5; i++) {
+                assertThat(template.opsForValue().get(keyPrefix + ":" + i))
+                    .isEqualTo("thread" + i);
+            }
+        } finally {
+            executor.shutdown();
+            template.delete(sharedKey);
+            for (int i = 0; i < 5; i++) {
+                template.delete(keyPrefix + ":" + i);
+            }
+        }
+    }
+
+    // ==================== Pipeline: Result Conversion Tests ====================
+
+    @Test
+    void testPipelineResultConversion() {
+        String key = "{pipe}:convert:key";
+        String counterKey = "{pipe}:convert:counter";
+
+        try {
+            template.execute((ValkeyCallback<Object>) connection -> {
+                connection.openPipeline();
+
+                connection.stringCommands().set(key.getBytes(), "42".getBytes());
+                connection.stringCommands().get(key.getBytes());
+                connection.stringCommands().set(counterKey.getBytes(), "10".getBytes());
+                connection.stringCommands().incr(counterKey.getBytes());
+                connection.stringCommands().strLen(counterKey.getBytes());
+
+                List<Object> results = connection.closePipeline();
+
+                assertThat(results).hasSize(5);
+                assertThat(results.get(0)).isEqualTo(true);
+                assertThat(results.get(1)).isEqualTo("42".getBytes());
+                assertThat(results.get(2)).isEqualTo(true);
+                assertThat(results.get(3)).isEqualTo(11L);
+                assertThat(results.get(4)).isEqualTo(2L);
+                return null;
+            });
+        } finally {
+            template.delete(key);
+            template.delete(counterKey);
+        }
+    }
+
+    // ==================== Pipeline: Error Recovery Tests ====================
+
+    @Test
+    void testPipelineErrorRecovery() {
+        String validKey = "{pipe}:error:valid";
+        String nonExistentKey = "{pipe}:error:nonexist";
+
+        try {
+            template.execute((ValkeyCallback<Object>) connection -> {
+                connection.openPipeline();
+
+                connection.stringCommands().set(validKey.getBytes(), "valid_value".getBytes());
+                connection.stringCommands().get(nonExistentKey.getBytes());
+                connection.stringCommands().get(validKey.getBytes());
+
+                List<Object> results = connection.closePipeline();
+
+                assertThat(results).hasSize(3);
+                assertThat(results.get(0)).isEqualTo(true);
+                assertThat(results.get(1)).isNull();
+                assertThat(results.get(2)).isEqualTo("valid_value".getBytes());
+                return null;
+            });
+        } finally {
+            template.delete(validKey);
+        }
+    }
+
+    // ==================== Pipeline: State Consistency Tests ====================
+
+    @Test
+    void testPipelineStateConsistency() {
+        template.execute((ValkeyCallback<Object>) connection -> {
+            assertThat(connection.isPipelined()).isFalse();
+
+            for (int i = 0; i < 3; i++) {
+                connection.openPipeline();
+                assertThat(connection.isPipelined()).isTrue();
+
+                List<Object> results = connection.closePipeline();
+                assertThat(connection.isPipelined()).isFalse();
+                assertThat(results).isEmpty();
+            }
+
+            assertThat(connection.isPipelined()).isFalse();
+            return null;
+        });
     }
 
     /**


### PR DESCRIPTION
## Overview

Added pipelining support for cluster mode. 

## Changes

- Implemented pipelining support to `ClusterGlideClientAdapter` and enabled pipelining in `ValkeyGlideClusterConnection`.
- Ported tests from standalone pipelining tests suites.
- Added a new `ClusterPipelineExample`.

## Related Issue
Close #82 
