### PR TITLE
Apply spring-javaformat to GLIDE classes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,10 +159,11 @@ git rebase -i HEAD~n --signoff
 ### Code Style & Spring Conventions
 
 - Follow existing Spring Data conventions and formatting in the codebase
+- Use the `spring-javaformat-maven-plugin` to format code: `./mvnw spring-javaformat:apply`
+- **Important:** Upstream-synced classes (Lettuce, Jedis, common packages) do NOT follow spring-javaformat conventions. Only apply formatting to classes in the `valkeyglide` packages or other classes we authored. Do not reformat upstream-synced files.
 - Use constructor injection over field injection for Spring beans
 - Use `@Configuration` classes for bean definitions, not XML
-- Amend the Apache license header date range if needed
-- For new types, copy the license header from an existing file with the current year
+- Copyright header format: `Copyright 2025-present the original author or authors.`
 - Submit test cases (unit or integration) that back your changes
 - Use `@DataValkeyTest` slice test annotation for focused Valkey component tests
 - New Spring Boot auto-configuration must be registered in `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports`

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -142,6 +142,46 @@ For non-Spring Boot applications, configure logging via `logback.xml` in your cl
 </configuration>
 ```
 
+## Code Style
+
+This project follows the [Spring Framework Code Style](https://github.com/spring-projects/spring-framework/wiki/Code-Style) conventions. Key points:
+
+- **Indentation**: Tabs (not spaces)
+- **Line endings**: Unix (LF)
+- **Trailing whitespace**: None
+- **Line length**: 90 characters preferred, 120 max
+- **Braces**: K&R style (opening brace on same line)
+- **Copyright header**: `Copyright 2025-present the original author or authors.`
+
+### Formatting with spring-javaformat
+
+The project includes the [spring-javaformat-maven-plugin](https://github.com/spring-io/spring-javaformat) for automated code formatting.
+
+**Recommended: IDE Plugin (formats only the file you're editing)**
+
+Install the Spring Java Format plugin for real-time formatting:
+
+- **IntelliJ IDEA**: Install "Spring Java Format" from the JetBrains Marketplace
+- **Eclipse**: Install from the [spring-javaformat releases](https://github.com/spring-io/spring-javaformat/releases)
+
+This is the recommended approach because upstream-synced classes (Lettuce, Jedis, common) do not follow spring-javaformat conventions. The IDE plugin lets you format only the files you're actively working on.
+
+**CLI (formats all sources in the module)**
+
+```bash
+# Format all sources — only commit changes to GLIDE classes you authored
+$ ./mvnw spring-javaformat:apply
+
+# Check formatting without modifying files
+$ ./mvnw spring-javaformat:validate
+```
+
+Note: The Maven command formats all Java files in the module, including upstream-synced classes that don't follow these conventions. If you use the CLI, only stage and commit changes to files in the `valkeyglide` packages or other classes you authored.
+
+### Scope
+
+The formatter is enforced (by convention) for classes in the `valkeyglide` packages and other classes we author. Upstream-synced classes (Lettuce, Jedis, common) follow their original formatting to minimize diff noise during future syncs.
+
 ## Redis Source Alignment
 
 This repository is forked from Spring Data Redis and related projects. This section documents the source repositories to help with future upgrades, patches, and alignment.

--- a/examples/cache/src/main/java/example/cache/CacheExample.java
+++ b/examples/cache/src/main/java/example/cache/CacheExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/cluster-pipeline/src/main/java/example/clusterpipeline/ClusterPipelineExample.java
+++ b/examples/cluster-pipeline/src/main/java/example/clusterpipeline/ClusterPipelineExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2026-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/cluster/src/main/java/example/cluster/ClusterExample.java
+++ b/examples/cluster/src/main/java/example/cluster/ClusterExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/collections/src/main/java/example/collections/CollectionsExample.java
+++ b/examples/collections/src/main/java/example/collections/CollectionsExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/operations/src/main/java/example/operations/OperationsExample.java
+++ b/examples/operations/src/main/java/example/operations/OperationsExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/pipeline/src/main/java/example/pipeline/PipelineExample.java
+++ b/examples/pipeline/src/main/java/example/pipeline/PipelineExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -88,5 +88,12 @@
 				</plugin>
 			</plugins>
 		</pluginManagement>
+		<plugins>
+			<plugin>
+				<groupId>io.spring.javaformat</groupId>
+				<artifactId>spring-javaformat-maven-plugin</artifactId>
+				<version>0.0.47</version>
+			</plugin>
+		</plugins>
 	</build>
 </project>

--- a/examples/quickstart/src/main/java/example/quickstart/QuickstartExample.java
+++ b/examples/quickstart/src/main/java/example/quickstart/QuickstartExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/repositories/src/main/java/example/repositories/Person.java
+++ b/examples/repositories/src/main/java/example/repositories/Person.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/repositories/src/main/java/example/repositories/PersonRepository.java
+++ b/examples/repositories/src/main/java/example/repositories/PersonRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/repositories/src/main/java/example/repositories/RepositoriesExample.java
+++ b/examples/repositories/src/main/java/example/repositories/RepositoriesExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/scripting/src/main/java/example/scripting/ScriptingExample.java
+++ b/examples/scripting/src/main/java/example/scripting/ScriptingExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/serialization/src/main/java/example/serialization/SerializationExample.java
+++ b/examples/serialization/src/main/java/example/serialization/SerializationExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/spring-boot/src/main/java/example/springboot/SpringBootExample.java
+++ b/examples/spring-boot/src/main/java/example/springboot/SpringBootExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/spring-boot/src/main/java/example/springboot/User.java
+++ b/examples/spring-boot/src/main/java/example/springboot/User.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/spring-boot/src/main/java/example/springboot/UserRepository.java
+++ b/examples/spring-boot/src/main/java/example/springboot/UserRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/spring-boot/src/main/java/example/springboot/UserService.java
+++ b/examples/spring-boot/src/main/java/example/springboot/UserService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/streams/src/main/java/example/streams/StreamsExample.java
+++ b/examples/streams/src/main/java/example/streams/StreamsExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/telemetry/src/main/java/example/telemetry/OpenTelemetryExample.java
+++ b/examples/telemetry/src/main/java/example/telemetry/OpenTelemetryExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/transactions/src/main/java/example/transactions/TransactionsExample.java
+++ b/examples/transactions/src/main/java/example/transactions/TransactionsExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/performance/pom.xml
+++ b/performance/pom.xml
@@ -95,6 +95,11 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>io.spring.javaformat</groupId>
+				<artifactId>spring-javaformat-maven-plugin</artifactId>
+				<version>0.0.47</version>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/performance/src/main/java/performance/DirectClientPerformanceTest.java
+++ b/performance/src/main/java/performance/DirectClientPerformanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,11 +31,12 @@ import redis.clients.jedis.Jedis;
 public class DirectClientPerformanceTest {
 
 	private static final int OPERATIONS = 10000;
+
 	private static final String KEY_PREFIX = "direct:test:";
 
 	public static void main(String[] args) throws Exception {
 		String clientType = System.getProperty("client", "valkeyglide");
-		
+
 		System.out.println("Running Direct Client Performance Test");
 		System.out.println("Client: " + clientType);
 		System.out.println("Operations: " + OPERATIONS);
@@ -53,7 +54,7 @@ public class DirectClientPerformanceTest {
 		GlideClientConfiguration config = GlideClientConfiguration.builder()
 			.address(NodeAddress.builder().host("localhost").port(6379).build())
 			.build();
-		
+
 		try (GlideClient client = GlideClient.createClient(config).get()) {
 			// SET operations
 			long start = System.nanoTime();
@@ -74,7 +75,7 @@ public class DirectClientPerformanceTest {
 			// DELETE operations
 			start = System.nanoTime();
 			for (int i = 0; i < OPERATIONS; i++) {
-				client.del(new GlideString[]{GlideString.of(KEY_PREFIX + i)}).get();
+				client.del(new GlideString[] { GlideString.of(KEY_PREFIX + i) }).get();
 			}
 			long deleteTime = System.nanoTime() - start;
 			printResult("DELETE", deleteTime);
@@ -83,10 +84,10 @@ public class DirectClientPerformanceTest {
 
 	private static void testLettuce() {
 		RedisClient client = RedisClient.create(RedisURI.create("redis://localhost:6379"));
-		
+
 		try (StatefulRedisConnection<String, String> connection = client.connect()) {
 			RedisCommands<String, String> commands = connection.sync();
-			
+
 			// SET operations
 			long start = System.nanoTime();
 			for (int i = 0; i < OPERATIONS; i++) {
@@ -110,7 +111,8 @@ public class DirectClientPerformanceTest {
 			}
 			long deleteTime = System.nanoTime() - start;
 			printResult("DELETE", deleteTime);
-		} finally {
+		}
+		finally {
 			client.shutdown();
 		}
 	}
@@ -145,7 +147,8 @@ public class DirectClientPerformanceTest {
 
 	private static void printResult(String operation, long durationNanos) {
 		long durationMs = durationNanos / 1_000_000;
-		System.out.printf("%s:    %,d ops/sec (%.2f ms total)%n", 
-			operation, (long) (OPERATIONS * 1000.0 / durationMs), durationMs / 1.0);
+		System.out.printf("%s:    %,d ops/sec (%.2f ms total)%n", operation, (long) (OPERATIONS * 1000.0 / durationMs),
+				durationMs / 1.0);
 	}
+
 }

--- a/performance/src/main/java/performance/MultiThreadedPerformanceTest.java
+++ b/performance/src/main/java/performance/MultiThreadedPerformanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,12 +35,14 @@ import org.springframework.beans.factory.InitializingBean;
 public class MultiThreadedPerformanceTest {
 
 	private static final int THREADS = 100;
+
 	private static final int OPERATIONS_PER_THREAD = 100;
+
 	private static final int TOTAL_OPERATIONS = THREADS * OPERATIONS_PER_THREAD;
 
 	public static void main(String[] args) throws Exception {
 		String clientType = System.getProperty("client", "valkeyglide");
-		
+
 		System.out.println("Running Multi-Threaded Performance Test");
 		System.out.println("Client: " + clientType);
 		System.out.println("Threads: " + THREADS);
@@ -55,7 +57,8 @@ public class MultiThreadedPerformanceTest {
 
 		try {
 			runMultiThreadedTest(factory);
-		} finally {
+		}
+		finally {
 			if (factory instanceof DisposableBean) {
 				((DisposableBean) factory).destroy();
 			}
@@ -91,34 +94,38 @@ public class MultiThreadedPerformanceTest {
 					IntStream.range(0, OPERATIONS_PER_THREAD).forEach(i -> {
 						String key = Thread.currentThread().getName() + ":" + i;
 						String value = "value" + i;
-						
+
 						// SET operation
 						try {
 							template.opsForValue().set(key, value);
 							setOperations.incrementAndGet();
-						} catch (Exception e) {
+						}
+						catch (Exception e) {
 							setFailures.incrementAndGet();
 						}
-						
+
 						// GET operation
 						try {
 							String result = template.opsForValue().get(key);
 							if (result != null) {
 								getOperations.incrementAndGet();
 							}
-						} catch (Exception e) {
+						}
+						catch (Exception e) {
 							getFailures.incrementAndGet();
 						}
-						
+
 						// DELETE operation
 						try {
 							template.delete(key);
 							deleteOperations.incrementAndGet();
-						} catch (Exception e) {
+						}
+						catch (Exception e) {
 							deleteFailures.incrementAndGet();
 						}
 					});
-				} catch (Exception e) {
+				}
+				catch (Exception e) {
 					System.err.println("Thread failed: " + e.getMessage());
 					setFailures.addAndGet(OPERATIONS_PER_THREAD);
 					getFailures.addAndGet(OPERATIONS_PER_THREAD);
@@ -135,13 +142,15 @@ public class MultiThreadedPerformanceTest {
 			printResult("SET", duration, setOperations.get(), setFailures.get());
 			printResult("GET", duration, getOperations.get(), getFailures.get());
 			printResult("DELETE", duration, deleteOperations.get(), deleteFailures.get());
-		} finally {
+		}
+		finally {
 			executorService.shutdown();
 		}
 	}
 
 	private static void printResult(String operation, long duration, int successful, int failed) {
-		System.out.printf("%s:    %,d ops/sec (%.2f ms total), %.1f%% successful%n", 
-			operation, (long) (successful * 1000.0 / duration), duration / 1.0, (successful * 100.0 / TOTAL_OPERATIONS));
+		System.out.printf("%s:    %,d ops/sec (%.2f ms total), %.1f%% successful%n", operation,
+				(long) (successful * 1000.0 / duration), duration / 1.0, (successful * 100.0 / TOTAL_OPERATIONS));
 	}
+
 }

--- a/performance/src/main/java/performance/TemplateLoadTest.java
+++ b/performance/src/main/java/performance/TemplateLoadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,100 +30,107 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 
 /**
- * Parameterized load test for ValkeyTemplate using different clients and under various concurrency levels.
+ * Parameterized load test for ValkeyTemplate using different clients and under various
+ * concurrency levels.
  */
 public class TemplateLoadTest {
 
-    public static void main(String[] args) throws Exception {
-        String client = System.getProperty("client", "valkeyglide");
-        int threads = Integer.parseInt(System.getProperty("threads", "10"));
-        int operations = Integer.parseInt(System.getProperty("operations", "50"));
-        int totalExpected = threads * operations * 2; // SET + GET
+	public static void main(String[] args) throws Exception {
+		String client = System.getProperty("client", "valkeyglide");
+		int threads = Integer.parseInt(System.getProperty("threads", "10"));
+		int operations = Integer.parseInt(System.getProperty("operations", "50"));
+		int totalExpected = threads * operations * 2; // SET + GET
 
-        System.out.println("Running Template Load Test");
-        System.out.println("Client: " + client);
-        System.out.println("Threads: " + threads);
-        System.out.println("Operations per thread: " + operations);
-        System.out.println("Total operations: " + totalExpected);
-        System.out.println("----------------------------------------");
+		System.out.println("Running Template Load Test");
+		System.out.println("Client: " + client);
+		System.out.println("Threads: " + threads);
+		System.out.println("Operations per thread: " + operations);
+		System.out.println("Total operations: " + totalExpected);
+		System.out.println("----------------------------------------");
 
-        ValkeyConnectionFactory factory = createConnectionFactory(client);
-        if (factory instanceof InitializingBean) {
-            ((InitializingBean) factory).afterPropertiesSet();
-        }
+		ValkeyConnectionFactory factory = createConnectionFactory(client);
+		if (factory instanceof InitializingBean) {
+			((InitializingBean) factory).afterPropertiesSet();
+		}
 
-        try {
-            runLoadTest(factory, threads, operations, totalExpected);
-        } finally {
-            if (factory instanceof DisposableBean) {
-                ((DisposableBean) factory).destroy();
-            }
-        }
-    }
+		try {
+			runLoadTest(factory, threads, operations, totalExpected);
+		}
+		finally {
+			if (factory instanceof DisposableBean) {
+				((DisposableBean) factory).destroy();
+			}
+		}
+	}
 
-    private static ValkeyConnectionFactory createConnectionFactory(String clientType) {
-        return switch (clientType.toLowerCase()) {
-            case "lettuce" -> new LettuceConnectionFactory();
-            case "jedis" -> new JedisConnectionFactory();
-            case "valkeyglide" -> new ValkeyGlideConnectionFactory();
-            default -> throw new IllegalArgumentException("Unknown client: " + clientType);
-        };
-    }
+	private static ValkeyConnectionFactory createConnectionFactory(String clientType) {
+		return switch (clientType.toLowerCase()) {
+			case "lettuce" -> new LettuceConnectionFactory();
+			case "jedis" -> new JedisConnectionFactory();
+			case "valkeyglide" -> new ValkeyGlideConnectionFactory();
+			default -> throw new IllegalArgumentException("Unknown client: " + clientType);
+		};
+	}
 
-    private static void runLoadTest(ValkeyConnectionFactory factory, int threads, 
-            int operations, int totalExpected) throws InterruptedException {
-        long startTime = System.currentTimeMillis();
+	private static void runLoadTest(ValkeyConnectionFactory factory, int threads, int operations, int totalExpected)
+			throws InterruptedException {
+		long startTime = System.currentTimeMillis();
 
-        ExecutorService executorService = Executors.newFixedThreadPool(threads);
-        StringValkeyTemplate valkeyTemplate = new StringValkeyTemplate(factory);
+		ExecutorService executorService = Executors.newFixedThreadPool(threads);
+		StringValkeyTemplate valkeyTemplate = new StringValkeyTemplate(factory);
 
-        AtomicInteger setOperations = new AtomicInteger(0);
-        AtomicInteger getOperations = new AtomicInteger(0);
+		AtomicInteger setOperations = new AtomicInteger(0);
+		AtomicInteger getOperations = new AtomicInteger(0);
 
-        try {
-            Runnable task = () -> IntStream.range(0, operations).forEach(i -> {
-                String key = Thread.currentThread().getName() + ":" + i;
-                String value = "value" + i;
+		try {
+			Runnable task = () -> IntStream.range(0, operations).forEach(i -> {
+				String key = Thread.currentThread().getName() + ":" + i;
+				String value = "value" + i;
 
-                // SET operation
-                try {
-                    valkeyTemplate.opsForValue().set(key, value);
-                    setOperations.incrementAndGet();
-                } catch (Exception e) {
-                    System.err.println("SET error: " + e.getMessage());
-                }
+				// SET operation
+				try {
+					valkeyTemplate.opsForValue().set(key, value);
+					setOperations.incrementAndGet();
+				}
+				catch (Exception e) {
+					System.err.println("SET error: " + e.getMessage());
+				}
 
-                // GET operation
-                try {
-                    String result = valkeyTemplate.opsForValue().get(key);
-                    getOperations.incrementAndGet();
-                    if (result != null && !result.equals(value)) {
-                        System.err.println("Data mismatch! Expected: " + value + ", Got: " + result);
-                    }
-                } catch (Exception e) {
-                    System.err.println("GET error: " + e.getMessage());
-                }
-            });
+				// GET operation
+				try {
+					String result = valkeyTemplate.opsForValue().get(key);
+					getOperations.incrementAndGet();
+					if (result != null && !result.equals(value)) {
+						System.err.println("Data mismatch! Expected: " + value + ", Got: " + result);
+					}
+				}
+				catch (Exception e) {
+					System.err.println("GET error: " + e.getMessage());
+				}
+			});
 
-            IntStream.range(0, threads).forEach(i -> executorService.submit(task));
+			IntStream.range(0, threads).forEach(i -> executorService.submit(task));
 
-            executorService.shutdown();
-            executorService.awaitTermination(10, TimeUnit.SECONDS);
+			executorService.shutdown();
+			executorService.awaitTermination(10, TimeUnit.SECONDS);
 
-            long duration = System.currentTimeMillis() - startTime;
-            int totalActual = setOperations.get() + getOperations.get();
-            int dropped = totalExpected - totalActual;
+			long duration = System.currentTimeMillis() - startTime;
+			int totalActual = setOperations.get() + getOperations.get();
+			int dropped = totalExpected - totalActual;
 
-            System.out.println("Duration: " + String.format("%.2f ms", (double) duration));
-            System.out.println("Expected operations: " + totalExpected);
-            System.out.println("SET operations: " + setOperations.get());
-            System.out.println("GET operations: " + getOperations.get());
-            System.out.println("Total operations: " + totalActual);
-            System.out.println("Dropped operations: " + dropped);
-            System.out.println("Success rate: " + String.format("%.2f%%", (totalActual * 100.0 / totalExpected)));
-            System.out.println("Operations per second: " + String.format("%,d", (long) (totalActual * 1000.0 / duration)));
-        } finally {
-            executorService.shutdown();
-        }
-    }
+			System.out.println("Duration: " + String.format("%.2f ms", (double) duration));
+			System.out.println("Expected operations: " + totalExpected);
+			System.out.println("SET operations: " + setOperations.get());
+			System.out.println("GET operations: " + getOperations.get());
+			System.out.println("Total operations: " + totalActual);
+			System.out.println("Dropped operations: " + dropped);
+			System.out.println("Success rate: " + String.format("%.2f%%", (totalActual * 100.0 / totalExpected)));
+			System.out
+				.println("Operations per second: " + String.format("%,d", (long) (totalActual * 1000.0 / duration)));
+		}
+		finally {
+			executorService.shutdown();
+		}
+	}
+
 }

--- a/performance/src/main/java/performance/TemplatePerformanceTest.java
+++ b/performance/src/main/java/performance/TemplatePerformanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,11 +29,12 @@ import org.springframework.beans.factory.DisposableBean;
 public class TemplatePerformanceTest {
 
 	private static final int OPERATIONS = 10000;
+
 	private static final String KEY_PREFIX = "perf:test:";
 
 	public static void main(String[] args) throws Exception {
 		String clientType = System.getProperty("client", "valkeyglide");
-		
+
 		System.out.println("Running ValkeyTemplate Performance Test");
 		System.out.println("Client: " + clientType);
 		System.out.println("Operations: " + OPERATIONS);
@@ -47,7 +48,8 @@ public class TemplatePerformanceTest {
 		try {
 			StringValkeyTemplate template = new StringValkeyTemplate(factory);
 			runPerformanceTest(template);
-		} finally {
+		}
+		finally {
 			if (factory instanceof DisposableBean) {
 				((DisposableBean) factory).destroy();
 			}
@@ -91,7 +93,8 @@ public class TemplatePerformanceTest {
 
 	private static void printResult(String operation, long durationNanos) {
 		long durationMs = durationNanos / 1_000_000;
-		System.out.printf("%s:    %,d ops/sec (%.2f ms total)%n", 
-			operation, (long) (OPERATIONS * 1000.0 / durationMs), durationMs / 1.0);
+		System.out.printf("%s:    %,d ops/sec (%.2f ms total)%n", operation, (long) (OPERATIONS * 1000.0 / durationMs),
+				durationMs / 1.0);
 	}
+
 }

--- a/performance/src/main/java/performance/ThreadedDirectClientPerformanceTest.java
+++ b/performance/src/main/java/performance/ThreadedDirectClientPerformanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,13 +36,16 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class ThreadedDirectClientPerformanceTest {
 
 	private static final int THREADS = 100;
+
 	private static final int OPERATIONS_PER_THREAD = 100;
+
 	private static final int TOTAL_OPERATIONS = THREADS * OPERATIONS_PER_THREAD;
+
 	private static final String KEY_PREFIX = "threaded:test:";
 
 	public static void main(String[] args) throws Exception {
 		String clientType = System.getProperty("client", "valkeyglide");
-		
+
 		System.out.println("Running Multi-Threaded Direct Client Performance Test");
 		System.out.println("Client: " + clientType);
 		System.out.println("Threads: " + THREADS);
@@ -62,13 +65,13 @@ public class ThreadedDirectClientPerformanceTest {
 		GlideClientConfiguration config = GlideClientConfiguration.builder()
 			.address(NodeAddress.builder().host("localhost").port(6379).build())
 			.build();
-		
+
 		try (GlideClient client = GlideClient.createClient(config).get()) {
 			ExecutorService executorService = Executors.newFixedThreadPool(THREADS);
 			AtomicInteger setSuccess = new AtomicInteger(0);
 			AtomicInteger getSuccess = new AtomicInteger(0);
 			AtomicInteger deleteSuccess = new AtomicInteger(0);
-			
+
 			try {
 				// SET operations
 				long start = System.nanoTime();
@@ -78,12 +81,13 @@ public class ThreadedDirectClientPerformanceTest {
 							int id = Thread.currentThread().hashCode() * OPERATIONS_PER_THREAD + i;
 							client.set(GlideString.of(KEY_PREFIX + id), GlideString.of("value" + id)).get();
 							setSuccess.incrementAndGet();
-						} catch (Exception e) {
+						}
+						catch (Exception e) {
 							// Ignore
 						}
 					}
 				};
-				
+
 				for (int i = 0; i < THREADS; i++) {
 					executorService.submit(setTask);
 				}
@@ -101,12 +105,13 @@ public class ThreadedDirectClientPerformanceTest {
 							int id = Thread.currentThread().hashCode() * OPERATIONS_PER_THREAD + i;
 							client.get(GlideString.of(KEY_PREFIX + id)).get();
 							getSuccess.incrementAndGet();
-						} catch (Exception e) {
+						}
+						catch (Exception e) {
 							// Ignore
 						}
 					}
 				};
-				
+
 				for (int i = 0; i < THREADS; i++) {
 					executorService.submit(getTask);
 				}
@@ -122,14 +127,15 @@ public class ThreadedDirectClientPerformanceTest {
 					for (int i = 0; i < OPERATIONS_PER_THREAD; i++) {
 						try {
 							int id = Thread.currentThread().hashCode() * OPERATIONS_PER_THREAD + i;
-							client.del(new GlideString[]{GlideString.of(KEY_PREFIX + id)}).get();
+							client.del(new GlideString[] { GlideString.of(KEY_PREFIX + id) }).get();
 							deleteSuccess.incrementAndGet();
-						} catch (Exception e) {
+						}
+						catch (Exception e) {
 							// Ignore
 						}
 					}
 				};
-				
+
 				for (int i = 0; i < THREADS; i++) {
 					executorService.submit(deleteTask);
 				}
@@ -137,7 +143,8 @@ public class ThreadedDirectClientPerformanceTest {
 				executorService.awaitTermination(10, TimeUnit.SECONDS);
 				long deleteTime = System.nanoTime() - start;
 				printResult("DELETE", deleteTime, deleteSuccess.get());
-			} finally {
+			}
+			finally {
 				if (!executorService.isShutdown()) {
 					executorService.shutdown();
 				}
@@ -147,14 +154,14 @@ public class ThreadedDirectClientPerformanceTest {
 
 	private static void testLettuce() throws Exception {
 		RedisClient client = RedisClient.create(RedisURI.create("redis://localhost:6379"));
-		
+
 		try (StatefulRedisConnection<String, String> connection = client.connect()) {
 			RedisCommands<String, String> commands = connection.sync();
 			ExecutorService executorService = Executors.newFixedThreadPool(THREADS);
 			AtomicInteger setSuccess = new AtomicInteger(0);
 			AtomicInteger getSuccess = new AtomicInteger(0);
 			AtomicInteger deleteSuccess = new AtomicInteger(0);
-			
+
 			try {
 				// SET operations
 				long start = System.nanoTime();
@@ -164,12 +171,13 @@ public class ThreadedDirectClientPerformanceTest {
 							int id = Thread.currentThread().hashCode() * OPERATIONS_PER_THREAD + i;
 							commands.set(KEY_PREFIX + id, "value" + id);
 							setSuccess.incrementAndGet();
-						} catch (Exception e) {
+						}
+						catch (Exception e) {
 							// Ignore
 						}
 					}
 				};
-				
+
 				for (int i = 0; i < THREADS; i++) {
 					executorService.submit(setTask);
 				}
@@ -187,12 +195,13 @@ public class ThreadedDirectClientPerformanceTest {
 							int id = Thread.currentThread().hashCode() * OPERATIONS_PER_THREAD + i;
 							commands.get(KEY_PREFIX + id);
 							getSuccess.incrementAndGet();
-						} catch (Exception e) {
+						}
+						catch (Exception e) {
 							// Ignore
 						}
 					}
 				};
-				
+
 				for (int i = 0; i < THREADS; i++) {
 					executorService.submit(getTask);
 				}
@@ -210,12 +219,13 @@ public class ThreadedDirectClientPerformanceTest {
 							int id = Thread.currentThread().hashCode() * OPERATIONS_PER_THREAD + i;
 							commands.del(KEY_PREFIX + id);
 							deleteSuccess.incrementAndGet();
-						} catch (Exception e) {
+						}
+						catch (Exception e) {
 							// Ignore
 						}
 					}
 				};
-				
+
 				for (int i = 0; i < THREADS; i++) {
 					executorService.submit(deleteTask);
 				}
@@ -223,12 +233,14 @@ public class ThreadedDirectClientPerformanceTest {
 				executorService.awaitTermination(10, TimeUnit.SECONDS);
 				long deleteTime = System.nanoTime() - start;
 				printResult("DELETE", deleteTime, deleteSuccess.get());
-			} finally {
+			}
+			finally {
 				if (!executorService.isShutdown()) {
 					executorService.shutdown();
 				}
 			}
-		} finally {
+		}
+		finally {
 			client.shutdown();
 		}
 	}
@@ -239,7 +251,7 @@ public class ThreadedDirectClientPerformanceTest {
 		AtomicInteger setSuccess = new AtomicInteger(0);
 		AtomicInteger getSuccess = new AtomicInteger(0);
 		AtomicInteger deleteSuccess = new AtomicInteger(0);
-		
+
 		try {
 			// SET operations
 			long start = System.nanoTime();
@@ -250,13 +262,14 @@ public class ThreadedDirectClientPerformanceTest {
 							int id = Thread.currentThread().hashCode() * OPERATIONS_PER_THREAD + i;
 							jedis.set(KEY_PREFIX + id, "value" + id);
 							setSuccess.incrementAndGet();
-						} catch (Exception e) {
+						}
+						catch (Exception e) {
 							// Ignore
 						}
 					}
 				}
 			};
-			
+
 			for (int i = 0; i < THREADS; i++) {
 				executorService.submit(setTask);
 			}
@@ -275,13 +288,14 @@ public class ThreadedDirectClientPerformanceTest {
 							int id = Thread.currentThread().hashCode() * OPERATIONS_PER_THREAD + i;
 							jedis.get(KEY_PREFIX + id);
 							getSuccess.incrementAndGet();
-						} catch (Exception e) {
+						}
+						catch (Exception e) {
 							// Ignore
 						}
 					}
 				}
 			};
-			
+
 			for (int i = 0; i < THREADS; i++) {
 				executorService.submit(getTask);
 			}
@@ -300,13 +314,14 @@ public class ThreadedDirectClientPerformanceTest {
 							int id = Thread.currentThread().hashCode() * OPERATIONS_PER_THREAD + i;
 							jedis.del(KEY_PREFIX + id);
 							deleteSuccess.incrementAndGet();
-						} catch (Exception e) {
+						}
+						catch (Exception e) {
 							// Ignore
 						}
 					}
 				}
 			};
-			
+
 			for (int i = 0; i < THREADS; i++) {
 				executorService.submit(deleteTask);
 			}
@@ -314,7 +329,8 @@ public class ThreadedDirectClientPerformanceTest {
 			executorService.awaitTermination(10, TimeUnit.SECONDS);
 			long deleteTime = System.nanoTime() - start;
 			printResult("DELETE", deleteTime, deleteSuccess.get());
-		} finally {
+		}
+		finally {
 			if (!executorService.isShutdown()) {
 				executorService.shutdown();
 			}
@@ -322,8 +338,9 @@ public class ThreadedDirectClientPerformanceTest {
 	}
 
 	private static void printResult(String operation, long duration, int successful) {
-		System.out.printf("%s:    %,d ops/sec (%.2f ms total), %.1f%% successful%n",
-			operation, (long) (TOTAL_OPERATIONS / (duration / 1_000_000_000.0)), duration / 1_000_000.0,
-			(successful * 100.0 / TOTAL_OPERATIONS));
+		System.out.printf("%s:    %,d ops/sec (%.2f ms total), %.1f%% successful%n", operation,
+				(long) (TOTAL_OPERATIONS / (duration / 1_000_000_000.0)), duration / 1_000_000.0,
+				(successful * 100.0 / TOTAL_OPERATIONS));
 	}
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -291,6 +291,11 @@
 				<artifactId>versions-maven-plugin</artifactId>
 				<version>2.16.2</version>
 			</plugin>
+			<plugin>
+				<groupId>io.spring.javaformat</groupId>
+				<artifactId>spring-javaformat-maven-plugin</artifactId>
+				<version>0.0.47</version>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/spring-boot-starter-data-valkey/src/main/java/io/valkey/springframework/boot/autoconfigure/data/valkey/ValkeyGlideClientConfigurationBuilderCustomizer.java
+++ b/spring-boot-starter-data-valkey/src/main/java/io/valkey/springframework/boot/autoconfigure/data/valkey/ValkeyGlideClientConfigurationBuilderCustomizer.java
@@ -21,8 +21,8 @@ import io.valkey.springframework.data.valkey.connection.valkeyglide.DefaultValke
 /**
  * Callback interface that can be implemented by beans wishing to customize the
  * {@link DefaultValkeyGlideClientConfiguration.ValkeyGlideClientConfigurationBuilder
- * ValkeyGlideClientConfigurationBuilder} via a {@link DefaultValkeyGlideClientConfiguration}
- * using the builder pattern.
+ * ValkeyGlideClientConfigurationBuilder} via a
+ * {@link DefaultValkeyGlideClientConfiguration} using the builder pattern.
  *
  * @author Jeremy Parr-Pearson
  * @since 3.5.1
@@ -31,9 +31,11 @@ import io.valkey.springframework.data.valkey.connection.valkeyglide.DefaultValke
 public interface ValkeyGlideClientConfigurationBuilderCustomizer {
 
 	/**
-	 * Customize the {@link DefaultValkeyGlideClientConfiguration.ValkeyGlideClientConfigurationBuilder}.
+	 * Customize the
+	 * {@link DefaultValkeyGlideClientConfiguration.ValkeyGlideClientConfigurationBuilder}.
 	 * @param clientConfigurationBuilder the builder to customize
 	 */
-	void customize(DefaultValkeyGlideClientConfiguration.ValkeyGlideClientConfigurationBuilder clientConfigurationBuilder);
+	void customize(
+			DefaultValkeyGlideClientConfiguration.ValkeyGlideClientConfigurationBuilder clientConfigurationBuilder);
 
 }

--- a/spring-boot-starter-data-valkey/src/main/java/io/valkey/springframework/boot/autoconfigure/data/valkey/ValkeyGlideConnectionConfiguration.java
+++ b/spring-boot-starter-data-valkey/src/main/java/io/valkey/springframework/boot/autoconfigure/data/valkey/ValkeyGlideConnectionConfiguration.java
@@ -42,17 +42,17 @@ import io.valkey.springframework.data.valkey.connection.valkeyglide.ValkeyGlideC
  * @author Jeremy Parr-Pearson
  */
 @Configuration(proxyBeanMethods = false)
-@ConditionalOnClass({ValkeyGlideConnectionFactory.class, glide.api.GlideClient.class})
+@ConditionalOnClass({ ValkeyGlideConnectionFactory.class, glide.api.GlideClient.class })
 @ConditionalOnProperty(name = "spring.data.valkey.client-type", havingValue = "valkeyglide", matchIfMissing = true)
 class ValkeyGlideConnectionConfiguration extends ValkeyConnectionConfiguration {
 
-	ValkeyGlideConnectionConfiguration(ValkeyProperties properties,
-			ValkeyConnectionDetails connectionDetails,
+	ValkeyGlideConnectionConfiguration(ValkeyProperties properties, ValkeyConnectionDetails connectionDetails,
 			ObjectProvider<ValkeyStandaloneConfiguration> standaloneConfigurationProvider,
 			ObjectProvider<ValkeySentinelConfiguration> sentinelConfigurationProvider,
 			ObjectProvider<ValkeyClusterConfiguration> clusterConfigurationProvider,
 			ObjectProvider<ValkeyStaticMasterReplicaConfiguration> masterReplicaConfiguration) {
-		super(properties, connectionDetails, standaloneConfigurationProvider, sentinelConfigurationProvider, clusterConfigurationProvider, masterReplicaConfiguration);
+		super(properties, connectionDetails, standaloneConfigurationProvider, sentinelConfigurationProvider,
+				clusterConfigurationProvider, masterReplicaConfiguration);
 	}
 
 	@Bean
@@ -85,11 +85,14 @@ class ValkeyGlideConnectionConfiguration extends ValkeyConnectionConfiguration {
 				Assert.state(clusterConfiguration != null, "'clusterConfiguration' must not be null");
 				yield new ValkeyGlideConnectionFactory(clusterConfiguration, clientConfiguration);
 			}
-			case SENTINEL -> throw new IllegalStateException("Valkey GLIDE does not support Sentinel. Use Lettuce or Jedis.");
-			case MASTER_REPLICA -> throw new IllegalStateException("Valkey GLIDE does not support Master/Replica topology configuration. Use Lettuce.");
+			case SENTINEL ->
+				throw new IllegalStateException("Valkey GLIDE does not support Sentinel. Use Lettuce or Jedis.");
+			case MASTER_REPLICA -> throw new IllegalStateException(
+					"Valkey GLIDE does not support Master/Replica topology configuration. Use Lettuce.");
 		};
 
-		// Disable early startup for Spring Boot to avoid connection attempts during bean creation
+		// Disable early startup for Spring Boot to avoid connection attempts during bean
+		// creation
 		factory.setEarlyStartup(false);
 		return factory;
 	}
@@ -97,7 +100,7 @@ class ValkeyGlideConnectionConfiguration extends ValkeyConnectionConfiguration {
 	private ValkeyGlideClientConfiguration getValkeyGlideClientConfiguration(
 			ObjectProvider<ValkeyGlideClientConfigurationBuilderCustomizer> builderCustomizers) {
 		ValkeyGlideClientConfiguration.ValkeyGlideClientConfigurationBuilder builder = ValkeyGlideClientConfiguration
-				.builder();
+			.builder();
 
 		if (getProperties().getTimeout() != null) {
 			builder.commandTimeout(getProperties().getTimeout());
@@ -130,13 +133,9 @@ class ValkeyGlideConnectionConfiguration extends ValkeyConnectionConfiguration {
 		// Apply OpenTelemetry configuration if enabled
 		ValkeyProperties.ValkeyGlide.OpenTelemetry otelProperties = valkeyGlideProperties.getOpenTelemetry();
 		if (otelProperties != null && otelProperties.isEnabled()) {
-			ValkeyGlideClientConfiguration.OpenTelemetryForGlide otelConfig =
-				new ValkeyGlideClientConfiguration.OpenTelemetryForGlide(
-					otelProperties.getTracesEndpoint(),
-					otelProperties.getMetricsEndpoint(),
-					otelProperties.getSamplePercentage(),
-					otelProperties.getFlushIntervalMs()
-				);
+			ValkeyGlideClientConfiguration.OpenTelemetryForGlide otelConfig = new ValkeyGlideClientConfiguration.OpenTelemetryForGlide(
+					otelProperties.getTracesEndpoint(), otelProperties.getMetricsEndpoint(),
+					otelProperties.getSamplePercentage(), otelProperties.getFlushIntervalMs());
 			builder.useOpenTelemetry(otelConfig);
 		}
 
@@ -144,28 +143,22 @@ class ValkeyGlideConnectionConfiguration extends ValkeyConnectionConfiguration {
 		ValkeyProperties.ValkeyGlide.IamAuthentication iamProperties = valkeyGlideProperties.getIamAuthentication();
 		if (iamProperties != null) {
 			if (!isSslEnabled()) {
-				throw new IllegalArgumentException(
-					"IAM authentication requires TLS/SSL to be enabled. "
-					+ "Please set spring.data.valkey.ssl.enabled=true or use a valkeys:// URL.");
+				throw new IllegalArgumentException("IAM authentication requires TLS/SSL to be enabled. "
+						+ "Please set spring.data.valkey.ssl.enabled=true or use a valkeys:// URL.");
 			}
-			if (!StringUtils.hasText(iamProperties.getClusterName())
-					|| !StringUtils.hasText(iamProperties.getService())
+			if (!StringUtils.hasText(iamProperties.getClusterName()) || !StringUtils.hasText(iamProperties.getService())
 					|| !StringUtils.hasText(iamProperties.getRegion())) {
 				throw new IllegalArgumentException(
-					"IAM authentication requires all of: cluster-name, service, and region. "
-					+ "Please set spring.data.valkey.valkey-glide.iam-authentication.cluster-name, "
-					+ "spring.data.valkey.valkey-glide.iam-authentication.service, and "
-					+ "spring.data.valkey.valkey-glide.iam-authentication.region");
+						"IAM authentication requires all of: cluster-name, service, and region. "
+								+ "Please set spring.data.valkey.valkey-glide.iam-authentication.cluster-name, "
+								+ "spring.data.valkey.valkey-glide.iam-authentication.service, and "
+								+ "spring.data.valkey.valkey-glide.iam-authentication.region");
 			}
-			ValkeyGlideClientConfiguration.AwsServiceType serviceType =
-				ValkeyGlideClientConfiguration.AwsServiceType.valueOf(iamProperties.getService().toUpperCase(java.util.Locale.ROOT));
-			ValkeyGlideClientConfiguration.IamAuthenticationForGlide iamConfig =
-				new ValkeyGlideClientConfiguration.IamAuthenticationForGlide(
-					iamProperties.getClusterName(),
-					serviceType,
-					iamProperties.getRegion(),
-					iamProperties.getRefreshIntervalSeconds()
-				);
+			ValkeyGlideClientConfiguration.AwsServiceType serviceType = ValkeyGlideClientConfiguration.AwsServiceType
+				.valueOf(iamProperties.getService().toUpperCase(java.util.Locale.ROOT));
+			ValkeyGlideClientConfiguration.IamAuthenticationForGlide iamConfig = new ValkeyGlideClientConfiguration.IamAuthenticationForGlide(
+					iamProperties.getClusterName(), serviceType, iamProperties.getRegion(),
+					iamProperties.getRefreshIntervalSeconds());
 			builder.useIamAuthentication(iamConfig);
 		}
 
@@ -173,7 +166,8 @@ class ValkeyGlideConnectionConfiguration extends ValkeyConnectionConfiguration {
 		return builder.build();
 	}
 
-	private void customizeConfigurationFromUrl(ValkeyGlideClientConfiguration.ValkeyGlideClientConfigurationBuilder builder) {
+	private void customizeConfigurationFromUrl(
+			ValkeyGlideClientConfiguration.ValkeyGlideClientConfigurationBuilder builder) {
 		if (urlUsesSsl(getProperties().getUrl())) {
 			builder.useSsl();
 		}
@@ -182,7 +176,8 @@ class ValkeyGlideConnectionConfiguration extends ValkeyConnectionConfiguration {
 	private ReadFrom getReadFrom(String readFrom) {
 		try {
 			return ReadFrom.valueOf(readFrom.toUpperCase());
-		} catch (IllegalArgumentException ex) {
+		}
+		catch (IllegalArgumentException ex) {
 			throw new IllegalArgumentException("Invalid readFrom value: " + readFrom, ex);
 		}
 	}

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ClusterGlideClientAdapter.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ClusterGlideClientAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,497 +50,529 @@ import glide.api.GlideClusterClient;
 import glide.api.models.ClusterBatch;
 
 /**
- * Unified interface that abstracts both GlideClient and GlideClusterClient
- * to enable code reuse between standalone and cluster modes.
- * 
+ * Unified interface that abstracts both GlideClient and GlideClusterClient to enable code
+ * reuse between standalone and cluster modes.
+ *
  * @author Ilia Kolominsky
  * @since 2.0
  */
 class ClusterGlideClientAdapter implements UnifiedGlideClient {
 
-    private final GlideClusterClient glideClusterClient;
-    private final @Nullable DelegatingPubSubListener listener;
-    @Nullable private Route nextCommandRoute = null;
-    private ClusterBatch currentBatch;
-    private BatchStatus batchStatus = BatchStatus.None;
+	private final GlideClusterClient glideClusterClient;
 
-    ClusterGlideClientAdapter(ValkeyClusterConfiguration clusterConfig, ValkeyGlideClientConfiguration valkeyGlideConfiguration) {
-        // Build GlideClusterClientConfiguration using Glide's API
-        var configBuilder = 
-            GlideClusterClientConfiguration.builder();
-        
-        // CONNECTION PROPERTIES from driver-agnostic configuration
-        // Add all cluster nodes
-        clusterConfig.getClusterNodes().forEach(node -> {
-            configBuilder.address(NodeAddress.builder()
-                .host(node.getHost())
-                .port(node.getPort())
-                .build());
-        });
-        
-        // Set credentials from driver-agnostic configuration
-        IamAuthenticationForGlide iamAuth = valkeyGlideConfiguration.getIamAuthentication();
-        ValkeyPassword password = clusterConfig.getPassword();
+	private final @Nullable DelegatingPubSubListener listener;
 
-        if (iamAuth != null) {
-            // IAM authentication — mutually exclusive with password
-            String username = clusterConfig.getUsername();
-            if (!StringUtils.hasText(username)) {
-                throw new IllegalArgumentException(
-                    "Username is required for IAM authentication. "
-                    + "Set spring.data.valkey.username or configure username in ValkeyClusterConfiguration.");
-            }
+	@Nullable private Route nextCommandRoute = null;
 
-            IamAuthConfig.IamAuthConfigBuilder iamConfigBuilder = IamAuthConfig.builder()
-                .clusterName(iamAuth.clusterName())
-                .service(mapServiceType(iamAuth.serviceType()))
-                .region(iamAuth.region());
+	private ClusterBatch currentBatch;
 
-            if (iamAuth.refreshIntervalSeconds() != null) {
-                iamConfigBuilder.refreshIntervalSeconds(iamAuth.refreshIntervalSeconds());
-            }
+	private BatchStatus batchStatus = BatchStatus.None;
 
-            configBuilder.credentials(
-                glide.api.models.configuration.ServerCredentials.builder()
-                    .username(username)
-                    .iamConfig(iamConfigBuilder.build())
-                    .build());
-        } else if (!password.equals(ValkeyPassword.none())) {
-            String username = clusterConfig.getUsername();
-            
-            if (StringUtils.hasText(username)) {
-                configBuilder.credentials(
-                    glide.api.models.configuration.ServerCredentials.builder()
-                        .username(username)
-                        .password(String.valueOf(password.get()))
-                        .build());
-            } else {
-                configBuilder.credentials(
-                    glide.api.models.configuration.ServerCredentials.builder()
-                        .password(String.valueOf(password.get()))
-                        .build());
-            }
-        }
-        
-        // DRIVER-SPECIFIC PROPERTIES from ValkeyGlideClientConfiguration
-        
-        // Request timeout
-        Duration commandTimeout = valkeyGlideConfiguration.getCommandTimeout();
-        if (commandTimeout != null) {
-            configBuilder.requestTimeout((int) commandTimeout.toMillis());
-        }
+	ClusterGlideClientAdapter(ValkeyClusterConfiguration clusterConfig,
+			ValkeyGlideClientConfiguration valkeyGlideConfiguration) {
+		// Build GlideClusterClientConfiguration using Glide's API
+		var configBuilder = GlideClusterClientConfiguration.builder();
 
-        // Connection timeout
-        Duration connectionTimeout = valkeyGlideConfiguration.getConnectionTimeout();
-        if (connectionTimeout != null) {
-            var advancedConfigBuilder = AdvancedGlideClusterClientConfiguration.builder();
-            advancedConfigBuilder.connectionTimeout((int) connectionTimeout.toMillis());
-            configBuilder.advancedConfiguration(advancedConfigBuilder.build());
-        }
+		// CONNECTION PROPERTIES from driver-agnostic configuration
+		// Add all cluster nodes
+		clusterConfig.getClusterNodes().forEach(node -> {
+			configBuilder.address(NodeAddress.builder().host(node.getHost()).port(node.getPort()).build());
+		});
 
-        // SSL/TLS
-        if (valkeyGlideConfiguration.isUseSsl()) {
-            configBuilder.useTLS(true);
-        }
-        
-        // Read from strategy
-        ReadFrom readFrom = valkeyGlideConfiguration.getReadFrom();
-        if (readFrom != null) {
-            configBuilder.readFrom(readFrom);
-        }
-        
-        // Inflight requests limit
-        Integer inflightRequestsLimit = valkeyGlideConfiguration.getInflightRequestsLimit();
-        if (inflightRequestsLimit != null) {
-            configBuilder.inflightRequestsLimit(inflightRequestsLimit);
-        }
-        
-        // Client AZ
-        String clientAZ = valkeyGlideConfiguration.getClientAZ();
-        if (clientAZ != null) {
-            configBuilder.clientAZ(clientAZ);
-        }
-        
-        // Reconnect strategy
-        BackoffStrategy reconnectStrategy = valkeyGlideConfiguration.getReconnectStrategy();
-        if (reconnectStrategy != null) {
-            configBuilder.reconnectStrategy(reconnectStrategy);
-        }
+		// Set credentials from driver-agnostic configuration
+		IamAuthenticationForGlide iamAuth = valkeyGlideConfiguration.getIamAuthentication();
+		ValkeyPassword password = clusterConfig.getPassword();
 
-        this.listener = new DelegatingPubSubListener();
+		if (iamAuth != null) {
+			// IAM authentication — mutually exclusive with password
+			String username = clusterConfig.getUsername();
+			if (!StringUtils.hasText(username)) {
+				throw new IllegalArgumentException("Username is required for IAM authentication. "
+						+ "Set spring.data.valkey.username or configure username in ValkeyClusterConfiguration.");
+			}
 
-        // Configure pub/sub with callback for event-driven message delivery
-        var subConfigBuilder = ClusterSubscriptionConfiguration.builder();
-        
-        // Set callback that delegates to our listener holder
-        subConfigBuilder.callback((msg, context) -> this.listener.onMessage(msg, context));
-        configBuilder.subscriptionConfiguration(subConfigBuilder.build());
+			IamAuthConfig.IamAuthConfigBuilder iamConfigBuilder = IamAuthConfig.builder()
+				.clusterName(iamAuth.clusterName())
+				.service(mapServiceType(iamAuth.serviceType()))
+				.region(iamAuth.region());
 
-        // Set library name for server-side client identification
-        configBuilder.libName("GlideSpringDataValkey");
+			if (iamAuth.refreshIntervalSeconds() != null) {
+				iamConfigBuilder.refreshIntervalSeconds(iamAuth.refreshIntervalSeconds());
+			}
 
-        // Build and create cluster client
-        GlideClusterClientConfiguration config = configBuilder.build();
-        try {
-            this.glideClusterClient = GlideClusterClient.createClient(config).get();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new IllegalStateException("Interrupted creating GlideClusterClient", e);
-        } catch (ExecutionException e) {
-            throw new IllegalStateException("Failed creating GlideClusterClient", e);
-        }
-    }
+			configBuilder.credentials(glide.api.models.configuration.ServerCredentials.builder()
+				.username(username)
+				.iamConfig(iamConfigBuilder.build())
+				.build());
+		}
+		else if (!password.equals(ValkeyPassword.none())) {
+			String username = clusterConfig.getUsername();
 
-    @Override
-    @Nullable
-    public DelegatingPubSubListener getDelegatingListener() {
-        return listener;
-    }
+			if (StringUtils.hasText(username)) {
+				configBuilder.credentials(glide.api.models.configuration.ServerCredentials.builder()
+					.username(username)
+					.password(String.valueOf(password.get()))
+					.build());
+			}
+			else {
+				configBuilder.credentials(glide.api.models.configuration.ServerCredentials.builder()
+					.password(String.valueOf(password.get()))
+					.build());
+			}
+		}
 
-    /**
-     * A zero-copy map view that reconstructs GlideString keys from String keys while preserving value types.
-     * This avoids copying values when working around ClusterValue.of() bug.
-     * 
-     * <p>ClusterValue.ofMultiValueBinary() incorrectly converts Map<GlideString, V> to
-     * Map<String, V> by calling getString() on the keys. This view reverses that
-     * transformation without copying the values.
-     * 
-     * @param <V> The value type (e.g., GlideString for HASH commands, Double for Z commands with scores)
-     */
-    private static class ReconstructedKeyMap<V> extends AbstractMap<GlideString, V> {
-        private final Map<String, V> sourceMap;
-        
-        ReconstructedKeyMap(Map<String, V> sourceMap) {
-            this.sourceMap = sourceMap;
-        }
-        
-        @Override
-        public Set<Entry<GlideString, V>> entrySet() {
-            return new AbstractSet<Entry<GlideString, V>>() {
-                @Override
-                public Iterator<Entry<GlideString, V>> iterator() {
-                    Iterator<? extends Entry<String, V>> sourceIterator = sourceMap.entrySet().iterator();
-                    return new Iterator<Entry<GlideString, V>>() {
-                        @Override
-                        public boolean hasNext() {
-                            return sourceIterator.hasNext();
-                        }
-                        
-                        @Override
-                        public Entry<GlideString, V> next() {
-                            Entry<String, V> sourceEntry = sourceIterator.next();
-                            // Reconstruct GlideString key, preserve original value type
-                            return new SimpleEntry<>(
-                                GlideString.of(sourceEntry.getKey()),
-                                sourceEntry.getValue()
-                            );
-                        }
-                    };
-                }
-                
-                @Override
-                public int size() {
-                    return sourceMap.size();
-                }
-            };
-        }
-        
-        @Override
-        public int size() {
-            return sourceMap.size();
-        }
-    }
+		// DRIVER-SPECIFIC PROPERTIES from ValkeyGlideClientConfiguration
 
-    private boolean needToAggregateResult(@Nullable Route route) {
-        // TODO: implement more sophisticated logic to determine if aggregation is needed based on command and route type
-        if (route == null) {
-            // we need to look at the valkey-glide default route for the command
-            // for now, assume no aggregation is needed
-            return false;
-        } else if (route instanceof SimpleMultiNodeRoute) {
-            return true;
-        }
-        return false;
-    }
+		// Request timeout
+		Duration commandTimeout = valkeyGlideConfiguration.getCommandTimeout();
+		if (commandTimeout != null) {
+			configBuilder.requestTimeout((int) commandTimeout.toMillis());
+		}
 
-    /**
-     * Determines if a command returns a nested Map structure that should bypass ReconstructedKeyMap.
-     * 
-     * <p>Stream commands (XREAD, XRANGE, etc.) return nested Maps where the outer map keys are stream keys
-     * and the values are LinkedHashMap objects containing the actual stream records. These should not go
-     * through ReconstructedKeyMap because:
-     * <ul>
-     *   <li>The outer map is just a container, not the actual data to be returned</li>
-     *   <li>The GlideString types are preserved in the nested field-value arrays</li>
-     *   <li>The parseByteRecords() method already handles the nested structure correctly</li>
-     * </ul>
-     *
-     * @param args The command arguments, where args[0] is the command name
-     * @return true if this command returns nested Maps that should bypass ReconstructedKeyMap
-     */
-    private boolean isNestedMapCommand(GlideString[] args) {
-        if (args == null || args.length == 0) return false;
-        
-        String cmd = args[0].getString().toUpperCase();
-        
-        // Stream commands that return nested Map structures
-        switch (cmd) {
-            case "XREAD":
-            case "XREADGROUP":
-            case "XRANGE":
-            case "XREVRANGE":
-            case "XCLAIM":
-            case "XAUTOCLAIM":
-            case "XPENDING": // detailed form
-                return true;
-            default:
-                return false;
-        }
-    }
+		// Connection timeout
+		Duration connectionTimeout = valkeyGlideConfiguration.getConnectionTimeout();
+		if (connectionTimeout != null) {
+			var advancedConfigBuilder = AdvancedGlideClusterClientConfiguration.builder();
+			advancedConfigBuilder.connectionTimeout((int) connectionTimeout.toMillis());
+			configBuilder.advancedConfiguration(advancedConfigBuilder.build());
+		}
 
-    /**
-     * Determines if a command has a default multi-node route in Valkey Glide's cluster routing.
-     * 
-     * <p>This method identifies commands that Glide routes to multiple nodes by default (when no explicit
-     * route is provided). The routing rules are defined in Glide's Rust implementation at:
-     * <code>valkey-glide/glide-core/redis-rs/redis/src/cluster_routing.rs</code> in the <code>base_routing()</code> function.
-     * 
-     * <p><b>Background:</b> Glide has a bug where <code>ClusterValue.of()</code> incorrectly treats any Map result
-     * as a multi-node response (where keys = node addresses). For commands returning Map results (like HGETALL),
-     * this causes the Map to be placed in <code>multiValue</code> instead of <code>singleValue</code>.
-     * 
-     * <p>To work around this bug, we need to distinguish between:
-     * <ul>
-     *   <li><b>True multi-node results:</b> Commands that Glide routes to multiple nodes by default,
-     *       where <code>multiValue</code> IS a map of {node-address → result}</li>
-     *   <li><b>False-positive multiValue:</b> Single-node commands returning Map results (like HGETALL),
-     *       where <code>multiValue</code> contains the actual result incorrectly</li>
-     * </ul>
-     *
-     * @param args The command arguments, where args[0] is the command name
-     * @return true if this command routes to multiple nodes by default in Glide's implementation
-     * 
-     * @see <a href="https://github.com/valkey-io/valkey-glide/blob/main/glide-core/redis-rs/redis/src/cluster_routing.rs">
-     *      Valkey Glide cluster_routing.rs</a>
-     */
-    private boolean isDefaultMultiNodeCommand(GlideString[] args) {
-        if (args == null || args.length == 0) return false;
-        
-        String cmd = args[0].getString().toUpperCase();
-        
-        // Commands from RouteBy::AllNodes in cluster_routing.rs
-        // These are routed to ALL cluster nodes (primaries and replicas)
-        if (cmd.startsWith("ACL ")) {
-            return cmd.matches("ACL (SETUSER|DELUSER|SAVE)");
-        }
-        if (cmd.startsWith("CLIENT ")) {
-            return cmd.matches("CLIENT (SETNAME|SETINFO)");
-        }
-        if (cmd.startsWith("SLOWLOG ")) {
-            return cmd.matches("SLOWLOG (GET|LEN|RESET)");
-        }
-        if (cmd.startsWith("CONFIG ")) {
-            return cmd.matches("CONFIG (SET|RESETSTAT|REWRITE)");
-        }
-        if (cmd.startsWith("SCRIPT ")) {
-            return cmd.matches("SCRIPT (FLUSH|LOAD|KILL)");
-        }
-        if (cmd.startsWith("LATENCY ")) {
-            return cmd.matches("LATENCY (RESET|GRAPH|HISTOGRAM|HISTORY|DOCTOR|LATEST)");
-        }
-        if (cmd.startsWith("PUBSUB ")) {
-            return cmd.matches("PUBSUB (NUMPAT|CHANNELS|NUMSUB|SHARDCHANNELS|SHARDNUMSUB)");
-        }
-        if (cmd.startsWith("FUNCTION ")) {
-            return cmd.matches("FUNCTION (KILL|STATS)");
-        }
-        
-        // Commands from RouteBy::AllPrimaries in cluster_routing.rs
-        // These are routed to all PRIMARY nodes in the cluster
-        switch (cmd) {
-            case "DBSIZE":
-            case "DEBUG":
-            case "FLUSHALL":
-            case "FLUSHDB":
-            case "FT._ALIASLIST":
-            case "FT._LIST":
-            case "INFO":
-            case "KEYS":
-            case "PING":
-            case "SCRIPT EXISTS":
-            case "UNWATCH":
-            case "WAIT":
-            case "RANDOMKEY":
-            case "WAITAOF":
-                return true;
-        }
-        
-        if (cmd.startsWith("FUNCTION ")) {
-            return cmd.matches("FUNCTION (DELETE|FLUSH|LOAD|RESTORE)");
-        }
-        if (cmd.startsWith("MEMORY ")) {
-            return cmd.matches("MEMORY (DOCTOR|MALLOC-STATS|PURGE|STATS)");
-        }
-        
-        return false;
-    }
+		// SSL/TLS
+		if (valkeyGlideConfiguration.isUseSsl()) {
+			configBuilder.useTLS(true);
+		}
 
-    @Override
-    public Object customCommand(GlideString[] args) throws InterruptedException, ExecutionException {
-        if (currentBatch != null) {
-            currentBatch.customCommand(args);
-            nextCommandRoute = null; // Clear route even in batch mode to prevent leaking to post-batch commands
-            return null;
-        }
-        try {
-            ClusterValue<?> clusterValue = nextCommandRoute == null
-                ? glideClusterClient.customCommand(args).get()
-                : glideClusterClient.customCommand(args, nextCommandRoute).get();
+		// Read from strategy
+		ReadFrom readFrom = valkeyGlideConfiguration.getReadFrom();
+		if (readFrom != null) {
+			configBuilder.readFrom(readFrom);
+		}
 
-            // Case 1: Explicit multi-node route - return multiValue for aggregation
-            if (needToAggregateResult(nextCommandRoute)) {
-                return clusterValue.getMultiValue();
-            }
-            
-            // Case 2: Default multi-node command (route is null but command routes to multiple nodes)
-            // These commands need special handling by the framework, so return multiValue
-            if (nextCommandRoute == null && isDefaultMultiNodeCommand(args)) {
-                // For default multi-node commands, check if we actually got multi-value data
-                if (clusterValue.hasMultiData()) {
-                    return clusterValue.getMultiValue();
-                }
-                // If not, fall through to single-value handling
-            }
-            
-            // Case 3: Single-node command, but ClusterValue.of() bug placed result in multiValue
-            // This happens for commands that return Map<GlideString, V> where V can be:
-            //   - GlideString for HASH commands (HGETALL)
-            //   - Double for Z commands with scores (ZRANGE WITHSCORES, ZDIFF WITHSCORES, etc.)
-            // ClusterValue.ofMultiValueBinary() converts GlideString keys to Strings:
-            //   Original: Map<GlideString, V> { GlideString("field1"): value1, ... }
-            //   Becomes:  Map<String, V> { "field1": value1, ... }
-            // Use ReconstructedKeyMap to convert keys back while preserving value types
-            // https://github.com/valkey-io/valkey-glide/issues/4963
-            //
-            // EXCEPTION: Stream commands return nested Maps and should NOT go through ReconstructedKeyMap
-            if (clusterValue.hasMultiData() && !isDefaultMultiNodeCommand(args) && !isNestedMapCommand(args)) {
-                Map<String, ?> multiValue = clusterValue.getMultiValue();
-                // Return a zero-copy view that reconstructs GlideString keys while preserving value types
-                return new ReconstructedKeyMap<>(multiValue);
-            }
-            
-            // Case 3b: Nested map commands (like streams) that have multiData but should return it as-is
-            if (clusterValue.hasMultiData() && isNestedMapCommand(args)) {
-                return clusterValue.getMultiValue();
-            }
-            
-            // Case 4: Normal single-value result
-            Object singleValue = clusterValue.getSingleValue();
-            return singleValue;
-        } finally {
-            nextCommandRoute = null; // ensure route is reset even on exception
-        }
-    }
+		// Inflight requests limit
+		Integer inflightRequestsLimit = valkeyGlideConfiguration.getInflightRequestsLimit();
+		if (inflightRequestsLimit != null) {
+			configBuilder.inflightRequestsLimit(inflightRequestsLimit);
+		}
 
-    @Override
-    public Object[] execBatch() throws InterruptedException, ExecutionException {
-        if (currentBatch == null) {
-            throw new IllegalStateException("No batch in progress");
-        }
-        return glideClusterClient.exec(currentBatch, false).get();
-    }
+		// Client AZ
+		String clientAZ = valkeyGlideConfiguration.getClientAZ();
+		if (clientAZ != null) {
+			configBuilder.clientAZ(clientAZ);
+		}
 
-    @Override
-    public Object getNativeClient() {
-        return glideClusterClient;
-    }
+		// Reconnect strategy
+		BackoffStrategy reconnectStrategy = valkeyGlideConfiguration.getReconnectStrategy();
+		if (reconnectStrategy != null) {
+			configBuilder.reconnectStrategy(reconnectStrategy);
+		}
 
-    @Override
-    public void close() throws ExecutionException {
-        // The native client might be pooled - dont close
-    }
+		this.listener = new DelegatingPubSubListener();
 
-    @Override
-    public BatchStatus getBatchStatus() {
-        return batchStatus;
-    }
+		// Configure pub/sub with callback for event-driven message delivery
+		var subConfigBuilder = ClusterSubscriptionConfiguration.builder();
 
-    @Override
-    public int getBatchCount() {
-        if (currentBatch == null) {
-            throw new IllegalStateException("No batch in progress");
-        }
-        return currentBatch.getProtobufBatch().getCommandsCount();
-    }
+		// Set callback that delegates to our listener holder
+		subConfigBuilder.callback((msg, context) -> this.listener.onMessage(msg, context));
+		configBuilder.subscriptionConfiguration(subConfigBuilder.build());
 
-    @Override
-    public void startNewBatch(boolean atomic) {
-        currentBatch = new ClusterBatch(atomic).withBinaryOutput();
-        batchStatus = atomic ? BatchStatus.Transaction : BatchStatus.Pipeline;
-    }
+		// Set library name for server-side client identification
+		configBuilder.libName("GlideSpringDataValkey");
 
-    @Override
-    public void discardBatch() {
-        currentBatch = null;
-        batchStatus = BatchStatus.None;
-    }
+		// Build and create cluster client
+		GlideClusterClientConfiguration config = configBuilder.build();
+		try {
+			this.glideClusterClient = GlideClusterClient.createClient(config).get();
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new IllegalStateException("Interrupted creating GlideClusterClient", e);
+		}
+		catch (ExecutionException e) {
+			throw new IllegalStateException("Failed creating GlideClusterClient", e);
+		}
+	}
 
-    @Override
-    public void reset() {
-        nextCommandRoute = null;
-        currentBatch = null;
-        batchStatus = BatchStatus.None;
-        if (getDelegatingListener() != null) {
-            getDelegatingListener().clearListener();
-        }
-    }
+	@Override
+	@Nullable public DelegatingPubSubListener getDelegatingListener() {
+		return listener;
+	}
 
-    public void setOneShotRouteForNextCommand(Route glideRoute) {
-        nextCommandRoute = glideRoute;
-    }
+	/**
+	 * A zero-copy map view that reconstructs GlideString keys from String keys while
+	 * preserving value types. This avoids copying values when working around
+	 * ClusterValue.of() bug.
+	 *
+	 * <p>
+	 * ClusterValue.ofMultiValueBinary() incorrectly converts Map<GlideString, V> to
+	 * Map<String, V> by calling getString() on the keys. This view reverses that
+	 * transformation without copying the values.
+	 *
+	 * @param <V> The value type (e.g., GlideString for HASH commands, Double for Z
+	 * commands with scores)
+	 */
+	private static class ReconstructedKeyMap<V> extends AbstractMap<GlideString, V> {
 
-    /**
-     * Consumes and returns the current one-shot route, clearing it.
-     * Used to capture the route for long-lived operations like multi-page SCAN.
-     */
-    @Nullable
-    Route consumeOneShotRoute() {
-        Route route = nextCommandRoute;
-        nextCommandRoute = null;
-        return route;
-    }
+		private final Map<String, V> sourceMap;
 
-    boolean hasOneShotRouteForNextCommand() {
-        return nextCommandRoute != null;
-    }
+		ReconstructedKeyMap(Map<String, V> sourceMap) {
+			this.sourceMap = sourceMap;
+		}
 
-    Object[] scan(ClusterScanCursor cursor) throws InterruptedException, ExecutionException {
-        try {
-            return glideClusterClient.scanBinary(cursor).get();
-        } finally {
-            nextCommandRoute = null;
-        }
-    }
+		@Override
+		public Set<Entry<GlideString, V>> entrySet() {
+			return new AbstractSet<Entry<GlideString, V>>() {
+				@Override
+				public Iterator<Entry<GlideString, V>> iterator() {
+					Iterator<? extends Entry<String, V>> sourceIterator = sourceMap.entrySet().iterator();
+					return new Iterator<Entry<GlideString, V>>() {
+						@Override
+						public boolean hasNext() {
+							return sourceIterator.hasNext();
+						}
 
-    Object[] scan(ClusterScanCursor cursor, ScanOptions options) throws InterruptedException, ExecutionException {
-        try {
-            return glideClusterClient.scanBinary(cursor, options).get();
-        } finally {
-            nextCommandRoute = null;
-        }
-    }
-    
-    public Object customCommand(GlideString[] args, ValkeyClusterNode node) throws InterruptedException, ExecutionException {
-        return glideClusterClient.customCommand(args, new ByAddressRoute(node.getHost(), node.getPort())).get().getSingleValue();
-    }
+						@Override
+						public Entry<GlideString, V> next() {
+							Entry<String, V> sourceEntry = sourceIterator.next();
+							// Reconstruct GlideString key, preserve original value type
+							return new SimpleEntry<>(GlideString.of(sourceEntry.getKey()), sourceEntry.getValue());
+						}
+					};
+				}
 
-    /**
-     * Maps the Spring Data Valkey {@link AwsServiceType} enum to the Glide-native {@link ServiceType} enum.
-     */
-    private static ServiceType mapServiceType(AwsServiceType serviceType) {
-        return switch (serviceType) {
-            case ELASTICACHE -> ServiceType.ELASTICACHE;
-            case MEMORYDB -> ServiceType.MEMORYDB;
-        };
-    }
+				@Override
+				public int size() {
+					return sourceMap.size();
+				}
+			};
+		}
+
+		@Override
+		public int size() {
+			return sourceMap.size();
+		}
+
+	}
+
+	private boolean needToAggregateResult(@Nullable Route route) {
+		// TODO: implement more sophisticated logic to determine if aggregation is needed
+		// based on command and route type
+		if (route == null) {
+			// we need to look at the valkey-glide default route for the command
+			// for now, assume no aggregation is needed
+			return false;
+		}
+		else if (route instanceof SimpleMultiNodeRoute) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Determines if a command returns a nested Map structure that should bypass
+	 * ReconstructedKeyMap.
+	 *
+	 * <p>
+	 * Stream commands (XREAD, XRANGE, etc.) return nested Maps where the outer map keys
+	 * are stream keys and the values are LinkedHashMap objects containing the actual
+	 * stream records. These should not go through ReconstructedKeyMap because:
+	 * <ul>
+	 * <li>The outer map is just a container, not the actual data to be returned</li>
+	 * <li>The GlideString types are preserved in the nested field-value arrays</li>
+	 * <li>The parseByteRecords() method already handles the nested structure
+	 * correctly</li>
+	 * </ul>
+	 * @param args The command arguments, where args[0] is the command name
+	 * @return true if this command returns nested Maps that should bypass
+	 * ReconstructedKeyMap
+	 */
+	private boolean isNestedMapCommand(GlideString[] args) {
+		if (args == null || args.length == 0)
+			return false;
+
+		String cmd = args[0].getString().toUpperCase();
+
+		// Stream commands that return nested Map structures
+		switch (cmd) {
+			case "XREAD":
+			case "XREADGROUP":
+			case "XRANGE":
+			case "XREVRANGE":
+			case "XCLAIM":
+			case "XAUTOCLAIM":
+			case "XPENDING": // detailed form
+				return true;
+			default:
+				return false;
+		}
+	}
+
+	/**
+	 * Determines if a command has a default multi-node route in Valkey Glide's cluster
+	 * routing.
+	 *
+	 * <p>
+	 * This method identifies commands that Glide routes to multiple nodes by default
+	 * (when no explicit route is provided). The routing rules are defined in Glide's Rust
+	 * implementation at:
+	 * <code>valkey-glide/glide-core/redis-rs/redis/src/cluster_routing.rs</code> in the
+	 * <code>base_routing()</code> function.
+	 *
+	 * <p>
+	 * <b>Background:</b> Glide has a bug where <code>ClusterValue.of()</code> incorrectly
+	 * treats any Map result as a multi-node response (where keys = node addresses). For
+	 * commands returning Map results (like HGETALL), this causes the Map to be placed in
+	 * <code>multiValue</code> instead of <code>singleValue</code>.
+	 *
+	 * <p>
+	 * To work around this bug, we need to distinguish between:
+	 * <ul>
+	 * <li><b>True multi-node results:</b> Commands that Glide routes to multiple nodes by
+	 * default, where <code>multiValue</code> IS a map of {node-address → result}</li>
+	 * <li><b>False-positive multiValue:</b> Single-node commands returning Map results
+	 * (like HGETALL), where <code>multiValue</code> contains the actual result
+	 * incorrectly</li>
+	 * </ul>
+	 * @param args The command arguments, where args[0] is the command name
+	 * @return true if this command routes to multiple nodes by default in Glide's
+	 * implementation
+	 *
+	 * @see <a href=
+	 * "https://github.com/valkey-io/valkey-glide/blob/main/glide-core/redis-rs/redis/src/cluster_routing.rs">
+	 * Valkey Glide cluster_routing.rs</a>
+	 */
+	private boolean isDefaultMultiNodeCommand(GlideString[] args) {
+		if (args == null || args.length == 0)
+			return false;
+
+		String cmd = args[0].getString().toUpperCase();
+
+		// Commands from RouteBy::AllNodes in cluster_routing.rs
+		// These are routed to ALL cluster nodes (primaries and replicas)
+		if (cmd.startsWith("ACL ")) {
+			return cmd.matches("ACL (SETUSER|DELUSER|SAVE)");
+		}
+		if (cmd.startsWith("CLIENT ")) {
+			return cmd.matches("CLIENT (SETNAME|SETINFO)");
+		}
+		if (cmd.startsWith("SLOWLOG ")) {
+			return cmd.matches("SLOWLOG (GET|LEN|RESET)");
+		}
+		if (cmd.startsWith("CONFIG ")) {
+			return cmd.matches("CONFIG (SET|RESETSTAT|REWRITE)");
+		}
+		if (cmd.startsWith("SCRIPT ")) {
+			return cmd.matches("SCRIPT (FLUSH|LOAD|KILL)");
+		}
+		if (cmd.startsWith("LATENCY ")) {
+			return cmd.matches("LATENCY (RESET|GRAPH|HISTOGRAM|HISTORY|DOCTOR|LATEST)");
+		}
+		if (cmd.startsWith("PUBSUB ")) {
+			return cmd.matches("PUBSUB (NUMPAT|CHANNELS|NUMSUB|SHARDCHANNELS|SHARDNUMSUB)");
+		}
+		if (cmd.startsWith("FUNCTION ")) {
+			return cmd.matches("FUNCTION (KILL|STATS)");
+		}
+
+		// Commands from RouteBy::AllPrimaries in cluster_routing.rs
+		// These are routed to all PRIMARY nodes in the cluster
+		switch (cmd) {
+			case "DBSIZE":
+			case "DEBUG":
+			case "FLUSHALL":
+			case "FLUSHDB":
+			case "FT._ALIASLIST":
+			case "FT._LIST":
+			case "INFO":
+			case "KEYS":
+			case "PING":
+			case "SCRIPT EXISTS":
+			case "UNWATCH":
+			case "WAIT":
+			case "RANDOMKEY":
+			case "WAITAOF":
+				return true;
+		}
+
+		if (cmd.startsWith("FUNCTION ")) {
+			return cmd.matches("FUNCTION (DELETE|FLUSH|LOAD|RESTORE)");
+		}
+		if (cmd.startsWith("MEMORY ")) {
+			return cmd.matches("MEMORY (DOCTOR|MALLOC-STATS|PURGE|STATS)");
+		}
+
+		return false;
+	}
+
+	@Override
+	public Object customCommand(GlideString[] args) throws InterruptedException, ExecutionException {
+		if (currentBatch != null) {
+			currentBatch.customCommand(args);
+			nextCommandRoute = null; // Clear route even in batch mode to prevent leaking
+										// to post-batch commands
+			return null;
+		}
+		try {
+			ClusterValue<?> clusterValue = nextCommandRoute == null ? glideClusterClient.customCommand(args).get()
+					: glideClusterClient.customCommand(args, nextCommandRoute).get();
+
+			// Case 1: Explicit multi-node route - return multiValue for aggregation
+			if (needToAggregateResult(nextCommandRoute)) {
+				return clusterValue.getMultiValue();
+			}
+
+			// Case 2: Default multi-node command (route is null but command routes to
+			// multiple nodes)
+			// These commands need special handling by the framework, so return multiValue
+			if (nextCommandRoute == null && isDefaultMultiNodeCommand(args)) {
+				// For default multi-node commands, check if we actually got multi-value
+				// data
+				if (clusterValue.hasMultiData()) {
+					return clusterValue.getMultiValue();
+				}
+				// If not, fall through to single-value handling
+			}
+
+			// Case 3: Single-node command, but ClusterValue.of() bug placed result in
+			// multiValue
+			// This happens for commands that return Map<GlideString, V> where V can be:
+			// - GlideString for HASH commands (HGETALL)
+			// - Double for Z commands with scores (ZRANGE WITHSCORES, ZDIFF WITHSCORES,
+			// etc.)
+			// ClusterValue.ofMultiValueBinary() converts GlideString keys to Strings:
+			// Original: Map<GlideString, V> { GlideString("field1"): value1, ... }
+			// Becomes: Map<String, V> { "field1": value1, ... }
+			// Use ReconstructedKeyMap to convert keys back while preserving value types
+			// https://github.com/valkey-io/valkey-glide/issues/4963
+			//
+			// EXCEPTION: Stream commands return nested Maps and should NOT go through
+			// ReconstructedKeyMap
+			if (clusterValue.hasMultiData() && !isDefaultMultiNodeCommand(args) && !isNestedMapCommand(args)) {
+				Map<String, ?> multiValue = clusterValue.getMultiValue();
+				// Return a zero-copy view that reconstructs GlideString keys while
+				// preserving value types
+				return new ReconstructedKeyMap<>(multiValue);
+			}
+
+			// Case 3b: Nested map commands (like streams) that have multiData but should
+			// return it as-is
+			if (clusterValue.hasMultiData() && isNestedMapCommand(args)) {
+				return clusterValue.getMultiValue();
+			}
+
+			// Case 4: Normal single-value result
+			Object singleValue = clusterValue.getSingleValue();
+			return singleValue;
+		}
+		finally {
+			nextCommandRoute = null; // ensure route is reset even on exception
+		}
+	}
+
+	@Override
+	public Object[] execBatch() throws InterruptedException, ExecutionException {
+		if (currentBatch == null) {
+			throw new IllegalStateException("No batch in progress");
+		}
+		return glideClusterClient.exec(currentBatch, false).get();
+	}
+
+	@Override
+	public Object getNativeClient() {
+		return glideClusterClient;
+	}
+
+	@Override
+	public void close() throws ExecutionException {
+		// The native client might be pooled - dont close
+	}
+
+	@Override
+	public BatchStatus getBatchStatus() {
+		return batchStatus;
+	}
+
+	@Override
+	public int getBatchCount() {
+		if (currentBatch == null) {
+			throw new IllegalStateException("No batch in progress");
+		}
+		return currentBatch.getProtobufBatch().getCommandsCount();
+	}
+
+	@Override
+	public void startNewBatch(boolean atomic) {
+		currentBatch = new ClusterBatch(atomic).withBinaryOutput();
+		batchStatus = atomic ? BatchStatus.Transaction : BatchStatus.Pipeline;
+	}
+
+	@Override
+	public void discardBatch() {
+		currentBatch = null;
+		batchStatus = BatchStatus.None;
+	}
+
+	@Override
+	public void reset() {
+		nextCommandRoute = null;
+		currentBatch = null;
+		batchStatus = BatchStatus.None;
+		if (getDelegatingListener() != null) {
+			getDelegatingListener().clearListener();
+		}
+	}
+
+	public void setOneShotRouteForNextCommand(Route glideRoute) {
+		nextCommandRoute = glideRoute;
+	}
+
+	/**
+	 * Consumes and returns the current one-shot route, clearing it. Used to capture the
+	 * route for long-lived operations like multi-page SCAN.
+	 */
+	@Nullable Route consumeOneShotRoute() {
+		Route route = nextCommandRoute;
+		nextCommandRoute = null;
+		return route;
+	}
+
+	boolean hasOneShotRouteForNextCommand() {
+		return nextCommandRoute != null;
+	}
+
+	Object[] scan(ClusterScanCursor cursor) throws InterruptedException, ExecutionException {
+		try {
+			return glideClusterClient.scanBinary(cursor).get();
+		}
+		finally {
+			nextCommandRoute = null;
+		}
+	}
+
+	Object[] scan(ClusterScanCursor cursor, ScanOptions options) throws InterruptedException, ExecutionException {
+		try {
+			return glideClusterClient.scanBinary(cursor, options).get();
+		}
+		finally {
+			nextCommandRoute = null;
+		}
+	}
+
+	public Object customCommand(GlideString[] args, ValkeyClusterNode node)
+			throws InterruptedException, ExecutionException {
+		return glideClusterClient.customCommand(args, new ByAddressRoute(node.getHost(), node.getPort()))
+			.get()
+			.getSingleValue();
+	}
+
+	/**
+	 * Maps the Spring Data Valkey {@link AwsServiceType} enum to the Glide-native
+	 * {@link ServiceType} enum.
+	 */
+	private static ServiceType mapServiceType(AwsServiceType serviceType) {
+		return switch (serviceType) {
+			case ELASTICACHE -> ServiceType.ELASTICACHE;
+			case MEMORYDB -> ServiceType.MEMORYDB;
+		};
+	}
+
 }

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/DefaultValkeyGlideClientConfiguration.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/DefaultValkeyGlideClientConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,104 +29,109 @@ import org.jspecify.annotations.Nullable;
  * @since 2.0
  */
 public class DefaultValkeyGlideClientConfiguration implements ValkeyGlideClientConfiguration {
-    private final @Nullable Duration commandTimeout;
-    private final boolean useSsl;
-    private final @Nullable Duration connectionTimeout;
-    private final @Nullable ReadFrom readFrom;
-    private final @Nullable Integer inflightRequestsLimit;
-    private final @Nullable String clientAZ;
-    private final @Nullable BackoffStrategy reconnectStrategy;
-    private final int maxPoolSize;
-    private final @Nullable OpenTelemetryForGlide openTelemetryForGlide;
-    private final @Nullable IamAuthenticationForGlide iamAuthentication;
 
-    DefaultValkeyGlideClientConfiguration() {
-        this(null, false, null, null, null, null, null, 8, null, null);
-    }
+	private final @Nullable Duration commandTimeout;
 
-    public DefaultValkeyGlideClientConfiguration(
-            @Nullable Duration commandTimeout,
-            boolean useSsl,
-            @Nullable Duration connectionTimeout,
-            @Nullable ReadFrom readFrom,
-            @Nullable Integer inflightRequestsLimit,
-            @Nullable String clientAZ,
-            @Nullable BackoffStrategy reconnectStrategy,
-            int maxPoolSize, 
-            @Nullable OpenTelemetryForGlide openTelemetryForGlide,
-            @Nullable IamAuthenticationForGlide iamAuthentication) {
-        this.commandTimeout = commandTimeout;
-        this.useSsl = useSsl;
-        this.connectionTimeout = connectionTimeout;
-        this.readFrom = readFrom;
-        this.inflightRequestsLimit = inflightRequestsLimit;
-        this.clientAZ = clientAZ;
-        this.reconnectStrategy = reconnectStrategy;
-        this.maxPoolSize = maxPoolSize;
-        this.openTelemetryForGlide = openTelemetryForGlide;
-        this.iamAuthentication = iamAuthentication;
-    }
+	private final boolean useSsl;
 
-    @Nullable
-    @Override
-    public Duration getCommandTimeout() {
-        return commandTimeout;
-    }
+	private final @Nullable Duration connectionTimeout;
 
-    @Override
-    public boolean isUseSsl() {
-        return useSsl;
-    }
+	private final @Nullable ReadFrom readFrom;
 
-    @Nullable
-    @Override
-    public Duration getConnectionTimeout() {
-        return connectionTimeout;
-    }
+	private final @Nullable Integer inflightRequestsLimit;
 
-    @Nullable
-    @Override
-    public ReadFrom getReadFrom() {
-        return readFrom;
-    }
+	private final @Nullable String clientAZ;
 
-    @Nullable
-    @Override
-    public Integer getInflightRequestsLimit() {
-        return inflightRequestsLimit;
-    }
+	private final @Nullable BackoffStrategy reconnectStrategy;
 
-    @Nullable
-    @Override
-    public String getClientAZ() {
-        return clientAZ;
-    }
+	private final int maxPoolSize;
 
-    @Nullable
-    @Override
-    public BackoffStrategy getReconnectStrategy() {
-        return reconnectStrategy;
-    }
+	private final @Nullable OpenTelemetryForGlide openTelemetryForGlide;
 
-    @Override
-    public int getMaxPoolSize() {
-        return maxPoolSize;
-    }
+	private final @Nullable IamAuthenticationForGlide iamAuthentication;
 
-    @Nullable
-    @Override
-    public OpenTelemetryForGlide getOpenTelemetryForGlide() {
-        return openTelemetryForGlide;
-    }
+	DefaultValkeyGlideClientConfiguration() {
+		this(null, false, null, null, null, null, null, 8, null, null);
+	}
 
-    @Nullable
-    @Override
-    public IamAuthenticationForGlide getIamAuthentication() {
-        return iamAuthentication;
-    }
+	public DefaultValkeyGlideClientConfiguration(@Nullable Duration commandTimeout, boolean useSsl,
+			@Nullable Duration connectionTimeout, @Nullable ReadFrom readFrom, @Nullable Integer inflightRequestsLimit,
+			@Nullable String clientAZ, @Nullable BackoffStrategy reconnectStrategy, int maxPoolSize,
+			@Nullable OpenTelemetryForGlide openTelemetryForGlide,
+			@Nullable IamAuthenticationForGlide iamAuthentication) {
+		this.commandTimeout = commandTimeout;
+		this.useSsl = useSsl;
+		this.connectionTimeout = connectionTimeout;
+		this.readFrom = readFrom;
+		this.inflightRequestsLimit = inflightRequestsLimit;
+		this.clientAZ = clientAZ;
+		this.reconnectStrategy = reconnectStrategy;
+		this.maxPoolSize = maxPoolSize;
+		this.openTelemetryForGlide = openTelemetryForGlide;
+		this.iamAuthentication = iamAuthentication;
+	}
 
-    @Override
-    public Optional<GlideClientOptions> getClientOptions() {
-        return Optional.empty();
-    }
+	@Nullable
+	@Override
+	public Duration getCommandTimeout() {
+		return commandTimeout;
+	}
+
+	@Override
+	public boolean isUseSsl() {
+		return useSsl;
+	}
+
+	@Nullable
+	@Override
+	public Duration getConnectionTimeout() {
+		return connectionTimeout;
+	}
+
+	@Nullable
+	@Override
+	public ReadFrom getReadFrom() {
+		return readFrom;
+	}
+
+	@Nullable
+	@Override
+	public Integer getInflightRequestsLimit() {
+		return inflightRequestsLimit;
+	}
+
+	@Nullable
+	@Override
+	public String getClientAZ() {
+		return clientAZ;
+	}
+
+	@Nullable
+	@Override
+	public BackoffStrategy getReconnectStrategy() {
+		return reconnectStrategy;
+	}
+
+	@Override
+	public int getMaxPoolSize() {
+		return maxPoolSize;
+	}
+
+	@Nullable
+	@Override
+	public OpenTelemetryForGlide getOpenTelemetryForGlide() {
+		return openTelemetryForGlide;
+	}
+
+	@Nullable
+	@Override
+	public IamAuthenticationForGlide getIamAuthentication() {
+		return iamAuthentication;
+	}
+
+	@Override
+	public Optional<GlideClientOptions> getClientOptions() {
+		return Optional.empty();
+	}
+
 }

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/StandaloneGlideClientAdapter.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/StandaloneGlideClientAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,224 +36,225 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.util.StringUtils;
 
 /**
- * 
  * @author Ilia Kolominsky
  * @since 2.0
  */
 class StandaloneGlideClientAdapter implements UnifiedGlideClient {
 
-    private final GlideClient glideClient;
-    private final @Nullable DelegatingPubSubListener listener;
-    private Batch currentBatch;
-    private BatchStatus batchStatus = BatchStatus.None;
+	private final GlideClient glideClient;
 
-    StandaloneGlideClientAdapter(ValkeyStandaloneConfiguration standaloneConfig, ValkeyGlideClientConfiguration valkeyGlideConfiguration) {
-        // Build GlideClientConfiguration using Glide's API
-        var configBuilder = GlideClientConfiguration.builder();
-        
-        // CONNECTION PROPERTIES from driver-agnostic configuration
-        configBuilder.address(NodeAddress.builder()
-            .host(standaloneConfig.getHostName())
-            .port(standaloneConfig.getPort())
-            .build());
-        
-        // Set credentials from driver-agnostic configuration
-        IamAuthenticationForGlide iamAuth = valkeyGlideConfiguration.getIamAuthentication();
-        ValkeyPassword password = standaloneConfig.getPassword();
+	private final @Nullable DelegatingPubSubListener listener;
 
-        if (iamAuth != null) {
-            // IAM authentication — mutually exclusive with password
-            String username = standaloneConfig.getUsername();
-            if (!StringUtils.hasText(username)) {
-                throw new IllegalArgumentException(
-                    "Username is required for IAM authentication. "
-                    + "Set spring.data.valkey.username or configure username in ValkeyStandaloneConfiguration.");
-            }
+	private Batch currentBatch;
 
-            IamAuthConfig.IamAuthConfigBuilder iamConfigBuilder = IamAuthConfig.builder()
-                .clusterName(iamAuth.clusterName())
-                .service(mapServiceType(iamAuth.serviceType()))
-                .region(iamAuth.region());
+	private BatchStatus batchStatus = BatchStatus.None;
 
-            if (iamAuth.refreshIntervalSeconds() != null) {
-                iamConfigBuilder.refreshIntervalSeconds(iamAuth.refreshIntervalSeconds());
-            }
+	StandaloneGlideClientAdapter(ValkeyStandaloneConfiguration standaloneConfig,
+			ValkeyGlideClientConfiguration valkeyGlideConfiguration) {
+		// Build GlideClientConfiguration using Glide's API
+		var configBuilder = GlideClientConfiguration.builder();
 
-            configBuilder.credentials(
-                glide.api.models.configuration.ServerCredentials.builder()
-                    .username(username)
-                    .iamConfig(iamConfigBuilder.build())
-                    .build());
-        } else if (!password.equals(ValkeyPassword.none())) {
-            String username = standaloneConfig.getUsername();
-            
-            if (StringUtils.hasText(username)) {
-                // Username + password authentication
-                configBuilder.credentials(
-                    glide.api.models.configuration.ServerCredentials.builder()
-                        .username(username)
-                        .password(String.valueOf(password.get()))
-                        .build());
-            } else {
-                // Password-only authentication
-                configBuilder.credentials(
-                    glide.api.models.configuration.ServerCredentials.builder()
-                        .password(String.valueOf(password.get()))
-                        .build());
-            }
-        }
-        
-        // Set database from driver-agnostic configuration
-        int database = standaloneConfig.getDatabase();
-        if (database != 0) {
-            configBuilder.databaseId(database);
-        }
-        
-        // DRIVER-SPECIFIC PROPERTIES from ValkeyGlideClientConfiguration
-        
-        // Request timeout
-        Duration commandTimeout = valkeyGlideConfiguration.getCommandTimeout();
-        if (commandTimeout != null) {
-            configBuilder.requestTimeout((int) commandTimeout.toMillis());
-        }
+		// CONNECTION PROPERTIES from driver-agnostic configuration
+		configBuilder.address(
+				NodeAddress.builder().host(standaloneConfig.getHostName()).port(standaloneConfig.getPort()).build());
 
-        // Connection timeout
-        Duration connectionTimeout = valkeyGlideConfiguration.getConnectionTimeout();
-        if (connectionTimeout != null) {
-            var advancedConfigBuilder = AdvancedGlideClientConfiguration.builder();
-            advancedConfigBuilder.connectionTimeout((int) connectionTimeout.toMillis());
-            configBuilder.advancedConfiguration(advancedConfigBuilder.build());
-        }
-        
-        // SSL/TLS
-        if (valkeyGlideConfiguration.isUseSsl()) {
-            configBuilder.useTLS(true);
-        }
-        
-        // Read from strategy
-        ReadFrom readFrom = valkeyGlideConfiguration.getReadFrom();
-        if (readFrom != null) {
-            configBuilder.readFrom(readFrom);
-        }
-        
-        // Inflight requests limit
-        Integer inflightRequestsLimit = valkeyGlideConfiguration.getInflightRequestsLimit();
-        if (inflightRequestsLimit != null) {
-            configBuilder.inflightRequestsLimit(inflightRequestsLimit);
-        }
-        
-        // Client AZ
-        String clientAZ = valkeyGlideConfiguration.getClientAZ();
-        if (clientAZ != null) {
-            configBuilder.clientAZ(clientAZ);
-        }
-        
-        // Reconnect strategy
-        BackoffStrategy reconnectStrategy = valkeyGlideConfiguration.getReconnectStrategy();
-        if (reconnectStrategy != null) {
-            configBuilder.reconnectStrategy(reconnectStrategy);
-        }
+		// Set credentials from driver-agnostic configuration
+		IamAuthenticationForGlide iamAuth = valkeyGlideConfiguration.getIamAuthentication();
+		ValkeyPassword password = standaloneConfig.getPassword();
 
-        // Pubsub listener 
-        this.listener = new DelegatingPubSubListener();
+		if (iamAuth != null) {
+			// IAM authentication — mutually exclusive with password
+			String username = standaloneConfig.getUsername();
+			if (!StringUtils.hasText(username)) {
+				throw new IllegalArgumentException("Username is required for IAM authentication. "
+						+ "Set spring.data.valkey.username or configure username in ValkeyStandaloneConfiguration.");
+			}
 
-        // Configure pub/sub with callback for event-driven message delivery
-        var subConfigBuilder = StandaloneSubscriptionConfiguration.builder();
-        
-        // Set callback that delegates to our listener holder
-        subConfigBuilder.callback((msg, context) -> this.listener.onMessage(msg, context));
-        configBuilder.subscriptionConfiguration(subConfigBuilder.build());
+			IamAuthConfig.IamAuthConfigBuilder iamConfigBuilder = IamAuthConfig.builder()
+				.clusterName(iamAuth.clusterName())
+				.service(mapServiceType(iamAuth.serviceType()))
+				.region(iamAuth.region());
 
-        // Set library name for server-side client identification
-        configBuilder.libName("GlideSpringDataValkey");
+			if (iamAuth.refreshIntervalSeconds() != null) {
+				iamConfigBuilder.refreshIntervalSeconds(iamAuth.refreshIntervalSeconds());
+			}
 
-        // Build and create client
-        GlideClientConfiguration config = configBuilder.build();
-        try {
-            this.glideClient = GlideClient.createClient(config).get();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new IllegalStateException("Interrupted creating GlideClient", e);
-        } catch (ExecutionException e) {
-            throw new IllegalStateException("Failed creating GlideClient", e);
-        }
-    }
+			configBuilder.credentials(glide.api.models.configuration.ServerCredentials.builder()
+				.username(username)
+				.iamConfig(iamConfigBuilder.build())
+				.build());
+		}
+		else if (!password.equals(ValkeyPassword.none())) {
+			String username = standaloneConfig.getUsername();
 
-    @Override
-    @Nullable
-    public DelegatingPubSubListener getDelegatingListener() {
-        return listener;
-    }
+			if (StringUtils.hasText(username)) {
+				// Username + password authentication
+				configBuilder.credentials(glide.api.models.configuration.ServerCredentials.builder()
+					.username(username)
+					.password(String.valueOf(password.get()))
+					.build());
+			}
+			else {
+				// Password-only authentication
+				configBuilder.credentials(glide.api.models.configuration.ServerCredentials.builder()
+					.password(String.valueOf(password.get()))
+					.build());
+			}
+		}
 
-    @Override
-    public Object customCommand(GlideString[] args) throws InterruptedException, ExecutionException {
-        if (currentBatch != null) {
-            currentBatch.customCommand(args);
-            return null;
-        }
-        return glideClient.customCommand(args).get();
-    }
+		// Set database from driver-agnostic configuration
+		int database = standaloneConfig.getDatabase();
+		if (database != 0) {
+			configBuilder.databaseId(database);
+		}
 
-    @Override
-    public Object[] execBatch() throws InterruptedException, ExecutionException {
-        if (currentBatch == null) {
-            throw new IllegalStateException("No batch in progress");
-        }
-        return glideClient.exec(currentBatch, false).get();
-    }
+		// DRIVER-SPECIFIC PROPERTIES from ValkeyGlideClientConfiguration
 
-    @Override
-    public Object getNativeClient() {
-        return glideClient;
-    }
+		// Request timeout
+		Duration commandTimeout = valkeyGlideConfiguration.getCommandTimeout();
+		if (commandTimeout != null) {
+			configBuilder.requestTimeout((int) commandTimeout.toMillis());
+		}
 
-    @Override
-    public void close() throws ExecutionException {
-        // The native client might be pooled - dont close
-    }
+		// Connection timeout
+		Duration connectionTimeout = valkeyGlideConfiguration.getConnectionTimeout();
+		if (connectionTimeout != null) {
+			var advancedConfigBuilder = AdvancedGlideClientConfiguration.builder();
+			advancedConfigBuilder.connectionTimeout((int) connectionTimeout.toMillis());
+			configBuilder.advancedConfiguration(advancedConfigBuilder.build());
+		}
 
-    @Override
-    public BatchStatus getBatchStatus() {
-        return batchStatus;
-    }
+		// SSL/TLS
+		if (valkeyGlideConfiguration.isUseSsl()) {
+			configBuilder.useTLS(true);
+		}
 
-    @Override
-    public int getBatchCount() {
-        if (currentBatch == null) {
-            throw new IllegalStateException("No batch in progress");
-        }
-        return currentBatch.getProtobufBatch().getCommandsCount();
-    }
+		// Read from strategy
+		ReadFrom readFrom = valkeyGlideConfiguration.getReadFrom();
+		if (readFrom != null) {
+			configBuilder.readFrom(readFrom);
+		}
 
-    @Override
-    public void startNewBatch(boolean atomic) {
-        currentBatch = new Batch(atomic).withBinaryOutput();
-        batchStatus = atomic ? BatchStatus.Transaction : BatchStatus.Pipeline;
-    }
+		// Inflight requests limit
+		Integer inflightRequestsLimit = valkeyGlideConfiguration.getInflightRequestsLimit();
+		if (inflightRequestsLimit != null) {
+			configBuilder.inflightRequestsLimit(inflightRequestsLimit);
+		}
 
-    @Override
-    public void discardBatch() {
-        currentBatch = null;
-        batchStatus = BatchStatus.None;
-    }
+		// Client AZ
+		String clientAZ = valkeyGlideConfiguration.getClientAZ();
+		if (clientAZ != null) {
+			configBuilder.clientAZ(clientAZ);
+		}
 
-    @Override
-    public void reset() {
-        currentBatch = null;
-        batchStatus = BatchStatus.None;
-        if (getDelegatingListener() != null) {
-            getDelegatingListener().clearListener();
-        }
-    }
+		// Reconnect strategy
+		BackoffStrategy reconnectStrategy = valkeyGlideConfiguration.getReconnectStrategy();
+		if (reconnectStrategy != null) {
+			configBuilder.reconnectStrategy(reconnectStrategy);
+		}
 
-    /**
-     * Maps the Spring Data Valkey {@link AwsServiceType} enum to the Glide-native {@link ServiceType} enum.
-     */
-    private static ServiceType mapServiceType(AwsServiceType serviceType) {
-        return switch (serviceType) {
-            case ELASTICACHE -> ServiceType.ELASTICACHE;
-            case MEMORYDB -> ServiceType.MEMORYDB;
-        };
-    }
+		// Pubsub listener
+		this.listener = new DelegatingPubSubListener();
+
+		// Configure pub/sub with callback for event-driven message delivery
+		var subConfigBuilder = StandaloneSubscriptionConfiguration.builder();
+
+		// Set callback that delegates to our listener holder
+		subConfigBuilder.callback((msg, context) -> this.listener.onMessage(msg, context));
+		configBuilder.subscriptionConfiguration(subConfigBuilder.build());
+
+		// Set library name for server-side client identification
+		configBuilder.libName("GlideSpringDataValkey");
+
+		// Build and create client
+		GlideClientConfiguration config = configBuilder.build();
+		try {
+			this.glideClient = GlideClient.createClient(config).get();
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new IllegalStateException("Interrupted creating GlideClient", e);
+		}
+		catch (ExecutionException e) {
+			throw new IllegalStateException("Failed creating GlideClient", e);
+		}
+	}
+
+	@Override
+	@Nullable public DelegatingPubSubListener getDelegatingListener() {
+		return listener;
+	}
+
+	@Override
+	public Object customCommand(GlideString[] args) throws InterruptedException, ExecutionException {
+		if (currentBatch != null) {
+			currentBatch.customCommand(args);
+			return null;
+		}
+		return glideClient.customCommand(args).get();
+	}
+
+	@Override
+	public Object[] execBatch() throws InterruptedException, ExecutionException {
+		if (currentBatch == null) {
+			throw new IllegalStateException("No batch in progress");
+		}
+		return glideClient.exec(currentBatch, false).get();
+	}
+
+	@Override
+	public Object getNativeClient() {
+		return glideClient;
+	}
+
+	@Override
+	public void close() throws ExecutionException {
+		// The native client might be pooled - dont close
+	}
+
+	@Override
+	public BatchStatus getBatchStatus() {
+		return batchStatus;
+	}
+
+	@Override
+	public int getBatchCount() {
+		if (currentBatch == null) {
+			throw new IllegalStateException("No batch in progress");
+		}
+		return currentBatch.getProtobufBatch().getCommandsCount();
+	}
+
+	@Override
+	public void startNewBatch(boolean atomic) {
+		currentBatch = new Batch(atomic).withBinaryOutput();
+		batchStatus = atomic ? BatchStatus.Transaction : BatchStatus.Pipeline;
+	}
+
+	@Override
+	public void discardBatch() {
+		currentBatch = null;
+		batchStatus = BatchStatus.None;
+	}
+
+	@Override
+	public void reset() {
+		currentBatch = null;
+		batchStatus = BatchStatus.None;
+		if (getDelegatingListener() != null) {
+			getDelegatingListener().clearListener();
+		}
+	}
+
+	/**
+	 * Maps the Spring Data Valkey {@link AwsServiceType} enum to the Glide-native
+	 * {@link ServiceType} enum.
+	 */
+	private static ServiceType mapServiceType(AwsServiceType serviceType) {
+		return switch (serviceType) {
+			case ELASTICACHE -> ServiceType.ELASTICACHE;
+			case MEMORYDB -> ServiceType.MEMORYDB;
+		};
+	}
 
 }

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/UnifiedGlideClient.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/UnifiedGlideClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,39 +21,46 @@ import glide.api.models.GlideString;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Unified interface that abstracts both GlideClient and GlideClusterClient
- * to enable code reuse between standalone and cluster modes.
- * 
+ * Unified interface that abstracts both GlideClient and GlideClusterClient to enable code
+ * reuse between standalone and cluster modes.
+ *
  * @author Ilia Kolominsky
  * @since 2.0
  */
 interface UnifiedGlideClient extends AutoCloseable {
-    public enum BatchStatus {
-        None,
-        Pipeline,
-        Transaction,
-    }
 
-    BatchStatus getBatchStatus();
-    int getBatchCount();
-    void startNewBatch(boolean atomic);
-    Object[] execBatch() throws InterruptedException, ExecutionException;
-    void discardBatch();
-    Object customCommand(GlideString[] args) throws InterruptedException, ExecutionException;
-    Object getNativeClient();
+	public enum BatchStatus {
 
-    /**
-     * Resets the adapter's mutable state so it can be safely reused from the pool.
-     * Must be called before returning the adapter to the pool.
-     */
-    void reset();
-    
-    /**
-     * Returns the {@link DelegatingPubSubListener} associated with this client.
-     * The listener is pre-associated at creation time to avoid per-command map lookups.
-     *
-     * @return the delegating pub/sub listener, or {@literal null} if pub/sub is not configured
-     */
-    @Nullable
-    DelegatingPubSubListener getDelegatingListener();
+		None, Pipeline, Transaction,
+
+	}
+
+	BatchStatus getBatchStatus();
+
+	int getBatchCount();
+
+	void startNewBatch(boolean atomic);
+
+	Object[] execBatch() throws InterruptedException, ExecutionException;
+
+	void discardBatch();
+
+	Object customCommand(GlideString[] args) throws InterruptedException, ExecutionException;
+
+	Object getNativeClient();
+
+	/**
+	 * Resets the adapter's mutable state so it can be safely reused from the pool. Must
+	 * be called before returning the adapter to the pool.
+	 */
+	void reset();
+
+	/**
+	 * Returns the {@link DelegatingPubSubListener} associated with this client. The
+	 * listener is pre-associated at creation time to avoid per-command map lookups.
+	 * @return the delegating pub/sub listener, or {@literal null} if pub/sub is not
+	 * configured
+	 */
+	@Nullable DelegatingPubSubListener getDelegatingListener();
+
 }

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideClientConfiguration.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideClientConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,335 +30,301 @@ import org.springframework.util.Assert;
  * @since 2.0
  */
 public interface ValkeyGlideClientConfiguration {
-    
-    /**
-     * Creates a new {@link ValkeyGlideClientConfigurationBuilder} to build {@link ValkeyGlideClientConfiguration}.
-     *
-     * @return a new {@link ValkeyGlideClientConfigurationBuilder}.
-     */
-    static ValkeyGlideClientConfigurationBuilder builder() {
-        return new ValkeyGlideClientConfigurationBuilder();
-    }
-    
-    /**
-     * Creates a default {@link ValkeyGlideClientConfiguration} with default settings.
-     *
-     * @return a {@link ValkeyGlideClientConfiguration} with defaults.
-     */
-    static ValkeyGlideClientConfiguration defaultConfiguration() {
-        return builder().build();
-    }
-    
-    /**
-     * Get the command timeout for Valkey-Glide client operations.
-     * 
-     * @return The command timeout duration. May be {@literal null} if not set.
-     */
-    @Nullable
-    Duration getCommandTimeout();
 
-    /**
-     * Get the connection timeout for Valkey-Glide client operations.
-     * 
-     * @return The connection timeout duration. May be {@literal null} if not set.
-     */
-    @Nullable
-    Duration getConnectionTimeout();
+	/**
+	 * Creates a new {@link ValkeyGlideClientConfigurationBuilder} to build
+	 * {@link ValkeyGlideClientConfiguration}.
+	 * @return a new {@link ValkeyGlideClientConfigurationBuilder}.
+	 */
+	static ValkeyGlideClientConfigurationBuilder builder() {
+		return new ValkeyGlideClientConfigurationBuilder();
+	}
 
-    /**
-     * Check if SSL is enabled.
-     * 
-     * @return {@literal true} if SSL is enabled.
-     */
-    boolean isUseSsl();
-    
-    /**
-     * Get the read from strategy for the client.
-     * 
-     * @return The {@link ReadFrom} strategy. May be {@literal null} if not set.
-     */
-    @Nullable
-    ReadFrom getReadFrom();
-    
-    /**
-     * Get the maximum number of concurrent in-flight requests.
-     * 
-     * @return The inflight requests limit. May be {@literal null} if not set.
-     */
-    @Nullable
-    Integer getInflightRequestsLimit();
-    
-    /**
-     * Get the client availability zone.
-     * 
-     * @return The client AZ. May be {@literal null} if not set.
-     */
-    @Nullable
-    String getClientAZ();
-    
-    /**
-     * Get the reconnection strategy.
-     * 
-     * @return The {@link BackoffStrategy}. May be {@literal null} if not set.
-     */
-    @Nullable
-    BackoffStrategy getReconnectStrategy();
+	/**
+	 * Creates a default {@link ValkeyGlideClientConfiguration} with default settings.
+	 * @return a {@link ValkeyGlideClientConfiguration} with defaults.
+	 */
+	static ValkeyGlideClientConfiguration defaultConfiguration() {
+		return builder().build();
+	}
 
-    /**
-     * Get the maximum pool size for client pooling.
-     * 
-     * @return The maximum pool size. Default is 8.
-     */
-    int getMaxPoolSize();
+	/**
+	 * Get the command timeout for Valkey-Glide client operations.
+	 * @return The command timeout duration. May be {@literal null} if not set.
+	 */
+	@Nullable Duration getCommandTimeout();
 
-    /**
-     * Get OpenTelemetry configuration for Valkey-Glide client.
-     * 
-     * @return The {@link OpenTelemetryForGlide} configuration. May be {@literal null} if not set.
-     */
-    @Nullable
-    OpenTelemetryForGlide getOpenTelemetryForGlide();
+	/**
+	 * Get the connection timeout for Valkey-Glide client operations.
+	 * @return The connection timeout duration. May be {@literal null} if not set.
+	 */
+	@Nullable Duration getConnectionTimeout();
 
-    /**
-     * Get IAM authentication configuration for Valkey-Glide client connecting to
-     * AWS ElastiCache or MemoryDB.
-     *
-     * @return The {@link IamAuthenticationForGlide} configuration. May be {@literal null} if not set.
-     */
-    @Nullable
-    IamAuthenticationForGlide getIamAuthentication();
+	/**
+	 * Check if SSL is enabled.
+	 * @return {@literal true} if SSL is enabled.
+	 */
+	boolean isUseSsl();
 
-    /**
-     * Get client options for mode-specific configurations.
-     * Placeholder for future mode-specific extensions.
-     * 
-     * @return Optional containing client options if configured.
-     */
-    Optional<GlideClientOptions> getClientOptions();
+	/**
+	 * Get the read from strategy for the client.
+	 * @return The {@link ReadFrom} strategy. May be {@literal null} if not set.
+	 */
+	@Nullable ReadFrom getReadFrom();
 
-    /**
-     * Supported AWS service types for IAM authentication with ElastiCache and MemoryDB.
-     */
-    enum AwsServiceType {
-        /** Amazon ElastiCache service. */
-        ELASTICACHE,
-        /** Amazon MemoryDB service. */
-        MEMORYDB
-    }
+	/**
+	 * Get the maximum number of concurrent in-flight requests.
+	 * @return The inflight requests limit. May be {@literal null} if not set.
+	 */
+	@Nullable Integer getInflightRequestsLimit();
 
-    /**
-     * IAM authentication configuration for GLIDE client connecting to AWS ElastiCache or MemoryDB.
-     *
-     * <p>When IAM authentication is configured, the GLIDE client will automatically generate and
-     * refresh IAM authentication tokens. This is mutually exclusive with password-based authentication.
-     *
-     * @param clusterName            the name of the ElastiCache/MemoryDB cluster (required)
-     * @param serviceType            the AWS service type — {@link AwsServiceType#ELASTICACHE} or
-     *                               {@link AwsServiceType#MEMORYDB} (required)
-     * @param region                 the AWS region where the cluster is located (required)
-     * @param refreshIntervalSeconds optional refresh interval in seconds for renewing IAM tokens;
-     *                               if {@code null}, defaults to 300 seconds (5 minutes)
-     */
-    record IamAuthenticationForGlide(
-            String clusterName,
-            AwsServiceType serviceType,
-            String region,
-            @Nullable Integer refreshIntervalSeconds
-    ) {
-        /**
-         * Creates a new IAM authentication configuration.
-         *
-         * @throws IllegalArgumentException if {@code clusterName}, {@code serviceType}, or
-         *                                  {@code region} is {@code null}
-         */
-        public IamAuthenticationForGlide {
-            Assert.notNull(clusterName, "clusterName must not be null");
-            Assert.notNull(serviceType, "serviceType must not be null");
-            Assert.notNull(region, "region must not be null");
-        }
-    }
+	/**
+	 * Get the client availability zone.
+	 * @return The client AZ. May be {@literal null} if not set.
+	 */
+	@Nullable String getClientAZ();
 
-    /**
-     * Record representing OpenTelemetry configuration for Valkey-Glide client.
-     *
-     * @param tracesEndpoint     the OTLP endpoint for traces, or {@code null} if not set.
-     * @param metricsEndpoint    the OTLP endpoint for metrics, or {@code null} if not set.
-     * @param samplePercentage   the sampling percentage for traces, or {@code null} if not set.
-     * @param flushIntervalMs    the flush interval in milliseconds, or {@code null} if not set.
-     */
-    public record OpenTelemetryForGlide(
-            @Nullable String tracesEndpoint,
-            @Nullable String metricsEndpoint,
-            @Nullable Integer samplePercentage,
-            @Nullable Long flushIntervalMs
-    ) {
+	/**
+	 * Get the reconnection strategy.
+	 * @return The {@link BackoffStrategy}. May be {@literal null} if not set.
+	 */
+	@Nullable BackoffStrategy getReconnectStrategy();
 
-        /**
-         * Default OpenTelemetry configuration for Valkey-Glide.
-         */
-        public static OpenTelemetryForGlide defaults() {
-            return new OpenTelemetryForGlide(
-                    "http://localhost:4318/v1/traces",
-                    "http://localhost:4318/v1/metrics",
-                    1,
-                    5000L
-            );
-        }
-    }
+	/**
+	 * Get the maximum pool size for client pooling.
+	 * @return The maximum pool size. Default is 8.
+	 */
+	int getMaxPoolSize();
 
-    /**
-     * Builder for {@link ValkeyGlideClientConfiguration}.
-     */
-    class ValkeyGlideClientConfigurationBuilder {
-        
-        private @Nullable Duration commandTimeout;
-        private @Nullable Duration connectionTimeout;
-        private boolean useSsl = false;
-        private @Nullable ReadFrom readFrom;
-        private @Nullable Integer inflightRequestsLimit;
-        private @Nullable String clientAZ;
-        private @Nullable BackoffStrategy reconnectStrategy;
-        private int maxPoolSize = 8; // Default pool size
-        private @Nullable OpenTelemetryForGlide openTelemetryForGlide;
-        private @Nullable IamAuthenticationForGlide iamAuthentication;
-        
-        
-        ValkeyGlideClientConfigurationBuilder() {}
-        
-        /**
-         * Set the command timeout.
-         * 
-         * @param commandTimeout the command timeout duration.
-         * @return {@literal this} builder.
-         */
-        public ValkeyGlideClientConfigurationBuilder commandTimeout(Duration commandTimeout) {
-            this.commandTimeout = commandTimeout;
-            return this;
-        }
-        
-        /**
-         * Set the connection timeout.
-         * 
-         * @param connectionTimeout the connection timeout duration.
-         * @return {@literal this} builder.
-         */
-        public ValkeyGlideClientConfigurationBuilder connectionTimeout(Duration connectionTimeout) {
-            this.connectionTimeout = connectionTimeout;
-            return this;
-        }
-        
-        /**
-         * Enable SSL for the connection.
-         * 
-         * @return {@literal this} builder.
-         */
-        public ValkeyGlideClientConfigurationBuilder useSsl() {
-            this.useSsl = true;
-            return this;
-        }
-        
-        /**
-         * Set the read from strategy.
-         * 
-         * @param readFrom the {@link ReadFrom} strategy.
-         * @return {@literal this} builder.
-         */
-        public ValkeyGlideClientConfigurationBuilder readFrom(ReadFrom readFrom) {
-            this.readFrom = readFrom;
-            return this;
-        }
-        
-        /**
-         * Set the maximum number of concurrent in-flight requests.
-         * 
-         * @param inflightRequestsLimit the inflight requests limit.
-         * @return {@literal this} builder.
-         */
-        public ValkeyGlideClientConfigurationBuilder inflightRequestsLimit(Integer inflightRequestsLimit) {
-            this.inflightRequestsLimit = inflightRequestsLimit;
-            return this;
-        }
-        
-        /**
-         * Set the client availability zone.
-         * 
-         * @param clientAZ the client AZ.
-         * @return {@literal this} builder.
-         */
-        public ValkeyGlideClientConfigurationBuilder clientAZ(String clientAZ) {
-            this.clientAZ = clientAZ;
-            return this;
-        }
-        
-        /**
-         * Set the reconnection strategy.
-         * 
-         * @param reconnectStrategy the {@link BackoffStrategy}.
-         * @return {@literal this} builder.
-         */
-        public ValkeyGlideClientConfigurationBuilder reconnectStrategy(BackoffStrategy reconnectStrategy) {
-            this.reconnectStrategy = reconnectStrategy;
-            return this;
-        }
+	/**
+	 * Get OpenTelemetry configuration for Valkey-Glide client.
+	 * @return The {@link OpenTelemetryForGlide} configuration. May be {@literal null} if
+	 * not set.
+	 */
+	@Nullable OpenTelemetryForGlide getOpenTelemetryForGlide();
 
-        /**
-         * Initialize GLIDE OpenTelemetry with OTLP endpoints.
-         *
-         * If at least one endpoint (traces or metrics) is provided, this will initialize
-         * OpenTelemetry once per JVM.
-         */
-        public ValkeyGlideClientConfigurationBuilder useOpenTelemetry(
-            OpenTelemetryForGlide openTelemetryForGlide
-        ) {
-            this.openTelemetryForGlide = openTelemetryForGlide;
-            return this;
-        }
+	/**
+	 * Get IAM authentication configuration for Valkey-Glide client connecting to AWS
+	 * ElastiCache or MemoryDB.
+	 * @return The {@link IamAuthenticationForGlide} configuration. May be {@literal null}
+	 * if not set.
+	 */
+	@Nullable IamAuthenticationForGlide getIamAuthentication();
 
-        /**
-         * Set the maximum pool size for client pooling.
-         * 
-         * @param maxPoolSize the maximum number of clients in the pool.
-         * @return {@literal this} builder.
-         */
-        public ValkeyGlideClientConfigurationBuilder maxPoolSize(int maxPoolSize) {
-            this.maxPoolSize = maxPoolSize;
-            return this;
-        }
+	/**
+	 * Get client options for mode-specific configurations. Placeholder for future
+	 * mode-specific extensions.
+	 * @return Optional containing client options if configured.
+	 */
+	Optional<GlideClientOptions> getClientOptions();
 
-        /**
-         * Configure IAM authentication for connecting to AWS ElastiCache or MemoryDB.
-         *
-         * <p>When IAM authentication is enabled, the GLIDE client will automatically generate and
-         * refresh IAM authentication tokens. This is mutually exclusive with password-based
-         * authentication.
-         *
-         * @param iamAuthentication the IAM authentication configuration.
-         * @return {@literal this} builder.
-         */
-        public ValkeyGlideClientConfigurationBuilder useIamAuthentication(
-                IamAuthenticationForGlide iamAuthentication) {
-            this.iamAuthentication = iamAuthentication;
-            return this;
-        }
-        
-        /**
-         * Build the {@link ValkeyGlideClientConfiguration}.
-         * 
-         * @return a new {@link ValkeyGlideClientConfiguration} instance.
-         */
-        public ValkeyGlideClientConfiguration build() {
-            return new DefaultValkeyGlideClientConfiguration(
-                commandTimeout, 
-                useSsl, 
-                connectionTimeout,
-                readFrom,
-                inflightRequestsLimit,
-                clientAZ,
-                reconnectStrategy,
-                maxPoolSize,
-                openTelemetryForGlide,
-                iamAuthentication
-            );
-        }
-    }
+	/**
+	 * Supported AWS service types for IAM authentication with ElastiCache and MemoryDB.
+	 */
+	enum AwsServiceType {
+
+		/** Amazon ElastiCache service. */
+		ELASTICACHE,
+		/** Amazon MemoryDB service. */
+		MEMORYDB
+
+	}
+
+	/**
+	 * IAM authentication configuration for GLIDE client connecting to AWS ElastiCache or
+	 * MemoryDB.
+	 *
+	 * <p>
+	 * When IAM authentication is configured, the GLIDE client will automatically generate
+	 * and refresh IAM authentication tokens. This is mutually exclusive with
+	 * password-based authentication.
+	 *
+	 * @param clusterName the name of the ElastiCache/MemoryDB cluster (required)
+	 * @param serviceType the AWS service type — {@link AwsServiceType#ELASTICACHE} or
+	 * {@link AwsServiceType#MEMORYDB} (required)
+	 * @param region the AWS region where the cluster is located (required)
+	 * @param refreshIntervalSeconds optional refresh interval in seconds for renewing IAM
+	 * tokens; if {@code null}, defaults to 300 seconds (5 minutes)
+	 */
+	record IamAuthenticationForGlide(String clusterName, AwsServiceType serviceType, String region,
+			@Nullable Integer refreshIntervalSeconds) {
+		/**
+		 * Creates a new IAM authentication configuration.
+		 * @throws IllegalArgumentException if {@code clusterName}, {@code serviceType},
+		 * or {@code region} is {@code null}
+		 */
+		public IamAuthenticationForGlide {
+			Assert.notNull(clusterName, "clusterName must not be null");
+			Assert.notNull(serviceType, "serviceType must not be null");
+			Assert.notNull(region, "region must not be null");
+		}
+	}
+
+	/**
+	 * Record representing OpenTelemetry configuration for Valkey-Glide client.
+	 *
+	 * @param tracesEndpoint the OTLP endpoint for traces, or {@code null} if not set.
+	 * @param metricsEndpoint the OTLP endpoint for metrics, or {@code null} if not set.
+	 * @param samplePercentage the sampling percentage for traces, or {@code null} if not
+	 * set.
+	 * @param flushIntervalMs the flush interval in milliseconds, or {@code null} if not
+	 * set.
+	 */
+	public record OpenTelemetryForGlide(@Nullable String tracesEndpoint, @Nullable String metricsEndpoint,
+			@Nullable Integer samplePercentage, @Nullable Long flushIntervalMs) {
+
+		/**
+		 * Default OpenTelemetry configuration for Valkey-Glide.
+		 */
+		public static OpenTelemetryForGlide defaults() {
+			return new OpenTelemetryForGlide("http://localhost:4318/v1/traces", "http://localhost:4318/v1/metrics", 1,
+					5000L);
+		}
+	}
+
+	/**
+	 * Builder for {@link ValkeyGlideClientConfiguration}.
+	 */
+	class ValkeyGlideClientConfigurationBuilder {
+
+		private @Nullable Duration commandTimeout;
+
+		private @Nullable Duration connectionTimeout;
+
+		private boolean useSsl = false;
+
+		private @Nullable ReadFrom readFrom;
+
+		private @Nullable Integer inflightRequestsLimit;
+
+		private @Nullable String clientAZ;
+
+		private @Nullable BackoffStrategy reconnectStrategy;
+
+		private int maxPoolSize = 8; // Default pool size
+
+		private @Nullable OpenTelemetryForGlide openTelemetryForGlide;
+
+		private @Nullable IamAuthenticationForGlide iamAuthentication;
+
+		ValkeyGlideClientConfigurationBuilder() {
+		}
+
+		/**
+		 * Set the command timeout.
+		 * @param commandTimeout the command timeout duration.
+		 * @return {@literal this} builder.
+		 */
+		public ValkeyGlideClientConfigurationBuilder commandTimeout(Duration commandTimeout) {
+			this.commandTimeout = commandTimeout;
+			return this;
+		}
+
+		/**
+		 * Set the connection timeout.
+		 * @param connectionTimeout the connection timeout duration.
+		 * @return {@literal this} builder.
+		 */
+		public ValkeyGlideClientConfigurationBuilder connectionTimeout(Duration connectionTimeout) {
+			this.connectionTimeout = connectionTimeout;
+			return this;
+		}
+
+		/**
+		 * Enable SSL for the connection.
+		 * @return {@literal this} builder.
+		 */
+		public ValkeyGlideClientConfigurationBuilder useSsl() {
+			this.useSsl = true;
+			return this;
+		}
+
+		/**
+		 * Set the read from strategy.
+		 * @param readFrom the {@link ReadFrom} strategy.
+		 * @return {@literal this} builder.
+		 */
+		public ValkeyGlideClientConfigurationBuilder readFrom(ReadFrom readFrom) {
+			this.readFrom = readFrom;
+			return this;
+		}
+
+		/**
+		 * Set the maximum number of concurrent in-flight requests.
+		 * @param inflightRequestsLimit the inflight requests limit.
+		 * @return {@literal this} builder.
+		 */
+		public ValkeyGlideClientConfigurationBuilder inflightRequestsLimit(Integer inflightRequestsLimit) {
+			this.inflightRequestsLimit = inflightRequestsLimit;
+			return this;
+		}
+
+		/**
+		 * Set the client availability zone.
+		 * @param clientAZ the client AZ.
+		 * @return {@literal this} builder.
+		 */
+		public ValkeyGlideClientConfigurationBuilder clientAZ(String clientAZ) {
+			this.clientAZ = clientAZ;
+			return this;
+		}
+
+		/**
+		 * Set the reconnection strategy.
+		 * @param reconnectStrategy the {@link BackoffStrategy}.
+		 * @return {@literal this} builder.
+		 */
+		public ValkeyGlideClientConfigurationBuilder reconnectStrategy(BackoffStrategy reconnectStrategy) {
+			this.reconnectStrategy = reconnectStrategy;
+			return this;
+		}
+
+		/**
+		 * Initialize GLIDE OpenTelemetry with OTLP endpoints.
+		 *
+		 * If at least one endpoint (traces or metrics) is provided, this will initialize
+		 * OpenTelemetry once per JVM.
+		 */
+		public ValkeyGlideClientConfigurationBuilder useOpenTelemetry(OpenTelemetryForGlide openTelemetryForGlide) {
+			this.openTelemetryForGlide = openTelemetryForGlide;
+			return this;
+		}
+
+		/**
+		 * Set the maximum pool size for client pooling.
+		 * @param maxPoolSize the maximum number of clients in the pool.
+		 * @return {@literal this} builder.
+		 */
+		public ValkeyGlideClientConfigurationBuilder maxPoolSize(int maxPoolSize) {
+			this.maxPoolSize = maxPoolSize;
+			return this;
+		}
+
+		/**
+		 * Configure IAM authentication for connecting to AWS ElastiCache or MemoryDB.
+		 *
+		 * <p>
+		 * When IAM authentication is enabled, the GLIDE client will automatically
+		 * generate and refresh IAM authentication tokens. This is mutually exclusive with
+		 * password-based authentication.
+		 * @param iamAuthentication the IAM authentication configuration.
+		 * @return {@literal this} builder.
+		 */
+		public ValkeyGlideClientConfigurationBuilder useIamAuthentication(IamAuthenticationForGlide iamAuthentication) {
+			this.iamAuthentication = iamAuthentication;
+			return this;
+		}
+
+		/**
+		 * Build the {@link ValkeyGlideClientConfiguration}.
+		 * @return a new {@link ValkeyGlideClientConfiguration} instance.
+		 */
+		public ValkeyGlideClientConfiguration build() {
+			return new DefaultValkeyGlideClientConfiguration(commandTimeout, useSsl, connectionTimeout, readFrom,
+					inflightRequestsLimit, clientAZ, reconnectStrategy, maxPoolSize, openTelemetryForGlide,
+					iamAuthentication);
+		}
+
+	}
+
 }

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideClusterConnection.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideClusterConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,125 +56,134 @@ import io.valkey.springframework.data.valkey.core.ScanOptions;
 
 /**
  * {@link ValkeyClusterConnection} implementation on top of {@link GlideClusterClient}.
- * Uses the unified client adapter to reuse existing command implementations while
- * adding cluster-specific functionality. Also implements {@link ClusterTopologyProvider}
- * to provide cluster topology information.
- * 
+ * Uses the unified client adapter to reuse existing command implementations while adding
+ * cluster-specific functionality. Also implements {@link ClusterTopologyProvider} to
+ * provide cluster topology information.
+ *
  * @author Ilia Kolominsky
  * @since 2.0
  */
-public class ValkeyGlideClusterConnection extends ValkeyGlideConnection implements ValkeyClusterConnection, ClusterTopologyProvider {
+public class ValkeyGlideClusterConnection extends ValkeyGlideConnection
+		implements ValkeyClusterConnection, ClusterTopologyProvider {
 
-    private final ClusterGlideClientAdapter clusterAdapter;
-    private final long cacheTimeoutMs;
-    
-    // Cached cluster topology with timestamp
-    private volatile ClusterTopology cachedTopology;
-    private volatile long lastCacheTime;
-    
-    // Cache of cluster nodes for backward compatibility
-    private final Map<String, ValkeyClusterNode> knownNodes = new ConcurrentHashMap<>();
-    private ValkeyGlideClusterServerCommands clusterServerCommands = null;
-    private ValkeyGlideClusterListCommands clusterListCommands = null;
-    private ValkeyGlideClusterKeyCommands clusterKeyCommands = null;
-    private ValkeyGlideClusterStringCommands clusterStringCommands = null;
-    private ValkeyGlideClusterSetCommands clusterSetCommands = null;
+	private final ClusterGlideClientAdapter clusterAdapter;
 
-    public ValkeyGlideClusterConnection(ClusterGlideClientAdapter clusterAdapter) {
-        this(clusterAdapter, null, Duration.ofMillis(100));
-    }
+	private final long cacheTimeoutMs;
 
-    public ValkeyGlideClusterConnection(ClusterGlideClientAdapter clusterAdapter, 
-            @Nullable ValkeyGlideConnectionFactory factory) {
-        this(clusterAdapter, factory, Duration.ofMillis(100));
-    }
+	// Cached cluster topology with timestamp
+	private volatile ClusterTopology cachedTopology;
 
-    public ValkeyGlideClusterConnection(ClusterGlideClientAdapter clusterAdapter, 
-            @Nullable ValkeyGlideConnectionFactory factory,
-            Duration cacheTimeout) {
-        super(clusterAdapter, factory);
-        Assert.notNull(cacheTimeout, "CacheTimeout must not be null!");
-        
-        this.clusterAdapter = clusterAdapter;
-        this.cacheTimeoutMs = cacheTimeout.toMillis();
-    }
+	private volatile long lastCacheTime;
 
-    public ClusterGlideClientAdapter getClusterAdapter() {
-        return clusterAdapter;
-    }
+	// Cache of cluster nodes for backward compatibility
+	private final Map<String, ValkeyClusterNode> knownNodes = new ConcurrentHashMap<>();
 
-    /**
-     * Sends an UNWATCH command to ALL_NODES in cluster mode.
-     * Overrides the standalone implementation which sends to a single node.
-     */
-    @Override
-    protected void sendUnwatch() {
-        GlideClusterClient nativeClient = (GlideClusterClient) unifiedClient.getNativeClient();
+	private ValkeyGlideClusterServerCommands clusterServerCommands = null;
 
-        try {
-            nativeClient.customCommand(new String[]{"UNWATCH"}, SimpleMultiNodeRoute.ALL_NODES).get();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new IllegalStateException("Interrupted UNWATCH command during connection cleanup", e);
-        } catch (ExecutionException e) {
-            throw new IllegalStateException("Failed to send UNWATCH command during connection cleanup", e);
-        }
-    }
+	private ValkeyGlideClusterListCommands clusterListCommands = null;
 
-    @Override
-    public ValkeyClusterServerCommands serverCommands() {
-        ValkeyGlideClusterServerCommands cmds = this.clusterServerCommands;
-        if (cmds == null) {
-            cmds = new ValkeyGlideClusterServerCommands(this);
-            this.clusterServerCommands = cmds;
-        }
-        return cmds;
-    }
+	private ValkeyGlideClusterKeyCommands clusterKeyCommands = null;
 
-    @Override
-    public ValkeyClusterCommands clusterCommands() {
-        return this;
-    }
+	private ValkeyGlideClusterStringCommands clusterStringCommands = null;
 
-    @Override
-    public ValkeyGlideClusterListCommands listCommands() {
-        ValkeyGlideClusterListCommands cmds = this.clusterListCommands;
-        if (cmds == null) {
-            cmds = new ValkeyGlideClusterListCommands(this);
-            this.clusterListCommands = cmds;
-        }
-        return cmds;
-    }
+	private ValkeyGlideClusterSetCommands clusterSetCommands = null;
 
-    @Override
-    public ValkeyGlideClusterKeyCommands keyCommands() {
-        ValkeyGlideClusterKeyCommands cmds = this.clusterKeyCommands;
-        if (cmds == null) {
-            cmds = new ValkeyGlideClusterKeyCommands(this);
-            this.clusterKeyCommands = cmds;
-        }
-        return cmds;
-    }
+	public ValkeyGlideClusterConnection(ClusterGlideClientAdapter clusterAdapter) {
+		this(clusterAdapter, null, Duration.ofMillis(100));
+	}
 
-    @Override
-    public ValkeyGlideClusterStringCommands stringCommands() {
-        ValkeyGlideClusterStringCommands cmds = this.clusterStringCommands;
-        if (cmds == null) {
-            cmds = new ValkeyGlideClusterStringCommands(this);
-            this.clusterStringCommands = cmds;
-        }
-        return cmds;
-    }
+	public ValkeyGlideClusterConnection(ClusterGlideClientAdapter clusterAdapter,
+			@Nullable ValkeyGlideConnectionFactory factory) {
+		this(clusterAdapter, factory, Duration.ofMillis(100));
+	}
 
-    @Override
-    public ValkeyGlideClusterSetCommands setCommands() {
-        ValkeyGlideClusterSetCommands cmds = this.clusterSetCommands;
-        if (cmds == null) {
-            cmds = new ValkeyGlideClusterSetCommands(this);
-            this.clusterSetCommands = cmds;
-        }
-        return cmds;
-    }
+	public ValkeyGlideClusterConnection(ClusterGlideClientAdapter clusterAdapter,
+			@Nullable ValkeyGlideConnectionFactory factory, Duration cacheTimeout) {
+		super(clusterAdapter, factory);
+		Assert.notNull(cacheTimeout, "CacheTimeout must not be null!");
+
+		this.clusterAdapter = clusterAdapter;
+		this.cacheTimeoutMs = cacheTimeout.toMillis();
+	}
+
+	public ClusterGlideClientAdapter getClusterAdapter() {
+		return clusterAdapter;
+	}
+
+	/**
+	 * Sends an UNWATCH command to ALL_NODES in cluster mode. Overrides the standalone
+	 * implementation which sends to a single node.
+	 */
+	@Override
+	protected void sendUnwatch() {
+		GlideClusterClient nativeClient = (GlideClusterClient) unifiedClient.getNativeClient();
+
+		try {
+			nativeClient.customCommand(new String[] { "UNWATCH" }, SimpleMultiNodeRoute.ALL_NODES).get();
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new IllegalStateException("Interrupted UNWATCH command during connection cleanup", e);
+		}
+		catch (ExecutionException e) {
+			throw new IllegalStateException("Failed to send UNWATCH command during connection cleanup", e);
+		}
+	}
+
+	@Override
+	public ValkeyClusterServerCommands serverCommands() {
+		ValkeyGlideClusterServerCommands cmds = this.clusterServerCommands;
+		if (cmds == null) {
+			cmds = new ValkeyGlideClusterServerCommands(this);
+			this.clusterServerCommands = cmds;
+		}
+		return cmds;
+	}
+
+	@Override
+	public ValkeyClusterCommands clusterCommands() {
+		return this;
+	}
+
+	@Override
+	public ValkeyGlideClusterListCommands listCommands() {
+		ValkeyGlideClusterListCommands cmds = this.clusterListCommands;
+		if (cmds == null) {
+			cmds = new ValkeyGlideClusterListCommands(this);
+			this.clusterListCommands = cmds;
+		}
+		return cmds;
+	}
+
+	@Override
+	public ValkeyGlideClusterKeyCommands keyCommands() {
+		ValkeyGlideClusterKeyCommands cmds = this.clusterKeyCommands;
+		if (cmds == null) {
+			cmds = new ValkeyGlideClusterKeyCommands(this);
+			this.clusterKeyCommands = cmds;
+		}
+		return cmds;
+	}
+
+	@Override
+	public ValkeyGlideClusterStringCommands stringCommands() {
+		ValkeyGlideClusterStringCommands cmds = this.clusterStringCommands;
+		if (cmds == null) {
+			cmds = new ValkeyGlideClusterStringCommands(this);
+			this.clusterStringCommands = cmds;
+		}
+		return cmds;
+	}
+
+	@Override
+	public ValkeyGlideClusterSetCommands setCommands() {
+		ValkeyGlideClusterSetCommands cmds = this.clusterSetCommands;
+		if (cmds == null) {
+			cmds = new ValkeyGlideClusterSetCommands(this);
+			this.clusterSetCommands = cmds;
+		}
+		return cmds;
+	}
 
 	@Override
 	public void multi() {
@@ -201,13 +210,12 @@ public class ValkeyGlideClusterConnection extends ValkeyGlideConnection implemen
 		throw new InvalidDataAccessApiUsageException("UNWATCH is currently not supported in cluster mode");
 	}
 
-
 	@Override
 	public ValkeySentinelConnection getSentinelConnection() {
 		throw new InvalidDataAccessApiUsageException("Sentinel is not supported in cluster mode");
 	}
 
-    @Override
+	@Override
 	public void select(int dbIndex) {
 
 		if (dbIndex != 0) {
@@ -220,445 +228,429 @@ public class ValkeyGlideClusterConnection extends ValkeyGlideConnection implemen
 		throw new InvalidDataAccessApiUsageException("Echo not supported in cluster mode");
 	}
 
-    @Override
-    public String ping(ValkeyClusterNode node) {
-        Assert.notNull(node, "node must not be null");
-        clusterAdapter.setOneShotRouteForNextCommand(new ByAddressRoute(node.getHost(), node.getPort()));
-        return ping();
-    }
+	@Override
+	public String ping(ValkeyClusterNode node) {
+		Assert.notNull(node, "node must not be null");
+		clusterAdapter.setOneShotRouteForNextCommand(new ByAddressRoute(node.getHost(), node.getPort()));
+		return ping();
+	}
 
-    @Override
-    public Set<byte[]> keys(ValkeyClusterNode node, byte[] pattern) {
-        Assert.notNull(node, "node must not be null");
-        clusterAdapter.setOneShotRouteForNextCommand(new ByAddressRoute(node.getHost(), node.getPort()));
-        return keys(pattern);
-    }
+	@Override
+	public Set<byte[]> keys(ValkeyClusterNode node, byte[] pattern) {
+		Assert.notNull(node, "node must not be null");
+		clusterAdapter.setOneShotRouteForNextCommand(new ByAddressRoute(node.getHost(), node.getPort()));
+		return keys(pattern);
+	}
 
-    @Override
-    public Cursor<byte[]> scan(ValkeyClusterNode node, ScanOptions options) {
-        Assert.notNull(node, "node must not be null");
-        clusterAdapter.setOneShotRouteForNextCommand(new ByAddressRoute(node.getHost(), node.getPort()));
-        return scan(options);
-    }
+	@Override
+	public Cursor<byte[]> scan(ValkeyClusterNode node, ScanOptions options) {
+		Assert.notNull(node, "node must not be null");
+		clusterAdapter.setOneShotRouteForNextCommand(new ByAddressRoute(node.getHost(), node.getPort()));
+		return scan(options);
+	}
 
-    @Override
-    public byte[] randomKey(ValkeyClusterNode node) {
-        Assert.notNull(node, "node must not be null");
-        clusterAdapter.setOneShotRouteForNextCommand(new ByAddressRoute(node.getHost(), node.getPort()));
-        return randomKey();
-    }
+	@Override
+	public byte[] randomKey(ValkeyClusterNode node) {
+		Assert.notNull(node, "node must not be null");
+		clusterAdapter.setOneShotRouteForNextCommand(new ByAddressRoute(node.getHost(), node.getPort()));
+		return randomKey();
+	}
 
-    // It seems that the interface is inadequate here - it does not allow to specify the node ID.
-    // Referencing Jedis implementation, the node id is taken from the node parameter, which is the destination node.
-    @Override
-    public void clusterSetSlot(ValkeyClusterNode node, int slot, AddSlots mode) {
-        Assert.notNull(node, "node must not be null");
-        Assert.notNull(mode, "mode must not be null");
+	// It seems that the interface is inadequate here - it does not allow to specify the
+	// node ID.
+	// Referencing Jedis implementation, the node id is taken from the node parameter,
+	// which is the destination node.
+	@Override
+	public void clusterSetSlot(ValkeyClusterNode node, int slot, AddSlots mode) {
+		Assert.notNull(node, "node must not be null");
+		Assert.notNull(mode, "mode must not be null");
 
-        // Lookup node from topology to get the node with ID
-        ValkeyClusterNode nodeToUse = getTopology().lookup(node);
-        String nodeId = nodeToUse.getId();
+		// Lookup node from topology to get the node with ID
+		ValkeyClusterNode nodeToUse = getTopology().lookup(node);
+		String nodeId = nodeToUse.getId();
 
-        clusterAdapter.setOneShotRouteForNextCommand(new ByAddressRoute(node.getHost(), node.getPort()));
+		clusterAdapter.setOneShotRouteForNextCommand(new ByAddressRoute(node.getHost(), node.getPort()));
 
-        // Build command based on mode
-        switch (mode) {
-        case IMPORTING, MIGRATING, NODE -> 
-            execute("CLUSTER", (String glideResult) -> glideResult,
-                "SETSLOT", String.valueOf(slot), mode.name(), nodeId);
-        case STABLE -> 
-            execute("CLUSTER", (String glideResult) -> glideResult,
-                "SETSLOT", String.valueOf(slot), "STABLE");
-        }
-        
-        // Invalidate topology cache after slot assignment changes
-        invalidateTopologyCache();
-    }
+		// Build command based on mode
+		switch (mode) {
+			case IMPORTING, MIGRATING, NODE -> execute("CLUSTER", (String glideResult) -> glideResult, "SETSLOT",
+					String.valueOf(slot), mode.name(), nodeId);
+			case STABLE ->
+				execute("CLUSTER", (String glideResult) -> glideResult, "SETSLOT", String.valueOf(slot), "STABLE");
+		}
 
-    private int nullSafeIntValue(@Nullable Integer value) {
-        return value != null ? value : Integer.MAX_VALUE;
-    }
+		// Invalidate topology cache after slot assignment changes
+		invalidateTopologyCache();
+	}
 
-    @Override
-    public List<byte[]> clusterGetKeysInSlot(int slot, Integer count) {
-        ValkeyClusterNode node = clusterGetNodeForSlot(slot);
-        clusterAdapter.setOneShotRouteForNextCommand(new ByAddressRoute(node.getHost(), node.getPort()));
-        return execute("CLUSTER", 
-            rawResult -> ValkeyGlideConverters.toBytesList(rawResult), 
-            "GETKEYSINSLOT", String.valueOf(slot), String.valueOf(nullSafeIntValue(count)));
-    }
+	private int nullSafeIntValue(@Nullable Integer value) {
+		return value != null ? value : Integer.MAX_VALUE;
+	}
 
-    @Override
-    public Long clusterCountKeysInSlot(int slot) {
-        ValkeyClusterNode node = clusterGetNodeForSlot(slot);
-        clusterAdapter.setOneShotRouteForNextCommand(new ByAddressRoute(node.getHost(), node.getPort()));
-        return execute("CLUSTER", 
-            (Long rawResult) -> rawResult, 
-            "COUNTKEYSINSLOT", String.valueOf(slot));
-    }
+	@Override
+	public List<byte[]> clusterGetKeysInSlot(int slot, Integer count) {
+		ValkeyClusterNode node = clusterGetNodeForSlot(slot);
+		clusterAdapter.setOneShotRouteForNextCommand(new ByAddressRoute(node.getHost(), node.getPort()));
+		return execute("CLUSTER", rawResult -> ValkeyGlideConverters.toBytesList(rawResult), "GETKEYSINSLOT",
+				String.valueOf(slot), String.valueOf(nullSafeIntValue(count)));
+	}
 
-    @Override
-    public void clusterAddSlots(ValkeyClusterNode node, int... slots) {
-        Assert.notNull(node, "node must not be null");
-        Assert.notNull(slots, "slots must not be null");
+	@Override
+	public Long clusterCountKeysInSlot(int slot) {
+		ValkeyClusterNode node = clusterGetNodeForSlot(slot);
+		clusterAdapter.setOneShotRouteForNextCommand(new ByAddressRoute(node.getHost(), node.getPort()));
+		return execute("CLUSTER", (Long rawResult) -> rawResult, "COUNTKEYSINSLOT", String.valueOf(slot));
+	}
 
-        Object[] args = new Object[slots.length + 1];
-        args[0] = "ADDSLOTS";
-        for (int i = 0; i < slots.length; i++) {
-            args[i + 1] = String.valueOf(slots[i]);
-        }
+	@Override
+	public void clusterAddSlots(ValkeyClusterNode node, int... slots) {
+		Assert.notNull(node, "node must not be null");
+		Assert.notNull(slots, "slots must not be null");
 
-        clusterAdapter.setOneShotRouteForNextCommand(new ByAddressRoute(node.getHost(), node.getPort()));
-        execute("CLUSTER",
-            rawResult -> null, args);
-        
-        // Invalidate topology cache after slot addition
-        invalidateTopologyCache();
-    }
+		Object[] args = new Object[slots.length + 1];
+		args[0] = "ADDSLOTS";
+		for (int i = 0; i < slots.length; i++) {
+			args[i + 1] = String.valueOf(slots[i]);
+		}
 
-    @Override
-    public void clusterAddSlots(ValkeyClusterNode node, ValkeyClusterNode.SlotRange range) {
-        Assert.notNull(range, "range must not be null");
-        clusterAddSlots(node, range.getSlotsArray());
-    }
+		clusterAdapter.setOneShotRouteForNextCommand(new ByAddressRoute(node.getHost(), node.getPort()));
+		execute("CLUSTER", rawResult -> null, args);
 
-    @Override
-    public void clusterDeleteSlots(ValkeyClusterNode node, int... slots) {
-        Assert.notNull(node, "node must not be null");
-        Assert.notNull(slots, "slots must not be null");
+		// Invalidate topology cache after slot addition
+		invalidateTopologyCache();
+	}
 
-        Object[] args = new Object[slots.length + 1];
-        args[0] = "DELSLOTS";
-        for (int i = 0; i < slots.length; i++) {
-            args[i + 1] = String.valueOf(slots[i]);
-        }
-        clusterAdapter.setOneShotRouteForNextCommand(new ByAddressRoute(node.getHost(), node.getPort()));
-        execute("CLUSTER",
-            rawResult -> null, args);
-        
-        // Invalidate topology cache after slot deletion
-        invalidateTopologyCache();
-    }
+	@Override
+	public void clusterAddSlots(ValkeyClusterNode node, ValkeyClusterNode.SlotRange range) {
+		Assert.notNull(range, "range must not be null");
+		clusterAddSlots(node, range.getSlotsArray());
+	}
 
-    @Override
-    public void clusterDeleteSlotsInRange(ValkeyClusterNode node, ValkeyClusterNode.SlotRange range) {
-        Assert.notNull(range, "range must not be null");
-        clusterDeleteSlots(node, range.getSlotsArray());
-    }
+	@Override
+	public void clusterDeleteSlots(ValkeyClusterNode node, int... slots) {
+		Assert.notNull(node, "node must not be null");
+		Assert.notNull(slots, "slots must not be null");
 
-    @Override
-    public void clusterForget(ValkeyClusterNode node) {
-        Assert.notNull(node, "node must not be null");
-    
-        // Lookup the actual node from topology to get its ID
-        ValkeyClusterNode nodeToRemove = getTopology().lookup(node);
-        
-        // Get all active master nodes EXCEPT the node being forgotten
-        Collection<ValkeyClusterNode> activeMasters = 
-            getTopology().getActiveMasterNodes();
-        
-        // Execute CLUSTER FORGET on each master node (except the one being removed)
-        for (ValkeyClusterNode masterNode : activeMasters) {
-            if (!masterNode.equals(nodeToRemove)) {
-                clusterAdapter.setOneShotRouteForNextCommand(
-                    new ByAddressRoute(masterNode.getHost(), masterNode.getPort()));
-                execute("CLUSTER", rawResult -> null, "FORGET", nodeToRemove.getId());
-            }
-        }
-        
-        // Invalidate topology cache after node removal
-        invalidateTopologyCache();
-    }
+		Object[] args = new Object[slots.length + 1];
+		args[0] = "DELSLOTS";
+		for (int i = 0; i < slots.length; i++) {
+			args[i + 1] = String.valueOf(slots[i]);
+		}
+		clusterAdapter.setOneShotRouteForNextCommand(new ByAddressRoute(node.getHost(), node.getPort()));
+		execute("CLUSTER", rawResult -> null, args);
 
-    @Override
-    public void clusterMeet(ValkeyClusterNode node) {
-        Assert.notNull(node, "node must not be null for CLUSTER MEET command");
+		// Invalidate topology cache after slot deletion
+		invalidateTopologyCache();
+	}
+
+	@Override
+	public void clusterDeleteSlotsInRange(ValkeyClusterNode node, ValkeyClusterNode.SlotRange range) {
+		Assert.notNull(range, "range must not be null");
+		clusterDeleteSlots(node, range.getSlotsArray());
+	}
+
+	@Override
+	public void clusterForget(ValkeyClusterNode node) {
+		Assert.notNull(node, "node must not be null");
+
+		// Lookup the actual node from topology to get its ID
+		ValkeyClusterNode nodeToRemove = getTopology().lookup(node);
+
+		// Get all active master nodes EXCEPT the node being forgotten
+		Collection<ValkeyClusterNode> activeMasters = getTopology().getActiveMasterNodes();
+
+		// Execute CLUSTER FORGET on each master node (except the one being removed)
+		for (ValkeyClusterNode masterNode : activeMasters) {
+			if (!masterNode.equals(nodeToRemove)) {
+				clusterAdapter
+					.setOneShotRouteForNextCommand(new ByAddressRoute(masterNode.getHost(), masterNode.getPort()));
+				execute("CLUSTER", rawResult -> null, "FORGET", nodeToRemove.getId());
+			}
+		}
+
+		// Invalidate topology cache after node removal
+		invalidateTopologyCache();
+	}
+
+	@Override
+	public void clusterMeet(ValkeyClusterNode node) {
+		Assert.notNull(node, "node must not be null for CLUSTER MEET command");
 		Assert.hasText(node.getHost(), "node to meet cluster must have a host");
 		Assert.isTrue(node.getPort() > 0, "node to meet cluster must have a port greater 0");
 
-        clusterAdapter.setOneShotRouteForNextCommand(SimpleMultiNodeRoute.ALL_PRIMARIES);
-        execute("CLUSTER",
-        (Map<String, ?> rawResult) -> null, 
-        "MEET", node.getHost(), String.valueOf(node.getPort()));
-        
-        // Invalidate topology cache after node addition
-        invalidateTopologyCache();
-    }
+		clusterAdapter.setOneShotRouteForNextCommand(SimpleMultiNodeRoute.ALL_PRIMARIES);
+		execute("CLUSTER", (Map<String, ?> rawResult) -> null, "MEET", node.getHost(), String.valueOf(node.getPort()));
 
-    @Override
-    public void clusterReplicate(ValkeyClusterNode master, ValkeyClusterNode replica) {
-        Assert.notNull(master, "master must not be null");
-        Assert.notNull(replica, "replica must not be null");
+		// Invalidate topology cache after node addition
+		invalidateTopologyCache();
+	}
 
-        ValkeyClusterNode masterNode = getTopology().lookup(master);
-        clusterAdapter.setOneShotRouteForNextCommand(new ByAddressRoute(replica.getHost(), replica.getPort()));
-        execute("CLUSTER",
-            rawResult -> null, 
-            "REPLICATE", masterNode.getId());
-        
-        // Invalidate topology cache after replication change
-        invalidateTopologyCache();
-    }
+	@Override
+	public void clusterReplicate(ValkeyClusterNode master, ValkeyClusterNode replica) {
+		Assert.notNull(master, "master must not be null");
+		Assert.notNull(replica, "replica must not be null");
 
-    @Override
-    public Integer clusterGetSlotForKey(byte[] key) {
-        return execute("CLUSTER",
-        (Long rawResult) -> ((Long) rawResult).intValue(), 
-        "KEYSLOT", key);
-    }
+		ValkeyClusterNode masterNode = getTopology().lookup(master);
+		clusterAdapter.setOneShotRouteForNextCommand(new ByAddressRoute(replica.getHost(), replica.getPort()));
+		execute("CLUSTER", rawResult -> null, "REPLICATE", masterNode.getId());
 
-    @Override
-    public ValkeyClusterNode clusterGetNodeForSlot(int slot) {
-        // Use topology to find node for slot
-        Set<ValkeyClusterNode> nodes = getTopology().getSlotServingNodes(slot);
-        return nodes.stream()
-            .filter(node -> node.getType() == ValkeyClusterNode.NodeType.MASTER)
-            .findFirst()
-            .orElse(nodes.iterator().next()); // Fallback to any node
-    }
+		// Invalidate topology cache after replication change
+		invalidateTopologyCache();
+	}
 
-    @Override
-    public ValkeyClusterNode clusterGetNodeForKey(byte[] key) {
-        return getTopology().getKeyServingMasterNode(key);
-    }
+	@Override
+	public Integer clusterGetSlotForKey(byte[] key) {
+		return execute("CLUSTER", (Long rawResult) -> ((Long) rawResult).intValue(), "KEYSLOT", key);
+	}
 
-    @Override
-    public Collection<ValkeyClusterNode> clusterGetNodes() {
-        return getTopology().getNodes();
-    }
+	@Override
+	public ValkeyClusterNode clusterGetNodeForSlot(int slot) {
+		// Use topology to find node for slot
+		Set<ValkeyClusterNode> nodes = getTopology().getSlotServingNodes(slot);
+		return nodes.stream()
+			.filter(node -> node.getType() == ValkeyClusterNode.NodeType.MASTER)
+			.findFirst()
+			.orElse(nodes.iterator().next()); // Fallback to any node
+	}
 
-    @Override
-    public Set<ValkeyClusterNode> clusterGetReplicas(ValkeyClusterNode master) {
-        Assert.notNull(master, "master must not be null");
+	@Override
+	public ValkeyClusterNode clusterGetNodeForKey(byte[] key) {
+		return getTopology().getKeyServingMasterNode(key);
+	}
 
-        ValkeyClusterNode nodeToMatch = getTopology().lookup(master);
-        
-        return getTopology().getNodes().stream()
-            .filter(node -> node.getType() == NodeType.REPLICA)
-            .filter(node -> nodeToMatch.getId().equals(node.getMasterId()))
-            .collect(java.util.stream.Collectors.toSet());
-    }
+	@Override
+	public Collection<ValkeyClusterNode> clusterGetNodes() {
+		return getTopology().getNodes();
+	}
 
-    @Override
-    public Map<ValkeyClusterNode, Collection<ValkeyClusterNode>> clusterGetMasterReplicaMap() {
-        // Simple approach: Use cached topology (refreshed periodically)
-        Map<ValkeyClusterNode, Collection<ValkeyClusterNode>> result = new LinkedHashMap<>();
-        
-        Collection<ValkeyClusterNode> activeMasters = 
-            getTopology().getActiveMasterNodes();
-        
-        for (ValkeyClusterNode master : activeMasters) {
-            Collection<ValkeyClusterNode> replicas = clusterGetReplicas(master);
-            result.put(master, replicas);
-        }
-        
-        return result;
-    }
+	@Override
+	public Set<ValkeyClusterNode> clusterGetReplicas(ValkeyClusterNode master) {
+		Assert.notNull(master, "master must not be null");
 
-    @Override
-    public ClusterInfo clusterGetClusterInfo() {
-        String infoString = execute("CLUSTER", 
-            (GlideString rawResult) -> rawResult.toString(), 
-            "INFO");
-        
-        Properties info = new Properties();
-        if (infoString != null) {
-            for (String line : infoString.split("\r?\n")) {
-                if (line.contains(":")) {
-                    String[] parts = line.split(":", 2);
-                    info.setProperty(parts[0], parts[1]);
-                }
-            }
-        }
-        
-        return new ClusterInfo(info);
-    }
+		ValkeyClusterNode nodeToMatch = getTopology().lookup(master);
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public ClusterTopology getTopology() {
-        // Check cache first
-        if (cachedTopology != null && !isCacheExpired()) {
-            return cachedTopology;
-        }
-        
-        // Execute CLUSTER SLOTS command using the connection's execute pattern
-        Object slotsResponse = execute("CLUSTER", rawResult -> rawResult, "SLOTS");
-        
-        // Parse the nested array response
-        Map<String, ValkeyClusterNode> nodes = parseClusterSlotsResponse(slotsResponse);
-        
-        // Update known nodes cache
-        synchronized (knownNodes) {
-            knownNodes.clear();
-            knownNodes.putAll(nodes);
-        }
-        
-        // Cache the topology
-        cachedTopology = new ClusterTopology(new HashSet<>(nodes.values()));
-        lastCacheTime = System.currentTimeMillis();
-        
-        return cachedTopology;
-    }
+		return getTopology().getNodes()
+			.stream()
+			.filter(node -> node.getType() == NodeType.REPLICA)
+			.filter(node -> nodeToMatch.getId().equals(node.getMasterId()))
+			.collect(java.util.stream.Collectors.toSet());
+	}
 
-    /**
-     * Checks if the cached topology has expired.
-     * 
-     * @return true if the cache has expired or no cache exists
-     */
-    private boolean isCacheExpired() {
-        return System.currentTimeMillis() - lastCacheTime > cacheTimeoutMs;
-    }
+	@Override
+	public Map<ValkeyClusterNode, Collection<ValkeyClusterNode>> clusterGetMasterReplicaMap() {
+		// Simple approach: Use cached topology (refreshed periodically)
+		Map<ValkeyClusterNode, Collection<ValkeyClusterNode>> result = new LinkedHashMap<>();
 
-    /**
-     * Invalidates the cached cluster topology, forcing a refresh on next access.
-     * This should be called after commands that modify the cluster topology
-     * (e.g., slot assignments, node additions/removals, replication changes).
-     */
-    private void invalidateTopologyCache() {
-        this.cachedTopology = null;
-        this.lastCacheTime = 0;
-    }
+		Collection<ValkeyClusterNode> activeMasters = getTopology().getActiveMasterNodes();
 
-    /**
-     * Parses the CLUSTER SLOTS response into ValkeyClusterNode objects.
-     * 
-     * @param response The response from CLUSTER SLOTS command
-     * @return A map of node ID to ValkeyClusterNode
-     */
-    private Map<String, ValkeyClusterNode> parseClusterSlotsResponse(Object response) {
-        Map<String, ValkeyClusterNode> nodes = new HashMap<>();
-        
-        if (!(response instanceof Object[])) {
-            throw new ClusterStateFailureException("Expected array response from CLUSTER SLOTS, got: " + 
-                (response != null ? response.getClass().getSimpleName() : "null"));
-        }
-        
-        Object[] slotsArray = (Object[]) response;
-        
-        for (Object slotInfo : slotsArray) {
-            if (!(slotInfo instanceof Object[])) {
-                continue;
-            }
-            
-            Object[] slotData = (Object[]) slotInfo;
-            if (slotData.length < 3) {
-                continue; // Need at least start_slot, end_slot, and master info
-            }
-            
-            // Parse: [start_slot, end_slot, [master_info], [replica1_info], ...]
-            int startSlot = ((Number) slotData[0]).intValue();
-            int endSlot = ((Number) slotData[1]).intValue();
-            
-            // Parse master node (index 2)
-            if (slotData[2] instanceof Object[]) {
-                Object[] masterInfo = (Object[]) slotData[2];
-                ValkeyClusterNode masterNode = parseNodeInfo(masterInfo, NodeType.MASTER, startSlot, endSlot);
-                nodes.put(masterNode.getId(), masterNode);
-                
-                // Parse replica nodes (indices 3+)
-                for (int i = 3; i < slotData.length; i++) {
-                    if (slotData[i] instanceof Object[]) {
-                        Object[] replicaInfo = (Object[]) slotData[i];
-                        ValkeyClusterNode replicaNode = parseNodeInfo(replicaInfo, NodeType.REPLICA, null, null);
-                        
-                        // Create replica node with master reference
-                        ValkeyClusterNode replicaWithMaster = ValkeyClusterNode.newValkeyClusterNode()
-                            .listeningAt(replicaNode.getHost(), replicaNode.getPort())
-                            .withId(replicaNode.getId())
-                            .promotedAs(NodeType.REPLICA)
-                            .replicaOf(masterNode.getId())
-                            .linkState(LinkState.CONNECTED)
-                            .build();
-                        
-                        nodes.put(replicaWithMaster.getId(), replicaWithMaster);
-                    }
-                }
-            }
-        }
-        
-        return nodes;
-    }
+		for (ValkeyClusterNode master : activeMasters) {
+			Collection<ValkeyClusterNode> replicas = clusterGetReplicas(master);
+			result.put(master, replicas);
+		}
 
-    /**
-     * Parses node information from CLUSTER SLOTS response.
-     * 
-     * @param nodeInfo Array containing [ip, port, node_id, additional_info...]
-     * @param nodeType The type of node (master or replica)
-     * @param startSlot Start slot (for master nodes only)
-     * @param endSlot End slot (for master nodes only)
-     * @return ValkeyClusterNode
-     * @throws ClusterStateFailureException if node info is malformed
-     */
-    private ValkeyClusterNode parseNodeInfo(Object[] nodeInfo, NodeType nodeType, @Nullable Integer startSlot, @Nullable Integer endSlot) {
-        if (nodeInfo.length < 3) {
-            throw new ClusterStateFailureException(
-                "Invalid node info from CLUSTER SLOTS: expected at least [host, port, node_id], got array of length " + nodeInfo.length);
-        }
-        
-        String host = nodeInfo[0] != null ? nodeInfo[0].toString() : "localhost";
-        int port = ((Number) nodeInfo[1]).intValue();
-        String nodeId = nodeInfo[2] != null ? nodeInfo[2].toString() : generateNodeId(host, port);
-        
-        // Validate required fields
-        if (!StringUtils.hasText(host)) {
-            throw new ClusterStateFailureException("Invalid node info from CLUSTER SLOTS: host is empty or null");
-        }
-        if (port <= 0) {
-            throw new ClusterStateFailureException("Invalid node info from CLUSTER SLOTS: invalid port " + port);
-        }
-        if (!StringUtils.hasText(nodeId)) {
-            throw new ClusterStateFailureException("Invalid node info from CLUSTER SLOTS: node ID is empty or null");
-        }
-        
-        ValkeyClusterNode.ValkeyClusterNodeBuilder builder = ValkeyClusterNode.newValkeyClusterNode()
-            .listeningAt(host, port)
-            .withId(nodeId)
-            .promotedAs(nodeType)
-            .linkState(LinkState.CONNECTED);
-        
-        // Add slot range for master nodes
-        if (nodeType == NodeType.MASTER && startSlot != null && endSlot != null) {
-            builder.serving(new SlotRange(startSlot, endSlot));
-        }
-        
-        return builder.build();
-    }
+		return result;
+	}
 
-    /**
-     * Generates a node ID when not provided in the response.
-     * 
-     * @param host The node host
-     * @param port The node port
-     * @return A generated node ID
-     */
-    private String generateNodeId(String host, int port) {
-        return String.format("%s:%d", host, port);
-    }
+	@Override
+	public ClusterInfo clusterGetClusterInfo() {
+		String infoString = execute("CLUSTER", (GlideString rawResult) -> rawResult.toString(), "INFO");
 
-    /**
-     * Execute a Valkey command with explicit routing.
-     * This is a convenience method that sets the route and executes the command in one call.
-     * 
-     * @param route The route to use for this command (can be single-node or multi-node)
-     * @param command The Valkey command name
-     * @param mapper A function to convert the raw driver result
-     * @param args The command arguments
-     * @param <I> The raw result type from the driver
-     * @param <R> The expected return type after mapping
-     * @return The mapped result, or null if pipelining/transaction is active
-     */
-    public <I, R> R execute(Route route, String command, ValkeyGlideConverters.ResultMapper<I, R> mapper, Object... args) {
-        clusterAdapter.setOneShotRouteForNextCommand(route);
-        return execute(command, mapper, args);
-    }
+		Properties info = new Properties();
+		if (infoString != null) {
+			for (String line : infoString.split("\r?\n")) {
+				if (line.contains(":")) {
+					String[] parts = line.split(":", 2);
+					info.setProperty(parts[0], parts[1]);
+				}
+			}
+		}
+
+		return new ClusterInfo(info);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public ClusterTopology getTopology() {
+		// Check cache first
+		if (cachedTopology != null && !isCacheExpired()) {
+			return cachedTopology;
+		}
+
+		// Execute CLUSTER SLOTS command using the connection's execute pattern
+		Object slotsResponse = execute("CLUSTER", rawResult -> rawResult, "SLOTS");
+
+		// Parse the nested array response
+		Map<String, ValkeyClusterNode> nodes = parseClusterSlotsResponse(slotsResponse);
+
+		// Update known nodes cache
+		synchronized (knownNodes) {
+			knownNodes.clear();
+			knownNodes.putAll(nodes);
+		}
+
+		// Cache the topology
+		cachedTopology = new ClusterTopology(new HashSet<>(nodes.values()));
+		lastCacheTime = System.currentTimeMillis();
+
+		return cachedTopology;
+	}
+
+	/**
+	 * Checks if the cached topology has expired.
+	 * @return true if the cache has expired or no cache exists
+	 */
+	private boolean isCacheExpired() {
+		return System.currentTimeMillis() - lastCacheTime > cacheTimeoutMs;
+	}
+
+	/**
+	 * Invalidates the cached cluster topology, forcing a refresh on next access. This
+	 * should be called after commands that modify the cluster topology (e.g., slot
+	 * assignments, node additions/removals, replication changes).
+	 */
+	private void invalidateTopologyCache() {
+		this.cachedTopology = null;
+		this.lastCacheTime = 0;
+	}
+
+	/**
+	 * Parses the CLUSTER SLOTS response into ValkeyClusterNode objects.
+	 * @param response The response from CLUSTER SLOTS command
+	 * @return A map of node ID to ValkeyClusterNode
+	 */
+	private Map<String, ValkeyClusterNode> parseClusterSlotsResponse(Object response) {
+		Map<String, ValkeyClusterNode> nodes = new HashMap<>();
+
+		if (!(response instanceof Object[])) {
+			throw new ClusterStateFailureException("Expected array response from CLUSTER SLOTS, got: "
+					+ (response != null ? response.getClass().getSimpleName() : "null"));
+		}
+
+		Object[] slotsArray = (Object[]) response;
+
+		for (Object slotInfo : slotsArray) {
+			if (!(slotInfo instanceof Object[])) {
+				continue;
+			}
+
+			Object[] slotData = (Object[]) slotInfo;
+			if (slotData.length < 3) {
+				continue; // Need at least start_slot, end_slot, and master info
+			}
+
+			// Parse: [start_slot, end_slot, [master_info], [replica1_info], ...]
+			int startSlot = ((Number) slotData[0]).intValue();
+			int endSlot = ((Number) slotData[1]).intValue();
+
+			// Parse master node (index 2)
+			if (slotData[2] instanceof Object[]) {
+				Object[] masterInfo = (Object[]) slotData[2];
+				ValkeyClusterNode masterNode = parseNodeInfo(masterInfo, NodeType.MASTER, startSlot, endSlot);
+				nodes.put(masterNode.getId(), masterNode);
+
+				// Parse replica nodes (indices 3+)
+				for (int i = 3; i < slotData.length; i++) {
+					if (slotData[i] instanceof Object[]) {
+						Object[] replicaInfo = (Object[]) slotData[i];
+						ValkeyClusterNode replicaNode = parseNodeInfo(replicaInfo, NodeType.REPLICA, null, null);
+
+						// Create replica node with master reference
+						ValkeyClusterNode replicaWithMaster = ValkeyClusterNode.newValkeyClusterNode()
+							.listeningAt(replicaNode.getHost(), replicaNode.getPort())
+							.withId(replicaNode.getId())
+							.promotedAs(NodeType.REPLICA)
+							.replicaOf(masterNode.getId())
+							.linkState(LinkState.CONNECTED)
+							.build();
+
+						nodes.put(replicaWithMaster.getId(), replicaWithMaster);
+					}
+				}
+			}
+		}
+
+		return nodes;
+	}
+
+	/**
+	 * Parses node information from CLUSTER SLOTS response.
+	 * @param nodeInfo Array containing [ip, port, node_id, additional_info...]
+	 * @param nodeType The type of node (master or replica)
+	 * @param startSlot Start slot (for master nodes only)
+	 * @param endSlot End slot (for master nodes only)
+	 * @return ValkeyClusterNode
+	 * @throws ClusterStateFailureException if node info is malformed
+	 */
+	private ValkeyClusterNode parseNodeInfo(Object[] nodeInfo, NodeType nodeType, @Nullable Integer startSlot,
+			@Nullable Integer endSlot) {
+		if (nodeInfo.length < 3) {
+			throw new ClusterStateFailureException(
+					"Invalid node info from CLUSTER SLOTS: expected at least [host, port, node_id], got array of length "
+							+ nodeInfo.length);
+		}
+
+		String host = nodeInfo[0] != null ? nodeInfo[0].toString() : "localhost";
+		int port = ((Number) nodeInfo[1]).intValue();
+		String nodeId = nodeInfo[2] != null ? nodeInfo[2].toString() : generateNodeId(host, port);
+
+		// Validate required fields
+		if (!StringUtils.hasText(host)) {
+			throw new ClusterStateFailureException("Invalid node info from CLUSTER SLOTS: host is empty or null");
+		}
+		if (port <= 0) {
+			throw new ClusterStateFailureException("Invalid node info from CLUSTER SLOTS: invalid port " + port);
+		}
+		if (!StringUtils.hasText(nodeId)) {
+			throw new ClusterStateFailureException("Invalid node info from CLUSTER SLOTS: node ID is empty or null");
+		}
+
+		ValkeyClusterNode.ValkeyClusterNodeBuilder builder = ValkeyClusterNode.newValkeyClusterNode()
+			.listeningAt(host, port)
+			.withId(nodeId)
+			.promotedAs(nodeType)
+			.linkState(LinkState.CONNECTED);
+
+		// Add slot range for master nodes
+		if (nodeType == NodeType.MASTER && startSlot != null && endSlot != null) {
+			builder.serving(new SlotRange(startSlot, endSlot));
+		}
+
+		return builder.build();
+	}
+
+	/**
+	 * Generates a node ID when not provided in the response.
+	 * @param host The node host
+	 * @param port The node port
+	 * @return A generated node ID
+	 */
+	private String generateNodeId(String host, int port) {
+		return String.format("%s:%d", host, port);
+	}
+
+	/**
+	 * Execute a Valkey command with explicit routing. This is a convenience method that
+	 * sets the route and executes the command in one call.
+	 * @param route The route to use for this command (can be single-node or multi-node)
+	 * @param command The Valkey command name
+	 * @param mapper A function to convert the raw driver result
+	 * @param args The command arguments
+	 * @param <I> The raw result type from the driver
+	 * @param <R> The expected return type after mapping
+	 * @return The mapped result, or null if pipelining/transaction is active
+	 */
+	public <I, R> R execute(Route route, String command, ValkeyGlideConverters.ResultMapper<I, R> mapper,
+			Object... args) {
+		clusterAdapter.setOneShotRouteForNextCommand(route);
+		return execute(command, mapper, args);
+	}
 
 	public Map<ValkeyClusterNode, List<byte[]>> buildNodeKeyMap(byte[]... keys) {
 		Map<ValkeyClusterNode, List<byte[]>> nodeKeyMap = new HashMap<>();
 		int keysResolved = 0;
-		
+
 		for (byte[] key : keys) {
 			for (ValkeyClusterNode node : getTopology().getKeyServingNodes(key)) {
 				if (node.isMaster()) {
@@ -668,12 +660,12 @@ public class ValkeyGlideClusterConnection extends ValkeyGlideConnection implemen
 				}
 			}
 		}
-		
+
 		if (keysResolved != keys.length) {
-			throw new IllegalStateException(
-				"Cannot determine cluster node for all keys, bad topology?");
+			throw new IllegalStateException("Cannot determine cluster node for all keys, bad topology?");
 		}
-		
+
 		return nodeKeyMap;
-	}	
+	}
+
 }

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideClusterKeyCommands.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideClusterKeyCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,379 +35,408 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.util.Assert;
 
 /**
- * Implementation of {@link ValkeyKeyCommands} for Valkey-Glide in cluster mode.
- * This implementation handles cross-slot operations by executing commands separately
- * and aggregating results when keys map to different cluster slots.
+ * Implementation of {@link ValkeyKeyCommands} for Valkey-Glide in cluster mode. This
+ * implementation handles cross-slot operations by executing commands separately and
+ * aggregating results when keys map to different cluster slots.
  *
  * @author Ilia Kolominsky
  * @since 2.0
  */
 public class ValkeyGlideClusterKeyCommands extends ValkeyGlideKeyCommands {
 
-    private final ValkeyGlideClusterConnection connection;
-
-    /**
-     * Creates a new {@link ValkeyGlideClusterKeyCommands}.
-     *
-     * @param connection must not be {@literal null}.
-     */
-    public ValkeyGlideClusterKeyCommands(ValkeyGlideClusterConnection connection) {
-        super(connection);
-        Assert.notNull(connection, "ValkeyGlideClusterConnection must not be null!");
-        this.connection = connection;
-    }
-
-    @Override
-    public Cursor<byte[]> scan(ScanOptions options) {
-        ScanOptions scanOptions = options != null ? options : ScanOptions.NONE;
-
-        // Node-scoped cluster scan sets a one-shot route before calling this method.
-        // Capture the route and pin it for the lifetime of the scan cursor so that
-        // all pages go to the same node.
-        if (connection.getClusterAdapter().hasOneShotRouteForNextCommand()) {
-            return new NodeScopedScanCursor(connection, scanOptions);
-        }
-
-        return new ValkeyGlideClusterScanCursor(connection, scanOptions);
-    }
-
-    /**
-     * Scan cursor that pins a specific node route for all pages.
-     * Used when a node-scoped scan is requested via the cluster connection.
-     */
-    private static class NodeScopedScanCursor implements Cursor<byte[]> {
-
-        private final ValkeyGlideClusterConnection connection;
-        private final ScanOptions scanOptions;
-        private final Route pinnedRoute;
-        private String cursor = "0";
-        private Iterator<byte[]> currentBatch = Collections.emptyIterator();
-        private boolean finished = false;
-        private boolean closed = false;
-        private long position = 0;
-
-        NodeScopedScanCursor(ValkeyGlideClusterConnection connection, ScanOptions scanOptions) {
-            this.connection = connection;
-            this.scanOptions = scanOptions;
-            // Capture and consume the one-shot route so it doesn't leak
-            this.pinnedRoute = connection.getClusterAdapter().consumeOneShotRoute();
-        }
-
-        @Override
-        public long getCursorId() {
-            try {
-                return Long.parseLong(cursor);
-            } catch (NumberFormatException e) {
-                return 0;
-            }
-        }
-
-        @Override
-        public CursorId getId() {
-            return CursorId.of(cursor);
-        }
-
-        @Override
-        public boolean hasNext() {
-            if (closed) return false;
-            if (currentBatch.hasNext()) return true;
-            if (finished) return false;
-            loadNextBatch();
-            return currentBatch.hasNext();
-        }
-
-        @Override
-        public byte[] next() {
-            if (!hasNext()) throw new NoSuchElementException();
-            position++;
-            return currentBatch.next();
-        }
-
-        @Override
-        public void close() {
-            closed = true;
-            finished = true;
-            currentBatch = Collections.emptyIterator();
-        }
-
-        @Override
-        public long getPosition() {
-            return position;
-        }
-
-        @Override
-        public boolean isClosed() {
-            return closed;
-        }
-
-        private void loadNextBatch() {
-            try {
-                List<Object> args = new ArrayList<>();
-                args.add(cursor);
-
-                if (scanOptions.getPattern() != null) {
-                    args.add("MATCH");
-                    args.add(scanOptions.getPattern());
-                } else if (scanOptions.getBytePattern() != null) {
-                    args.add("MATCH");
-                    args.add(scanOptions.getBytePattern());
-                }
-
-                if (scanOptions.getCount() != null) {
-                    args.add("COUNT");
-                    args.add(scanOptions.getCount());
-                }
-
-                if (scanOptions instanceof io.valkey.springframework.data.valkey.core.KeyScanOptions kso && kso.getType() != null) {
-                    args.add("TYPE");
-                    args.add(kso.getType());
-                }
-
-                // Re-set the pinned route before each page
-                connection.getClusterAdapter().setOneShotRouteForNextCommand(pinnedRoute);
-
-                Object[] scanResult = connection.execute("SCAN",
-                    (Object[] glideResult) -> glideResult,
-                    args.toArray());
-
-                if (scanResult != null && scanResult.length >= 2) {
-                    Object nextCursor = scanResult[0];
-                    if (nextCursor instanceof GlideString gs) {
-                        cursor = gs.getString();
-                    } else if (nextCursor instanceof byte[] b) {
-                        cursor = new String(b, java.nio.charset.StandardCharsets.UTF_8);
-                    } else {
-                        cursor = nextCursor.toString();
-                    }
-
-                    if ("0".equals(cursor)) {
-                        finished = true;
-                    }
-
-                    List<byte[]> keys = ValkeyGlideConverters.toBytesList(scanResult[1]);
-                    currentBatch = keys.iterator();
-                } else {
-                    finished = true;
-                    currentBatch = Collections.emptyIterator();
-                }
-            } catch (Exception ex) {
-                throw new ValkeyGlideExceptionConverter().convert(ex);
-            }
-        }
-    }
-
-    private static class ValkeyGlideClusterScanCursor implements Cursor<byte[]> {
-
-        private final ValkeyGlideClusterConnection connection;
-        private final ScanOptions scanOptions;
-        private ClusterScanCursor cursorState = ClusterScanCursor.initialCursor();
-        private Iterator<byte[]> currentBatch = Collections.emptyIterator();
-        private long position = 0;
-        private boolean finished = false;
-        private boolean closed = false;
-
-        private ValkeyGlideClusterScanCursor(ValkeyGlideClusterConnection connection, ScanOptions scanOptions) {
-            this.connection = connection;
-            this.scanOptions = scanOptions;
-        }
-
-        @Override
-        public long getCursorId() {
-            return position;
-        }
-
-        @Override
-        public CursorId getId() {
-            return CursorId.of(String.valueOf(position));
-        }
-
-        @Override
-        public boolean hasNext() {
-            if (closed) {
-                return false;
-            }
-
-            if (currentBatch.hasNext()) {
-                return true;
-            }
-
-            while (!finished) {
-                loadNextBatch();
-                if (currentBatch.hasNext()) {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        @Override
-        public byte[] next() {
-            if (!hasNext()) {
-                throw new NoSuchElementException();
-            }
-            return currentBatch.next();
-        }
-
-        @Override
-        public void close() {
-            closed = true;
-            finished = true;
-            currentBatch = Collections.emptyIterator();
-            cursorState.releaseCursorHandle();
-        }
-
-        @Override
-        public long getPosition() {
-            return position;
-        }
-
-        @Override
-        public boolean isClosed() {
-            return closed;
-        }
-
-        private void loadNextBatch() {
-            if (connection.isQueueing() || connection.isPipelined()) {
-                throw new InvalidDataAccessApiUsageException("'SCAN' cannot be called in pipeline / transaction mode");
-            }
-
-            try {
-                ClusterGlideClientAdapter adapter = connection.getClusterAdapter();
-                Object[] scanResult = hasScanOptions(scanOptions) ? adapter.scan(cursorState, toGlideScanOptions(scanOptions)) : adapter.scan(cursorState);
-
-                if (scanResult == null || scanResult.length < 2 || !(scanResult[0] instanceof ClusterScanCursor)) {
-                    finished = true;
-                    currentBatch = Collections.emptyIterator();
-                    return;
-                }
-
-                ClusterScanCursor previousCursor = cursorState;
-                cursorState = (ClusterScanCursor) scanResult[0];
-                previousCursor.releaseCursorHandle();
-                finished = cursorState.isFinished();
-
-                List<byte[]> keys = ValkeyGlideConverters.toBytesList(scanResult[1]);
-                position += keys.size();
-                currentBatch = keys.iterator();
-            } catch (InterruptedException ex) {
-                Thread.currentThread().interrupt();
-                throw new IllegalStateException("Interrupted while scanning cluster", ex);
-            } catch (Exception ex) {
-                throw new ValkeyGlideExceptionConverter().convert(ex);
-            }
-        }
-
-        private static boolean hasScanOptions(ScanOptions options) {
-            return options.getCount() != null || options.getPattern() != null
-                    || options.getBytePattern() != null
-                    || (options instanceof io.valkey.springframework.data.valkey.core.KeyScanOptions kso && kso.getType() != null);
-        }
-
-        private static glide.api.models.commands.scan.ScanOptions toGlideScanOptions(ScanOptions options) {
-            var builder = glide.api.models.commands.scan.ScanOptions.builder();
-
-            if (options.getBytePattern() != null) {
-                builder.matchPatternBinary(GlideString.of(options.getBytePattern()));
-            } else if (options.getPattern() != null) {
-                builder.matchPattern(options.getPattern());
-            }
-
-            if (options.getCount() != null) {
-                builder.count(options.getCount());
-            }
-
-            if (options instanceof io.valkey.springframework.data.valkey.core.KeyScanOptions kso && kso.getType() != null) {
-                builder.type(glide.api.models.commands.scan.ScanOptions.ObjectType.valueOf(kso.getType().toUpperCase(java.util.Locale.ROOT)));
-            }
-
-            return builder.build();
-        }
-    }
-
-    @Override
-    public Boolean move(byte[] key, int dbIndex) {
-        throw new InvalidDataAccessApiUsageException("Cluster mode does not allow moving keys");
-    }
-
-    @Override
-    public void rename(byte[] oldKey, byte[] newKey) {
-
-        Assert.notNull(oldKey, "Old key must not be null");
-        Assert.notNull(newKey, "New key must not be null");
-
-        if (ClusterSlotHashUtil.isSameSlotForAllKeys(oldKey, newKey)) {
-            super.rename(oldKey, newKey);
-            return;
-        }
-
-        if (connection.isPipelined() || connection.isQueueing()) {
-            throw new InvalidDataAccessApiUsageException(
-                    "Cross-slot RENAME cannot be used in pipeline or transaction mode");
-        }
-
-        byte[] value = dump(oldKey);
-
-        if (value != null && value.length > 0) {
-
-            restore(newKey, 0, value, true);
-            del(oldKey);
-        }
-    }
-
-    @Override
-    public Boolean renameNX(byte[] sourceKey, byte[] targetKey) {
-
-        Assert.notNull(sourceKey, "Source key must not be null");
-        Assert.notNull(targetKey, "Target key must not be null");
-
-        if (ClusterSlotHashUtil.isSameSlotForAllKeys(sourceKey, targetKey)) {
-            return super.renameNX(sourceKey, targetKey);
-        }
-
-        if (connection.isPipelined() || connection.isQueueing()) {
-            throw new InvalidDataAccessApiUsageException(
-                    "Cross-slot RENAMENX cannot be used in pipeline or transaction mode");
-        }
-
-        byte[] value = dump(sourceKey);
-
-        if (value != null && value.length > 0 && !exists(targetKey)) {
-
-            restore(targetKey, 0, value);
-            del(sourceKey);
-            return Boolean.TRUE;
-        }
-        return Boolean.FALSE;
-    }
-
-    @Override
-    @Nullable
-    public Long sort(byte[] key, SortParameters params, byte[] storeKey) {
-
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(storeKey, "Store key must not be null");
-
-        // Fast path: same slot
-        if (ClusterSlotHashUtil.isSameSlotForAllKeys(key, storeKey)) {
-            return super.sort(key, params, storeKey);
-        }
-
-        if (connection.isPipelined() || connection.isQueueing()) {
-            throw new InvalidDataAccessApiUsageException(
-                    "Cross-slot SORT STORE cannot be used in pipeline or transaction mode");
-        }
-
-        // Cross-slot path: sort without store, then manually store results
-        List<byte[]> sorted = sort(key, params);
-        if (sorted == null || sorted.isEmpty()) {
-            connection.keyCommands().unlink(storeKey);
-            return 0L;
-        }
-
-        byte[][] arr = new byte[sorted.size()][];
-        connection.keyCommands().unlink(storeKey);
-        connection.listCommands().lPush(storeKey, sorted.toArray(arr));
-        return (long) sorted.size();
-    }
+	private final ValkeyGlideClusterConnection connection;
+
+	/**
+	 * Creates a new {@link ValkeyGlideClusterKeyCommands}.
+	 * @param connection must not be {@literal null}.
+	 */
+	public ValkeyGlideClusterKeyCommands(ValkeyGlideClusterConnection connection) {
+		super(connection);
+		Assert.notNull(connection, "ValkeyGlideClusterConnection must not be null!");
+		this.connection = connection;
+	}
+
+	@Override
+	public Cursor<byte[]> scan(ScanOptions options) {
+		ScanOptions scanOptions = options != null ? options : ScanOptions.NONE;
+
+		// Node-scoped cluster scan sets a one-shot route before calling this method.
+		// Capture the route and pin it for the lifetime of the scan cursor so that
+		// all pages go to the same node.
+		if (connection.getClusterAdapter().hasOneShotRouteForNextCommand()) {
+			return new NodeScopedScanCursor(connection, scanOptions);
+		}
+
+		return new ValkeyGlideClusterScanCursor(connection, scanOptions);
+	}
+
+	/**
+	 * Scan cursor that pins a specific node route for all pages. Used when a node-scoped
+	 * scan is requested via the cluster connection.
+	 */
+	private static class NodeScopedScanCursor implements Cursor<byte[]> {
+
+		private final ValkeyGlideClusterConnection connection;
+
+		private final ScanOptions scanOptions;
+
+		private final Route pinnedRoute;
+
+		private String cursor = "0";
+
+		private Iterator<byte[]> currentBatch = Collections.emptyIterator();
+
+		private boolean finished = false;
+
+		private boolean closed = false;
+
+		private long position = 0;
+
+		NodeScopedScanCursor(ValkeyGlideClusterConnection connection, ScanOptions scanOptions) {
+			this.connection = connection;
+			this.scanOptions = scanOptions;
+			// Capture and consume the one-shot route so it doesn't leak
+			this.pinnedRoute = connection.getClusterAdapter().consumeOneShotRoute();
+		}
+
+		@Override
+		public long getCursorId() {
+			try {
+				return Long.parseLong(cursor);
+			}
+			catch (NumberFormatException e) {
+				return 0;
+			}
+		}
+
+		@Override
+		public CursorId getId() {
+			return CursorId.of(cursor);
+		}
+
+		@Override
+		public boolean hasNext() {
+			if (closed)
+				return false;
+			if (currentBatch.hasNext())
+				return true;
+			if (finished)
+				return false;
+			loadNextBatch();
+			return currentBatch.hasNext();
+		}
+
+		@Override
+		public byte[] next() {
+			if (!hasNext())
+				throw new NoSuchElementException();
+			position++;
+			return currentBatch.next();
+		}
+
+		@Override
+		public void close() {
+			closed = true;
+			finished = true;
+			currentBatch = Collections.emptyIterator();
+		}
+
+		@Override
+		public long getPosition() {
+			return position;
+		}
+
+		@Override
+		public boolean isClosed() {
+			return closed;
+		}
+
+		private void loadNextBatch() {
+			try {
+				List<Object> args = new ArrayList<>();
+				args.add(cursor);
+
+				if (scanOptions.getPattern() != null) {
+					args.add("MATCH");
+					args.add(scanOptions.getPattern());
+				}
+				else if (scanOptions.getBytePattern() != null) {
+					args.add("MATCH");
+					args.add(scanOptions.getBytePattern());
+				}
+
+				if (scanOptions.getCount() != null) {
+					args.add("COUNT");
+					args.add(scanOptions.getCount());
+				}
+
+				if (scanOptions instanceof io.valkey.springframework.data.valkey.core.KeyScanOptions kso
+						&& kso.getType() != null) {
+					args.add("TYPE");
+					args.add(kso.getType());
+				}
+
+				// Re-set the pinned route before each page
+				connection.getClusterAdapter().setOneShotRouteForNextCommand(pinnedRoute);
+
+				Object[] scanResult = connection.execute("SCAN", (Object[] glideResult) -> glideResult, args.toArray());
+
+				if (scanResult != null && scanResult.length >= 2) {
+					Object nextCursor = scanResult[0];
+					if (nextCursor instanceof GlideString gs) {
+						cursor = gs.getString();
+					}
+					else if (nextCursor instanceof byte[] b) {
+						cursor = new String(b, java.nio.charset.StandardCharsets.UTF_8);
+					}
+					else {
+						cursor = nextCursor.toString();
+					}
+
+					if ("0".equals(cursor)) {
+						finished = true;
+					}
+
+					List<byte[]> keys = ValkeyGlideConverters.toBytesList(scanResult[1]);
+					currentBatch = keys.iterator();
+				}
+				else {
+					finished = true;
+					currentBatch = Collections.emptyIterator();
+				}
+			}
+			catch (Exception ex) {
+				throw new ValkeyGlideExceptionConverter().convert(ex);
+			}
+		}
+
+	}
+
+	private static class ValkeyGlideClusterScanCursor implements Cursor<byte[]> {
+
+		private final ValkeyGlideClusterConnection connection;
+
+		private final ScanOptions scanOptions;
+
+		private ClusterScanCursor cursorState = ClusterScanCursor.initialCursor();
+
+		private Iterator<byte[]> currentBatch = Collections.emptyIterator();
+
+		private long position = 0;
+
+		private boolean finished = false;
+
+		private boolean closed = false;
+
+		private ValkeyGlideClusterScanCursor(ValkeyGlideClusterConnection connection, ScanOptions scanOptions) {
+			this.connection = connection;
+			this.scanOptions = scanOptions;
+		}
+
+		@Override
+		public long getCursorId() {
+			return position;
+		}
+
+		@Override
+		public CursorId getId() {
+			return CursorId.of(String.valueOf(position));
+		}
+
+		@Override
+		public boolean hasNext() {
+			if (closed) {
+				return false;
+			}
+
+			if (currentBatch.hasNext()) {
+				return true;
+			}
+
+			while (!finished) {
+				loadNextBatch();
+				if (currentBatch.hasNext()) {
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		@Override
+		public byte[] next() {
+			if (!hasNext()) {
+				throw new NoSuchElementException();
+			}
+			return currentBatch.next();
+		}
+
+		@Override
+		public void close() {
+			closed = true;
+			finished = true;
+			currentBatch = Collections.emptyIterator();
+			cursorState.releaseCursorHandle();
+		}
+
+		@Override
+		public long getPosition() {
+			return position;
+		}
+
+		@Override
+		public boolean isClosed() {
+			return closed;
+		}
+
+		private void loadNextBatch() {
+			if (connection.isQueueing() || connection.isPipelined()) {
+				throw new InvalidDataAccessApiUsageException("'SCAN' cannot be called in pipeline / transaction mode");
+			}
+
+			try {
+				ClusterGlideClientAdapter adapter = connection.getClusterAdapter();
+				Object[] scanResult = hasScanOptions(scanOptions)
+						? adapter.scan(cursorState, toGlideScanOptions(scanOptions)) : adapter.scan(cursorState);
+
+				if (scanResult == null || scanResult.length < 2 || !(scanResult[0] instanceof ClusterScanCursor)) {
+					finished = true;
+					currentBatch = Collections.emptyIterator();
+					return;
+				}
+
+				ClusterScanCursor previousCursor = cursorState;
+				cursorState = (ClusterScanCursor) scanResult[0];
+				previousCursor.releaseCursorHandle();
+				finished = cursorState.isFinished();
+
+				List<byte[]> keys = ValkeyGlideConverters.toBytesList(scanResult[1]);
+				position += keys.size();
+				currentBatch = keys.iterator();
+			}
+			catch (InterruptedException ex) {
+				Thread.currentThread().interrupt();
+				throw new IllegalStateException("Interrupted while scanning cluster", ex);
+			}
+			catch (Exception ex) {
+				throw new ValkeyGlideExceptionConverter().convert(ex);
+			}
+		}
+
+		private static boolean hasScanOptions(ScanOptions options) {
+			return options.getCount() != null || options.getPattern() != null || options.getBytePattern() != null
+					|| (options instanceof io.valkey.springframework.data.valkey.core.KeyScanOptions kso
+							&& kso.getType() != null);
+		}
+
+		private static glide.api.models.commands.scan.ScanOptions toGlideScanOptions(ScanOptions options) {
+			var builder = glide.api.models.commands.scan.ScanOptions.builder();
+
+			if (options.getBytePattern() != null) {
+				builder.matchPatternBinary(GlideString.of(options.getBytePattern()));
+			}
+			else if (options.getPattern() != null) {
+				builder.matchPattern(options.getPattern());
+			}
+
+			if (options.getCount() != null) {
+				builder.count(options.getCount());
+			}
+
+			if (options instanceof io.valkey.springframework.data.valkey.core.KeyScanOptions kso
+					&& kso.getType() != null) {
+				builder.type(glide.api.models.commands.scan.ScanOptions.ObjectType
+					.valueOf(kso.getType().toUpperCase(java.util.Locale.ROOT)));
+			}
+
+			return builder.build();
+		}
+
+	}
+
+	@Override
+	public Boolean move(byte[] key, int dbIndex) {
+		throw new InvalidDataAccessApiUsageException("Cluster mode does not allow moving keys");
+	}
+
+	@Override
+	public void rename(byte[] oldKey, byte[] newKey) {
+
+		Assert.notNull(oldKey, "Old key must not be null");
+		Assert.notNull(newKey, "New key must not be null");
+
+		if (ClusterSlotHashUtil.isSameSlotForAllKeys(oldKey, newKey)) {
+			super.rename(oldKey, newKey);
+			return;
+		}
+
+		if (connection.isPipelined() || connection.isQueueing()) {
+			throw new InvalidDataAccessApiUsageException(
+					"Cross-slot RENAME cannot be used in pipeline or transaction mode");
+		}
+
+		byte[] value = dump(oldKey);
+
+		if (value != null && value.length > 0) {
+
+			restore(newKey, 0, value, true);
+			del(oldKey);
+		}
+	}
+
+	@Override
+	public Boolean renameNX(byte[] sourceKey, byte[] targetKey) {
+
+		Assert.notNull(sourceKey, "Source key must not be null");
+		Assert.notNull(targetKey, "Target key must not be null");
+
+		if (ClusterSlotHashUtil.isSameSlotForAllKeys(sourceKey, targetKey)) {
+			return super.renameNX(sourceKey, targetKey);
+		}
+
+		if (connection.isPipelined() || connection.isQueueing()) {
+			throw new InvalidDataAccessApiUsageException(
+					"Cross-slot RENAMENX cannot be used in pipeline or transaction mode");
+		}
+
+		byte[] value = dump(sourceKey);
+
+		if (value != null && value.length > 0 && !exists(targetKey)) {
+
+			restore(targetKey, 0, value);
+			del(sourceKey);
+			return Boolean.TRUE;
+		}
+		return Boolean.FALSE;
+	}
+
+	@Override
+	@Nullable public Long sort(byte[] key, SortParameters params, byte[] storeKey) {
+
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(storeKey, "Store key must not be null");
+
+		// Fast path: same slot
+		if (ClusterSlotHashUtil.isSameSlotForAllKeys(key, storeKey)) {
+			return super.sort(key, params, storeKey);
+		}
+
+		if (connection.isPipelined() || connection.isQueueing()) {
+			throw new InvalidDataAccessApiUsageException(
+					"Cross-slot SORT STORE cannot be used in pipeline or transaction mode");
+		}
+
+		// Cross-slot path: sort without store, then manually store results
+		List<byte[]> sorted = sort(key, params);
+		if (sorted == null || sorted.isEmpty()) {
+			connection.keyCommands().unlink(storeKey);
+			return 0L;
+		}
+
+		byte[][] arr = new byte[sorted.size()][];
+		connection.keyCommands().unlink(storeKey);
+		connection.listCommands().lPush(storeKey, sorted.toArray(arr));
+		return (long) sorted.size();
+	}
+
 }

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideClusterListCommands.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideClusterListCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,24 +49,22 @@ class ValkeyGlideClusterListCommands extends ValkeyGlideListCommands {
 	}
 
 	/**
-	 * Executes a blocking pop command across multiple cluster nodes in parallel.
-	 * Returns the first available result from any node. The timeout is enforced
-	 * by the Valkey server, not by this method.
-	 * 
+	 * Executes a blocking pop command across multiple cluster nodes in parallel. Returns
+	 * the first available result from any node. The timeout is enforced by the Valkey
+	 * server, not by this method.
 	 * @param command the command name ("BLPOP" or "BRPOP")
 	 * @param timeout the Valkey server timeout in seconds
 	 * @param keys the keys to pop from
 	 * @return the first available [key, value] pair, or empty list if all nodes timeout
 	 */
-	private List<byte[]> executeBlockingPopOnMultipleNodes(
-			String command, int timeout, byte[]... keys) {
-		
+	private List<byte[]> executeBlockingPopOnMultipleNodes(String command, int timeout, byte[]... keys) {
+
 		Assert.notNull(keys, "Keys must not be null");
 		Assert.noNullElements(keys, "Keys must not contain null elements");
 
 		Map<ValkeyClusterNode, List<byte[]>> nodeKeyMap = connection.buildNodeKeyMap(keys);
 		List<CompletableFuture<?>> futures = new ArrayList<>();
-		
+
 		for (Map.Entry<ValkeyClusterNode, List<byte[]>> entry : nodeKeyMap.entrySet()) {
 			ValkeyClusterNode node = entry.getKey();
 			List<byte[]> nodeKeys = entry.getValue();
@@ -79,29 +77,30 @@ class ValkeyGlideClusterListCommands extends ValkeyGlideListCommands {
 			args[args.length - 1] = GlideString.of(String.valueOf(timeout));
 
 			GlideClusterClient nativeConn = (GlideClusterClient) connection.getNativeConnection();
-			futures.add(nativeConn.customCommand(args, 
-				new ByAddressRoute(node.getHost(), node.getPort())));
+			futures.add(nativeConn.customCommand(args, new ByAddressRoute(node.getHost(), node.getPort())));
 		}
 
 		try {
-			CompletableFuture<Object> anyResult = CompletableFuture.anyOf(
-				futures.toArray(new CompletableFuture[0]));
-			
+			CompletableFuture<Object> anyResult = CompletableFuture.anyOf(futures.toArray(new CompletableFuture[0]));
+
 			@SuppressWarnings("unchecked")
 			ClusterValue<Object> glideResult = (ClusterValue<Object>) anyResult.get();
-			
+
 			Object result = glideResult.getSingleValue();
 			if (result == null) {
 				return Collections.emptyList();
 			}
 			return ValkeyGlideConverters.toBytesList((Object[]) result);
-			
-		} catch (InterruptedException ex) {
+
+		}
+		catch (InterruptedException ex) {
 			Thread.currentThread().interrupt();
 			throw new RuntimeException("Interrupted while waiting for " + command, ex);
-		} catch (ExecutionException ex) {
+		}
+		catch (ExecutionException ex) {
 			throw new RuntimeException("Error executing " + command + " on cluster", ex);
-		} finally {
+		}
+		finally {
 			futures.forEach(f -> f.cancel(true));
 		}
 	}
@@ -151,4 +150,5 @@ class ValkeyGlideClusterListCommands extends ValkeyGlideListCommands {
 
 		return null;
 	}
+
 }

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideClusterServerCommands.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideClusterServerCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,495 +35,515 @@ import io.valkey.springframework.data.valkey.connection.ValkeyNode;
 import io.valkey.springframework.data.valkey.core.types.ValkeyClientInfo;
 
 /**
- * Implementation of {@link ValkeyClusterServerCommands} for Valkey-Glide.
- * Uses the elegant execute(Route, ...) pattern for cluster command routing.
+ * Implementation of {@link ValkeyClusterServerCommands} for Valkey-Glide. Uses the
+ * elegant execute(Route, ...) pattern for cluster command routing.
  *
  * @author Ilia Kolominsky
  * @since 2.0
  */
 public class ValkeyGlideClusterServerCommands implements ValkeyClusterServerCommands {
 
-    private final ValkeyGlideClusterConnection connection;
+	private final ValkeyGlideClusterConnection connection;
 
-    /**
-     * Create a new {@link ValkeyGlideClusterServerCommands}.
-     *
-     * @param connection must not be {@literal null}.
-     */
-    public ValkeyGlideClusterServerCommands(ValkeyGlideClusterConnection connection) {
-        Assert.notNull(connection, "Connection must not be null!");
-        this.connection = connection;
-    }
+	/**
+	 * Create a new {@link ValkeyGlideClusterServerCommands}.
+	 * @param connection must not be {@literal null}.
+	 */
+	public ValkeyGlideClusterServerCommands(ValkeyGlideClusterConnection connection) {
+		Assert.notNull(connection, "Connection must not be null!");
+		this.connection = connection;
+	}
 
-    // ========== Cluster-wide operations (execute on all primaries) ==========
+	// ========== Cluster-wide operations (execute on all primaries) ==========
 
-    @Override
-    public void bgReWriteAof() {
-        // valkey-glide default route is bogus - by first key, so we specify ALL_PRIMARIES
-        connection.execute(SimpleMultiNodeRoute.ALL_PRIMARIES, "BGREWRITEAOF", (Map<String, ?> rawResult) -> null);
-    }
+	@Override
+	public void bgReWriteAof() {
+		// valkey-glide default route is bogus - by first key, so we specify ALL_PRIMARIES
+		connection.execute(SimpleMultiNodeRoute.ALL_PRIMARIES, "BGREWRITEAOF", (Map<String, ?> rawResult) -> null);
+	}
 
-    @Override
-    public void bgSave() {
-        // valkey-glide default route is - random, so we specify ALL_PRIMARIES
-        connection.execute(SimpleMultiNodeRoute.ALL_PRIMARIES, "BGSAVE", (Map<String, ?> rawResult) -> null);
-    }
+	@Override
+	public void bgSave() {
+		// valkey-glide default route is - random, so we specify ALL_PRIMARIES
+		connection.execute(SimpleMultiNodeRoute.ALL_PRIMARIES, "BGSAVE", (Map<String, ?> rawResult) -> null);
+	}
 
-    @Override
-    public Long lastSave() {
-        // valkey-glide default route is "random", so we specify ALL_PRIMARIES
-        // Return the most recent LASTSAVE timestamp across all nodes
-        return connection.execute(SimpleMultiNodeRoute.ALL_PRIMARIES, "LASTSAVE",
-            (Map<String, Long> rawResult) -> rawResult.isEmpty() ? null : Collections.max(rawResult.values()));
-    }
+	@Override
+	public Long lastSave() {
+		// valkey-glide default route is "random", so we specify ALL_PRIMARIES
+		// Return the most recent LASTSAVE timestamp across all nodes
+		return connection.execute(SimpleMultiNodeRoute.ALL_PRIMARIES, "LASTSAVE",
+				(Map<String, Long> rawResult) -> rawResult.isEmpty() ? null : Collections.max(rawResult.values()));
+	}
 
-    public void save() {
-        // valkey-glide default route is "random", so we specify ALL_PRIMARIES
-        connection.execute(SimpleMultiNodeRoute.ALL_PRIMARIES, "SAVE", (Map<String, ?> rawResult) -> null);
-    }
+	public void save() {
+		// valkey-glide default route is "random", so we specify ALL_PRIMARIES
+		connection.execute(SimpleMultiNodeRoute.ALL_PRIMARIES, "SAVE", (Map<String, ?> rawResult) -> null);
+	}
 
-    @Override
-    public Long dbSize() {
-        // valkey-glide default route is "all primaries" and aggregation is summation, as expected
-        return connection.execute("DBSIZE", (Long rawResult) -> rawResult);
-    }
+	@Override
+	public Long dbSize() {
+		// valkey-glide default route is "all primaries" and aggregation is summation, as
+		// expected
+		return connection.execute("DBSIZE", (Long rawResult) -> rawResult);
+	}
 
-    @Override
-    public void flushDb() {
-        // valkey-glide default route is "all nodes" and response policy is "all succeeded", as expected
-        connection.execute("FLUSHDB", rawResult -> null);
-    }
+	@Override
+	public void flushDb() {
+		// valkey-glide default route is "all nodes" and response policy is "all
+		// succeeded", as expected
+		connection.execute("FLUSHDB", rawResult -> null);
+	}
 
-    @Override
-    public void flushDb(FlushOption option) {
-        // valkey-glide default route is "all nodes" and response policy is "all succeeded", as expected
-        Assert.notNull(option, "FlushOption must not be null");
-        connection.execute("FLUSHDB", rawResult -> null, option.name());
-    }
+	@Override
+	public void flushDb(FlushOption option) {
+		// valkey-glide default route is "all nodes" and response policy is "all
+		// succeeded", as expected
+		Assert.notNull(option, "FlushOption must not be null");
+		connection.execute("FLUSHDB", rawResult -> null, option.name());
+	}
 
-    @Override
-    public void flushAll() {
-        // valkey-glide default route is "all primaries" and response policy is "all succeeded", as expected
-        connection.execute("FLUSHALL", rawResult -> null);
-    }
+	@Override
+	public void flushAll() {
+		// valkey-glide default route is "all primaries" and response policy is "all
+		// succeeded", as expected
+		connection.execute("FLUSHALL", rawResult -> null);
+	}
 
-    @Override
-    public void flushAll(FlushOption option) {
-        Assert.notNull(option, "FlushOption must not be null");
-        // valkey-glide default route is "all primaries" and response policy is "all succeeded", as expected
-        connection.execute("FLUSHALL", rawResult -> null, option.name());
-    }
+	@Override
+	public void flushAll(FlushOption option) {
+		Assert.notNull(option, "FlushOption must not be null");
+		// valkey-glide default route is "all primaries" and response policy is "all
+		// succeeded", as expected
+		connection.execute("FLUSHALL", rawResult -> null, option.name());
+	}
 
-    @Override
-    public Properties info() {
-        // valkey-glide default route is "all primaries", as expected
-        Map<String, GlideString> results = connection.execute("INFO", 
-            (Map<String, GlideString> rawResult) -> rawResult);
-        
-        return aggregateInfoResults(results);
-    }
+	@Override
+	public Properties info() {
+		// valkey-glide default route is "all primaries", as expected
+		Map<String, GlideString> results = connection.execute("INFO",
+				(Map<String, GlideString> rawResult) -> rawResult);
 
-    @Override
-    public Properties info(String section) {
-        Assert.notNull(section, "Section must not be null");
-        // valkey-glide default route is "all primaries", as expected
-        Map<String, GlideString> results = connection.execute("INFO", 
-            (Map<String, GlideString> rawResult) -> rawResult, section);
-        
-        return aggregateInfoResults(results);
-    }
+		return aggregateInfoResults(results);
+	}
 
-    @Override
-    public void shutdown() {
-        connection.execute(SimpleMultiNodeRoute.ALL_PRIMARIES, "SHUTDOWN", rawResult -> null);
-    }
+	@Override
+	public Properties info(String section) {
+		Assert.notNull(section, "Section must not be null");
+		// valkey-glide default route is "all primaries", as expected
+		Map<String, GlideString> results = connection.execute("INFO", (Map<String, GlideString> rawResult) -> rawResult,
+				section);
 
-    @Override
-    public void shutdown(ShutdownOption option) {
-        if (option == null) {
-            shutdown();
-            return;
-        }
-        connection.execute(SimpleMultiNodeRoute.ALL_PRIMARIES, "SHUTDOWN", rawResult -> null, option.name());
-    }
+		return aggregateInfoResults(results);
+	}
 
-    @Override
-    public Properties getConfig(String pattern) {
-        Assert.notNull(pattern, "Pattern must not be null");
-        Map<String, Object> results = connection.execute(SimpleMultiNodeRoute.ALL_PRIMARIES, "CONFIG", 
-            (Map<String, Object> rawResult) -> rawResult, "GET", pattern);
-        
-        return aggregateConfigResults(results);
-    }
+	@Override
+	public void shutdown() {
+		connection.execute(SimpleMultiNodeRoute.ALL_PRIMARIES, "SHUTDOWN", rawResult -> null);
+	}
 
-    @Override
-    public void setConfig(String param, String value) {
-        Assert.notNull(param, "Parameter must not be null");
-        Assert.notNull(value, "Value must not be null");
-        // valkey-glide default route is "all nodes" and response policy is "all succeeded"
-        connection.execute("CONFIG", rawResult -> null, "SET", param, value);
-    }
+	@Override
+	public void shutdown(ShutdownOption option) {
+		if (option == null) {
+			shutdown();
+			return;
+		}
+		connection.execute(SimpleMultiNodeRoute.ALL_PRIMARIES, "SHUTDOWN", rawResult -> null, option.name());
+	}
 
-    @Override
-    public void resetConfigStats() {
-        // valkey-glide default route is "all nodes" with aggregation policy "all succeeded",
-        // with is better than "all primaries" for this command
-        connection.execute("CONFIG", rawResult -> null, "RESETSTAT");
-    }
+	@Override
+	public Properties getConfig(String pattern) {
+		Assert.notNull(pattern, "Pattern must not be null");
+		Map<String, Object> results = connection.execute(SimpleMultiNodeRoute.ALL_PRIMARIES, "CONFIG",
+				(Map<String, Object> rawResult) -> rawResult, "GET", pattern);
 
-    @Override
-    public void rewriteConfig() {
-        // valkey-glide default route is "all nodes" with aggregation policy "all succeeded",
-        // with is better than "all primaries" for this command
-        connection.execute("CONFIG", rawResult -> null, "REWRITE");
-    }
+		return aggregateConfigResults(results);
+	}
 
-    @Override
-    public Long time(TimeUnit timeUnit) {
-        Assert.notNull(timeUnit, "TimeUnit must not be null");
+	@Override
+	public void setConfig(String param, String value) {
+		Assert.notNull(param, "Parameter must not be null");
+		Assert.notNull(value, "Value must not be null");
+		// valkey-glide default route is "all nodes" and response policy is "all
+		// succeeded"
+		connection.execute("CONFIG", rawResult -> null, "SET", param, value);
+	}
 
-        // valkey-glide default route is Random, as expected
-        return connection.execute("TIME", (Object[] rawResult) -> ValkeyGlideConverters.parseTimeResponse(rawResult, timeUnit));
-    }
+	@Override
+	public void resetConfigStats() {
+		// valkey-glide default route is "all nodes" with aggregation policy "all
+		// succeeded",
+		// with is better than "all primaries" for this command
+		connection.execute("CONFIG", rawResult -> null, "RESETSTAT");
+	}
 
-    @Override
-    public List<ValkeyClientInfo> getClientList() {
-        // valkey-glide default route is bogus - by first key, so we specify ALL_PRIMARIES
-        Map<String, GlideString> results = connection.execute(SimpleMultiNodeRoute.ALL_PRIMARIES, "CLIENT", 
-            (Map<String, GlideString> rawResult) -> rawResult, "LIST");
-        
-        List<ValkeyClientInfo> clientInfos = new ArrayList<>();
-        for (GlideString clientList : results.values()) {
-            clientInfos.addAll(parseClientListResponse(clientList.toString()));
-        }
-        return clientInfos;
-    }
+	@Override
+	public void rewriteConfig() {
+		// valkey-glide default route is "all nodes" with aggregation policy "all
+		// succeeded",
+		// with is better than "all primaries" for this command
+		connection.execute("CONFIG", rawResult -> null, "REWRITE");
+	}
 
-    @Override
-    public void killClient(String host, int port) {
-        Assert.hasText(host, "Host must not be empty");
-        String hostAndPort = String.format("%s:%d", host, port);
-        
-        connection.execute(SimpleMultiNodeRoute.ALL_PRIMARIES, "CLIENT", (Map<String, ?> rawResult) -> null, "KILL", hostAndPort);
-    }
+	@Override
+	public Long time(TimeUnit timeUnit) {
+		Assert.notNull(timeUnit, "TimeUnit must not be null");
 
-    // ========== Node-specific operations ==========
+		// valkey-glide default route is Random, as expected
+		return connection.execute("TIME",
+				(Object[] rawResult) -> ValkeyGlideConverters.parseTimeResponse(rawResult, timeUnit));
+	}
 
-    @Override
-    public void bgReWriteAof(ValkeyClusterNode node) {
-        Assert.notNull(node, "Node must not be null");
-        connection.execute(new ByAddressRoute(node.getHost(), node.getPort()), "BGREWRITEAOF", glideResult -> glideResult);
-    }
+	@Override
+	public List<ValkeyClientInfo> getClientList() {
+		// valkey-glide default route is bogus - by first key, so we specify ALL_PRIMARIES
+		Map<String, GlideString> results = connection.execute(SimpleMultiNodeRoute.ALL_PRIMARIES, "CLIENT",
+				(Map<String, GlideString> rawResult) -> rawResult, "LIST");
 
-    @Override
-    public void bgSave(ValkeyClusterNode node) {
-        Assert.notNull(node, "Node must not be null");
-        connection.execute(new ByAddressRoute(node.getHost(), node.getPort()), "BGSAVE", glideResult -> glideResult);
-    }
+		List<ValkeyClientInfo> clientInfos = new ArrayList<>();
+		for (GlideString clientList : results.values()) {
+			clientInfos.addAll(parseClientListResponse(clientList.toString()));
+		}
+		return clientInfos;
+	}
 
-    @Override
-    public Long lastSave(ValkeyClusterNode node) {
-        Assert.notNull(node, "Node must not be null");
-        return connection.execute(new ByAddressRoute(node.getHost(), node.getPort()), "LASTSAVE", (Long rawResult) -> rawResult);
-    }
+	@Override
+	public void killClient(String host, int port) {
+		Assert.hasText(host, "Host must not be empty");
+		String hostAndPort = String.format("%s:%d", host, port);
 
-    @Override
-    public void save(ValkeyClusterNode node) {
-        Assert.notNull(node, "Node must not be null");
-        connection.execute(new ByAddressRoute(node.getHost(), node.getPort()), "SAVE", glideResult -> glideResult);
-    }
+		connection.execute(SimpleMultiNodeRoute.ALL_PRIMARIES, "CLIENT", (Map<String, ?> rawResult) -> null, "KILL",
+				hostAndPort);
+	}
 
-    @Override
-    public Long dbSize(ValkeyClusterNode node) {
-        Assert.notNull(node, "Node must not be null");
-        return connection.execute(new ByAddressRoute(node.getHost(), node.getPort()), "DBSIZE", (Long rawResult) -> rawResult);
-    }
+	// ========== Node-specific operations ==========
 
-    @Override
-    public void flushDb(ValkeyClusterNode node) {
-        Assert.notNull(node, "Node must not be null");
-        connection.execute(new ByAddressRoute(node.getHost(), node.getPort()), "FLUSHDB", glideResult -> glideResult);
-    }
+	@Override
+	public void bgReWriteAof(ValkeyClusterNode node) {
+		Assert.notNull(node, "Node must not be null");
+		connection.execute(new ByAddressRoute(node.getHost(), node.getPort()), "BGREWRITEAOF",
+				glideResult -> glideResult);
+	}
 
-    @Override
-    public void flushDb(ValkeyClusterNode node, FlushOption option) {
-        Assert.notNull(node, "Node must not be null");
-        Assert.notNull(option, "FlushOption must not be null");
-        connection.execute(new ByAddressRoute(node.getHost(), node.getPort()), "FLUSHDB", glideResult -> glideResult, option.name());
-    }
+	@Override
+	public void bgSave(ValkeyClusterNode node) {
+		Assert.notNull(node, "Node must not be null");
+		connection.execute(new ByAddressRoute(node.getHost(), node.getPort()), "BGSAVE", glideResult -> glideResult);
+	}
 
-    @Override
-    public void flushAll(ValkeyClusterNode node) {
-        Assert.notNull(node, "Node must not be null");
-        connection.execute(new ByAddressRoute(node.getHost(), node.getPort()), "FLUSHALL", glideResult -> glideResult);
-    }
+	@Override
+	public Long lastSave(ValkeyClusterNode node) {
+		Assert.notNull(node, "Node must not be null");
+		return connection.execute(new ByAddressRoute(node.getHost(), node.getPort()), "LASTSAVE",
+				(Long rawResult) -> rawResult);
+	}
 
-    @Override
-    public void flushAll(ValkeyClusterNode node, FlushOption option) {
-        Assert.notNull(node, "Node must not be null");
-        Assert.notNull(option, "FlushOption must not be null");
-        connection.execute(new ByAddressRoute(node.getHost(), node.getPort()), "FLUSHALL", glideResult -> glideResult, option.name());
-    }
+	@Override
+	public void save(ValkeyClusterNode node) {
+		Assert.notNull(node, "Node must not be null");
+		connection.execute(new ByAddressRoute(node.getHost(), node.getPort()), "SAVE", glideResult -> glideResult);
+	}
 
-    @Override
-    public Properties info(ValkeyClusterNode node) {
-        Assert.notNull(node, "Node must not be null");
-        GlideString result = connection.execute(new ByAddressRoute(node.getHost(), node.getPort()), "INFO", (GlideString rawResult) -> rawResult);
-        return parseInfoResponse(result != null ? result.toString() : null);
-    }
+	@Override
+	public Long dbSize(ValkeyClusterNode node) {
+		Assert.notNull(node, "Node must not be null");
+		return connection.execute(new ByAddressRoute(node.getHost(), node.getPort()), "DBSIZE",
+				(Long rawResult) -> rawResult);
+	}
 
-    @Override
-    public Properties info(ValkeyClusterNode node, String section) {
-        Assert.notNull(node, "Node must not be null");
-        Assert.notNull(section, "Section must not be null");
-        GlideString result = connection.execute(new ByAddressRoute(node.getHost(), node.getPort()), "INFO", (GlideString rawResult) -> rawResult, section);
-        return parseInfoResponse(result != null ? result.toString() : null);
-    }
+	@Override
+	public void flushDb(ValkeyClusterNode node) {
+		Assert.notNull(node, "Node must not be null");
+		connection.execute(new ByAddressRoute(node.getHost(), node.getPort()), "FLUSHDB", glideResult -> glideResult);
+	}
 
-    @Override
-    public void shutdown(ValkeyClusterNode node) {
-        Assert.notNull(node, "Node must not be null");
-        connection.execute(new ByAddressRoute(node.getHost(), node.getPort()), "SHUTDOWN", glideResult -> glideResult);
-    }
+	@Override
+	public void flushDb(ValkeyClusterNode node, FlushOption option) {
+		Assert.notNull(node, "Node must not be null");
+		Assert.notNull(option, "FlushOption must not be null");
+		connection.execute(new ByAddressRoute(node.getHost(), node.getPort()), "FLUSHDB", glideResult -> glideResult,
+				option.name());
+	}
 
-    @Override
-    public Properties getConfig(ValkeyClusterNode node, String pattern) {
-        Assert.notNull(node, "Node must not be null");
-        Assert.notNull(pattern, "Pattern must not be null");
-        Object result = connection.execute(new ByAddressRoute(node.getHost(), node.getPort()), "CONFIG", (Object rawResult) -> rawResult, "GET", pattern);
-        return parseConfigResponse(result);
-    }
+	@Override
+	public void flushAll(ValkeyClusterNode node) {
+		Assert.notNull(node, "Node must not be null");
+		connection.execute(new ByAddressRoute(node.getHost(), node.getPort()), "FLUSHALL", glideResult -> glideResult);
+	}
 
-    @Override
-    public void setConfig(ValkeyClusterNode node, String param, String value) {
-        Assert.notNull(node, "Node must not be null");
-        Assert.notNull(param, "Parameter must not be null");
-        Assert.notNull(value, "Value must not be null");
-        connection.execute(new ByAddressRoute(node.getHost(), node.getPort()), "CONFIG", glideResult -> glideResult, "SET", param, value);
-    }
+	@Override
+	public void flushAll(ValkeyClusterNode node, FlushOption option) {
+		Assert.notNull(node, "Node must not be null");
+		Assert.notNull(option, "FlushOption must not be null");
+		connection.execute(new ByAddressRoute(node.getHost(), node.getPort()), "FLUSHALL", glideResult -> glideResult,
+				option.name());
+	}
 
-    @Override
-    public void resetConfigStats(ValkeyClusterNode node) {
-        Assert.notNull(node, "Node must not be null");
-        connection.execute(new ByAddressRoute(node.getHost(), node.getPort()), "CONFIG", glideResult -> glideResult, "RESETSTAT");
-    }
+	@Override
+	public Properties info(ValkeyClusterNode node) {
+		Assert.notNull(node, "Node must not be null");
+		GlideString result = connection.execute(new ByAddressRoute(node.getHost(), node.getPort()), "INFO",
+				(GlideString rawResult) -> rawResult);
+		return parseInfoResponse(result != null ? result.toString() : null);
+	}
 
-    @Override
-    public void rewriteConfig(ValkeyClusterNode node) {
-        Assert.notNull(node, "Node must not be null");
-        connection.execute(new ByAddressRoute(node.getHost(), node.getPort()), "CONFIG", glideResult -> glideResult, "REWRITE");
-    }
+	@Override
+	public Properties info(ValkeyClusterNode node, String section) {
+		Assert.notNull(node, "Node must not be null");
+		Assert.notNull(section, "Section must not be null");
+		GlideString result = connection.execute(new ByAddressRoute(node.getHost(), node.getPort()), "INFO",
+				(GlideString rawResult) -> rawResult, section);
+		return parseInfoResponse(result != null ? result.toString() : null);
+	}
 
-    @Override
-    public Long time(ValkeyClusterNode node, TimeUnit timeUnit) {
-        Assert.notNull(node, "Node must not be null");
-        Assert.notNull(timeUnit, "TimeUnit must not be null");
-        return connection.execute(new ByAddressRoute(node.getHost(), node.getPort()), "TIME", (Object[] rawResult) -> ValkeyGlideConverters.parseTimeResponse(rawResult, timeUnit));
-    }
+	@Override
+	public void shutdown(ValkeyClusterNode node) {
+		Assert.notNull(node, "Node must not be null");
+		connection.execute(new ByAddressRoute(node.getHost(), node.getPort()), "SHUTDOWN", glideResult -> glideResult);
+	}
 
-    @Override
-    public List<ValkeyClientInfo> getClientList(ValkeyClusterNode node) {
-        Assert.notNull(node, "Node must not be null");
-        GlideString result = connection.execute(new ByAddressRoute(node.getHost(), node.getPort()), "CLIENT", (GlideString rawResult) -> rawResult, "LIST");
-        return parseClientListResponse(result.toString());
-    }
+	@Override
+	public Properties getConfig(ValkeyClusterNode node, String pattern) {
+		Assert.notNull(node, "Node must not be null");
+		Assert.notNull(pattern, "Pattern must not be null");
+		Object result = connection.execute(new ByAddressRoute(node.getHost(), node.getPort()), "CONFIG",
+				(Object rawResult) -> rawResult, "GET", pattern);
+		return parseConfigResponse(result);
+	}
 
-    // ========== Unsupported operations ==========
+	@Override
+	public void setConfig(ValkeyClusterNode node, String param, String value) {
+		Assert.notNull(node, "Node must not be null");
+		Assert.notNull(param, "Parameter must not be null");
+		Assert.notNull(value, "Value must not be null");
+		connection.execute(new ByAddressRoute(node.getHost(), node.getPort()), "CONFIG", glideResult -> glideResult,
+				"SET", param, value);
+	}
 
-    @Override
-    public void setClientName(byte[] name) {
-        throw new InvalidDataAccessApiUsageException("CLIENT SETNAME is not supported in cluster environment");
-    }
+	@Override
+	public void resetConfigStats(ValkeyClusterNode node) {
+		Assert.notNull(node, "Node must not be null");
+		connection.execute(new ByAddressRoute(node.getHost(), node.getPort()), "CONFIG", glideResult -> glideResult,
+				"RESETSTAT");
+	}
 
-    @Override
-    public String getClientName() {
-        throw new InvalidDataAccessApiUsageException("CLIENT GETNAME is not supported in cluster environment");
-    }
+	@Override
+	public void rewriteConfig(ValkeyClusterNode node) {
+		Assert.notNull(node, "Node must not be null");
+		connection.execute(new ByAddressRoute(node.getHost(), node.getPort()), "CONFIG", glideResult -> glideResult,
+				"REWRITE");
+	}
 
-    @Override
-    public void replicaOf(String host, int port) {
-        throw new InvalidDataAccessApiUsageException(
-                "REPLICAOF is not supported in cluster environment; Please use CLUSTER REPLICATE");
-    }
+	@Override
+	public Long time(ValkeyClusterNode node, TimeUnit timeUnit) {
+		Assert.notNull(node, "Node must not be null");
+		Assert.notNull(timeUnit, "TimeUnit must not be null");
+		return connection.execute(new ByAddressRoute(node.getHost(), node.getPort()), "TIME",
+				(Object[] rawResult) -> ValkeyGlideConverters.parseTimeResponse(rawResult, timeUnit));
+	}
 
-    @Override
-    public void replicaOfNoOne() {
-        throw new InvalidDataAccessApiUsageException(
-                "REPLICAOF is not supported in cluster environment; Please use CLUSTER REPLICATE");
-    }
+	@Override
+	public List<ValkeyClientInfo> getClientList(ValkeyClusterNode node) {
+		Assert.notNull(node, "Node must not be null");
+		GlideString result = connection.execute(new ByAddressRoute(node.getHost(), node.getPort()), "CLIENT",
+				(GlideString rawResult) -> rawResult, "LIST");
+		return parseClientListResponse(result.toString());
+	}
 
-    @Override
-    public void migrate(byte[] key, ValkeyNode target, int dbIndex, @Nullable MigrateOption option) {
-        migrate(key, target, dbIndex, option, 0);
-    }
+	// ========== Unsupported operations ==========
 
-    @Override
-    public void migrate(byte[] key, ValkeyNode target, int dbIndex, @Nullable MigrateOption option, long timeout) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(target, "Target must not be null");
-        
-        // Find the source node where the key currently resides
-        ValkeyClusterNode sourceNode = connection.clusterCommands().clusterGetNodeForKey(key);
-        Assert.notNull(sourceNode, "Could not determine source node for key");
-        
-        // Build MIGRATE command arguments
-        List<Object> args = new ArrayList<>();
-        args.add(target.getHost());
-        args.add(String.valueOf(target.getPort()));
-        args.add(key);
-        args.add(String.valueOf(dbIndex));
-        args.add(String.valueOf(timeout));
-        
-        if (option != null) {
-            args.add(option.name());
-        }
-        
-        // Execute MIGRATE on the source node
-        connection.execute(
-            new ByAddressRoute(sourceNode.getHost(), sourceNode.getPort()),
-            "MIGRATE",
-            glideResult -> glideResult,
-            args.toArray()
-        );
-    }
+	@Override
+	public void setClientName(byte[] name) {
+		throw new InvalidDataAccessApiUsageException("CLIENT SETNAME is not supported in cluster environment");
+	}
 
-    // ========== Helper methods ==========
+	@Override
+	public String getClientName() {
+		throw new InvalidDataAccessApiUsageException("CLIENT GETNAME is not supported in cluster environment");
+	}
 
-    /**
-     * Aggregates INFO results from multiple nodes into a single Properties object.
-     * Each property is prefixed with the node address.
-     */
-    private Properties aggregateInfoResults(Map<String, GlideString> results) {
-        Properties aggregated = new Properties();
-        
-        if (results == null) {
-            return aggregated;
-        }
-        
-        for (Map.Entry<String, GlideString> entry : results.entrySet()) {
-            String nodeAddress = entry.getKey();
-            Properties nodeInfo = parseInfoResponse(entry.getValue().toString());
-            for (Map.Entry<Object, Object> prop : nodeInfo.entrySet()) {
-                String key = nodeAddress + "." + prop.getKey();
-                aggregated.setProperty(key, prop.getValue().toString());
-            }
-        }
-        
-        return aggregated;
-    }
+	@Override
+	public void replicaOf(String host, int port) {
+		throw new InvalidDataAccessApiUsageException(
+				"REPLICAOF is not supported in cluster environment; Please use CLUSTER REPLICATE");
+	}
 
-    /**
-     * Parses INFO command response into Properties.
-     */
-    private Properties parseInfoResponse(String infoResponse) {
-        Properties properties = new Properties();
-        
-        if (infoResponse == null || infoResponse.isEmpty()) {
-            return properties;
-        }
-        
-        for (String line : infoResponse.split("\r?\n")) {
-            line = line.trim();
-            
-            // Skip empty lines and comments
-            if (line.isEmpty() || line.startsWith("#")) {
-                continue;
-            }
-            
-            int colonIndex = line.indexOf(':');
-            if (colonIndex > 0 && colonIndex < line.length() - 1) {
-                String key = line.substring(0, colonIndex).trim();
-                String value = line.substring(colonIndex + 1).trim();
-                properties.setProperty(key, value);
-            }
-        }
-        
-        return properties;
-    }
+	@Override
+	public void replicaOfNoOne() {
+		throw new InvalidDataAccessApiUsageException(
+				"REPLICAOF is not supported in cluster environment; Please use CLUSTER REPLICATE");
+	}
 
-    /**
-     * Aggregates CONFIG GET results from multiple nodes into a single Properties object.
-     * Each property is prefixed with the node address.
-     */
-    private Properties aggregateConfigResults(Map<String, Object> results) {
-        Properties aggregated = new Properties();
-        
-        if (results == null) {
-            return aggregated;
-        }
-        
-        for (Map.Entry<String, Object> entry : results.entrySet()) {
-            String nodeAddress = entry.getKey();
-            Properties nodeConfig = parseConfigResponse(entry.getValue());
-            for (Map.Entry<Object, Object> prop : nodeConfig.entrySet()) {
-                String key = nodeAddress + "." + prop.getKey();
-                aggregated.setProperty(key, prop.getValue().toString());
-            }
-        }
-        
-        return aggregated;
-    }
+	@Override
+	public void migrate(byte[] key, ValkeyNode target, int dbIndex, @Nullable MigrateOption option) {
+		migrate(key, target, dbIndex, option, 0);
+	}
 
-    /**
-     * Parses CONFIG GET command response into Properties.
-     */
-    private Properties parseConfigResponse(Object result) {
-        Properties properties = new Properties();
-        
-        if (result == null) {
-            return properties;
-        }
-        
-        // CONFIG GET can return Map or List
-        if (result instanceof Map) {
-            Map<?, ?> map = (Map<?, ?>) result;
-            for (Map.Entry<?, ?> entry : map.entrySet()) {
-                String key = entry.getKey().toString();
-                String value = entry.getValue().toString();
-                properties.setProperty(key, value);
-            }
-        } else if (result instanceof List) {
-            List<?> list = (List<?>) result;
-            // Flat list: [key1, value1, key2, value2, ...]
-            for (int i = 0; i < list.size(); i += 2) {
-                if (i + 1 < list.size()) {
-                    String key = list.get(i).toString();
-                    String value = list.get(i + 1).toString();
-                    properties.setProperty(key, value);
-                }
-            }
-        }
-        
-        return properties;
-    }
+	@Override
+	public void migrate(byte[] key, ValkeyNode target, int dbIndex, @Nullable MigrateOption option, long timeout) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(target, "Target must not be null");
 
-    /**
-     * Parses CLIENT LIST command response into a list of ValkeyClientInfo objects.
-     */
-    private List<ValkeyClientInfo> parseClientListResponse(String clientListResponse) {
-        List<ValkeyClientInfo> clientInfos = new ArrayList<>();
-        
-        if (clientListResponse == null || clientListResponse.isEmpty()) {
-            return clientInfos;
-        }
-        
-        for (String line : clientListResponse.split("\r?\n")) {
-            line = line.trim();
-            Properties properties = new Properties();
-            for (String part : line.split("\\s+")) {
-                int equalsIndex = part.indexOf('=');
-                if (equalsIndex > 0 && equalsIndex < part.length() - 1) {
-                    String key = part.substring(0, equalsIndex).trim();
-                    String value = part.substring(equalsIndex + 1).trim();
-                    properties.setProperty(key, value);
-                }
-            }
-            
-            if (!properties.isEmpty()) {
-                clientInfos.add(new ValkeyClientInfo(properties));
-            }
-        }
-        
-        return clientInfos;
-    }
+		// Find the source node where the key currently resides
+		ValkeyClusterNode sourceNode = connection.clusterCommands().clusterGetNodeForKey(key);
+		Assert.notNull(sourceNode, "Could not determine source node for key");
+
+		// Build MIGRATE command arguments
+		List<Object> args = new ArrayList<>();
+		args.add(target.getHost());
+		args.add(String.valueOf(target.getPort()));
+		args.add(key);
+		args.add(String.valueOf(dbIndex));
+		args.add(String.valueOf(timeout));
+
+		if (option != null) {
+			args.add(option.name());
+		}
+
+		// Execute MIGRATE on the source node
+		connection.execute(new ByAddressRoute(sourceNode.getHost(), sourceNode.getPort()), "MIGRATE",
+				glideResult -> glideResult, args.toArray());
+	}
+
+	// ========== Helper methods ==========
+
+	/**
+	 * Aggregates INFO results from multiple nodes into a single Properties object. Each
+	 * property is prefixed with the node address.
+	 */
+	private Properties aggregateInfoResults(Map<String, GlideString> results) {
+		Properties aggregated = new Properties();
+
+		if (results == null) {
+			return aggregated;
+		}
+
+		for (Map.Entry<String, GlideString> entry : results.entrySet()) {
+			String nodeAddress = entry.getKey();
+			Properties nodeInfo = parseInfoResponse(entry.getValue().toString());
+			for (Map.Entry<Object, Object> prop : nodeInfo.entrySet()) {
+				String key = nodeAddress + "." + prop.getKey();
+				aggregated.setProperty(key, prop.getValue().toString());
+			}
+		}
+
+		return aggregated;
+	}
+
+	/**
+	 * Parses INFO command response into Properties.
+	 */
+	private Properties parseInfoResponse(String infoResponse) {
+		Properties properties = new Properties();
+
+		if (infoResponse == null || infoResponse.isEmpty()) {
+			return properties;
+		}
+
+		for (String line : infoResponse.split("\r?\n")) {
+			line = line.trim();
+
+			// Skip empty lines and comments
+			if (line.isEmpty() || line.startsWith("#")) {
+				continue;
+			}
+
+			int colonIndex = line.indexOf(':');
+			if (colonIndex > 0 && colonIndex < line.length() - 1) {
+				String key = line.substring(0, colonIndex).trim();
+				String value = line.substring(colonIndex + 1).trim();
+				properties.setProperty(key, value);
+			}
+		}
+
+		return properties;
+	}
+
+	/**
+	 * Aggregates CONFIG GET results from multiple nodes into a single Properties object.
+	 * Each property is prefixed with the node address.
+	 */
+	private Properties aggregateConfigResults(Map<String, Object> results) {
+		Properties aggregated = new Properties();
+
+		if (results == null) {
+			return aggregated;
+		}
+
+		for (Map.Entry<String, Object> entry : results.entrySet()) {
+			String nodeAddress = entry.getKey();
+			Properties nodeConfig = parseConfigResponse(entry.getValue());
+			for (Map.Entry<Object, Object> prop : nodeConfig.entrySet()) {
+				String key = nodeAddress + "." + prop.getKey();
+				aggregated.setProperty(key, prop.getValue().toString());
+			}
+		}
+
+		return aggregated;
+	}
+
+	/**
+	 * Parses CONFIG GET command response into Properties.
+	 */
+	private Properties parseConfigResponse(Object result) {
+		Properties properties = new Properties();
+
+		if (result == null) {
+			return properties;
+		}
+
+		// CONFIG GET can return Map or List
+		if (result instanceof Map) {
+			Map<?, ?> map = (Map<?, ?>) result;
+			for (Map.Entry<?, ?> entry : map.entrySet()) {
+				String key = entry.getKey().toString();
+				String value = entry.getValue().toString();
+				properties.setProperty(key, value);
+			}
+		}
+		else if (result instanceof List) {
+			List<?> list = (List<?>) result;
+			// Flat list: [key1, value1, key2, value2, ...]
+			for (int i = 0; i < list.size(); i += 2) {
+				if (i + 1 < list.size()) {
+					String key = list.get(i).toString();
+					String value = list.get(i + 1).toString();
+					properties.setProperty(key, value);
+				}
+			}
+		}
+
+		return properties;
+	}
+
+	/**
+	 * Parses CLIENT LIST command response into a list of ValkeyClientInfo objects.
+	 */
+	private List<ValkeyClientInfo> parseClientListResponse(String clientListResponse) {
+		List<ValkeyClientInfo> clientInfos = new ArrayList<>();
+
+		if (clientListResponse == null || clientListResponse.isEmpty()) {
+			return clientInfos;
+		}
+
+		for (String line : clientListResponse.split("\r?\n")) {
+			line = line.trim();
+			Properties properties = new Properties();
+			for (String part : line.split("\\s+")) {
+				int equalsIndex = part.indexOf('=');
+				if (equalsIndex > 0 && equalsIndex < part.length() - 1) {
+					String key = part.substring(0, equalsIndex).trim();
+					String value = part.substring(equalsIndex + 1).trim();
+					properties.setProperty(key, value);
+				}
+			}
+
+			if (!properties.isEmpty()) {
+				clientInfos.add(new ValkeyClientInfo(properties));
+			}
+		}
+
+		return clientInfos;
+	}
+
 }

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideClusterSetCommands.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideClusterSetCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,392 +37,389 @@ import io.valkey.springframework.data.valkey.connection.ValkeyClusterNode;
 import io.valkey.springframework.data.valkey.connection.util.ByteArraySet;
 
 /**
- * Implementation of {@link ValkeySetCommands} for Valkey Glide in cluster mode.
- * This implementation handles multi-slot routing by fetching set members from different
+ * Implementation of {@link ValkeySetCommands} for Valkey Glide in cluster mode. This
+ * implementation handles multi-slot routing by fetching set members from different
  * cluster nodes in parallel and performing set operations locally.
- * 
+ *
  * @author Ilia Kolominsky
  * @since 2.0
  */
 public class ValkeyGlideClusterSetCommands extends ValkeyGlideSetCommands {
 
-    private final ValkeyGlideClusterConnection connection;
+	private final ValkeyGlideClusterConnection connection;
 
-    /**
-     * Creates a new {@link ValkeyGlideClusterSetCommands}.
-     *
-     * @param connection must not be {@literal null}.
-     */
-    public ValkeyGlideClusterSetCommands(ValkeyGlideClusterConnection connection) {
-        super(connection);
-        Assert.notNull(connection, "ValkeyGlideClusterConnection must not be null!");
-        this.connection = connection;
-    }
+	/**
+	 * Creates a new {@link ValkeyGlideClusterSetCommands}.
+	 * @param connection must not be {@literal null}.
+	 */
+	public ValkeyGlideClusterSetCommands(ValkeyGlideClusterConnection connection) {
+		super(connection);
+		Assert.notNull(connection, "ValkeyGlideClusterConnection must not be null!");
+		this.connection = connection;
+	}
 
-    @Override
-    @Nullable
-    public Set<byte[]> sInter(byte[]... keys) {
-        Assert.notNull(keys, "Keys must not be null");
-        Assert.noNullElements(keys, "Keys must not contain null elements");
+	@Override
+	@Nullable public Set<byte[]> sInter(byte[]... keys) {
+		Assert.notNull(keys, "Keys must not be null");
+		Assert.noNullElements(keys, "Keys must not contain null elements");
 
-        // Fast path: all keys in same slot
-        if (ClusterSlotHashUtil.isSameSlotForAllKeys(keys)) {
-            return super.sInter(keys);
-        }
+		// Fast path: all keys in same slot
+		if (ClusterSlotHashUtil.isSameSlotForAllKeys(keys)) {
+			return super.sInter(keys);
+		}
 
-        // Parallel path: keys across multiple nodes
-        Map<ValkeyClusterNode, List<byte[]>> nodeKeyMap = connection.buildNodeKeyMap(keys);
-        
-        List<CompletableFuture<Set<byte[]>>> futures = new ArrayList<>();
-        
-        try {
-            // Fetch SMEMBERS for each key in parallel
-            for (Map.Entry<ValkeyClusterNode, List<byte[]>> entry : nodeKeyMap.entrySet()) {
-                ValkeyClusterNode node = entry.getKey();
-                List<byte[]> nodeKeys = entry.getValue();
-                
-                for (byte[] key : nodeKeys) {
-                    // Build SMEMBERS command for this key
-                    GlideString[] args = new GlideString[] {
-                        GlideString.of("SMEMBERS"),
-                        GlideString.of(key)
-                    };
-                    
-                    GlideClusterClient nativeConn = (GlideClusterClient) connection.getNativeConnection();
-                    CompletableFuture<Set<byte[]>> future = nativeConn.customCommand(args,
-                        new ByAddressRoute(node.getHost(), node.getPort()))
-                        .thenApply(result -> {
-                            ClusterValue<Object> clusterValue = (ClusterValue<Object>) result;
-                            @SuppressWarnings("unchecked")
-                            HashSet<GlideString> glideSet = (HashSet<GlideString>) clusterValue.getSingleValue();
-                            
-                            if (glideSet == null) {
-                                return Collections.emptySet();
-                            }
-                            
-                            Set<byte[]> resultSet = new HashSet<>();
-                            for (GlideString gs : glideSet) {
-                                resultSet.add(gs.getBytes());
-                            }
-                            return resultSet;
-                        });
-                    
-                    futures.add(future);
-                }
-            }
-            
-            // Wait for all nodes to complete
-            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get();
-            
-            // Aggregate results - compute intersection
-            ByteArraySet result = null;
-            
-            for (CompletableFuture<Set<byte[]>> future : futures) {
-                Set<byte[]> value = future.get();
-                ByteArraySet tmp = new ByteArraySet(value);
-                
-                if (result == null) {
-                    result = tmp;
-                } else {
-                    result.retainAll(tmp);
-                    // Early termination if intersection becomes empty
-                    if (result.isEmpty()) {
-                        break;
-                    }
-                }
-            }
-            
-            if (result == null || result.isEmpty()) {
-                return Collections.emptySet();
-            }
-            
-            return result.asRawSet();
-            
-        } catch (InterruptedException ex) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException("Interrupted while executing sInter on cluster", ex);
-        } catch (ExecutionException ex) {
-            throw new RuntimeException("Error executing sInter on cluster", ex);
-        } finally {
-            // Cancel all futures to ensure proper cleanup
-            futures.forEach(f -> f.cancel(true));
-        }
-    }
+		// Parallel path: keys across multiple nodes
+		Map<ValkeyClusterNode, List<byte[]>> nodeKeyMap = connection.buildNodeKeyMap(keys);
 
-    @Override
-    @Nullable
-    public Set<byte[]> sUnion(byte[]... keys) {
-        Assert.notNull(keys, "Keys must not be null");
-        Assert.noNullElements(keys, "Keys must not contain null elements");
+		List<CompletableFuture<Set<byte[]>>> futures = new ArrayList<>();
 
-        // Fast path: all keys in same slot
-        if (ClusterSlotHashUtil.isSameSlotForAllKeys(keys)) {
-            return super.sUnion(keys);
-        }
+		try {
+			// Fetch SMEMBERS for each key in parallel
+			for (Map.Entry<ValkeyClusterNode, List<byte[]>> entry : nodeKeyMap.entrySet()) {
+				ValkeyClusterNode node = entry.getKey();
+				List<byte[]> nodeKeys = entry.getValue();
 
-        // Parallel path: keys across multiple nodes
-        Map<ValkeyClusterNode, List<byte[]>> nodeKeyMap = connection.buildNodeKeyMap(keys);
-        
-        List<CompletableFuture<Set<byte[]>>> futures = new ArrayList<>();
-        
-        try {
-            // Fetch SMEMBERS for each key in parallel
-            for (Map.Entry<ValkeyClusterNode, List<byte[]>> entry : nodeKeyMap.entrySet()) {
-                ValkeyClusterNode node = entry.getKey();
-                List<byte[]> nodeKeys = entry.getValue();
-                
-                for (byte[] key : nodeKeys) {
-                    // Build SMEMBERS command for this key
-                    GlideString[] args = new GlideString[] {
-                        GlideString.of("SMEMBERS"),
-                        GlideString.of(key)
-                    };
-                    
-                    GlideClusterClient nativeConn = (GlideClusterClient) connection.getNativeConnection();
-                    CompletableFuture<Set<byte[]>> future = nativeConn.customCommand(args,
-                        new ByAddressRoute(node.getHost(), node.getPort()))
-                        .thenApply(result -> {
-                            ClusterValue<Object> clusterValue = (ClusterValue<Object>) result;
-                            @SuppressWarnings("unchecked")
-                            HashSet<GlideString> glideSet = (HashSet<GlideString>) clusterValue.getSingleValue();
-                            
-                            if (glideSet == null) {
-                                return Collections.emptySet();
-                            }
-                            
-                            Set<byte[]> resultSet = new HashSet<>();
-                            for (GlideString gs : glideSet) {
-                                resultSet.add(gs.getBytes());
-                            }
-                            return resultSet;
-                        });
-                    
-                    futures.add(future);
-                }
-            }
-            
-            // Wait for all nodes to complete
-            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get();
-            
-            // Aggregate results - compute union
-            ByteArraySet result = new ByteArraySet();
-            
-            for (CompletableFuture<Set<byte[]>> future : futures) {
-                Set<byte[]> value = future.get();
-                result.addAll(value);
-            }
-            
-            if (result.isEmpty()) {
-                return Collections.emptySet();
-            }
-            
-            return result.asRawSet();
-            
-        } catch (InterruptedException ex) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException("Interrupted while executing sUnion on cluster", ex);
-        } catch (ExecutionException ex) {
-            throw new RuntimeException("Error executing sUnion on cluster", ex);
-        } finally {
-            // Cancel all futures to ensure proper cleanup
-            futures.forEach(f -> f.cancel(true));
-        }
-    }
+				for (byte[] key : nodeKeys) {
+					// Build SMEMBERS command for this key
+					GlideString[] args = new GlideString[] { GlideString.of("SMEMBERS"), GlideString.of(key) };
 
-    @Override
-    @Nullable
-    public Set<byte[]> sDiff(byte[]... keys) {
-        Assert.notNull(keys, "Keys must not be null");
-        Assert.noNullElements(keys, "Keys must not contain null elements");
+					GlideClusterClient nativeConn = (GlideClusterClient) connection.getNativeConnection();
+					CompletableFuture<Set<byte[]>> future = nativeConn
+						.customCommand(args, new ByAddressRoute(node.getHost(), node.getPort()))
+						.thenApply(result -> {
+							ClusterValue<Object> clusterValue = (ClusterValue<Object>) result;
+							@SuppressWarnings("unchecked")
+							HashSet<GlideString> glideSet = (HashSet<GlideString>) clusterValue.getSingleValue();
 
-        // Fast path: all keys in same slot
-        if (ClusterSlotHashUtil.isSameSlotForAllKeys(keys)) {
-            return super.sDiff(keys);
-        }
+							if (glideSet == null) {
+								return Collections.emptySet();
+							}
 
-        // Parallel path: keys across multiple nodes
-        // Note: First key is the base set, others are subtracted from it
-        // IMPORTANT: We must preserve the order of keys - first key is base, others are subtracted
-        Map<ValkeyClusterNode, List<byte[]>> nodeKeyMap = connection.buildNodeKeyMap(keys);
-        
-        // Map to store futures by key to preserve order
-        Map<byte[], CompletableFuture<Set<byte[]>>> futuresByKey = new HashMap<>();
-        
-        try {
-            // Fetch SMEMBERS for each key in parallel, but track by key to maintain order
-            for (Map.Entry<ValkeyClusterNode, List<byte[]>> entry : nodeKeyMap.entrySet()) {
-                ValkeyClusterNode node = entry.getKey();
-                List<byte[]> nodeKeys = entry.getValue();
-                
-                for (byte[] key : nodeKeys) {
-                    // Build SMEMBERS command for this key
-                    GlideString[] args = new GlideString[] {
-                        GlideString.of("SMEMBERS"),
-                        GlideString.of(key)
-                    };
-                    
-                    GlideClusterClient nativeConn = (GlideClusterClient) connection.getNativeConnection();
-                    CompletableFuture<Set<byte[]>> future = nativeConn.customCommand(args,
-                        new ByAddressRoute(node.getHost(), node.getPort()))
-                        .thenApply(result -> {
-                            ClusterValue<Object> clusterValue = (ClusterValue<Object>) result;
-                            @SuppressWarnings("unchecked")
-                            HashSet<GlideString> glideSet = (HashSet<GlideString>) clusterValue.getSingleValue();
-                            
-                            if (glideSet == null) {
-                                return Collections.emptySet();
-                            }
-                            
-                            Set<byte[]> resultSet = new HashSet<>();
-                            for (GlideString gs : glideSet) {
-                                resultSet.add(gs.getBytes());
-                            }
-                            return resultSet;
-                        });
-                    
-                    futuresByKey.put(key, future);
-                }
-            }
-            
-            // Wait for all nodes to complete
-            CompletableFuture.allOf(futuresByKey.values().toArray(new CompletableFuture[0])).get();
-            
-            // Aggregate results in the correct order - first key is base, subtract all others
-            ByteArraySet result = null;
-            
-            for (int i = 0; i < keys.length; i++) {
-                byte[] key = keys[i];
-                Set<byte[]> value = futuresByKey.get(key).get();
-                
-                if (i == 0) {
-                    // First set is the base
-                    result = new ByteArraySet(value);
-                } else {
-                    // Subtract this set from the result
-                    result.removeAll(value);
-                }
-            }
-            
-            if (result == null || result.isEmpty()) {
-                return Collections.emptySet();
-            }
-            
-            return result.asRawSet();
-            
-        } catch (InterruptedException ex) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException("Interrupted while executing sDiff on cluster", ex);
-        } catch (ExecutionException ex) {
-            throw new RuntimeException("Error executing sDiff on cluster", ex);
-        } finally {
-            // Cancel all futures to ensure proper cleanup
-            futuresByKey.values().forEach(f -> f.cancel(true));
-        }
-    }
+							Set<byte[]> resultSet = new HashSet<>();
+							for (GlideString gs : glideSet) {
+								resultSet.add(gs.getBytes());
+							}
+							return resultSet;
+						});
 
-    @Override
-    @Nullable
-    public Long sDiffStore(byte[] destKey, byte[]... keys) {
-        Assert.notNull(destKey, "Destination key must not be null");
-        Assert.notNull(keys, "Keys must not be null");
-        Assert.noNullElements(keys, "Keys must not contain null elements");
+					futures.add(future);
+				}
+			}
 
-        // Build array with destKey and source keys for slot check
-        byte[][] allKeys = new byte[keys.length + 1][];
-        allKeys[0] = destKey;
-        System.arraycopy(keys, 0, allKeys, 1, keys.length);
+			// Wait for all nodes to complete
+			CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get();
 
-        // Fast path: all keys in same slot
-        if (ClusterSlotHashUtil.isSameSlotForAllKeys(allKeys)) {
-            return super.sDiffStore(destKey, keys);
-        }
+			// Aggregate results - compute intersection
+			ByteArraySet result = null;
 
-        // Parallel path: compute diff, then store result
-        Set<byte[]> diff = sDiff(keys);
-        if (diff == null || diff.isEmpty()) {
-            return 0L;
-        }
-        
-        return sAdd(destKey, diff.toArray(new byte[diff.size()][]));
-    }
+			for (CompletableFuture<Set<byte[]>> future : futures) {
+				Set<byte[]> value = future.get();
+				ByteArraySet tmp = new ByteArraySet(value);
 
-    @Override
-    @Nullable
-    public Long sInterStore(byte[] destKey, byte[]... keys) {
-        Assert.notNull(destKey, "Destination key must not be null");
-        Assert.notNull(keys, "Keys must not be null");
-        Assert.noNullElements(keys, "Keys must not contain null elements");
+				if (result == null) {
+					result = tmp;
+				}
+				else {
+					result.retainAll(tmp);
+					// Early termination if intersection becomes empty
+					if (result.isEmpty()) {
+						break;
+					}
+				}
+			}
 
-        // Build array with destKey and source keys for slot check
-        byte[][] allKeys = new byte[keys.length + 1][];
-        allKeys[0] = destKey;
-        System.arraycopy(keys, 0, allKeys, 1, keys.length);
+			if (result == null || result.isEmpty()) {
+				return Collections.emptySet();
+			}
 
-        // Fast path: all keys in same slot
-        if (ClusterSlotHashUtil.isSameSlotForAllKeys(allKeys)) {
-            return super.sInterStore(destKey, keys);
-        }
+			return result.asRawSet();
 
-        // Parallel path: compute intersection, then store result
-        Set<byte[]> result = sInter(keys);
-        if (result == null || result.isEmpty()) {
-            return 0L;
-        }
-        
-        return sAdd(destKey, result.toArray(new byte[result.size()][]));
-    }
+		}
+		catch (InterruptedException ex) {
+			Thread.currentThread().interrupt();
+			throw new RuntimeException("Interrupted while executing sInter on cluster", ex);
+		}
+		catch (ExecutionException ex) {
+			throw new RuntimeException("Error executing sInter on cluster", ex);
+		}
+		finally {
+			// Cancel all futures to ensure proper cleanup
+			futures.forEach(f -> f.cancel(true));
+		}
+	}
 
-    @Override
-    @Nullable
-    public Long sUnionStore(byte[] destKey, byte[]... keys) {
-        Assert.notNull(destKey, "Destination key must not be null");
-        Assert.notNull(keys, "Keys must not be null");
-        Assert.noNullElements(keys, "Keys must not contain null elements");
+	@Override
+	@Nullable public Set<byte[]> sUnion(byte[]... keys) {
+		Assert.notNull(keys, "Keys must not be null");
+		Assert.noNullElements(keys, "Keys must not contain null elements");
 
-        // Build array with destKey and source keys for slot check
-        byte[][] allKeys = new byte[keys.length + 1][];
-        allKeys[0] = destKey;
-        System.arraycopy(keys, 0, allKeys, 1, keys.length);
+		// Fast path: all keys in same slot
+		if (ClusterSlotHashUtil.isSameSlotForAllKeys(keys)) {
+			return super.sUnion(keys);
+		}
 
-        // Fast path: all keys in same slot
-        if (ClusterSlotHashUtil.isSameSlotForAllKeys(allKeys)) {
-            return super.sUnionStore(destKey, keys);
-        }
+		// Parallel path: keys across multiple nodes
+		Map<ValkeyClusterNode, List<byte[]>> nodeKeyMap = connection.buildNodeKeyMap(keys);
 
-        // Parallel path: compute union, then store result
-        Set<byte[]> result = sUnion(keys);
-        if (result == null || result.isEmpty()) {
-            return 0L;
-        }
-        
-        return sAdd(destKey, result.toArray(new byte[result.size()][]));
-    }
+		List<CompletableFuture<Set<byte[]>>> futures = new ArrayList<>();
 
-    @Override
-    @Nullable
-    public Boolean sMove(byte[] srcKey, byte[] destKey, byte[] value) {
-        Assert.notNull(srcKey, "Source key must not be null");
-        Assert.notNull(destKey, "Destination key must not be null");
-        Assert.notNull(value, "Value must not be null");
+		try {
+			// Fetch SMEMBERS for each key in parallel
+			for (Map.Entry<ValkeyClusterNode, List<byte[]>> entry : nodeKeyMap.entrySet()) {
+				ValkeyClusterNode node = entry.getKey();
+				List<byte[]> nodeKeys = entry.getValue();
 
-        // Fast path: keys in same slot
-        if (ClusterSlotHashUtil.isSameSlotForAllKeys(srcKey, destKey)) {
-            return super.sMove(srcKey, destKey, value);
-        }
+				for (byte[] key : nodeKeys) {
+					// Build SMEMBERS command for this key
+					GlideString[] args = new GlideString[] { GlideString.of("SMEMBERS"), GlideString.of(key) };
 
-        // Parallel path: manual move across slots
-        // Check if source key exists and contains the value
-        if (connection.keyCommands().exists(srcKey)) {
-            // Remove from source
-            if (sRem(srcKey, value) > 0) {
-                // Check if value already exists in destination
-                if (!sIsMember(destKey, value)) {
-                    // Add to destination
-                    return sAdd(destKey, value) > 0;
-                }
-                return Boolean.TRUE;
-            }
-        }
-        return Boolean.FALSE;
-    }
+					GlideClusterClient nativeConn = (GlideClusterClient) connection.getNativeConnection();
+					CompletableFuture<Set<byte[]>> future = nativeConn
+						.customCommand(args, new ByAddressRoute(node.getHost(), node.getPort()))
+						.thenApply(result -> {
+							ClusterValue<Object> clusterValue = (ClusterValue<Object>) result;
+							@SuppressWarnings("unchecked")
+							HashSet<GlideString> glideSet = (HashSet<GlideString>) clusterValue.getSingleValue();
+
+							if (glideSet == null) {
+								return Collections.emptySet();
+							}
+
+							Set<byte[]> resultSet = new HashSet<>();
+							for (GlideString gs : glideSet) {
+								resultSet.add(gs.getBytes());
+							}
+							return resultSet;
+						});
+
+					futures.add(future);
+				}
+			}
+
+			// Wait for all nodes to complete
+			CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get();
+
+			// Aggregate results - compute union
+			ByteArraySet result = new ByteArraySet();
+
+			for (CompletableFuture<Set<byte[]>> future : futures) {
+				Set<byte[]> value = future.get();
+				result.addAll(value);
+			}
+
+			if (result.isEmpty()) {
+				return Collections.emptySet();
+			}
+
+			return result.asRawSet();
+
+		}
+		catch (InterruptedException ex) {
+			Thread.currentThread().interrupt();
+			throw new RuntimeException("Interrupted while executing sUnion on cluster", ex);
+		}
+		catch (ExecutionException ex) {
+			throw new RuntimeException("Error executing sUnion on cluster", ex);
+		}
+		finally {
+			// Cancel all futures to ensure proper cleanup
+			futures.forEach(f -> f.cancel(true));
+		}
+	}
+
+	@Override
+	@Nullable public Set<byte[]> sDiff(byte[]... keys) {
+		Assert.notNull(keys, "Keys must not be null");
+		Assert.noNullElements(keys, "Keys must not contain null elements");
+
+		// Fast path: all keys in same slot
+		if (ClusterSlotHashUtil.isSameSlotForAllKeys(keys)) {
+			return super.sDiff(keys);
+		}
+
+		// Parallel path: keys across multiple nodes
+		// Note: First key is the base set, others are subtracted from it
+		// IMPORTANT: We must preserve the order of keys - first key is base, others are
+		// subtracted
+		Map<ValkeyClusterNode, List<byte[]>> nodeKeyMap = connection.buildNodeKeyMap(keys);
+
+		// Map to store futures by key to preserve order
+		Map<byte[], CompletableFuture<Set<byte[]>>> futuresByKey = new HashMap<>();
+
+		try {
+			// Fetch SMEMBERS for each key in parallel, but track by key to maintain order
+			for (Map.Entry<ValkeyClusterNode, List<byte[]>> entry : nodeKeyMap.entrySet()) {
+				ValkeyClusterNode node = entry.getKey();
+				List<byte[]> nodeKeys = entry.getValue();
+
+				for (byte[] key : nodeKeys) {
+					// Build SMEMBERS command for this key
+					GlideString[] args = new GlideString[] { GlideString.of("SMEMBERS"), GlideString.of(key) };
+
+					GlideClusterClient nativeConn = (GlideClusterClient) connection.getNativeConnection();
+					CompletableFuture<Set<byte[]>> future = nativeConn
+						.customCommand(args, new ByAddressRoute(node.getHost(), node.getPort()))
+						.thenApply(result -> {
+							ClusterValue<Object> clusterValue = (ClusterValue<Object>) result;
+							@SuppressWarnings("unchecked")
+							HashSet<GlideString> glideSet = (HashSet<GlideString>) clusterValue.getSingleValue();
+
+							if (glideSet == null) {
+								return Collections.emptySet();
+							}
+
+							Set<byte[]> resultSet = new HashSet<>();
+							for (GlideString gs : glideSet) {
+								resultSet.add(gs.getBytes());
+							}
+							return resultSet;
+						});
+
+					futuresByKey.put(key, future);
+				}
+			}
+
+			// Wait for all nodes to complete
+			CompletableFuture.allOf(futuresByKey.values().toArray(new CompletableFuture[0])).get();
+
+			// Aggregate results in the correct order - first key is base, subtract all
+			// others
+			ByteArraySet result = null;
+
+			for (int i = 0; i < keys.length; i++) {
+				byte[] key = keys[i];
+				Set<byte[]> value = futuresByKey.get(key).get();
+
+				if (i == 0) {
+					// First set is the base
+					result = new ByteArraySet(value);
+				}
+				else {
+					// Subtract this set from the result
+					result.removeAll(value);
+				}
+			}
+
+			if (result == null || result.isEmpty()) {
+				return Collections.emptySet();
+			}
+
+			return result.asRawSet();
+
+		}
+		catch (InterruptedException ex) {
+			Thread.currentThread().interrupt();
+			throw new RuntimeException("Interrupted while executing sDiff on cluster", ex);
+		}
+		catch (ExecutionException ex) {
+			throw new RuntimeException("Error executing sDiff on cluster", ex);
+		}
+		finally {
+			// Cancel all futures to ensure proper cleanup
+			futuresByKey.values().forEach(f -> f.cancel(true));
+		}
+	}
+
+	@Override
+	@Nullable public Long sDiffStore(byte[] destKey, byte[]... keys) {
+		Assert.notNull(destKey, "Destination key must not be null");
+		Assert.notNull(keys, "Keys must not be null");
+		Assert.noNullElements(keys, "Keys must not contain null elements");
+
+		// Build array with destKey and source keys for slot check
+		byte[][] allKeys = new byte[keys.length + 1][];
+		allKeys[0] = destKey;
+		System.arraycopy(keys, 0, allKeys, 1, keys.length);
+
+		// Fast path: all keys in same slot
+		if (ClusterSlotHashUtil.isSameSlotForAllKeys(allKeys)) {
+			return super.sDiffStore(destKey, keys);
+		}
+
+		// Parallel path: compute diff, then store result
+		Set<byte[]> diff = sDiff(keys);
+		if (diff == null || diff.isEmpty()) {
+			return 0L;
+		}
+
+		return sAdd(destKey, diff.toArray(new byte[diff.size()][]));
+	}
+
+	@Override
+	@Nullable public Long sInterStore(byte[] destKey, byte[]... keys) {
+		Assert.notNull(destKey, "Destination key must not be null");
+		Assert.notNull(keys, "Keys must not be null");
+		Assert.noNullElements(keys, "Keys must not contain null elements");
+
+		// Build array with destKey and source keys for slot check
+		byte[][] allKeys = new byte[keys.length + 1][];
+		allKeys[0] = destKey;
+		System.arraycopy(keys, 0, allKeys, 1, keys.length);
+
+		// Fast path: all keys in same slot
+		if (ClusterSlotHashUtil.isSameSlotForAllKeys(allKeys)) {
+			return super.sInterStore(destKey, keys);
+		}
+
+		// Parallel path: compute intersection, then store result
+		Set<byte[]> result = sInter(keys);
+		if (result == null || result.isEmpty()) {
+			return 0L;
+		}
+
+		return sAdd(destKey, result.toArray(new byte[result.size()][]));
+	}
+
+	@Override
+	@Nullable public Long sUnionStore(byte[] destKey, byte[]... keys) {
+		Assert.notNull(destKey, "Destination key must not be null");
+		Assert.notNull(keys, "Keys must not be null");
+		Assert.noNullElements(keys, "Keys must not contain null elements");
+
+		// Build array with destKey and source keys for slot check
+		byte[][] allKeys = new byte[keys.length + 1][];
+		allKeys[0] = destKey;
+		System.arraycopy(keys, 0, allKeys, 1, keys.length);
+
+		// Fast path: all keys in same slot
+		if (ClusterSlotHashUtil.isSameSlotForAllKeys(allKeys)) {
+			return super.sUnionStore(destKey, keys);
+		}
+
+		// Parallel path: compute union, then store result
+		Set<byte[]> result = sUnion(keys);
+		if (result == null || result.isEmpty()) {
+			return 0L;
+		}
+
+		return sAdd(destKey, result.toArray(new byte[result.size()][]));
+	}
+
+	@Override
+	@Nullable public Boolean sMove(byte[] srcKey, byte[] destKey, byte[] value) {
+		Assert.notNull(srcKey, "Source key must not be null");
+		Assert.notNull(destKey, "Destination key must not be null");
+		Assert.notNull(value, "Value must not be null");
+
+		// Fast path: keys in same slot
+		if (ClusterSlotHashUtil.isSameSlotForAllKeys(srcKey, destKey)) {
+			return super.sMove(srcKey, destKey, value);
+		}
+
+		// Parallel path: manual move across slots
+		// Check if source key exists and contains the value
+		if (connection.keyCommands().exists(srcKey)) {
+			// Remove from source
+			if (sRem(srcKey, value) > 0) {
+				// Check if value already exists in destination
+				if (!sIsMember(destKey, value)) {
+					// Add to destination
+					return sAdd(destKey, value) > 0;
+				}
+				return Boolean.TRUE;
+			}
+		}
+		return Boolean.FALSE;
+	}
+
 }

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideClusterStringCommands.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideClusterStringCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,92 +40,93 @@ import glide.api.models.configuration.RequestRoutingConfiguration.ByAddressRoute
  */
 public class ValkeyGlideClusterStringCommands extends ValkeyGlideStringCommands {
 
-    private final ValkeyGlideClusterConnection connection;
+	private final ValkeyGlideClusterConnection connection;
 
-    /**
-     * Creates a new {@link ValkeyGlideStringCommands}.
-     *
-     * @param connection must not be {@literal null}.
-     */
-    public ValkeyGlideClusterStringCommands(ValkeyGlideClusterConnection connection) {
-        super(connection);
-        Assert.notNull(connection, "Connection must not be null!");
-        this.connection = connection;
-    }
+	/**
+	 * Creates a new {@link ValkeyGlideStringCommands}.
+	 * @param connection must not be {@literal null}.
+	 */
+	public ValkeyGlideClusterStringCommands(ValkeyGlideClusterConnection connection) {
+		super(connection);
+		Assert.notNull(connection, "Connection must not be null!");
+		this.connection = connection;
+	}
 
-    /**
-     * Executes mSetNX across multiple cluster nodes in parallel.
-     * Groups keys by their cluster node and executes MSETNX operations
-     * in parallel on each node. Returns true only if all MSETNX operations succeed.
-     * 
-     * @param tuples the key-value pairs to set
-     * @return true if all keys were set, false otherwise
-     */
-    @Override
-    @Nullable
-    public Boolean mSetNX(Map<byte[], byte[]> tuples) {
-        Assert.notNull(tuples, "Tuples must not be null");
-        Assert.notEmpty(tuples, "Tuples must not be empty");
+	/**
+	 * Executes mSetNX across multiple cluster nodes in parallel. Groups keys by their
+	 * cluster node and executes MSETNX operations in parallel on each node. Returns true
+	 * only if all MSETNX operations succeed.
+	 * @param tuples the key-value pairs to set
+	 * @return true if all keys were set, false otherwise
+	 */
+	@Override
+	@Nullable public Boolean mSetNX(Map<byte[], byte[]> tuples) {
+		Assert.notNull(tuples, "Tuples must not be null");
+		Assert.notEmpty(tuples, "Tuples must not be empty");
 
-        // Fast path: all keys in same slot
-        if (ClusterSlotHashUtil.isSameSlotForAllKeys(tuples.keySet().toArray(new byte[tuples.keySet().size()][]))) {
-            return super.mSetNX(tuples);
-        }
+		// Fast path: all keys in same slot
+		if (ClusterSlotHashUtil.isSameSlotForAllKeys(tuples.keySet().toArray(new byte[tuples.keySet().size()][]))) {
+			return super.mSetNX(tuples);
+		}
 
-        // Parallel path: keys across multiple nodes
-        Map<ValkeyClusterNode, List<byte[]>> nodeKeyMap = connection.buildNodeKeyMap(
-            tuples.keySet().toArray(new byte[tuples.keySet().size()][]));
-        
-        List<CompletableFuture<Boolean>> futures = new ArrayList<>();
-        
-        try {
-            for (Map.Entry<ValkeyClusterNode, List<byte[]>> entry : nodeKeyMap.entrySet()) {
-                ValkeyClusterNode node = entry.getKey();
-                List<byte[]> nodeKeys = entry.getValue();
-                
-                // Build MSETNX command arguments for this node
-                GlideString[] args = new GlideString[nodeKeys.size() * 2 + 1];
-                args[0] = GlideString.of("MSETNX");
-                
-                int argIndex = 1;
-                for (byte[] key : nodeKeys) {
-                    args[argIndex++] = GlideString.of(key);
-                    args[argIndex++] = GlideString.of(tuples.get(key));
-                }
-                
-                GlideClusterClient nativeConn = (GlideClusterClient) connection.getNativeConnection();
-                CompletableFuture<Boolean> future = nativeConn.customCommand(args, 
-                    new ByAddressRoute(node.getHost(), node.getPort()))
-                    .thenApply(result -> {
-                        ClusterValue<Object> clusterValue = (ClusterValue<Object>) result;
-                        return  (Boolean) clusterValue.getSingleValue();
-                    });
-                
-                futures.add(future);
-            }
-            
-            // Wait for all nodes to complete
-            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get();
-            
-            // Aggregate results - all must be true
-            boolean result = true;
-            for (CompletableFuture<Boolean> future : futures) {
-                if (!future.get()) {
-                    result = false;
-                    break;
-                }
-            }
-            
-            return result;
-            
-        } catch (InterruptedException ex) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException("Interrupted while executing mSetNX on cluster", ex);
-        } catch (ExecutionException ex) {
-            throw new RuntimeException("Error executing mSetNX on cluster", ex);
-        } finally {
-            // Cancel all futures to ensure proper cleanup
-            futures.forEach(f -> f.cancel(true));
-        }
-    }
+		// Parallel path: keys across multiple nodes
+		Map<ValkeyClusterNode, List<byte[]>> nodeKeyMap = connection
+			.buildNodeKeyMap(tuples.keySet().toArray(new byte[tuples.keySet().size()][]));
+
+		List<CompletableFuture<Boolean>> futures = new ArrayList<>();
+
+		try {
+			for (Map.Entry<ValkeyClusterNode, List<byte[]>> entry : nodeKeyMap.entrySet()) {
+				ValkeyClusterNode node = entry.getKey();
+				List<byte[]> nodeKeys = entry.getValue();
+
+				// Build MSETNX command arguments for this node
+				GlideString[] args = new GlideString[nodeKeys.size() * 2 + 1];
+				args[0] = GlideString.of("MSETNX");
+
+				int argIndex = 1;
+				for (byte[] key : nodeKeys) {
+					args[argIndex++] = GlideString.of(key);
+					args[argIndex++] = GlideString.of(tuples.get(key));
+				}
+
+				GlideClusterClient nativeConn = (GlideClusterClient) connection.getNativeConnection();
+				CompletableFuture<Boolean> future = nativeConn
+					.customCommand(args, new ByAddressRoute(node.getHost(), node.getPort()))
+					.thenApply(result -> {
+						ClusterValue<Object> clusterValue = (ClusterValue<Object>) result;
+						return (Boolean) clusterValue.getSingleValue();
+					});
+
+				futures.add(future);
+			}
+
+			// Wait for all nodes to complete
+			CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get();
+
+			// Aggregate results - all must be true
+			boolean result = true;
+			for (CompletableFuture<Boolean> future : futures) {
+				if (!future.get()) {
+					result = false;
+					break;
+				}
+			}
+
+			return result;
+
+		}
+		catch (InterruptedException ex) {
+			Thread.currentThread().interrupt();
+			throw new RuntimeException("Interrupted while executing mSetNX on cluster", ex);
+		}
+		catch (ExecutionException ex) {
+			throw new RuntimeException("Error executing mSetNX on cluster", ex);
+		}
+		finally {
+			// Cancel all futures to ensure proper cleanup
+			futures.forEach(f -> f.cancel(true));
+		}
+	}
+
 }

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnection.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,410 +54,440 @@ import glide.api.GlideClient;
 import glide.api.models.GlideString;
 
 /**
- * Connection to a Valkey server using Valkey-Glide client. The connection
- * adapts Valkey-Glide's asynchronous API to Spring Data Valkey's synchronous API.
+ * Connection to a Valkey server using Valkey-Glide client. The connection adapts
+ * Valkey-Glide's asynchronous API to Spring Data Valkey's synchronous API.
  *
  * @author Ilia Kolominsky
  */
 public class ValkeyGlideConnection extends AbstractValkeyConnection {
 
-    protected final UnifiedGlideClient unifiedClient;
-    protected final @Nullable ValkeyGlideConnectionFactory factory;
-    private final AtomicBoolean closed = new AtomicBoolean(false);
+	protected final UnifiedGlideClient unifiedClient;
 
-    private final List<ResultMapper<?, ?>> batchCommandsConverters = new ArrayList<>();
-    private final Set<byte[]> watchedKeys = new HashSet<>();
-    /** Tracks whether a WATCH command was issued via execute() directly, bypassing the watch() API */
-    private boolean watchCommandIssued = false;
-    private volatile @Nullable ValkeyGlideSubscription subscription;
+	protected final @Nullable ValkeyGlideConnectionFactory factory;
 
-    // Command interfaces
-    private ValkeyGlideKeyCommands keyCommands = null;
-    private ValkeyGlideStringCommands stringCommands = null;
-    private ValkeyGlideListCommands listCommands = null;
-    private ValkeyGlideSetCommands setCommands = null;
-    private ValkeyGlideZSetCommands zSetCommands = null;
-    private ValkeyGlideHashCommands hashCommands = null;
-    private ValkeyGlideGeoCommands geoCommands = null;
-    private ValkeyGlideHyperLogLogCommands hyperLogLogCommands = null;
-    private ValkeyGlideScriptingCommands scriptingCommands = null;
-    private ValkeyGlideServerCommands serverCommands = null;
-    private ValkeyGlideStreamCommands streamCommands = null;
+	private final AtomicBoolean closed = new AtomicBoolean(false);
 
-    /**
-     * Creates a new {@link ValkeyGlideConnection} with a unified client adapter.
-     * Each connection owns and manages its own client instance.
-     *
-     * @param unifiedClient unified client adapter (standalone or cluster)
-     * @param factory the connection factory (optional, for pooling support)
-     */
-    public ValkeyGlideConnection(UnifiedGlideClient unifiedClient, @Nullable ValkeyGlideConnectionFactory factory) {
-        Assert.notNull(unifiedClient, "UnifiedClient must not be null");
-        
-        this.unifiedClient = unifiedClient;
-        this.factory = factory;
-    }
+	private final List<ResultMapper<?, ?>> batchCommandsConverters = new ArrayList<>();
 
-    /**
-     * Verifies that the connection is open.
-     *
-     * @throws InvalidDataAccessApiUsageException if the connection is closed
-     */
-    protected void verifyConnectionOpen() {
-        if (isClosed()) {
-            throw new InvalidDataAccessApiUsageException("Connection is closed");
-        }
-    }
+	private final Set<byte[]> watchedKeys = new HashSet<>();
 
-    @Override
-    public ValkeyGeoCommands geoCommands() {
-        ValkeyGlideGeoCommands cmds = this.geoCommands;
-        if (cmds == null) {
-            cmds = new ValkeyGlideGeoCommands(this);
-            this.geoCommands = cmds;
-        }
-        return cmds;
-    }
+	/**
+	 * Tracks whether a WATCH command was issued via execute() directly, bypassing the
+	 * watch() API
+	 */
+	private boolean watchCommandIssued = false;
 
-    @Override
-    public ValkeyHashCommands hashCommands() {
-        ValkeyGlideHashCommands cmds = this.hashCommands;
-        if (cmds == null) {
-            cmds = new ValkeyGlideHashCommands(this);
-            this.hashCommands = cmds;
-        }
-        return cmds;
-    }
+	private volatile @Nullable ValkeyGlideSubscription subscription;
 
-    @Override
-    public ValkeyHyperLogLogCommands hyperLogLogCommands() {
-        ValkeyGlideHyperLogLogCommands cmds = this.hyperLogLogCommands;
-        if (cmds == null) {
-            cmds = new ValkeyGlideHyperLogLogCommands(this);
-            this.hyperLogLogCommands = cmds;
-        }
-        return cmds;
-    }
+	// Command interfaces
+	private ValkeyGlideKeyCommands keyCommands = null;
 
-    @Override
-    public ValkeyKeyCommands keyCommands() {
-        ValkeyGlideKeyCommands cmds = this.keyCommands;
-        if (cmds == null) {
-            cmds = new ValkeyGlideKeyCommands(this);
-            this.keyCommands = cmds;
-        }
-        return cmds;
-    }
+	private ValkeyGlideStringCommands stringCommands = null;
 
-    @Override
-    public ValkeyListCommands listCommands() {
-        ValkeyGlideListCommands cmds = this.listCommands;
-        if (cmds == null) {
-            cmds = new ValkeyGlideListCommands(this);
-            this.listCommands = cmds;
-        }
-        return cmds;
-    }
+	private ValkeyGlideListCommands listCommands = null;
 
-    @Override
-    public ValkeySetCommands setCommands() {
-        ValkeyGlideSetCommands cmds = this.setCommands;
-        if (cmds == null) {
-            cmds = new ValkeyGlideSetCommands(this);
-            this.setCommands = cmds;
-        }
-        return cmds;
-    }
+	private ValkeyGlideSetCommands setCommands = null;
 
-    @Override
-    public ValkeyScriptingCommands scriptingCommands() {
-        ValkeyGlideScriptingCommands cmds = this.scriptingCommands;
-        if (cmds == null) {
-            cmds = new ValkeyGlideScriptingCommands(this);
-            this.scriptingCommands = cmds;
-        }
-        return cmds;
-    }
+	private ValkeyGlideZSetCommands zSetCommands = null;
 
-    @Override
-    public ValkeyServerCommands serverCommands() {
-        ValkeyGlideServerCommands cmds = this.serverCommands;
-        if (cmds == null) {
-            cmds = new ValkeyGlideServerCommands(this);
-            this.serverCommands = cmds;
-        }
-        return cmds;
-    }
+	private ValkeyGlideHashCommands hashCommands = null;
 
-    @Override
-    public ValkeyStreamCommands streamCommands() {
-        ValkeyGlideStreamCommands cmds = this.streamCommands;
-        if (cmds == null) {
-            cmds = new ValkeyGlideStreamCommands(this);
-            this.streamCommands = cmds;
-        }
-        return cmds;
-    }
+	private ValkeyGlideGeoCommands geoCommands = null;
 
-    @Override
-    public ValkeyStringCommands stringCommands() {
-        ValkeyGlideStringCommands cmds = this.stringCommands;
-        if (cmds == null) {
-            cmds = new ValkeyGlideStringCommands(this);
-            this.stringCommands = cmds;
-        }
-        return cmds;
-    }
+	private ValkeyGlideHyperLogLogCommands hyperLogLogCommands = null;
 
-    @Override
-    public ValkeyZSetCommands zSetCommands() {
-        ValkeyGlideZSetCommands cmds = this.zSetCommands;
-        if (cmds == null) {
-            cmds = new ValkeyGlideZSetCommands(this);
-            this.zSetCommands = cmds;
-        }
-        return cmds;
-    }
+	private ValkeyGlideScriptingCommands scriptingCommands = null;
 
-    @Override
-    public ValkeyCommands commands() {
-        return this;
-    }
+	private ValkeyGlideServerCommands serverCommands = null;
 
-    @Override
-    public void close() throws DataAccessException {
-        try {
-            if (closed.compareAndSet(false, true)) {
-                // Close subscription first
-                ValkeyGlideSubscription sub = this.subscription;
-                if (sub != null) {
-                    sub.close();
-                    this.subscription = null;
-                }
+	private ValkeyGlideStreamCommands streamCommands = null;
 
-                if (!watchedKeys.isEmpty() || watchCommandIssued) {
-                    sendUnwatch();
-                    watchedKeys.clear();
-                    watchCommandIssued = false;
-                }
+	/**
+	 * Creates a new {@link ValkeyGlideConnection} with a unified client adapter. Each
+	 * connection owns and manages its own client instance.
+	 * @param unifiedClient unified client adapter (standalone or cluster)
+	 * @param factory the connection factory (optional, for pooling support)
+	 */
+	public ValkeyGlideConnection(UnifiedGlideClient unifiedClient, @Nullable ValkeyGlideConnectionFactory factory) {
+		Assert.notNull(unifiedClient, "UnifiedClient must not be null");
 
-                // Reset adapter state and return to pool
-                if (factory != null) {
-                    unifiedClient.reset();
-                    factory.releaseAdapter(unifiedClient);
-                }
-            }
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		this.unifiedClient = unifiedClient;
+		this.factory = factory;
+	}
 
-    protected void sendUnwatch() {
-        GlideClient nativeClient = (GlideClient) unifiedClient.getNativeClient();
-        try {
-            nativeClient.customCommand(new String[]{"UNWATCH"}).get();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new IllegalStateException("Interrupted UNWATCH command during connection cleanup", e);
-        } catch (ExecutionException e) {
-            throw new IllegalStateException("Failed to send UNWATCH command during connection cleanup", e);
-        }
-    }
+	/**
+	 * Verifies that the connection is open.
+	 * @throws InvalidDataAccessApiUsageException if the connection is closed
+	 */
+	protected void verifyConnectionOpen() {
+		if (isClosed()) {
+			throw new InvalidDataAccessApiUsageException("Connection is closed");
+		}
+	}
 
-    @Override
-    public boolean isClosed() {
-        return closed.get();
-    }
+	@Override
+	public ValkeyGeoCommands geoCommands() {
+		ValkeyGlideGeoCommands cmds = this.geoCommands;
+		if (cmds == null) {
+			cmds = new ValkeyGlideGeoCommands(this);
+			this.geoCommands = cmds;
+		}
+		return cmds;
+	}
 
-    @Override
-    public Object getNativeConnection() {
-        verifyConnectionOpen();
-        return unifiedClient.getNativeClient();
-    }
+	@Override
+	public ValkeyHashCommands hashCommands() {
+		ValkeyGlideHashCommands cmds = this.hashCommands;
+		if (cmds == null) {
+			cmds = new ValkeyGlideHashCommands(this);
+			this.hashCommands = cmds;
+		}
+		return cmds;
+	}
 
-    @Override
-    public boolean isQueueing() {
-        return unifiedClient.getBatchStatus() == UnifiedGlideClient.BatchStatus.Transaction;
-    }
+	@Override
+	public ValkeyHyperLogLogCommands hyperLogLogCommands() {
+		ValkeyGlideHyperLogLogCommands cmds = this.hyperLogLogCommands;
+		if (cmds == null) {
+			cmds = new ValkeyGlideHyperLogLogCommands(this);
+			this.hyperLogLogCommands = cmds;
+		}
+		return cmds;
+	}
 
-    @Override
-    public boolean isPipelined() {
-        return unifiedClient.getBatchStatus() == UnifiedGlideClient.BatchStatus.Pipeline;
-    }
+	@Override
+	public ValkeyKeyCommands keyCommands() {
+		ValkeyGlideKeyCommands cmds = this.keyCommands;
+		if (cmds == null) {
+			cmds = new ValkeyGlideKeyCommands(this);
+			this.keyCommands = cmds;
+		}
+		return cmds;
+	}
 
-    @Override
-    public void openPipeline() {
-        if (isQueueing()) {
+	@Override
+	public ValkeyListCommands listCommands() {
+		ValkeyGlideListCommands cmds = this.listCommands;
+		if (cmds == null) {
+			cmds = new ValkeyGlideListCommands(this);
+			this.listCommands = cmds;
+		}
+		return cmds;
+	}
+
+	@Override
+	public ValkeySetCommands setCommands() {
+		ValkeyGlideSetCommands cmds = this.setCommands;
+		if (cmds == null) {
+			cmds = new ValkeyGlideSetCommands(this);
+			this.setCommands = cmds;
+		}
+		return cmds;
+	}
+
+	@Override
+	public ValkeyScriptingCommands scriptingCommands() {
+		ValkeyGlideScriptingCommands cmds = this.scriptingCommands;
+		if (cmds == null) {
+			cmds = new ValkeyGlideScriptingCommands(this);
+			this.scriptingCommands = cmds;
+		}
+		return cmds;
+	}
+
+	@Override
+	public ValkeyServerCommands serverCommands() {
+		ValkeyGlideServerCommands cmds = this.serverCommands;
+		if (cmds == null) {
+			cmds = new ValkeyGlideServerCommands(this);
+			this.serverCommands = cmds;
+		}
+		return cmds;
+	}
+
+	@Override
+	public ValkeyStreamCommands streamCommands() {
+		ValkeyGlideStreamCommands cmds = this.streamCommands;
+		if (cmds == null) {
+			cmds = new ValkeyGlideStreamCommands(this);
+			this.streamCommands = cmds;
+		}
+		return cmds;
+	}
+
+	@Override
+	public ValkeyStringCommands stringCommands() {
+		ValkeyGlideStringCommands cmds = this.stringCommands;
+		if (cmds == null) {
+			cmds = new ValkeyGlideStringCommands(this);
+			this.stringCommands = cmds;
+		}
+		return cmds;
+	}
+
+	@Override
+	public ValkeyZSetCommands zSetCommands() {
+		ValkeyGlideZSetCommands cmds = this.zSetCommands;
+		if (cmds == null) {
+			cmds = new ValkeyGlideZSetCommands(this);
+			this.zSetCommands = cmds;
+		}
+		return cmds;
+	}
+
+	@Override
+	public ValkeyCommands commands() {
+		return this;
+	}
+
+	@Override
+	public void close() throws DataAccessException {
+		try {
+			if (closed.compareAndSet(false, true)) {
+				// Close subscription first
+				ValkeyGlideSubscription sub = this.subscription;
+				if (sub != null) {
+					sub.close();
+					this.subscription = null;
+				}
+
+				if (!watchedKeys.isEmpty() || watchCommandIssued) {
+					sendUnwatch();
+					watchedKeys.clear();
+					watchCommandIssued = false;
+				}
+
+				// Reset adapter state and return to pool
+				if (factory != null) {
+					unifiedClient.reset();
+					factory.releaseAdapter(unifiedClient);
+				}
+			}
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	protected void sendUnwatch() {
+		GlideClient nativeClient = (GlideClient) unifiedClient.getNativeClient();
+		try {
+			nativeClient.customCommand(new String[] { "UNWATCH" }).get();
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new IllegalStateException("Interrupted UNWATCH command during connection cleanup", e);
+		}
+		catch (ExecutionException e) {
+			throw new IllegalStateException("Failed to send UNWATCH command during connection cleanup", e);
+		}
+	}
+
+	@Override
+	public boolean isClosed() {
+		return closed.get();
+	}
+
+	@Override
+	public Object getNativeConnection() {
+		verifyConnectionOpen();
+		return unifiedClient.getNativeClient();
+	}
+
+	@Override
+	public boolean isQueueing() {
+		return unifiedClient.getBatchStatus() == UnifiedGlideClient.BatchStatus.Transaction;
+	}
+
+	@Override
+	public boolean isPipelined() {
+		return unifiedClient.getBatchStatus() == UnifiedGlideClient.BatchStatus.Pipeline;
+	}
+
+	@Override
+	public void openPipeline() {
+		if (isQueueing()) {
 			throw new InvalidDataAccessApiUsageException("Cannot use pipelining while a transaction is active");
 		}
-        if (!isPipelined()) {
-            unifiedClient.startNewBatch(false);
-        }
-    }
+		if (!isPipelined()) {
+			unifiedClient.startNewBatch(false);
+		}
+	}
 
-    @Override
-    public List<Object> closePipeline() {
-        if (!isPipelined()) {
-            return new ArrayList<>();
-        }
+	@Override
+	public List<Object> closePipeline() {
+		if (!isPipelined()) {
+			return new ArrayList<>();
+		}
 
-        try {
-            if (unifiedClient.getBatchCount() == 0) {
-                return new ArrayList<>();
-            }
+		try {
+			if (unifiedClient.getBatchCount() == 0) {
+				return new ArrayList<>();
+			}
 
-            Object[] results = unifiedClient.execBatch();
-            List<Object> resultList = new ArrayList<>(results.length);
-            for (int i = 0; i < results.length; i++) {
-                Object item = results[i];
-                if (item instanceof Exception) {
-                    // Convert exceptions in pipeline results
-                    resultList.add(new ValkeyGlideExceptionConverter().convert((Exception) item));
-                    continue;
-                }
-                @SuppressWarnings("unchecked")
-                ResultMapper<Object, ?> mapper = (ResultMapper<Object, ?>) batchCommandsConverters.get(i);
-                resultList.add(mapper.map(item));
-            }
-            return resultList;
-        } catch (Exception ex) {
-            throw new ValkeyPipelineException(ex);
-        } finally {
-            unifiedClient.discardBatch();
-            batchCommandsConverters.clear();
-        }
-    }
+			Object[] results = unifiedClient.execBatch();
+			List<Object> resultList = new ArrayList<>(results.length);
+			for (int i = 0; i < results.length; i++) {
+				Object item = results[i];
+				if (item instanceof Exception) {
+					// Convert exceptions in pipeline results
+					resultList.add(new ValkeyGlideExceptionConverter().convert((Exception) item));
+					continue;
+				}
+				@SuppressWarnings("unchecked")
+				ResultMapper<Object, ?> mapper = (ResultMapper<Object, ?>) batchCommandsConverters.get(i);
+				resultList.add(mapper.map(item));
+			}
+			return resultList;
+		}
+		catch (Exception ex) {
+			throw new ValkeyPipelineException(ex);
+		}
+		finally {
+			unifiedClient.discardBatch();
+			batchCommandsConverters.clear();
+		}
+	}
 
-    @Override
-    public void multi() {
-        if (isPipelined()) {
+	@Override
+	public void multi() {
+		if (isPipelined()) {
 			throw new InvalidDataAccessApiUsageException("Cannot use transaction while a pipeline is open");
 		}
-        
-        if (!isQueueing()) {
-            // Create atomic batch (transaction)
-            unifiedClient.startNewBatch(true);
-        }
-    }
 
-    @Override
-    public void discard() {
-        if (!isQueueing()) { 
-            throw new InvalidDataAccessApiUsageException("No ongoing transaction; Did you forget to call multi");
-        }
-        
-        // Clear the current batch and reset transaction state
-        unifiedClient.discardBatch();
-        batchCommandsConverters.clear();
-    }
+		if (!isQueueing()) {
+			// Create atomic batch (transaction)
+			unifiedClient.startNewBatch(true);
+		}
+	}
 
-    @Override
-    public List<Object> exec() {
-        if (!isQueueing()) {
-		    throw new InvalidDataAccessApiUsageException("No ongoing transaction; Did you forget to call multi");
-        }
-		
-        try {
-            if (unifiedClient.getBatchCount() == 0) {
-                return new ArrayList<>();
-            }
+	@Override
+	public void discard() {
+		if (!isQueueing()) {
+			throw new InvalidDataAccessApiUsageException("No ongoing transaction; Did you forget to call multi");
+		}
 
-            Object[] results = unifiedClient.execBatch();
-            
-            // Handle transaction abort cases - valkey-glide returns null for WATCH conflicts
-            if (results == null) {
-                // Return empty list for WATCH conflicts (matches Jedis behavior and Valkey specification)
-                return new ArrayList<>();
-            }
-            
-            List<Object> resultList = new ArrayList<>(results.length);
-            for (int i = 0; i < results.length; i++) {
-                Object item = results[i];
-                if (item instanceof Exception) {
-                    // Convert exceptions in pipeline results
-                    resultList.add(new ValkeyGlideExceptionConverter().convert((Exception) item));
-                    continue;
-                }
-                @SuppressWarnings("unchecked")
-                ResultMapper<Object, ?> mapper = (ResultMapper<Object, ?>) batchCommandsConverters.get(i);
-                resultList.add(mapper.map(item));
-            }
-            return resultList;
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        } finally {
-            // Clean up transaction state
-            unifiedClient.discardBatch();
-            batchCommandsConverters.clear();
-            // Watches are automatically cleared by the server after EXEC
-            watchedKeys.clear();
-            watchCommandIssued = false;
-        }
-    }
+		// Clear the current batch and reset transaction state
+		unifiedClient.discardBatch();
+		batchCommandsConverters.clear();
+	}
 
-    @Override
-    public void select(int dbIndex) {
-        Assert.isTrue(dbIndex >= 0, "DB index must be non-negative");
-        try {
-            byte[] dbArg = Integer.toString(dbIndex).getBytes(StandardCharsets.US_ASCII);
-            execute("SELECT", dbArg);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	@Override
+	public List<Object> exec() {
+		if (!isQueueing()) {
+			throw new InvalidDataAccessApiUsageException("No ongoing transaction; Did you forget to call multi");
+		}
 
-    @Override
-    public void unwatch() {
-        try {
-            if (watchedKeys.isEmpty() || !watchCommandIssued) {
-                return; // No keys to unwatch
-            }
-            execute("UNWATCH");
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        } finally {
-            watchedKeys.clear();
-        }
-    }
+		try {
+			if (unifiedClient.getBatchCount() == 0) {
+				return new ArrayList<>();
+			}
 
-    @Override
-    public void watch(byte[]... keys) {
-        Assert.notNull(keys, "Keys must not be null");
-        Assert.noNullElements(keys, "Keys must not contain null elements");
+			Object[] results = unifiedClient.execBatch();
 
-        if (isQueueing()) {
-            throw new InvalidDataAccessApiUsageException("WATCH is not allowed during MULTI");
-        }
+			// Handle transaction abort cases - valkey-glide returns null for WATCH
+			// conflicts
+			if (results == null) {
+				// Return empty list for WATCH conflicts (matches Jedis behavior and
+				// Valkey specification)
+				return new ArrayList<>();
+			}
 
-        try {
-            // Execute WATCH immediately to set up key monitoring at connection level
-            execute("WATCH", keys);
-            
-            // Track watched keys for cleanup
-            Collections.addAll(watchedKeys, keys);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+			List<Object> resultList = new ArrayList<>(results.length);
+			for (int i = 0; i < results.length; i++) {
+				Object item = results[i];
+				if (item instanceof Exception) {
+					// Convert exceptions in pipeline results
+					resultList.add(new ValkeyGlideExceptionConverter().convert((Exception) item));
+					continue;
+				}
+				@SuppressWarnings("unchecked")
+				ResultMapper<Object, ?> mapper = (ResultMapper<Object, ?>) batchCommandsConverters.get(i);
+				resultList.add(mapper.map(item));
+			}
+			return resultList;
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+		finally {
+			// Clean up transaction state
+			unifiedClient.discardBatch();
+			batchCommandsConverters.clear();
+			// Watches are automatically cleared by the server after EXEC
+			watchedKeys.clear();
+			watchCommandIssued = false;
+		}
+	}
 
-    @Override
-    public Long publish(byte[] channel, byte[] message) {
-        Assert.notNull(channel, "Channel must not be null");
-        Assert.notNull(message, "Message must not be null");
+	@Override
+	public void select(int dbIndex) {
+		Assert.isTrue(dbIndex >= 0, "DB index must be non-negative");
+		try {
+			byte[] dbArg = Integer.toString(dbIndex).getBytes(StandardCharsets.US_ASCII);
+			execute("SELECT", dbArg);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-        try {
-            Object result = execute("PUBLISH", channel, message);
-            return (Long) result;
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	@Override
+	public void unwatch() {
+		try {
+			if (watchedKeys.isEmpty() || !watchCommandIssued) {
+				return; // No keys to unwatch
+			}
+			execute("UNWATCH");
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+		finally {
+			watchedKeys.clear();
+		}
+	}
 
-    @Override
-    public void subscribe(MessageListener listener, byte[]... channels) {
-        Assert.notNull(listener, "MessageListener must not be null");
-        Assert.notNull(channels, "Channels must not be null");
-        Assert.noNullElements(channels, "Channels must not contain null elements");
+	@Override
+	public void watch(byte[]... keys) {
+		Assert.notNull(keys, "Keys must not be null");
+		Assert.noNullElements(keys, "Keys must not contain null elements");
+
+		if (isQueueing()) {
+			throw new InvalidDataAccessApiUsageException("WATCH is not allowed during MULTI");
+		}
+
+		try {
+			// Execute WATCH immediately to set up key monitoring at connection level
+			execute("WATCH", keys);
+
+			// Track watched keys for cleanup
+			Collections.addAll(watchedKeys, keys);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public Long publish(byte[] channel, byte[] message) {
+		Assert.notNull(channel, "Channel must not be null");
+		Assert.notNull(message, "Message must not be null");
+
+		try {
+			Object result = execute("PUBLISH", channel, message);
+			return (Long) result;
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public void subscribe(MessageListener listener, byte[]... channels) {
+		Assert.notNull(listener, "MessageListener must not be null");
+		Assert.notNull(channels, "Channels must not be null");
+		Assert.noNullElements(channels, "Channels must not contain null elements");
 
 		if (isSubscribed()) {
 			throw new ValkeySubscribedConnectionException(
@@ -468,33 +498,34 @@ public class ValkeyGlideConnection extends AbstractValkeyConnection {
 			throw new InvalidDataAccessApiUsageException("Cannot subscribe in pipeline / transaction mode");
 		}
 
-        if (unifiedClient.getDelegatingListener() == null) {
-            throw new InvalidDataAccessApiUsageException(
-                    "Pub/Sub not configured. Ensure the connection factory was created with pub/sub callback support.");
-        }
+		if (unifiedClient.getDelegatingListener() == null) {
+			throw new InvalidDataAccessApiUsageException(
+					"Pub/Sub not configured. Ensure the connection factory was created with pub/sub callback support.");
+		}
 
-        try {
-            unifiedClient.getDelegatingListener().setListener(listener);
-            
-            ValkeyGlideSubscription glideSubscription = new ValkeyGlideSubscription(
-                    listener, unifiedClient, unifiedClient.getDelegatingListener());
-            this.subscription = glideSubscription;
-            glideSubscription.subscribe(channels);
-            
-        } catch (Exception ex) {
-            if (unifiedClient.getDelegatingListener() != null) {
-                unifiedClient.getDelegatingListener().clearListener();
-            }
-            this.subscription = null;
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		try {
+			unifiedClient.getDelegatingListener().setListener(listener);
 
-    @Override
-    public void pSubscribe(MessageListener listener, byte[]... patterns) {
-        Assert.notNull(listener, "MessageListener must not be null");
-        Assert.notNull(patterns, "Patterns must not be null");
-        Assert.noNullElements(patterns, "Patterns must not contain null elements");
+			ValkeyGlideSubscription glideSubscription = new ValkeyGlideSubscription(listener, unifiedClient,
+					unifiedClient.getDelegatingListener());
+			this.subscription = glideSubscription;
+			glideSubscription.subscribe(channels);
+
+		}
+		catch (Exception ex) {
+			if (unifiedClient.getDelegatingListener() != null) {
+				unifiedClient.getDelegatingListener().clearListener();
+			}
+			this.subscription = null;
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public void pSubscribe(MessageListener listener, byte[]... patterns) {
+		Assert.notNull(listener, "MessageListener must not be null");
+		Assert.notNull(patterns, "Patterns must not be null");
+		Assert.noNullElements(patterns, "Patterns must not contain null elements");
 
 		if (isSubscribed()) {
 			throw new ValkeySubscribedConnectionException(
@@ -504,172 +535,181 @@ public class ValkeyGlideConnection extends AbstractValkeyConnection {
 		if (isQueueing() || isPipelined()) {
 			throw new InvalidDataAccessApiUsageException("Cannot subscribe in pipeline / transaction mode");
 		}
-        
-        if (unifiedClient.getDelegatingListener() == null) {
-            throw new InvalidDataAccessApiUsageException(
-                    "Pub/Sub not configured. Ensure the connection factory was created with pub/sub callback support.");
-        }
 
-        try {
-            unifiedClient.getDelegatingListener().setListener(listener);
-            
-            ValkeyGlideSubscription glideSubscription = new ValkeyGlideSubscription(
-                    listener, unifiedClient, unifiedClient.getDelegatingListener());
-            this.subscription = glideSubscription;
-            glideSubscription.pSubscribe(patterns);
-            
-        } catch (Exception ex) {
-            if (unifiedClient.getDelegatingListener() != null) {
-                unifiedClient.getDelegatingListener().clearListener();
-            }
-            this.subscription = null;
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		if (unifiedClient.getDelegatingListener() == null) {
+			throw new InvalidDataAccessApiUsageException(
+					"Pub/Sub not configured. Ensure the connection factory was created with pub/sub callback support.");
+		}
 
-    @Override
-    public Subscription getSubscription() {
-        return subscription;
-    }
+		try {
+			unifiedClient.getDelegatingListener().setListener(listener);
 
-    @Override
-    public boolean isSubscribed() {
-        Subscription sub = this.subscription;
-        return sub != null && sub.isAlive();
-    }
+			ValkeyGlideSubscription glideSubscription = new ValkeyGlideSubscription(listener, unifiedClient,
+					unifiedClient.getDelegatingListener());
+			this.subscription = glideSubscription;
+			glideSubscription.pSubscribe(patterns);
 
-    /**
-     * Execute a Valkey command using string arguments.
-     * 
-     * @param command the command to execute
-     * @param args the command arguments
-     * @return the command result
-     */
+		}
+		catch (Exception ex) {
+			if (unifiedClient.getDelegatingListener() != null) {
+				unifiedClient.getDelegatingListener().clearListener();
+			}
+			this.subscription = null;
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    /**
-     * Executes a Valkey command with arguments and converts the raw driver result
-     * into a strongly typed value using the provided {@link ResultMapper}.
-     *
-     * <p>Behavior depends on whether pipelining/transaction is enabled:
-     * <ul>
-     *   <li><b>Immediate mode</b> – the command is sent directly to the driver,
-     *       and the raw result is synchronously converted via {@code mapper.map(raw)}.</li>
-     *   <li><b>Pipeline/Transaction mode</b> – the command and mapper are queued for later execution.
-     *       In this case, the method returns {@code null}. When
-     *       {@link #closePipeline()}/{@link #exec()} are called, all queued commands are flushed,
-     *       raw results are collected, and each queued {@code ResultMapper}
-     *       is applied in order.</li>
-     * </ul>
-     *
-     * <p>The caller (API layer) is responsible for providing the appropriate
-     * {@link ResultMapper} for the Valkey command being executed. This allows each
-     * high-level API method to encapsulate its own decoding logic.
-     *
-     * @param command The Valkey command name (e.g. "GET", "SMEMBERS").
-     * @param mapper  A function that knows how to convert the raw driver result
-     *                into a strongly typed value of type {@code R}.
-     * @param args    The command arguments, already encoded into driver-acceptable
-     *                representations (e.g. {@code byte[]} or primitives).
-     * @param <R>     The expected return type after mapping the driver result.
-     * @return        The mapped result in immediate mode, or {@code null} if
-     *                pipelining/transaction is active (result will be available after
-     *                {@link #closePipeline()} or {@link #exec()}).
-     */
-    @SuppressWarnings("unchecked")
-    @Nullable
-    public <I, R> R execute(String command, ResultMapper<I, R> mapper, Object... args) {
-        Assert.notNull(args, "Arguments must not be null");
-        Assert.notNull(mapper, "ResultMapper must not be null");
+	@Override
+	public Subscription getSubscription() {
+		return subscription;
+	}
 
-        verifyConnectionOpen();
+	@Override
+	public boolean isSubscribed() {
+		Subscription sub = this.subscription;
+		return sub != null && sub.isAlive();
+	}
 
-        // Track WATCH commands issued directly via execute() to ensure UNWATCH on close
-        if ("WATCH".equalsIgnoreCase(command)) {
-            watchCommandIssued = true;
-        }
+	/**
+	 * Execute a Valkey command using string arguments.
+	 * @param command the command to execute
+	 * @param args the command arguments
+	 * @return the command result
+	 */
 
-        try {
-            // Convert arguments to appropriate format for Glide
-            GlideString[] glideArgs = new GlideString[args.length + 1];
-            glideArgs[0] = GlideString.of(command);
-            for (int i = 0; i < args.length; i++) {
-                if (args[i] == null) {
-                    glideArgs[i + 1] = null;
-                } else if (args[i] instanceof byte[]) {
-                    glideArgs[i + 1] = GlideString.of((byte[]) args[i]);
-                } else if (args[i] instanceof String) {
-                    glideArgs[i + 1] = GlideString.of((String) args[i]);
-                } else {
-                    glideArgs[i + 1] = GlideString.of(args[i].toString());
-                }
-            }
-            // Handle pipeline/transaction mode - add command to batch instead of executing
-            if (isQueueing() || isPipelined()) {
-                // Store converter for later conversion
-                batchCommandsConverters.add(mapper);
-                // Add command to the current batch
-                unifiedClient.customCommand(glideArgs);
-                return null; // Return null for queued commands in transaction
-            }
-            
-            // Immediate execution mode
-            I result = (I) unifiedClient.customCommand(glideArgs);
-            return mapper.map(result);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	/**
+	 * Executes a Valkey command with arguments and converts the raw driver result into a
+	 * strongly typed value using the provided {@link ResultMapper}.
+	 *
+	 * <p>
+	 * Behavior depends on whether pipelining/transaction is enabled:
+	 * <ul>
+	 * <li><b>Immediate mode</b> – the command is sent directly to the driver, and the raw
+	 * result is synchronously converted via {@code mapper.map(raw)}.</li>
+	 * <li><b>Pipeline/Transaction mode</b> – the command and mapper are queued for later
+	 * execution. In this case, the method returns {@code null}. When
+	 * {@link #closePipeline()}/{@link #exec()} are called, all queued commands are
+	 * flushed, raw results are collected, and each queued {@code ResultMapper} is applied
+	 * in order.</li>
+	 * </ul>
+	 *
+	 * <p>
+	 * The caller (API layer) is responsible for providing the appropriate
+	 * {@link ResultMapper} for the Valkey command being executed. This allows each
+	 * high-level API method to encapsulate its own decoding logic.
+	 * @param command The Valkey command name (e.g. "GET", "SMEMBERS").
+	 * @param mapper A function that knows how to convert the raw driver result into a
+	 * strongly typed value of type {@code R}.
+	 * @param args The command arguments, already encoded into driver-acceptable
+	 * representations (e.g. {@code byte[]} or primitives).
+	 * @param <R> The expected return type after mapping the driver result.
+	 * @return The mapped result in immediate mode, or {@code null} if
+	 * pipelining/transaction is active (result will be available after
+	 * {@link #closePipeline()} or {@link #exec()}).
+	 */
+	@SuppressWarnings("unchecked")
+	@Nullable public <I, R> R execute(String command, ResultMapper<I, R> mapper, Object... args) {
+		Assert.notNull(args, "Arguments must not be null");
+		Assert.notNull(mapper, "ResultMapper must not be null");
 
-    @Override
-    public Object execute(String command, byte[]... args) {
-        Assert.notNull(command, "Command must not be null");
-        Assert.notNull(args, "Arguments must not be null");
-        Assert.noNullElements(args, "Arguments must not contain null elements");
-        try {
-            // Delegate to the generic execute method
-            return execute(command, rawResult -> {
-                return ValkeyGlideConverters.defaultFromGlideResult(rawResult);
-            },
-            (Object[]) args);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		verifyConnectionOpen();
 
-    @Override
-    protected boolean isActive(ValkeyNode node) {
-        Assert.notNull(node, "ValkeyNode must not be null");
-        // TODO: Create new valkey-glide GlideClient instance to test connection to the node
-        // connection params should be clonned from the current client except host/port
-        throw new UnsupportedOperationException("Not yet implemented");
-    }
+		// Track WATCH commands issued directly via execute() to ensure UNWATCH on close
+		if ("WATCH".equalsIgnoreCase(command)) {
+			watchCommandIssued = true;
+		}
 
-    @Override
-    protected ValkeySentinelConnection getSentinelConnection(ValkeyNode sentinel) {
-        // TODO: Uncomment when sentinel support is added to valkey-glide
-        // and implement sentinel connection using a dedicated GlideClient instance
-        // Assert.notNull(sentinel, "Sentinel ValkeyNode must not be null");
-        throw new UnsupportedOperationException("Sentinel is not supported by this client.");
-    }
+		try {
+			// Convert arguments to appropriate format for Glide
+			GlideString[] glideArgs = new GlideString[args.length + 1];
+			glideArgs[0] = GlideString.of(command);
+			for (int i = 0; i < args.length; i++) {
+				if (args[i] == null) {
+					glideArgs[i + 1] = null;
+				}
+				else if (args[i] instanceof byte[]) {
+					glideArgs[i + 1] = GlideString.of((byte[]) args[i]);
+				}
+				else if (args[i] instanceof String) {
+					glideArgs[i + 1] = GlideString.of((String) args[i]);
+				}
+				else {
+					glideArgs[i + 1] = GlideString.of(args[i].toString());
+				}
+			}
+			// Handle pipeline/transaction mode - add command to batch instead of
+			// executing
+			if (isQueueing() || isPipelined()) {
+				// Store converter for later conversion
+				batchCommandsConverters.add(mapper);
+				// Add command to the current batch
+				unifiedClient.customCommand(glideArgs);
+				return null; // Return null for queued commands in transaction
+			}
 
-    @Override
-    public byte[] echo(byte[] message) {
-        Assert.notNull(message, "Message must not be null");
-        try {
-            Object result = execute("ECHO", message);
-            return result != null ? (byte[]) result : null;
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+			// Immediate execution mode
+			I result = (I) unifiedClient.customCommand(glideArgs);
+			return mapper.map(result);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    @Override
-    public String ping() {
-        try {
-            Object result = execute("PING");
-            return result != null ? new String((byte[]) result, StandardCharsets.UTF_8) : null;
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	@Override
+	public Object execute(String command, byte[]... args) {
+		Assert.notNull(command, "Command must not be null");
+		Assert.notNull(args, "Arguments must not be null");
+		Assert.noNullElements(args, "Arguments must not contain null elements");
+		try {
+			// Delegate to the generic execute method
+			return execute(command, rawResult -> {
+				return ValkeyGlideConverters.defaultFromGlideResult(rawResult);
+			}, (Object[]) args);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	protected boolean isActive(ValkeyNode node) {
+		Assert.notNull(node, "ValkeyNode must not be null");
+		// TODO: Create new valkey-glide GlideClient instance to test connection to the
+		// node
+		// connection params should be clonned from the current client except host/port
+		throw new UnsupportedOperationException("Not yet implemented");
+	}
+
+	@Override
+	protected ValkeySentinelConnection getSentinelConnection(ValkeyNode sentinel) {
+		// TODO: Uncomment when sentinel support is added to valkey-glide
+		// and implement sentinel connection using a dedicated GlideClient instance
+		// Assert.notNull(sentinel, "Sentinel ValkeyNode must not be null");
+		throw new UnsupportedOperationException("Sentinel is not supported by this client.");
+	}
+
+	@Override
+	public byte[] echo(byte[] message) {
+		Assert.notNull(message, "Message must not be null");
+		try {
+			Object result = execute("ECHO", message);
+			return result != null ? (byte[]) result : null;
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public String ping() {
+		try {
+			Object result = execute("PING");
+			return result != null ? new String((byte[]) result, StandardCharsets.UTF_8) : null;
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
 }

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionFactory.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,461 +47,461 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
- * Connection factory creating <a href="https://github.com/valkey-io/valkey-glide">Valkey Glide</a> based
- * connections. This is the central class for connecting to Valkey using Valkey-Glide.
- * 
- * <p>This factory creates a new {@link ValkeyGlideConnection} on each call to {@link #getConnection()}.
- * The underlying client instance is shared among all connections.
- * 
- * <p>This class implements the {@link org.springframework.beans.factory.InitializingBean} interface,
- * triggering the creation of the client instance on {@link #afterPropertiesSet()}.
- * It also implements {@link org.springframework.beans.factory.DisposableBean} for closing the client on
+ * Connection factory creating <a href="https://github.com/valkey-io/valkey-glide">Valkey
+ * Glide</a> based connections. This is the central class for connecting to Valkey using
+ * Valkey-Glide.
+ *
+ * <p>
+ * This factory creates a new {@link ValkeyGlideConnection} on each call to
+ * {@link #getConnection()}. The underlying client instance is shared among all
+ * connections.
+ *
+ * <p>
+ * This class implements the {@link org.springframework.beans.factory.InitializingBean}
+ * interface, triggering the creation of the client instance on
+ * {@link #afterPropertiesSet()}. It also implements
+ * {@link org.springframework.beans.factory.DisposableBean} for closing the client on
  * application shutdown.
- * 
- * <p>The Valkey Glide connection factory can be used both with a standalone Valkey server and with a
- * Valkey cluster. For standalone mode, use the {@link #ValkeyGlideConnectionFactory()} constructor
- * or {@link #ValkeyGlideConnectionFactory(ValkeyGlideClientConfiguration)} constructor. For cluster mode,
- * ensure the {@link ValkeyGlideClientConfiguration} is configured for cluster mode.
- * 
+ *
+ * <p>
+ * The Valkey Glide connection factory can be used both with a standalone Valkey server
+ * and with a Valkey cluster. For standalone mode, use the
+ * {@link #ValkeyGlideConnectionFactory()} constructor or
+ * {@link #ValkeyGlideConnectionFactory(ValkeyGlideClientConfiguration)} constructor. For
+ * cluster mode, ensure the {@link ValkeyGlideClientConfiguration} is configured for
+ * cluster mode.
+ *
  * @author Ilia Kolominsky
  * @since 2.0
  */
 public class ValkeyGlideConnectionFactory
-    implements ValkeyConnectionFactory, InitializingBean, DisposableBean, SmartLifecycle {
+		implements ValkeyConnectionFactory, InitializingBean, DisposableBean, SmartLifecycle {
 
-    private static final Log logger = LogFactory.getLog(ValkeyGlideConnectionFactory.class);
+	private static final Log logger = LogFactory.getLog(ValkeyGlideConnectionFactory.class);
 
-    private final @Nullable ValkeyGlideClientConfiguration valkeyGlideConfiguration;
-    private final ValkeyConfiguration configuration;
-    
-    // Bounded pool of pre-created adapters (with listeners pre-associated).
-    private final LinkedBlockingQueue<UnifiedGlideClient> adapterPool;
-    
-    private @Nullable AsyncTaskExecutor executor;
-    
-    private boolean initialized = false;
-    private boolean running = false;
-    private boolean autoStartup = true;
-    private boolean earlyStartup = true;
-    private int phase = 0;
-    private static final AtomicBoolean OTEL_INITIALIZED = new AtomicBoolean(false);
-    private static @Nullable OpenTelemetryForGlide OTEL_INITIALIZED_CONFIG;
-    private static final Object OTEL_LOCK = new Object();
+	private final @Nullable ValkeyGlideClientConfiguration valkeyGlideConfiguration;
 
+	private final ValkeyConfiguration configuration;
 
-    /**
-     * Constructs a new {@link ValkeyGlideConnectionFactory} instance with default settings.
-     */
-    public ValkeyGlideConnectionFactory() {
-        this(new ValkeyStandaloneConfiguration(), new DefaultValkeyGlideClientConfiguration());
-    }
+	// Bounded pool of pre-created adapters (with listeners pre-associated).
+	private final LinkedBlockingQueue<UnifiedGlideClient> adapterPool;
 
-    public ValkeyGlideConnectionFactory(ValkeyStandaloneConfiguration standaloneConfiguration) {
+	private @Nullable AsyncTaskExecutor executor;
+
+	private boolean initialized = false;
+
+	private boolean running = false;
+
+	private boolean autoStartup = true;
+
+	private boolean earlyStartup = true;
+
+	private int phase = 0;
+
+	private static final AtomicBoolean OTEL_INITIALIZED = new AtomicBoolean(false);
+
+	private static @Nullable OpenTelemetryForGlide OTEL_INITIALIZED_CONFIG;
+
+	private static final Object OTEL_LOCK = new Object();
+
+	/**
+	 * Constructs a new {@link ValkeyGlideConnectionFactory} instance with default
+	 * settings.
+	 */
+	public ValkeyGlideConnectionFactory() {
+		this(new ValkeyStandaloneConfiguration(), new DefaultValkeyGlideClientConfiguration());
+	}
+
+	public ValkeyGlideConnectionFactory(ValkeyStandaloneConfiguration standaloneConfiguration) {
 		this(standaloneConfiguration, new DefaultValkeyGlideClientConfiguration());
 	}
 
-    /**
-     * Constructs a new {@link ValkeyGlideConnectionFactory} instance with the given {@link ValkeyStandaloneConfiguration}
-     * and {@link ValkeyGlideClientConfiguration}.
-     *
-     * @param standaloneConfiguration must not be {@literal null}
-     * @param clientConfiguration must not be {@literal null}
-     * @since 3.0
-     */
-    public ValkeyGlideConnectionFactory(ValkeyStandaloneConfiguration standaloneConfiguration,
-            ValkeyGlideClientConfiguration valkeyGlideConfiguration) {
-        
-        Assert.notNull(standaloneConfiguration, "ValkeyStandaloneConfiguration must not be null!");
-        Assert.notNull(valkeyGlideConfiguration, "ValkeyGlideClientConfiguration must not be null!");
-        
-        this.configuration = standaloneConfiguration;
-        this.valkeyGlideConfiguration = valkeyGlideConfiguration;
-        this.adapterPool = new LinkedBlockingQueue<>(valkeyGlideConfiguration.getMaxPoolSize());
-    }
+	/**
+	 * Constructs a new {@link ValkeyGlideConnectionFactory} instance with the given
+	 * {@link ValkeyStandaloneConfiguration} and {@link ValkeyGlideClientConfiguration}.
+	 * @param standaloneConfiguration must not be {@literal null}
+	 * @param clientConfiguration must not be {@literal null}
+	 * @since 3.0
+	 */
+	public ValkeyGlideConnectionFactory(ValkeyStandaloneConfiguration standaloneConfiguration,
+			ValkeyGlideClientConfiguration valkeyGlideConfiguration) {
 
-    /**
-     * Constructs a new {@link ValkeyGlideConnectionFactory} instance with the given {@link ValkeyClusterConfiguration}.
-     *
-     * @param clusterConfiguration must not be {@literal null}
-     * @since 3.0
-     */
-    public ValkeyGlideConnectionFactory(ValkeyClusterConfiguration clusterConfiguration) {
-        this(clusterConfiguration, new DefaultValkeyGlideClientConfiguration());
-    }
+		Assert.notNull(standaloneConfiguration, "ValkeyStandaloneConfiguration must not be null!");
+		Assert.notNull(valkeyGlideConfiguration, "ValkeyGlideClientConfiguration must not be null!");
 
-    /**
-     * Constructs a new {@link ValkeyGlideConnectionFactory} instance with the given {@link ValkeyClusterConfiguration}
-     * and {@link ValkeyGlideClientConfiguration}.
-     *
-     * @param clusterConfiguration must not be {@literal null}
-     * @param clusterClientConfiguration must not be {@literal null}
-     * @since 3.0
-     */
-    public ValkeyGlideConnectionFactory(ValkeyClusterConfiguration clusterConfiguration,
-        ValkeyGlideClientConfiguration valkeyGlideConfiguration) {
-        
-        Assert.notNull(clusterConfiguration, "ValkeyClusterConfiguration must not be null!");
-        Assert.notNull(valkeyGlideConfiguration, "ValkeyGlideClientConfiguration must not be null!");
-        
-        this.configuration = clusterConfiguration;
-        this.valkeyGlideConfiguration = valkeyGlideConfiguration;
-        this.adapterPool = new LinkedBlockingQueue<>(valkeyGlideConfiguration.getMaxPoolSize());
-    }
+		this.configuration = standaloneConfiguration;
+		this.valkeyGlideConfiguration = valkeyGlideConfiguration;
+		this.adapterPool = new LinkedBlockingQueue<>(valkeyGlideConfiguration.getMaxPoolSize());
+	}
 
-    /**
-     * Constructs a new {@link ValkeyGlideConnectionFactory} instance using the given {@link ValkeySentinelConfiguration}.
-     *
-     * @param sentinelConfiguration must not be {@literal null}.
-     * @throws UnsupportedOperationException as Sentinel connections are not supported with Valkey-Glide.
-     * @since 3.0
-     */
-    public ValkeyGlideConnectionFactory(ValkeySentinelConfiguration sentinelConfiguration) {
-        throw new UnsupportedOperationException("Sentinel connections not supported with Valkey-Glide!");
-    }
+	/**
+	 * Constructs a new {@link ValkeyGlideConnectionFactory} instance with the given
+	 * {@link ValkeyClusterConfiguration}.
+	 * @param clusterConfiguration must not be {@literal null}
+	 * @since 3.0
+	 */
+	public ValkeyGlideConnectionFactory(ValkeyClusterConfiguration clusterConfiguration) {
+		this(clusterConfiguration, new DefaultValkeyGlideClientConfiguration());
+	}
 
-    /**
-     * Constructs a new {@link ValkeyGlideConnectionFactory} instance using the given {@link ValkeySentinelConfiguration} and
-     * {@link ValkeyGlideClientConfiguration}.
-     *
-     * @param sentinelConfiguration must not be {@literal null}.
-     * @param clientConfiguration must not be {@literal null}.
-     * @throws UnsupportedOperationException as Sentinel connections are not supported with Valkey-Glide.
-     * @since 3.0
-     */
-    public ValkeyGlideConnectionFactory(ValkeySentinelConfiguration sentinelConfiguration,
-            ValkeyGlideClientConfiguration clientConfiguration) {
-        throw new UnsupportedOperationException("Sentinel connections not supported with Valkey-Glide!");
-    }
+	/**
+	 * Constructs a new {@link ValkeyGlideConnectionFactory} instance with the given
+	 * {@link ValkeyClusterConfiguration} and {@link ValkeyGlideClientConfiguration}.
+	 * @param clusterConfiguration must not be {@literal null}
+	 * @param clusterClientConfiguration must not be {@literal null}
+	 * @since 3.0
+	 */
+	public ValkeyGlideConnectionFactory(ValkeyClusterConfiguration clusterConfiguration,
+			ValkeyGlideClientConfiguration valkeyGlideConfiguration) {
 
-    /**
-     * Constructs a new {@link ValkeyGlideConnectionFactory} instance with the given {@link ValkeyGlideClientConfiguration}.
-     *
-     * @param clientConfiguration must not be {@literal null}
-     * @deprecated since 3.0, use {@link #ValkeyGlideConnectionFactory(ValkeyStandaloneConfiguration, ValkeyGlideClientConfiguration)}
-     *             or {@link #ValkeyGlideConnectionFactory(ValkeyClusterConfiguration, ValkeyGlideClusterClientConfiguration)} instead
-     */
-    @Deprecated
-    public ValkeyGlideConnectionFactory(ValkeyGlideClientConfiguration valkeyGlideConfiguration) {
-        Assert.notNull(valkeyGlideConfiguration, "ValkeyGlideClientConfiguration must not be null!");
-        
-        this.configuration = new ValkeyStandaloneConfiguration();
-        this.valkeyGlideConfiguration = valkeyGlideConfiguration;
-        this.adapterPool = new LinkedBlockingQueue<>(valkeyGlideConfiguration.getMaxPoolSize());
-    }
+		Assert.notNull(clusterConfiguration, "ValkeyClusterConfiguration must not be null!");
+		Assert.notNull(valkeyGlideConfiguration, "ValkeyGlideClientConfiguration must not be null!");
 
-    /**
-     * Initialize the factory by pre-creating a pool of client instances if early startup is enabled.
-     */
-    @Override
-    public void afterPropertiesSet() {
-        if (initialized) {
-            return;
-        }
-        
-        // Skip eager initialization if early startup is disabled (useful for Spring Boot testing)
-        if (!earlyStartup) {
-            initialized = true;
-            return;
-        }
-        
-        // Initialize OpenTelemetry before creating any clients
-        if (valkeyGlideConfiguration != null) {
-            OpenTelemetryForGlide openTelemetryForGlide = valkeyGlideConfiguration.getOpenTelemetryForGlide();
-            if (openTelemetryForGlide != null) {
-                useOpenTelemetry(openTelemetryForGlide);
-            }
-        }
+		this.configuration = clusterConfiguration;
+		this.valkeyGlideConfiguration = valkeyGlideConfiguration;
+		this.adapterPool = new LinkedBlockingQueue<>(valkeyGlideConfiguration.getMaxPoolSize());
+	}
 
-        // Pre-create pool of adapters based on configuration mode
-        if (isClusterAware()) {
-            for (int i = 0; i < valkeyGlideConfiguration.getMaxPoolSize(); i++) {
-                adapterPool.offer(new ClusterGlideClientAdapter((ValkeyClusterConfiguration) configuration, valkeyGlideConfiguration));
-            }
-        } else {
-            for (int i = 0; i < valkeyGlideConfiguration.getMaxPoolSize(); i++) {
-                adapterPool.offer(new StandaloneGlideClientAdapter((ValkeyStandaloneConfiguration) configuration, valkeyGlideConfiguration));
-            }
-        }
-        
-        initialized = true;
-    }
+	/**
+	 * Constructs a new {@link ValkeyGlideConnectionFactory} instance using the given
+	 * {@link ValkeySentinelConfiguration}.
+	 * @param sentinelConfiguration must not be {@literal null}.
+	 * @throws UnsupportedOperationException as Sentinel connections are not supported
+	 * with Valkey-Glide.
+	 * @since 3.0
+	 */
+	public ValkeyGlideConnectionFactory(ValkeySentinelConfiguration sentinelConfiguration) {
+		throw new UnsupportedOperationException("Sentinel connections not supported with Valkey-Glide!");
+	}
 
-    @Override
-    public ValkeyConnection getConnection() {
-        afterPropertiesSet();
-        
-        // Return cluster connection when in cluster mode
-        if (isClusterAware()) {
-            return getClusterConnection();
-        }
-        
-        // Get adapter from lock-free pool (or create new if pool is empty)
-        UnifiedGlideClient adapter = adapterPool.poll();
-        if (adapter == null) {
-            if (ValkeyConfiguration.isClusterConfiguration(configuration)) {
-                throw new IllegalStateException("Cannot create StandaloneGlideClientAdapter in cluster mode");
-            }
-            adapter = new StandaloneGlideClientAdapter((ValkeyStandaloneConfiguration) configuration, valkeyGlideConfiguration);
-        }
-        return new ValkeyGlideConnection(adapter, this);
-    }
+	/**
+	 * Constructs a new {@link ValkeyGlideConnectionFactory} instance using the given
+	 * {@link ValkeySentinelConfiguration} and {@link ValkeyGlideClientConfiguration}.
+	 * @param sentinelConfiguration must not be {@literal null}.
+	 * @param clientConfiguration must not be {@literal null}.
+	 * @throws UnsupportedOperationException as Sentinel connections are not supported
+	 * with Valkey-Glide.
+	 * @since 3.0
+	 */
+	public ValkeyGlideConnectionFactory(ValkeySentinelConfiguration sentinelConfiguration,
+			ValkeyGlideClientConfiguration clientConfiguration) {
+		throw new UnsupportedOperationException("Sentinel connections not supported with Valkey-Glide!");
+	}
 
-    @Override
-    public ValkeyClusterConnection getClusterConnection() {
-        afterPropertiesSet();
-        
-        if (!isClusterAware()) {
-            throw new InvalidDataAccessResourceUsageException("Cluster mode is not configured!");
-        }
+	/**
+	 * Constructs a new {@link ValkeyGlideConnectionFactory} instance with the given
+	 * {@link ValkeyGlideClientConfiguration}.
+	 * @param clientConfiguration must not be {@literal null}
+	 * @deprecated since 3.0, use
+	 * {@link #ValkeyGlideConnectionFactory(ValkeyStandaloneConfiguration, ValkeyGlideClientConfiguration)}
+	 * or
+	 * {@link #ValkeyGlideConnectionFactory(ValkeyClusterConfiguration, ValkeyGlideClusterClientConfiguration)}
+	 * instead
+	 */
+	@Deprecated
+	public ValkeyGlideConnectionFactory(ValkeyGlideClientConfiguration valkeyGlideConfiguration) {
+		Assert.notNull(valkeyGlideConfiguration, "ValkeyGlideClientConfiguration must not be null!");
 
-        // Get adapter from lock-free pool (or create new if pool is empty)
-        UnifiedGlideClient adapter = adapterPool.poll();
-        if (adapter == null) {
-            if (!ValkeyConfiguration.isClusterConfiguration(configuration)) {
-                throw new IllegalStateException("Cannot create ClusterGlideClientAdapter in non-cluster mode");
-            }
-            adapter = new ClusterGlideClientAdapter((ValkeyClusterConfiguration) configuration, valkeyGlideConfiguration);
-        }
-        return new ValkeyGlideClusterConnection((ClusterGlideClientAdapter) adapter, this);
-    }
+		this.configuration = new ValkeyStandaloneConfiguration();
+		this.valkeyGlideConfiguration = valkeyGlideConfiguration;
+		this.adapterPool = new LinkedBlockingQueue<>(valkeyGlideConfiguration.getMaxPoolSize());
+	}
 
-    @Override
-    public boolean getConvertPipelineAndTxResults() {
-        return true;
-    }
+	/**
+	 * Initialize the factory by pre-creating a pool of client instances if early startup
+	 * is enabled.
+	 */
+	@Override
+	public void afterPropertiesSet() {
+		if (initialized) {
+			return;
+		}
 
-    @Override
-    public ValkeySentinelConnection getSentinelConnection() {
-        throw new UnsupportedOperationException("Sentinel connections not supported with Valkey-Glide!");
-    }
+		// Skip eager initialization if early startup is disabled (useful for Spring Boot
+		// testing)
+		if (!earlyStartup) {
+			initialized = true;
+			return;
+		}
 
-    /**
-     * Release an adapter back to the bounded pool.
-     * If the pool is full, the adapter is discarded (will be GC'd).
-     * 
-     * @param adapter the adapter to release
-     */
-    void releaseAdapter(UnifiedGlideClient adapter) {
-        adapterPool.offer(adapter);
-    }
+		// Initialize OpenTelemetry before creating any clients
+		if (valkeyGlideConfiguration != null) {
+			OpenTelemetryForGlide openTelemetryForGlide = valkeyGlideConfiguration.getOpenTelemetryForGlide();
+			if (openTelemetryForGlide != null) {
+				useOpenTelemetry(openTelemetryForGlide);
+			}
+		}
 
-    /**
-     * Shut down the factory when this factory is destroyed.
-     * Closes all pooled client instances.
-     */
-    @Override
-    public void destroy() {
-        initialized = false;
-        running = false;
-    }
+		// Pre-create pool of adapters based on configuration mode
+		if (isClusterAware()) {
+			for (int i = 0; i < valkeyGlideConfiguration.getMaxPoolSize(); i++) {
+				adapterPool.offer(new ClusterGlideClientAdapter((ValkeyClusterConfiguration) configuration,
+						valkeyGlideConfiguration));
+			}
+		}
+		else {
+			for (int i = 0; i < valkeyGlideConfiguration.getMaxPoolSize(); i++) {
+				adapterPool.offer(new StandaloneGlideClientAdapter((ValkeyStandaloneConfiguration) configuration,
+						valkeyGlideConfiguration));
+			}
+		}
 
-    private boolean sameOtelConfig(@Nullable OpenTelemetryForGlide a, @Nullable OpenTelemetryForGlide b) {
-        return java.util.Objects.equals(a, b);
-    }
+		initialized = true;
+	}
 
-    private void useOpenTelemetry(OpenTelemetryForGlide openTelemetryForGlide) {
-        Assert.notNull(openTelemetryForGlide, "OpenTelemetryForGlide must not be null");
+	@Override
+	public ValkeyConnection getConnection() {
+		afterPropertiesSet();
 
-        String tracesEndpoint = openTelemetryForGlide.tracesEndpoint();
-        String metricsEndpoint = openTelemetryForGlide.metricsEndpoint();
-        Integer samplePercentage = openTelemetryForGlide.samplePercentage();
-        Long flushIntervalMs = openTelemetryForGlide.flushIntervalMs();
+		// Return cluster connection when in cluster mode
+		if (isClusterAware()) {
+			return getClusterConnection();
+		}
 
-        boolean hasTraces = tracesEndpoint != null && !tracesEndpoint.isBlank();
-        boolean hasMetrics = metricsEndpoint != null && !metricsEndpoint.isBlank();
+		// Get adapter from lock-free pool (or create new if pool is empty)
+		UnifiedGlideClient adapter = adapterPool.poll();
+		if (adapter == null) {
+			if (ValkeyConfiguration.isClusterConfiguration(configuration)) {
+				throw new IllegalStateException("Cannot create StandaloneGlideClientAdapter in cluster mode");
+			}
+			adapter = new StandaloneGlideClientAdapter((ValkeyStandaloneConfiguration) configuration,
+					valkeyGlideConfiguration);
+		}
+		return new ValkeyGlideConnection(adapter, this);
+	}
 
-        if (!hasTraces && !hasMetrics){
-                throw new IllegalArgumentException(
-                "OpenTelemetryForGlide requires at least one of tracesEndpoint or metricsEndpoint"
-            );
-        }
-        
-        if (samplePercentage != null) {
-            Assert.isTrue(
-                samplePercentage >= 0 && samplePercentage <= 100,
-                "samplePercentage must be in range [0..100]"
-            );
-        }
+	@Override
+	public ValkeyClusterConnection getClusterConnection() {
+		afterPropertiesSet();
 
-        if (flushIntervalMs != null) {
-            Assert.isTrue(
-                flushIntervalMs > 0,
-                "flushIntervalMs must be > 0"
-            );
-        }
+		if (!isClusterAware()) {
+			throw new InvalidDataAccessResourceUsageException("Cluster mode is not configured!");
+		}
 
-        synchronized (OTEL_LOCK) {
-            if (OTEL_INITIALIZED.getAndSet(true)) {
-                if (sameOtelConfig(OTEL_INITIALIZED_CONFIG, openTelemetryForGlide)) {
-                    return; // Already initialized with the same config
-                }
+		// Get adapter from lock-free pool (or create new if pool is empty)
+		UnifiedGlideClient adapter = adapterPool.poll();
+		if (adapter == null) {
+			if (!ValkeyConfiguration.isClusterConfiguration(configuration)) {
+				throw new IllegalStateException("Cannot create ClusterGlideClientAdapter in non-cluster mode");
+			}
+			adapter = new ClusterGlideClientAdapter((ValkeyClusterConfiguration) configuration,
+					valkeyGlideConfiguration);
+		}
+		return new ValkeyGlideClusterConnection((ClusterGlideClientAdapter) adapter, this);
+	}
 
-                throw new IllegalStateException(
-                    "OpenTelemetry is already initialized with a different configuration. "
-                        + "existing=" + OTEL_INITIALIZED_CONFIG
-                        + ", requested=" + openTelemetryForGlide
-                );
-            }
+	@Override
+	public boolean getConvertPipelineAndTxResults() {
+		return true;
+	}
 
-            OpenTelemetryConfig.Builder otelBuilder = OpenTelemetryConfig.builder();
+	@Override
+	public ValkeySentinelConnection getSentinelConnection() {
+		throw new UnsupportedOperationException("Sentinel connections not supported with Valkey-Glide!");
+	}
 
-            if (hasTraces) {
-                TracesConfig.Builder tracesBuilder =
-                    TracesConfig.builder().endpoint(tracesEndpoint);
+	/**
+	 * Release an adapter back to the bounded pool. If the pool is full, the adapter is
+	 * discarded (will be GC'd).
+	 * @param adapter the adapter to release
+	 */
+	void releaseAdapter(UnifiedGlideClient adapter) {
+		adapterPool.offer(adapter);
+	}
 
-                if (samplePercentage != null) {
-                    tracesBuilder.samplePercentage(samplePercentage);
-                }
+	/**
+	 * Shut down the factory when this factory is destroyed. Closes all pooled client
+	 * instances.
+	 */
+	@Override
+	public void destroy() {
+		initialized = false;
+		running = false;
+	}
 
-                otelBuilder.traces(tracesBuilder.build());
-            }
+	private boolean sameOtelConfig(@Nullable OpenTelemetryForGlide a, @Nullable OpenTelemetryForGlide b) {
+		return java.util.Objects.equals(a, b);
+	}
 
-            if (hasMetrics) {
-                otelBuilder.metrics(
-                    MetricsConfig.builder()
-                        .endpoint(metricsEndpoint)
-                        .build()
-                );
-            }
+	private void useOpenTelemetry(OpenTelemetryForGlide openTelemetryForGlide) {
+		Assert.notNull(openTelemetryForGlide, "OpenTelemetryForGlide must not be null");
 
-            if (flushIntervalMs != null) {
-                otelBuilder.flushIntervalMs(flushIntervalMs);
-            }
+		String tracesEndpoint = openTelemetryForGlide.tracesEndpoint();
+		String metricsEndpoint = openTelemetryForGlide.metricsEndpoint();
+		Integer samplePercentage = openTelemetryForGlide.samplePercentage();
+		Long flushIntervalMs = openTelemetryForGlide.flushIntervalMs();
 
-            OTEL_INITIALIZED_CONFIG = openTelemetryForGlide;
-            OpenTelemetry.init(otelBuilder.build());
-        }
-    }
+		boolean hasTraces = tracesEndpoint != null && !tracesEndpoint.isBlank();
+		boolean hasMetrics = metricsEndpoint != null && !metricsEndpoint.isBlank();
 
-    /**
-     * Initializes the factory, starting it.
-     */
-    @Override
-    public void start() {
-        if (!initialized) {
-            afterPropertiesSet();
-        }
-        running = true;
-    }
-    
-    /**
-     * Stops the factory.
-     */
-    @Override
-    public void stop() {
-        running = false;
-    }
-    
-    /**
-     * Returns if the client is running.
-     * 
-     * @return true if running
-     */
-    @Override
-    public boolean isRunning() {
-        return initialized && running;
-    }
+		if (!hasTraces && !hasMetrics) {
+			throw new IllegalArgumentException(
+					"OpenTelemetryForGlide requires at least one of tracesEndpoint or metricsEndpoint");
+		}
 
-    /**
-     * @return true if cluster mode is enabled.
-     */
-    public boolean isClusterAware() {
-        return ValkeyConfiguration.isClusterConfiguration(this.configuration);
-    }
-    /**
-     * @return The client configuration used.
-     */
-    public ValkeyGlideClientConfiguration getClientConfiguration() {
-        return valkeyGlideConfiguration;
-    }
+		if (samplePercentage != null) {
+			Assert.isTrue(samplePercentage >= 0 && samplePercentage <= 100,
+					"samplePercentage must be in range [0..100]");
+		}
 
-    /**
-     * @return the {@link ValkeyStandaloneConfiguration}, may be {@literal null}.
-     * @since 3.0
-     */
-    @Nullable
-    public ValkeyStandaloneConfiguration getStandaloneConfiguration() {
-        return configuration instanceof ValkeyStandaloneConfiguration 
-            ? (ValkeyStandaloneConfiguration) configuration 
-            : null;
-    }
+		if (flushIntervalMs != null) {
+			Assert.isTrue(flushIntervalMs > 0, "flushIntervalMs must be > 0");
+		}
 
-    /**
-     * @return the {@link ValkeyClusterConfiguration}, may be {@literal null}.
-     * @since 3.0
-     */
-    @Nullable
-    public ValkeyClusterConfiguration getClusterConfiguration() {
-        return configuration instanceof ValkeyClusterConfiguration 
-            ? (ValkeyClusterConfiguration) configuration 
-            : null;
-    }
+		synchronized (OTEL_LOCK) {
+			if (OTEL_INITIALIZED.getAndSet(true)) {
+				if (sameOtelConfig(OTEL_INITIALIZED_CONFIG, openTelemetryForGlide)) {
+					return; // Already initialized with the same config
+				}
 
-    /**
-     * @return the {@link ValkeySentinelConfiguration}, may be {@literal null}.
-     * @since 3.0
-     * @throws UnsupportedOperationException as Sentinel connections are not supported with Valkey-Glide.
-     */
-    @Nullable
-    public ValkeySentinelConfiguration getSentinelConfiguration() {
-        throw new UnsupportedOperationException("Sentinel connections not supported with Valkey-Glide!");
-    }
+				throw new IllegalStateException("OpenTelemetry is already initialized with a different configuration. "
+						+ "existing=" + OTEL_INITIALIZED_CONFIG + ", requested=" + openTelemetryForGlide);
+			}
 
-    /**
-     * Set the {@link AsyncTaskExecutor} to use for asynchronous command execution.
-     *
-     * @param executor {@link AsyncTaskExecutor executor} used to execute commands asynchronously.
-     * @since 3.2
-     */
-    public void setExecutor(AsyncTaskExecutor executor) {
-        if (executor != null) {
-            logger.warn("AsyncTaskExecutor configuration ignored for Valkey-Glide. " +
-                "Valkey-Glide provides async operations via CompletableFuture internally.");
-        }
-        this.executor = executor;
-    }
+			OpenTelemetryConfig.Builder otelBuilder = OpenTelemetryConfig.builder();
 
-    /**
-     * Returns the current host.
-     *
-     * @return the host.
-     */
-    public String getHostName() {
-        return ValkeyConfiguration.getHostOrElse(configuration, () -> "localhost");
-    }
+			if (hasTraces) {
+				TracesConfig.Builder tracesBuilder = TracesConfig.builder().endpoint(tracesEndpoint);
 
-    /**
-     * Returns the current port.
-     *
-     * @return the port.
-     */
-    public int getPort() {
-        return ValkeyConfiguration.getPortOrElse(configuration, () -> 6379);
-    }
+				if (samplePercentage != null) {
+					tracesBuilder.samplePercentage(samplePercentage);
+				}
 
-    /**
-     * Returns the index of the database.
-     *
-     * @return the database index.
-     */
-    public int getDatabase() {
-        return ValkeyConfiguration.getDatabaseOrElse(configuration, () -> 0);
-    }
+				otelBuilder.traces(tracesBuilder.build());
+			}
 
-    /**
-     * Returns the client name.
-     *
-     * @return the client name or {@literal null} if not set.
-     */
-    @Nullable
-    public String getClientName() {
-        // Valkey Glide supports client names via CLIENT SETNAME/GETNAME command but not in configuration
-        return null;
-    }
+			if (hasMetrics) {
+				otelBuilder.metrics(MetricsConfig.builder().endpoint(metricsEndpoint).build());
+			}
+
+			if (flushIntervalMs != null) {
+				otelBuilder.flushIntervalMs(flushIntervalMs);
+			}
+
+			OTEL_INITIALIZED_CONFIG = openTelemetryForGlide;
+			OpenTelemetry.init(otelBuilder.build());
+		}
+	}
+
+	/**
+	 * Initializes the factory, starting it.
+	 */
+	@Override
+	public void start() {
+		if (!initialized) {
+			afterPropertiesSet();
+		}
+		running = true;
+	}
+
+	/**
+	 * Stops the factory.
+	 */
+	@Override
+	public void stop() {
+		running = false;
+	}
+
+	/**
+	 * Returns if the client is running.
+	 * @return true if running
+	 */
+	@Override
+	public boolean isRunning() {
+		return initialized && running;
+	}
+
+	/**
+	 * @return true if cluster mode is enabled.
+	 */
+	public boolean isClusterAware() {
+		return ValkeyConfiguration.isClusterConfiguration(this.configuration);
+	}
+
+	/**
+	 * @return The client configuration used.
+	 */
+	public ValkeyGlideClientConfiguration getClientConfiguration() {
+		return valkeyGlideConfiguration;
+	}
+
+	/**
+	 * @return the {@link ValkeyStandaloneConfiguration}, may be {@literal null}.
+	 * @since 3.0
+	 */
+	@Nullable public ValkeyStandaloneConfiguration getStandaloneConfiguration() {
+		return configuration instanceof ValkeyStandaloneConfiguration ? (ValkeyStandaloneConfiguration) configuration
+				: null;
+	}
+
+	/**
+	 * @return the {@link ValkeyClusterConfiguration}, may be {@literal null}.
+	 * @since 3.0
+	 */
+	@Nullable public ValkeyClusterConfiguration getClusterConfiguration() {
+		return configuration instanceof ValkeyClusterConfiguration ? (ValkeyClusterConfiguration) configuration : null;
+	}
+
+	/**
+	 * @return the {@link ValkeySentinelConfiguration}, may be {@literal null}.
+	 * @since 3.0
+	 * @throws UnsupportedOperationException as Sentinel connections are not supported
+	 * with Valkey-Glide.
+	 */
+	@Nullable public ValkeySentinelConfiguration getSentinelConfiguration() {
+		throw new UnsupportedOperationException("Sentinel connections not supported with Valkey-Glide!");
+	}
+
+	/**
+	 * Set the {@link AsyncTaskExecutor} to use for asynchronous command execution.
+	 * @param executor {@link AsyncTaskExecutor executor} used to execute commands
+	 * asynchronously.
+	 * @since 3.2
+	 */
+	public void setExecutor(AsyncTaskExecutor executor) {
+		if (executor != null) {
+			logger.warn("AsyncTaskExecutor configuration ignored for Valkey-Glide. "
+					+ "Valkey-Glide provides async operations via CompletableFuture internally.");
+		}
+		this.executor = executor;
+	}
+
+	/**
+	 * Returns the current host.
+	 * @return the host.
+	 */
+	public String getHostName() {
+		return ValkeyConfiguration.getHostOrElse(configuration, () -> "localhost");
+	}
+
+	/**
+	 * Returns the current port.
+	 * @return the port.
+	 */
+	public int getPort() {
+		return ValkeyConfiguration.getPortOrElse(configuration, () -> 6379);
+	}
+
+	/**
+	 * Returns the index of the database.
+	 * @return the database index.
+	 */
+	public int getDatabase() {
+		return ValkeyConfiguration.getDatabaseOrElse(configuration, () -> 0);
+	}
+
+	/**
+	 * Returns the client name.
+	 * @return the client name or {@literal null} if not set.
+	 */
+	@Nullable public String getClientName() {
+		// Valkey Glide supports client names via CLIENT SETNAME/GETNAME command but not
+		// in configuration
+		return null;
+	}
 
 	/**
 	 * Returns whether to use SSL.
-	 *
 	 * @return use of SSL.
 	 */
 	public boolean isUseSsl() {
@@ -510,84 +510,83 @@ public class ValkeyGlideConnectionFactory
 
 	/**
 	 * Returns the password used for authenticating with the Valkey server.
-	 *
 	 * @return password for authentication or {@literal null} if not set.
 	 */
-	@Nullable
-	public String getPassword() {
+	@Nullable public String getPassword() {
 		return getValkeyPassword().map(String::new).orElse(null);
 	}
 
-    @Nullable
-    private String getValkeyUsername() {
-        return ValkeyConfiguration.getUsernameOrElse(configuration, () -> null);
-    }
+	@Nullable private String getValkeyUsername() {
+		return ValkeyConfiguration.getUsernameOrElse(configuration, () -> null);
+	}
 
-    private ValkeyPassword getValkeyPassword() {
-        return ValkeyConfiguration.getPasswordOrElse(configuration, () -> ValkeyPassword.none());
-    }
+	private ValkeyPassword getValkeyPassword() {
+		return ValkeyConfiguration.getPasswordOrElse(configuration, () -> ValkeyPassword.none());
+	}
 
-    /**
-     * @return whether this lifecycle component should get started automatically by the container
-     */
-    @Override
-    public boolean isAutoStartup() {
-        return this.autoStartup;
-    }
+	/**
+	 * @return whether this lifecycle component should get started automatically by the
+	 * container
+	 */
+	@Override
+	public boolean isAutoStartup() {
+		return this.autoStartup;
+	}
 
-    /**
-     * Configure if this Lifecycle connection factory should get started automatically by the container.
-     *
-     * @param autoStartup {@literal true} to automatically {@link #start()} the connection factory; {@literal false} otherwise.
-     */
-    public void setAutoStartup(boolean autoStartup) {
-        this.autoStartup = autoStartup;
-    }
+	/**
+	 * Configure if this Lifecycle connection factory should get started automatically by
+	 * the container.
+	 * @param autoStartup {@literal true} to automatically {@link #start()} the connection
+	 * factory; {@literal false} otherwise.
+	 */
+	public void setAutoStartup(boolean autoStartup) {
+		this.autoStartup = autoStartup;
+	}
 
-    /**
-     * @return whether to {@link #start()} the component during {@link #afterPropertiesSet()}.
-     */
-    public boolean isEarlyStartup() {
-        return this.earlyStartup;
-    }
+	/**
+	 * @return whether to {@link #start()} the component during
+	 * {@link #afterPropertiesSet()}.
+	 */
+	public boolean isEarlyStartup() {
+		return this.earlyStartup;
+	}
 
-    /**
-     * Configure if this InitializingBean's component Lifecycle should get started early by {@link #afterPropertiesSet()}
-     * at the time that the bean is initialized. The component defaults to auto-startup.
-     *
-     * @param earlyStartup {@literal true} to early {@link #start()} the component; {@literal false} otherwise.
-     */
-    public void setEarlyStartup(boolean earlyStartup) {
-        this.earlyStartup = earlyStartup;
-    }
-    
-    /**
-     * @return the phase value for this lifecycle component
-     */
-    @Override
-    public int getPhase() {
-        return this.phase;
-    }
-    
-    /**
-     * Specify the lifecycle phase for pausing and resuming this executor.
-     * 
-     * @param phase the phase value to set
-     */
-    public void setPhase(int phase) {
-        this.phase = phase;
-    }
-    
-    /**
-     * Translates a Valkey-Glide exception to a Spring DAO exception.
-     * 
-     * @param ex The exception to translate
-     * @return The translated exception, or null if the exception cannot be translated
-     */
-    @Override
-    @Nullable
-    public DataAccessException translateExceptionIfPossible(RuntimeException ex) {
-        // Use ValkeyGlideExceptionConverter to translate exceptions
-        return new ValkeyGlideExceptionConverter().convert(ex);
-    }
+	/**
+	 * Configure if this InitializingBean's component Lifecycle should get started early
+	 * by {@link #afterPropertiesSet()} at the time that the bean is initialized. The
+	 * component defaults to auto-startup.
+	 * @param earlyStartup {@literal true} to early {@link #start()} the component;
+	 * {@literal false} otherwise.
+	 */
+	public void setEarlyStartup(boolean earlyStartup) {
+		this.earlyStartup = earlyStartup;
+	}
+
+	/**
+	 * @return the phase value for this lifecycle component
+	 */
+	@Override
+	public int getPhase() {
+		return this.phase;
+	}
+
+	/**
+	 * Specify the lifecycle phase for pausing and resuming this executor.
+	 * @param phase the phase value to set
+	 */
+	public void setPhase(int phase) {
+		this.phase = phase;
+	}
+
+	/**
+	 * Translates a Valkey-Glide exception to a Spring DAO exception.
+	 * @param ex The exception to translate
+	 * @return The translated exception, or null if the exception cannot be translated
+	 */
+	@Override
+	@Nullable public DataAccessException translateExceptionIfPossible(RuntimeException ex) {
+		// Use ValkeyGlideExceptionConverter to translate exceptions
+		return new ValkeyGlideExceptionConverter().convert(ex);
+	}
+
 }

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConverters.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConverters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,612 +35,628 @@ import io.valkey.springframework.data.valkey.connection.ValueEncoding;
 import glide.api.models.GlideString;
 
 /**
- * Converter utilities for mapping between Spring Data Valkey types and Valkey-Glide types.
+ * Converter utilities for mapping between Spring Data Valkey types and Valkey-Glide
+ * types.
  *
  * @author Ilia Kolominsky
  * @since 2.0
  */
 public abstract class ValkeyGlideConverters {
 
-    /**
-     * A functional interface used to convert raw driver results
-     * (returned as {@link I}) into a strongly typed result {@code R}.
-     *
-     * <p>This is intended to be supplied by the higher-level API
-     * that knows the correct decoding strategy for a specific Valkey command.
-     *
-     * @param <I> The type of the raw driver result.
-     * @param <R> The target type that the raw driver result should be mapped to.
-     */
-    @FunctionalInterface
-    public interface ResultMapper<I, R> {
-        /**
-         * Maps the raw result object of type {@code I} returned by the driver into
-         * a strongly typed value of type {@code R}.
-         *
-         * @param item The raw driver result, typically a low-level
-         *                     representation like Number, byte[], or {@code List<Object>}.
-         * @return The mapped, higher-level type I.
-         */
-        R map(I item);
-    }
+	/**
+	 * A functional interface used to convert raw driver results (returned as {@link I})
+	 * into a strongly typed result {@code R}.
+	 *
+	 * <p>
+	 * This is intended to be supplied by the higher-level API that knows the correct
+	 * decoding strategy for a specific Valkey command.
+	 *
+	 * @param <I> The type of the raw driver result.
+	 * @param <R> The target type that the raw driver result should be mapped to.
+	 */
+	@FunctionalInterface
+	public interface ResultMapper<I, R> {
 
-    /**
-     * Convert a Spring Data Valkey command argument to the corresponding Valkey-Glide format.
-     *
-     * @param arg The command argument to convert
-     * @return The converted argument
-     */
-    public static Object toGlideArgument(Object arg) {
-        if (arg == null) {
-            return null;
-        }
-        
-        if (arg instanceof byte[]) {
-            // Convert byte array to ByteBuffer as Glide might expect ByteBuffer
-            return ByteBuffer.wrap((byte[]) arg);
-        } else if (arg instanceof Map) {
-            // Handle Map conversions if needed
-            return arg;
-        } else if (arg instanceof Collection) {
-            // Handle Collection conversions if needed
-            List<Object> result = new ArrayList<>();
-            for (Object item : (Collection<?>) arg) {
-                result.add(toGlideArgument(item));
-            }
-            return result;
-        } else if (arg instanceof Number || arg instanceof Boolean || arg instanceof String) {
-            // Simple types can be passed as-is
-            return arg;
-        }
-        
-        // Default: return as is
-        return arg;
-    }
+		/**
+		 * Maps the raw result object of type {@code I} returned by the driver into a
+		 * strongly typed value of type {@code R}.
+		 * @param item The raw driver result, typically a low-level representation like
+		 * Number, byte[], or {@code List<Object>}.
+		 * @return The mapped, higher-level type I.
+		 */
+		R map(I item);
 
-    /**
-     * Convert a Valkey-Glide result to the Spring Data Valkey format using best-fit.
-     *
-     * @param result The Glide result to convert
-     * @return The converted result
-     */
-    public @Nullable static Object defaultFromGlideResult(@Nullable Object result) {
-        if (result == null) {
-            return null;
-        }
-        
-        if (result instanceof GlideString) {
-            GlideString glideResult = (GlideString) result;
-            // Handle special Valkey responses - check if GlideString represents "OK"
-            if ("OK".equals(glideResult.toString())) {
-                // Valkey SET, SETEX, PSETEX commands return "OK" on success, 
-                // but Spring Data Valkey expects Boolean true
-                return Boolean.TRUE;
-            }
-            // Convert GlideString back to byte[]
-            return glideResult.getBytes();
-        } else if (result instanceof ByteBuffer) {
-            // Convert ByteBuffer back to byte[]
-            ByteBuffer buffer = (ByteBuffer) result;
-            byte[] bytes = new byte[buffer.remaining()];
-            buffer.get(bytes);
-            return bytes;
-        } else if (result instanceof List) {
-            // Convert list elements recursively
-            List<?> list = (List<?>) result;
-            List<Object> converted = new ArrayList<>(list.size());
-            for (Object item : list) {
-                converted.add(defaultFromGlideResult(item));
-            }
-            return converted;
-        } else if (result instanceof Set) {
-            // Convert set elements recursively, but return as Set
-            Set<?> set = (Set<?>) result;
-            Set<Object> converted = new HashSet<>(set.size());
-            for (Object item : set) {
-                converted.add(defaultFromGlideResult(item));
-            }
-            return converted;
-        } else if (result instanceof Object[]) {
-            // Convert array elements recursively
-            Object[] array = (Object[]) result;
-            List<Object> converted = new ArrayList<>(array.length);
-            for (Object item : array) {
-                converted.add(defaultFromGlideResult(item));
-            }
-            return converted;
-        } else if (result instanceof Map) {
-            // Convert map entries recursively
-            Map<?, ?> map = (Map<?, ?>) result;
-            Map<Object, Object> converted = new java.util.HashMap<>(map.size());
-            for (Map.Entry<?, ?> entry : map.entrySet()) {
-                converted.put(defaultFromGlideResult(entry.getKey()), defaultFromGlideResult(entry.getValue()));
-            }
-            return converted;
-        } else if (result instanceof String) {
-            // Handle special Valkey responses
-            String strResult = (String) result;
-            if ("OK".equals(strResult)) {
-                // Valkey SET, SETEX, PSETEX commands return "OK" on success, 
-                // but Spring Data Valkey expects Boolean true
-                return Boolean.TRUE;
-            }
-            // Other strings should be converted to byte[] for Spring Data Valkey compatibility
-            // This handles pipeline/transaction mode where Glide returns String instead of GlideString
-            return strResult.getBytes(StandardCharsets.UTF_8);
-        } else if (result instanceof Number || result instanceof Boolean) {
-            // Simple types can be passed as-is
-            return result;
-        } else if (result instanceof byte[]) {
-            // byte[] should be passed as-is (already in Spring format)
-            return result;
-        }
-        
-        // Default: return as is
-        return result;
-    }
-    
-    /**
-     * Convert a byte array to a string using the UTF-8 charset.
-     *
-     * @param bytes The bytes to convert
-     * @return The resulting string or null if input is null
-     */
-    public @Nullable static String toString(@Nullable byte[] bytes) {
-        return bytes == null ? null : new String(bytes, StandardCharsets.UTF_8);
-    }
+	}
 
-    /**
-     * Convert a string to a byte array using the UTF-8 charset.
-     *
-     * @param string The string to convert
-     * @return The resulting byte array or null if input is null
-     */
-    public @Nullable static byte[] toBytes(@Nullable String string) {
-        return string == null ? null : string.getBytes(StandardCharsets.UTF_8);
-    }
+	/**
+	 * Convert a Spring Data Valkey command argument to the corresponding Valkey-Glide
+	 * format.
+	 * @param arg The command argument to convert
+	 * @return The converted argument
+	 */
+	public static Object toGlideArgument(Object arg) {
+		if (arg == null) {
+			return null;
+		}
 
-    /**
-     * Convert a Valkey command result to a Boolean value.
-     * Valkey SET command returns "OK" on success, null on failure with conditions.
-     * Valkey conditional commands return 1/0 for true/false.
-     *
-     * @param result The command result
-     * @return Boolean representation of the result
-     */
-    public @Nullable static Boolean stringToBoolean(@Nullable Object result) {
-        if (result == null) {
-            return null;
-        }
-        return "OK".equals(result);
-    }
+		if (arg instanceof byte[]) {
+			// Convert byte array to ByteBuffer as Glide might expect ByteBuffer
+			return ByteBuffer.wrap((byte[]) arg);
+		}
+		else if (arg instanceof Map) {
+			// Handle Map conversions if needed
+			return arg;
+		}
+		else if (arg instanceof Collection) {
+			// Handle Collection conversions if needed
+			List<Object> result = new ArrayList<>();
+			for (Object item : (Collection<?>) arg) {
+				result.add(toGlideArgument(item));
+			}
+			return result;
+		}
+		else if (arg instanceof Number || arg instanceof Boolean || arg instanceof String) {
+			// Simple types can be passed as-is
+			return arg;
+		}
 
-    /**
-     * Convert a numeric Valkey command result to a Boolean value.
-     * Valkey conditional commands return 1/0 for true/false.
-     *
-     * @param result The numeric command result
-     * @return Boolean representation of the result
-     */
-    public @Nullable static Boolean numberToBoolean(@Nullable Object result) {
-        return result != null ? ((Number) result).longValue() != 0 : null;
-    }
+		// Default: return as is
+		return arg;
+	}
 
-    /**
-     * Convert Valkey TYPE command result to DataType enum.
-     *
-     * @param result The TYPE command result (GlideString is converted to byte[])
-     * @return The corresponding DataType
-     */
-    public static DataType toDataType(@Nullable byte[] result) {
-        if (result == null) {
-            return DataType.NONE;
-        }
-        
+	/**
+	 * Convert a Valkey-Glide result to the Spring Data Valkey format using best-fit.
+	 * @param result The Glide result to convert
+	 * @return The converted result
+	 */
+	public @Nullable static Object defaultFromGlideResult(@Nullable Object result) {
+		if (result == null) {
+			return null;
+		}
 
-        // Convert byte[] to String using UTF-8 encoding
-        String resultStr = new String(result, StandardCharsets.UTF_8);
-        switch (resultStr.toLowerCase()) {
-            case "string":
-                return DataType.STRING;
-            case "list":
-                return DataType.LIST;
-            case "set":
-                return DataType.SET;
-            case "zset":
-                return DataType.ZSET;
-            case "hash":
-                return DataType.HASH;
-            case "stream":
-                return DataType.STREAM;
-            case "none":
-            default:
-                return DataType.NONE;
-        }
-    }
+		if (result instanceof GlideString) {
+			GlideString glideResult = (GlideString) result;
+			// Handle special Valkey responses - check if GlideString represents "OK"
+			if ("OK".equals(glideResult.toString())) {
+				// Valkey SET, SETEX, PSETEX commands return "OK" on success,
+				// but Spring Data Valkey expects Boolean true
+				return Boolean.TRUE;
+			}
+			// Convert GlideString back to byte[]
+			return glideResult.getBytes();
+		}
+		else if (result instanceof ByteBuffer) {
+			// Convert ByteBuffer back to byte[]
+			ByteBuffer buffer = (ByteBuffer) result;
+			byte[] bytes = new byte[buffer.remaining()];
+			buffer.get(bytes);
+			return bytes;
+		}
+		else if (result instanceof List) {
+			// Convert list elements recursively
+			List<?> list = (List<?>) result;
+			List<Object> converted = new ArrayList<>(list.size());
+			for (Object item : list) {
+				converted.add(defaultFromGlideResult(item));
+			}
+			return converted;
+		}
+		else if (result instanceof Set) {
+			// Convert set elements recursively, but return as Set
+			Set<?> set = (Set<?>) result;
+			Set<Object> converted = new HashSet<>(set.size());
+			for (Object item : set) {
+				converted.add(defaultFromGlideResult(item));
+			}
+			return converted;
+		}
+		else if (result instanceof Object[]) {
+			// Convert array elements recursively
+			Object[] array = (Object[]) result;
+			List<Object> converted = new ArrayList<>(array.length);
+			for (Object item : array) {
+				converted.add(defaultFromGlideResult(item));
+			}
+			return converted;
+		}
+		else if (result instanceof Map) {
+			// Convert map entries recursively
+			Map<?, ?> map = (Map<?, ?>) result;
+			Map<Object, Object> converted = new java.util.HashMap<>(map.size());
+			for (Map.Entry<?, ?> entry : map.entrySet()) {
+				converted.put(defaultFromGlideResult(entry.getKey()), defaultFromGlideResult(entry.getValue()));
+			}
+			return converted;
+		}
+		else if (result instanceof String) {
+			// Handle special Valkey responses
+			String strResult = (String) result;
+			if ("OK".equals(strResult)) {
+				// Valkey SET, SETEX, PSETEX commands return "OK" on success,
+				// but Spring Data Valkey expects Boolean true
+				return Boolean.TRUE;
+			}
+			// Other strings should be converted to byte[] for Spring Data Valkey
+			// compatibility
+			// This handles pipeline/transaction mode where Glide returns String instead
+			// of GlideString
+			return strResult.getBytes(StandardCharsets.UTF_8);
+		}
+		else if (result instanceof Number || result instanceof Boolean) {
+			// Simple types can be passed as-is
+			return result;
+		}
+		else if (result instanceof byte[]) {
+			// byte[] should be passed as-is (already in Spring format)
+			return result;
+		}
 
-    /**
-     * Convert result to {@code Set<byte[]>}.
-     *
-     * @param glideResult The command result
-     * @return Set of byte arrays
-     */
-    public @Nullable static Set<byte[]> toBytesSet(@Nullable Object[] glideResult) {
-        if (glideResult == null) {
-            return new HashSet<>();
-        }
+		// Default: return as is
+		return result;
+	}
 
-        Set<byte[]> resultSet = new HashSet<>(glideResult.length);
-        for (Object item : glideResult) {
-            GlideString glideString = (GlideString) item;
-            resultSet.add(glideString != null ? glideString.getBytes() : null);
-        }
-        return resultSet;
-        
-        // if (result instanceof Collection) {
-        //     Set<byte[]> set = new HashSet<>();
-        //     for (Object item : (Collection<?>) result) {
-        //         if (item instanceof byte[]) {
-        //             set.add((byte[]) item);
-        //         } else if (item instanceof String) {
-        //             set.add(((String) item).getBytes(StandardCharsets.UTF_8));
-        //         } else if (item != null) {
-        //             set.add(item.toString().getBytes(StandardCharsets.UTF_8));
-        //         }
-        //     }
-        //     return set;
-        // }
-        
-        // Handle array types (Object[] and specific array types)
-        // if (result instanceof Object[]) {
-        //     Set<byte[]> set = new HashSet<>();
-        //     for (Object item : (Object[]) result) {
-        //         if (item instanceof byte[]) {
-        //             set.add((byte[]) item);
-        //         } else if (item instanceof String) {
-        //             set.add(((String) item).getBytes(StandardCharsets.UTF_8));
-        //         } else if (item != null) {
-        //             set.add(item.toString().getBytes(StandardCharsets.UTF_8));
-        //         }
-        //     }
-        //     return set;
-        // }
-        
-        // // Handle byte[][] specifically
-        // if (result instanceof byte[][]) {
-        //     Set<byte[]> set = new HashSet<>();
-        //     for (byte[] item : (byte[][]) result) {
-        //         if (item != null) {
-        //             set.add(item);
-        //         }
-        //     }
-        //     return set;
-        // }
-        
-        // // Handle String[] specifically
-        // if (result instanceof String[]) {
-        //     Set<byte[]> set = new HashSet<>();
-        //     for (String item : (String[]) result) {
-        //         if (item != null) {
-        //             set.add(item.getBytes(StandardCharsets.UTF_8));
-        //         }
-        //     }
-        //     return set;
-        // }
-        
-        // return new HashSet<>();
-    }
+	/**
+	 * Convert a byte array to a string using the UTF-8 charset.
+	 * @param bytes The bytes to convert
+	 * @return The resulting string or null if input is null
+	 */
+	public @Nullable static String toString(@Nullable byte[] bytes) {
+		return bytes == null ? null : new String(bytes, StandardCharsets.UTF_8);
+	}
 
-    public @Nullable static Set<byte[]> toBytesSet(@Nullable Object result) {
-        if (result == null) {
-            return new HashSet<>();
-        }
-        
-        if (result instanceof Collection) {
-            Set<byte[]> set = new HashSet<>();
-            for (Object item : (Collection<?>) result) {
-                if (item instanceof byte[]) {
-                    set.add((byte[]) item);
-                } else if (item instanceof String) {
-                    set.add(((String) item).getBytes(StandardCharsets.UTF_8));
-                } else if (item != null) {
-                    set.add(item.toString().getBytes(StandardCharsets.UTF_8));
-                }
-            }
-            return set;
-        }
-        
-        // Handle array types (Object[] and specific array types)
-        if (result instanceof Object[]) {
-            Set<byte[]> set = new HashSet<>();
-            for (Object item : (Object[]) result) {
-                if (item instanceof byte[]) {
-                    set.add((byte[]) item);
-                } else if (item instanceof String) {
-                    set.add(((String) item).getBytes(StandardCharsets.UTF_8));
-                } else if (item != null) {
-                    set.add(item.toString().getBytes(StandardCharsets.UTF_8));
-                }
-            }
-            return set;
-        }
-        
-        // Handle byte[][] specifically
-        if (result instanceof byte[][]) {
-            Set<byte[]> set = new HashSet<>();
-            for (byte[] item : (byte[][]) result) {
-                if (item != null) {
-                    set.add(item);
-                }
-            }
-            return set;
-        }
-        
-        // Handle String[] specifically
-        if (result instanceof String[]) {
-            Set<byte[]> set = new HashSet<>();
-            for (String item : (String[]) result) {
-                if (item != null) {
-                    set.add(item.getBytes(StandardCharsets.UTF_8));
-                }
-            }
-            return set;
-        }
-        
-        return new HashSet<>();
-    }
+	/**
+	 * Convert a string to a byte array using the UTF-8 charset.
+	 * @param string The string to convert
+	 * @return The resulting byte array or null if input is null
+	 */
+	public @Nullable static byte[] toBytes(@Nullable String string) {
+		return string == null ? null : string.getBytes(StandardCharsets.UTF_8);
+	}
 
-    public @Nullable static List<Map.Entry<byte[], byte[]>> toMapEntriesList(@Nullable Object glideResult) {
-        if (glideResult == null) {
-            return null;
-        }
+	/**
+	 * Convert a Valkey command result to a Boolean value. Valkey SET command returns "OK"
+	 * on success, null on failure with conditions. Valkey conditional commands return 1/0
+	 * for true/false.
+	 * @param result The command result
+	 * @return Boolean representation of the result
+	 */
+	public @Nullable static Boolean stringToBoolean(@Nullable Object result) {
+		if (result == null) {
+			return null;
+		}
+		return "OK".equals(result);
+	}
 
-        Object[] result = (Object[]) glideResult;
-        if (result.length == 0) {
-            return null;
-        }
+	/**
+	 * Convert a numeric Valkey command result to a Boolean value. Valkey conditional
+	 * commands return 1/0 for true/false.
+	 * @param result The numeric command result
+	 * @return Boolean representation of the result
+	 */
+	public @Nullable static Boolean numberToBoolean(@Nullable Object result) {
+		return result != null ? ((Number) result).longValue() != 0 : null;
+	}
 
-        List<Map.Entry<byte[], byte[]>> resultList = new ArrayList<>();
-        for (Object item : result) {
-            Object[] keyValuePair = (Object[]) item;
-            GlideString keyObj = (GlideString) keyValuePair[0];
-            GlideString valueObj = (GlideString) keyValuePair[1];
-            resultList.add(new HashMap.SimpleEntry<>(keyObj.getBytes(), valueObj.getBytes()));
-        }
-        return resultList;
-    }
+	/**
+	 * Convert Valkey TYPE command result to DataType enum.
+	 * @param result The TYPE command result (GlideString is converted to byte[])
+	 * @return The corresponding DataType
+	 */
+	public static DataType toDataType(@Nullable byte[] result) {
+		if (result == null) {
+			return DataType.NONE;
+		}
 
-    /**
-     * Convert result to {@code List<byte[]>}.
-     *
-     * @param glideResult The command result
-     * @return List of byte arrays
-     */
-    public @Nullable static List<byte[]> toBytesList(@Nullable Object[] glideResult) {
-        if (glideResult == null) {
-            return new ArrayList<>();
-        }
+		// Convert byte[] to String using UTF-8 encoding
+		String resultStr = new String(result, StandardCharsets.UTF_8);
+		switch (resultStr.toLowerCase()) {
+			case "string":
+				return DataType.STRING;
+			case "list":
+				return DataType.LIST;
+			case "set":
+				return DataType.SET;
+			case "zset":
+				return DataType.ZSET;
+			case "hash":
+				return DataType.HASH;
+			case "stream":
+				return DataType.STREAM;
+			case "none":
+			default:
+				return DataType.NONE;
+		}
+	}
 
-        List<byte[]> convertedList = new ArrayList<>(glideResult.length);
-        for (Object item : glideResult) {
-            GlideString glideString = (GlideString) item;
-            convertedList.add(glideString != null ? glideString.getBytes() : null);
-        }
-        return convertedList;
-    }
+	/**
+	 * Convert result to {@code Set<byte[]>}.
+	 * @param glideResult The command result
+	 * @return Set of byte arrays
+	 */
+	public @Nullable static Set<byte[]> toBytesSet(@Nullable Object[] glideResult) {
+		if (glideResult == null) {
+			return new HashSet<>();
+		}
 
-    public @Nullable static List<Long> toLongsList(@Nullable Object[] glideResult) {
-        if (glideResult == null) {
-            return null;
-        }
+		Set<byte[]> resultSet = new HashSet<>(glideResult.length);
+		for (Object item : glideResult) {
+			GlideString glideString = (GlideString) item;
+			resultSet.add(glideString != null ? glideString.getBytes() : null);
+		}
+		return resultSet;
 
-        List<Long> resultList = new ArrayList<>(glideResult.length);
-        for (Object item : glideResult) {
-            resultList.add(((Number) item).longValue());
-        }
-        return resultList;
-    }
+		// if (result instanceof Collection) {
+		// Set<byte[]> set = new HashSet<>();
+		// for (Object item : (Collection<?>) result) {
+		// if (item instanceof byte[]) {
+		// set.add((byte[]) item);
+		// } else if (item instanceof String) {
+		// set.add(((String) item).getBytes(StandardCharsets.UTF_8));
+		// } else if (item != null) {
+		// set.add(item.toString().getBytes(StandardCharsets.UTF_8));
+		// }
+		// }
+		// return set;
+		// }
 
-    public @Nullable static List<Boolean> toBooleansList(@Nullable Object[] glideResult) {
-        if (glideResult == null) {
-            return null;
-        }
+		// Handle array types (Object[] and specific array types)
+		// if (result instanceof Object[]) {
+		// Set<byte[]> set = new HashSet<>();
+		// for (Object item : (Object[]) result) {
+		// if (item instanceof byte[]) {
+		// set.add((byte[]) item);
+		// } else if (item instanceof String) {
+		// set.add(((String) item).getBytes(StandardCharsets.UTF_8));
+		// } else if (item != null) {
+		// set.add(item.toString().getBytes(StandardCharsets.UTF_8));
+		// }
+		// }
+		// return set;
+		// }
 
-        List<Boolean> resultList = new ArrayList<>(glideResult.length);
-        for (Object item : glideResult) {
-            resultList.add((Boolean) item);
-        }
-        return resultList;
-    }
+		// // Handle byte[][] specifically
+		// if (result instanceof byte[][]) {
+		// Set<byte[]> set = new HashSet<>();
+		// for (byte[] item : (byte[][]) result) {
+		// if (item != null) {
+		// set.add(item);
+		// }
+		// }
+		// return set;
+		// }
 
-    public @Nullable static List<byte[]> toBytesList(@Nullable Object result) {
-        if (result == null) {
-            return new ArrayList<>();
-        }
-        
-        if (result instanceof Collection) {
-            List<byte[]> list = new ArrayList<>();
-            for (Object item : (Collection<?>) result) {
-                if (item instanceof byte[]) {
-                    list.add((byte[]) item);
-                } else if (item instanceof String) {
-                    list.add(((String) item).getBytes(StandardCharsets.UTF_8));
-                } else if (item != null) {
-                    list.add(item.toString().getBytes(StandardCharsets.UTF_8));
-                }
-            }
-            return list;
-        }
-        
-        // Handle array types (Object[] and specific array types)
-        if (result instanceof Object[]) {
-            List<byte[]> list = new ArrayList<>();
-            for (Object item : (Object[]) result) {
-                if (item instanceof byte[]) {
-                    list.add((byte[]) item);
-                } else if (item instanceof GlideString) {
-                    // Handle GlideString properly - use getBytes() to preserve binary data
-                    list.add(((GlideString) item).getBytes());
-                } else if (item instanceof String) {
-                    list.add(((String) item).getBytes(StandardCharsets.UTF_8));
-                } else if (item != null) {
-                    list.add(item.toString().getBytes(StandardCharsets.UTF_8));
-                }
-            }
-            return list;
-        }
-        
-        // Handle byte[][] specifically
-        if (result instanceof byte[][]) {
-            List<byte[]> list = new ArrayList<>();
-            for (byte[] item : (byte[][]) result) {
-                if (item != null) {
-                    list.add(item);
-                }
-            }
-            return list;
-        }
-        
-        // Handle String[] specifically
-        if (result instanceof String[]) {
-            List<byte[]> list = new ArrayList<>();
-            for (String item : (String[]) result) {
-                if (item != null) {
-                    list.add(item.getBytes(StandardCharsets.UTF_8));
-                }
-            }
-            return list;
-        }
-        
-        return new ArrayList<>();
-    }
+		// // Handle String[] specifically
+		// if (result instanceof String[]) {
+		// Set<byte[]> set = new HashSet<>();
+		// for (String item : (String[]) result) {
+		// if (item != null) {
+		// set.add(item.getBytes(StandardCharsets.UTF_8));
+		// }
+		// }
+		// return set;
+		// }
 
-    public @Nullable static Map<byte[],  byte[]> toBytesMap(@Nullable Object glideResult) {
-        if (glideResult == null) {
-            return null;
-        }
-        @SuppressWarnings("unchecked")
-        Map<GlideString, GlideString> coverted = (Map<GlideString, GlideString>) glideResult;
-        Map<byte[], byte[]> resultMap = new HashMap<>(coverted.size());
-        for (Map.Entry<GlideString, GlideString> entry : coverted.entrySet()) {
-            resultMap.put(entry.getKey().getBytes(), entry.getValue().getBytes());
-        }
-        return resultMap;
-    }
+		// return new HashSet<>();
+	}
 
-    public static Map.Entry<byte[],  byte[]> toBytesMapEntry(@Nullable Object glideResult) {
-        if (glideResult == null) {
-            return null;
-        }
+	public @Nullable static Set<byte[]> toBytesSet(@Nullable Object result) {
+		if (result == null) {
+			return new HashSet<>();
+		}
 
-        Object[] result = (Object[]) glideResult;
-        if (result.length == 0) {
-            return null;
-        }
+		if (result instanceof Collection) {
+			Set<byte[]> set = new HashSet<>();
+			for (Object item : (Collection<?>) result) {
+				if (item instanceof byte[]) {
+					set.add((byte[]) item);
+				}
+				else if (item instanceof String) {
+					set.add(((String) item).getBytes(StandardCharsets.UTF_8));
+				}
+				else if (item != null) {
+					set.add(item.toString().getBytes(StandardCharsets.UTF_8));
+				}
+			}
+			return set;
+		}
 
-        Object[] keyValuePair = (Object[]) result[0];
+		// Handle array types (Object[] and specific array types)
+		if (result instanceof Object[]) {
+			Set<byte[]> set = new HashSet<>();
+			for (Object item : (Object[]) result) {
+				if (item instanceof byte[]) {
+					set.add((byte[]) item);
+				}
+				else if (item instanceof String) {
+					set.add(((String) item).getBytes(StandardCharsets.UTF_8));
+				}
+				else if (item != null) {
+					set.add(item.toString().getBytes(StandardCharsets.UTF_8));
+				}
+			}
+			return set;
+		}
 
-        GlideString keyObj = (GlideString) keyValuePair[0];
-        GlideString valueObj = (GlideString) keyValuePair[1];
-        return new HashMap.SimpleEntry<>(keyObj.getBytes(), valueObj.getBytes());
-    }
-    /**
-     * Append sort parameters to the command arguments.
-     *
-     * @param args The command arguments list
-     * @param params The sort parameters
-     */
-    public static void appendSortParameters(List<Object> args, SortParameters params) {
-        if (params == null) {
-            return;
-        }
-        
-        // Add BY pattern if specified
-        if (params.getByPattern() != null) {
-            args.add("BY");
-            args.add(params.getByPattern());
-        }
-        
-        // Add LIMIT if specified
-        if (params.getLimit() != null) {
-            args.add("LIMIT");
-            args.add(params.getLimit().getStart());
-            args.add(params.getLimit().getCount());
-        }
-        
-        // Add GET patterns if specified
-        if (params.getGetPattern() != null) {
-            for (byte[] pattern : params.getGetPattern()) {
-                args.add("GET");
-                args.add(pattern);
-            }
-        }
-        
-        // Add ORDER if specified
-        if (params.getOrder() != null) {
-            args.add(params.getOrder().name());
-        }
-        
-        // Add ALPHA if specified - check for null safely
-        Boolean isAlphabetic = params.isAlphabetic();
-        if (isAlphabetic != null && isAlphabetic) {
-            args.add("ALPHA");
-        }
-    }
+		// Handle byte[][] specifically
+		if (result instanceof byte[][]) {
+			Set<byte[]> set = new HashSet<>();
+			for (byte[] item : (byte[][]) result) {
+				if (item != null) {
+					set.add(item);
+				}
+			}
+			return set;
+		}
 
-    /**
-     * Convert OBJECT ENCODING result to ValueEncoding.
-     *
-     * @param result The OBJECT ENCODING command result
-     * @return The corresponding ValueEncoding
-     */
-    public @Nullable static ValueEncoding toValueEncoding(@Nullable GlideString glideResult) {
-        if (glideResult == null) {
-            return ValueEncoding.ValkeyValueEncoding.VACANT;
-        }
+		// Handle String[] specifically
+		if (result instanceof String[]) {
+			Set<byte[]> set = new HashSet<>();
+			for (String item : (String[]) result) {
+				if (item != null) {
+					set.add(item.getBytes(StandardCharsets.UTF_8));
+				}
+			}
+			return set;
+		}
 
-        switch (glideResult.toString()) {
-            case "raw":
-                return ValueEncoding.ValkeyValueEncoding.RAW;
-            case "int":
-                return ValueEncoding.ValkeyValueEncoding.INT;
-            case "hashtable":
-                return ValueEncoding.ValkeyValueEncoding.HASHTABLE;
-            case "zipmap":
-            case "linkedlist":
-                return ValueEncoding.ValkeyValueEncoding.LINKEDLIST;
-            case "ziplist":
-            case "listpack":
-                return ValueEncoding.ValkeyValueEncoding.ZIPLIST;
-            case "intset":
-                return ValueEncoding.ValkeyValueEncoding.INTSET;
-            case "skiplist":
-                return ValueEncoding.ValkeyValueEncoding.SKIPLIST;
-            case "embstr":
-            case "quicklist":
-            case "stream":
-                return ValueEncoding.ValkeyValueEncoding.RAW;
-            default:
-                return ValueEncoding.ValkeyValueEncoding.VACANT;
-        }
-    }
+		return new HashSet<>();
+	}
 
-    /**
-     * Parses the TIME command response into a Long value in the specified TimeUnit.
-     * 
-     * @param result the result from the TIME command (Object[] from Glide)
-     * @param timeUnit the desired time unit
-     * @return the time in the specified unit
-     */
-    public static Long parseTimeResponse(Object[] result, TimeUnit timeUnit) {
-        
-        // TIME returns [GlideString seconds, GlideString microseconds] as Object[]
-        Long seconds = Long.parseLong(((GlideString) result[0]).getString());
-        Long microseconds = Long.parseLong(((GlideString) result[1]).getString());
-        
-        // Convert to milliseconds first
-        long milliseconds = seconds * 1000 + microseconds / 1000;
-        
-        return timeUnit.convert(milliseconds, TimeUnit.MILLISECONDS);
-    }
+	public @Nullable static List<Map.Entry<byte[], byte[]>> toMapEntriesList(@Nullable Object glideResult) {
+		if (glideResult == null) {
+			return null;
+		}
+
+		Object[] result = (Object[]) glideResult;
+		if (result.length == 0) {
+			return null;
+		}
+
+		List<Map.Entry<byte[], byte[]>> resultList = new ArrayList<>();
+		for (Object item : result) {
+			Object[] keyValuePair = (Object[]) item;
+			GlideString keyObj = (GlideString) keyValuePair[0];
+			GlideString valueObj = (GlideString) keyValuePair[1];
+			resultList.add(new HashMap.SimpleEntry<>(keyObj.getBytes(), valueObj.getBytes()));
+		}
+		return resultList;
+	}
+
+	/**
+	 * Convert result to {@code List<byte[]>}.
+	 * @param glideResult The command result
+	 * @return List of byte arrays
+	 */
+	public @Nullable static List<byte[]> toBytesList(@Nullable Object[] glideResult) {
+		if (glideResult == null) {
+			return new ArrayList<>();
+		}
+
+		List<byte[]> convertedList = new ArrayList<>(glideResult.length);
+		for (Object item : glideResult) {
+			GlideString glideString = (GlideString) item;
+			convertedList.add(glideString != null ? glideString.getBytes() : null);
+		}
+		return convertedList;
+	}
+
+	public @Nullable static List<Long> toLongsList(@Nullable Object[] glideResult) {
+		if (glideResult == null) {
+			return null;
+		}
+
+		List<Long> resultList = new ArrayList<>(glideResult.length);
+		for (Object item : glideResult) {
+			resultList.add(((Number) item).longValue());
+		}
+		return resultList;
+	}
+
+	public @Nullable static List<Boolean> toBooleansList(@Nullable Object[] glideResult) {
+		if (glideResult == null) {
+			return null;
+		}
+
+		List<Boolean> resultList = new ArrayList<>(glideResult.length);
+		for (Object item : glideResult) {
+			resultList.add((Boolean) item);
+		}
+		return resultList;
+	}
+
+	public @Nullable static List<byte[]> toBytesList(@Nullable Object result) {
+		if (result == null) {
+			return new ArrayList<>();
+		}
+
+		if (result instanceof Collection) {
+			List<byte[]> list = new ArrayList<>();
+			for (Object item : (Collection<?>) result) {
+				if (item instanceof byte[]) {
+					list.add((byte[]) item);
+				}
+				else if (item instanceof String) {
+					list.add(((String) item).getBytes(StandardCharsets.UTF_8));
+				}
+				else if (item != null) {
+					list.add(item.toString().getBytes(StandardCharsets.UTF_8));
+				}
+			}
+			return list;
+		}
+
+		// Handle array types (Object[] and specific array types)
+		if (result instanceof Object[]) {
+			List<byte[]> list = new ArrayList<>();
+			for (Object item : (Object[]) result) {
+				if (item instanceof byte[]) {
+					list.add((byte[]) item);
+				}
+				else if (item instanceof GlideString) {
+					// Handle GlideString properly - use getBytes() to preserve binary
+					// data
+					list.add(((GlideString) item).getBytes());
+				}
+				else if (item instanceof String) {
+					list.add(((String) item).getBytes(StandardCharsets.UTF_8));
+				}
+				else if (item != null) {
+					list.add(item.toString().getBytes(StandardCharsets.UTF_8));
+				}
+			}
+			return list;
+		}
+
+		// Handle byte[][] specifically
+		if (result instanceof byte[][]) {
+			List<byte[]> list = new ArrayList<>();
+			for (byte[] item : (byte[][]) result) {
+				if (item != null) {
+					list.add(item);
+				}
+			}
+			return list;
+		}
+
+		// Handle String[] specifically
+		if (result instanceof String[]) {
+			List<byte[]> list = new ArrayList<>();
+			for (String item : (String[]) result) {
+				if (item != null) {
+					list.add(item.getBytes(StandardCharsets.UTF_8));
+				}
+			}
+			return list;
+		}
+
+		return new ArrayList<>();
+	}
+
+	public @Nullable static Map<byte[], byte[]> toBytesMap(@Nullable Object glideResult) {
+		if (glideResult == null) {
+			return null;
+		}
+		@SuppressWarnings("unchecked")
+		Map<GlideString, GlideString> coverted = (Map<GlideString, GlideString>) glideResult;
+		Map<byte[], byte[]> resultMap = new HashMap<>(coverted.size());
+		for (Map.Entry<GlideString, GlideString> entry : coverted.entrySet()) {
+			resultMap.put(entry.getKey().getBytes(), entry.getValue().getBytes());
+		}
+		return resultMap;
+	}
+
+	public static Map.Entry<byte[], byte[]> toBytesMapEntry(@Nullable Object glideResult) {
+		if (glideResult == null) {
+			return null;
+		}
+
+		Object[] result = (Object[]) glideResult;
+		if (result.length == 0) {
+			return null;
+		}
+
+		Object[] keyValuePair = (Object[]) result[0];
+
+		GlideString keyObj = (GlideString) keyValuePair[0];
+		GlideString valueObj = (GlideString) keyValuePair[1];
+		return new HashMap.SimpleEntry<>(keyObj.getBytes(), valueObj.getBytes());
+	}
+
+	/**
+	 * Append sort parameters to the command arguments.
+	 * @param args The command arguments list
+	 * @param params The sort parameters
+	 */
+	public static void appendSortParameters(List<Object> args, SortParameters params) {
+		if (params == null) {
+			return;
+		}
+
+		// Add BY pattern if specified
+		if (params.getByPattern() != null) {
+			args.add("BY");
+			args.add(params.getByPattern());
+		}
+
+		// Add LIMIT if specified
+		if (params.getLimit() != null) {
+			args.add("LIMIT");
+			args.add(params.getLimit().getStart());
+			args.add(params.getLimit().getCount());
+		}
+
+		// Add GET patterns if specified
+		if (params.getGetPattern() != null) {
+			for (byte[] pattern : params.getGetPattern()) {
+				args.add("GET");
+				args.add(pattern);
+			}
+		}
+
+		// Add ORDER if specified
+		if (params.getOrder() != null) {
+			args.add(params.getOrder().name());
+		}
+
+		// Add ALPHA if specified - check for null safely
+		Boolean isAlphabetic = params.isAlphabetic();
+		if (isAlphabetic != null && isAlphabetic) {
+			args.add("ALPHA");
+		}
+	}
+
+	/**
+	 * Convert OBJECT ENCODING result to ValueEncoding.
+	 * @param result The OBJECT ENCODING command result
+	 * @return The corresponding ValueEncoding
+	 */
+	public @Nullable static ValueEncoding toValueEncoding(@Nullable GlideString glideResult) {
+		if (glideResult == null) {
+			return ValueEncoding.ValkeyValueEncoding.VACANT;
+		}
+
+		switch (glideResult.toString()) {
+			case "raw":
+				return ValueEncoding.ValkeyValueEncoding.RAW;
+			case "int":
+				return ValueEncoding.ValkeyValueEncoding.INT;
+			case "hashtable":
+				return ValueEncoding.ValkeyValueEncoding.HASHTABLE;
+			case "zipmap":
+			case "linkedlist":
+				return ValueEncoding.ValkeyValueEncoding.LINKEDLIST;
+			case "ziplist":
+			case "listpack":
+				return ValueEncoding.ValkeyValueEncoding.ZIPLIST;
+			case "intset":
+				return ValueEncoding.ValkeyValueEncoding.INTSET;
+			case "skiplist":
+				return ValueEncoding.ValkeyValueEncoding.SKIPLIST;
+			case "embstr":
+			case "quicklist":
+			case "stream":
+				return ValueEncoding.ValkeyValueEncoding.RAW;
+			default:
+				return ValueEncoding.ValkeyValueEncoding.VACANT;
+		}
+	}
+
+	/**
+	 * Parses the TIME command response into a Long value in the specified TimeUnit.
+	 * @param result the result from the TIME command (Object[] from Glide)
+	 * @param timeUnit the desired time unit
+	 * @return the time in the specified unit
+	 */
+	public static Long parseTimeResponse(Object[] result, TimeUnit timeUnit) {
+
+		// TIME returns [GlideString seconds, GlideString microseconds] as Object[]
+		Long seconds = Long.parseLong(((GlideString) result[0]).getString());
+		Long microseconds = Long.parseLong(((GlideString) result[1]).getString());
+
+		// Convert to milliseconds first
+		long milliseconds = seconds * 1000 + microseconds / 1000;
+
+		return timeUnit.convert(milliseconds, TimeUnit.MILLISECONDS);
+	}
+
 }

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideDelegatingPubSubListener.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideDelegatingPubSubListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,47 +22,45 @@ import io.valkey.springframework.data.valkey.connection.DefaultMessage;
 import io.valkey.springframework.data.valkey.connection.MessageListener;
 
 /**
- * A delegating pub/sub listener that is configured at client creation time,
- * with the actual listener set later when subscribe() is called.
+ * A delegating pub/sub listener that is configured at client creation time, with the
+ * actual listener set later when subscribe() is called.
  */
 class DelegatingPubSubListener {
-    
-    private volatile MessageListener messageListener;
-    
-    /**
-     * Called by Glide when a pub/sub message arrives.
-     */
-    void onMessage(PubSubMessage msg, Object context) {
-        MessageListener listener = this.messageListener;
-        if (listener != null && msg != null) {
-            byte[] channel = msg.getChannel().getBytes();
-            byte[] body = msg.getMessage().getBytes();
-            byte[] pattern = msg.getPattern()
-                .map(GlideString::getBytes)
-                .orElse(null);
-            
-            listener.onMessage(new DefaultMessage(channel, body), pattern);
-            
-        }
 
-    }
-    
-    /**
-     * Set the actual listener when subscribe() is called.
-     */
-    void setListener(MessageListener listener) {
-        this.messageListener = listener;
-    }
-    
-    /**
-     * Clear the listener when subscription closes.
-     */
-    void clearListener() {
-        this.messageListener = null;
-    }
-    
-    
-    boolean hasListener() {
-        return messageListener != null;
-    }
+	private volatile MessageListener messageListener;
+
+	/**
+	 * Called by Glide when a pub/sub message arrives.
+	 */
+	void onMessage(PubSubMessage msg, Object context) {
+		MessageListener listener = this.messageListener;
+		if (listener != null && msg != null) {
+			byte[] channel = msg.getChannel().getBytes();
+			byte[] body = msg.getMessage().getBytes();
+			byte[] pattern = msg.getPattern().map(GlideString::getBytes).orElse(null);
+
+			listener.onMessage(new DefaultMessage(channel, body), pattern);
+
+		}
+
+	}
+
+	/**
+	 * Set the actual listener when subscribe() is called.
+	 */
+	void setListener(MessageListener listener) {
+		this.messageListener = listener;
+	}
+
+	/**
+	 * Clear the listener when subscription closes.
+	 */
+	void clearListener() {
+		this.messageListener = null;
+	}
+
+	boolean hasListener() {
+		return messageListener != null;
+	}
+
 }

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideExceptionConverter.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideExceptionConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,61 +31,62 @@ import org.jspecify.annotations.Nullable;
  */
 public class ValkeyGlideExceptionConverter {
 
-    /**
-     * Convert a Valkey-Glide exception to a Spring DataAccessException.
-     *
-     * @param ex The exception to convert
-     * @return The converted exception, or null if the exception could not be converted
-     */
-    @Nullable
-    public DataAccessException convert(Exception ex) {
-        // Currently, we don't have access to the actual Valkey-Glide exception classes
-        // So we have to rely on the exception message and class name for conversion
-        // In a real implementation, we would check the exception type using instanceof
-        
-        // This implementation is a placeholder and should be expanded with real exception types
-        // once the Valkey-Glide API is available
-        
-        String message = ex.getMessage();
-        if (message == null) {
-            message = ex.getClass().getSimpleName();
-        }
-        
-        // Check common Valkey error patterns in the message
-        if (message.contains("Connection") && (message.contains("refused") || 
-                message.contains("reset") || message.contains("closed") || 
-                message.contains("aborted") || message.contains("timeout"))) {
-            return new ValkeyConnectionFailureException(message, ex);
-        }
-        
-        if (message.contains("timeout") || message.contains("Timeout")) {
-            return new QueryTimeoutException(message, ex);
-        }
-        
-        if (message.contains("WRONGTYPE")) {
-            return new InvalidDataAccessApiUsageException(message, ex);
-        }
-        
-        // Handle NOSCRIPT errors - these are API usage errors (script doesn't exist)
-        // Valkey-Glide returns "NoScriptError" but Spring's ScriptUtils looks for "NOSCRIPT"
-        // We need to normalize the message so the fallback mechanism works
-        if (message.contains("NOSCRIPT") || message.contains("NoScriptError") || message.contains("No matching script")) {
-            // Convert "NoScriptError" to "NOSCRIPT" for Spring Data Valkey compatibility
-            String normalizedMessage = message.replace("NoScriptError", "NOSCRIPT");
-            return new InvalidDataAccessApiUsageException(normalizedMessage, ex);
-        }
-        
-        if (message.contains("NOAUTH") || message.contains("Authentication")) {
-            return new InvalidDataAccessResourceUsageException(message, ex);
-        }
-        
-        if (message.contains("BUSY") || message.contains("LOADING")) {
-            return new ValkeySystemException(message, ex);
-        }
-        
-        // For other exceptions, we need more context
-        // This implementation can be expanded based on real error patterns observed
-        
-        return new ValkeySystemException(message, ex);
-    }
+	/**
+	 * Convert a Valkey-Glide exception to a Spring DataAccessException.
+	 * @param ex The exception to convert
+	 * @return The converted exception, or null if the exception could not be converted
+	 */
+	@Nullable public DataAccessException convert(Exception ex) {
+		// Currently, we don't have access to the actual Valkey-Glide exception classes
+		// So we have to rely on the exception message and class name for conversion
+		// In a real implementation, we would check the exception type using instanceof
+
+		// This implementation is a placeholder and should be expanded with real exception
+		// types
+		// once the Valkey-Glide API is available
+
+		String message = ex.getMessage();
+		if (message == null) {
+			message = ex.getClass().getSimpleName();
+		}
+
+		// Check common Valkey error patterns in the message
+		if (message.contains("Connection") && (message.contains("refused") || message.contains("reset")
+				|| message.contains("closed") || message.contains("aborted") || message.contains("timeout"))) {
+			return new ValkeyConnectionFailureException(message, ex);
+		}
+
+		if (message.contains("timeout") || message.contains("Timeout")) {
+			return new QueryTimeoutException(message, ex);
+		}
+
+		if (message.contains("WRONGTYPE")) {
+			return new InvalidDataAccessApiUsageException(message, ex);
+		}
+
+		// Handle NOSCRIPT errors - these are API usage errors (script doesn't exist)
+		// Valkey-Glide returns "NoScriptError" but Spring's ScriptUtils looks for
+		// "NOSCRIPT"
+		// We need to normalize the message so the fallback mechanism works
+		if (message.contains("NOSCRIPT") || message.contains("NoScriptError")
+				|| message.contains("No matching script")) {
+			// Convert "NoScriptError" to "NOSCRIPT" for Spring Data Valkey compatibility
+			String normalizedMessage = message.replace("NoScriptError", "NOSCRIPT");
+			return new InvalidDataAccessApiUsageException(normalizedMessage, ex);
+		}
+
+		if (message.contains("NOAUTH") || message.contains("Authentication")) {
+			return new InvalidDataAccessResourceUsageException(message, ex);
+		}
+
+		if (message.contains("BUSY") || message.contains("LOADING")) {
+			return new ValkeySystemException(message, ex);
+		}
+
+		// For other exceptions, we need more context
+		// This implementation can be expanded based on real error patterns observed
+
+		return new ValkeySystemException(message, ex);
+	}
+
 }

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideFutureUtils.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideFutureUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,72 +31,80 @@ import java.util.concurrent.TimeoutException;
  */
 public abstract class ValkeyGlideFutureUtils {
 
-    /**
-     * Get the result of a CompletableFuture, waiting for the specified timeout.
-     *
-     * @param <T> The type of the result
-     * @param future The future to get the result from
-     * @param timeout The timeout in milliseconds
-     * @param exceptionConverter The exception converter to use for converting glide exceptions
-     * @return The result of the future
-     * @throws DataAccessException if an error occurs while getting the result
-     */
-    public static <T> T get(CompletableFuture<T> future, long timeout, ValkeyGlideExceptionConverter exceptionConverter) {
-        try {
-            return timeout > 0 ? future.get(timeout, TimeUnit.MILLISECONDS) : future.get();
-        } catch (InterruptedException ex) {
-            Thread.currentThread().interrupt();
-            throw new ValkeyConnectionFailureException("Interrupted while waiting for Valkey response", ex);
-        } catch (ExecutionException ex) {
-            Throwable cause = ex.getCause() != null ? ex.getCause() : ex;
-            if (cause instanceof Exception) {
-                DataAccessException converted = exceptionConverter.convert((Exception) cause);
-                if (converted != null) {
-                    throw converted;
-                }
-            }
-            throw new ValkeyConnectionFailureException("Error executing Valkey command", ex.getCause());
-        } catch (TimeoutException ex) {
-            throw new ValkeyConnectionFailureException("Valkey command timed out", ex);
-        }
-    }
+	/**
+	 * Get the result of a CompletableFuture, waiting for the specified timeout.
+	 * @param <T> The type of the result
+	 * @param future The future to get the result from
+	 * @param timeout The timeout in milliseconds
+	 * @param exceptionConverter The exception converter to use for converting glide
+	 * exceptions
+	 * @return The result of the future
+	 * @throws DataAccessException if an error occurs while getting the result
+	 */
+	public static <T> T get(CompletableFuture<T> future, long timeout,
+			ValkeyGlideExceptionConverter exceptionConverter) {
+		try {
+			return timeout > 0 ? future.get(timeout, TimeUnit.MILLISECONDS) : future.get();
+		}
+		catch (InterruptedException ex) {
+			Thread.currentThread().interrupt();
+			throw new ValkeyConnectionFailureException("Interrupted while waiting for Valkey response", ex);
+		}
+		catch (ExecutionException ex) {
+			Throwable cause = ex.getCause() != null ? ex.getCause() : ex;
+			if (cause instanceof Exception) {
+				DataAccessException converted = exceptionConverter.convert((Exception) cause);
+				if (converted != null) {
+					throw converted;
+				}
+			}
+			throw new ValkeyConnectionFailureException("Error executing Valkey command", ex.getCause());
+		}
+		catch (TimeoutException ex) {
+			throw new ValkeyConnectionFailureException("Valkey command timed out", ex);
+		}
+	}
 
-    /**
-     * Execute a CompletableFuture synchronously, waiting for the specified timeout.
-     *
-     * @param <T> The type of the result
-     * @param supplier A supplier that returns a CompletableFuture
-     * @param timeout The timeout in milliseconds
-     * @param exceptionConverter The exception converter to use for converting glide exceptions
-     * @return The result of the future
-     * @throws DataAccessException if an error occurs while executing the future
-     */
-    public static <T> T execute(FutureSupplier<T> supplier, long timeout, ValkeyGlideExceptionConverter exceptionConverter) {
-        try {
-            CompletableFuture<T> future = supplier.get();
-            return get(future, timeout, exceptionConverter);
-        } catch (Exception ex) {
-            DataAccessException converted = exceptionConverter.convert(ex);
-            if (converted != null) {
-                throw converted;
-            }
-            throw ex;
-        }
-    }
+	/**
+	 * Execute a CompletableFuture synchronously, waiting for the specified timeout.
+	 * @param <T> The type of the result
+	 * @param supplier A supplier that returns a CompletableFuture
+	 * @param timeout The timeout in milliseconds
+	 * @param exceptionConverter The exception converter to use for converting glide
+	 * exceptions
+	 * @return The result of the future
+	 * @throws DataAccessException if an error occurs while executing the future
+	 */
+	public static <T> T execute(FutureSupplier<T> supplier, long timeout,
+			ValkeyGlideExceptionConverter exceptionConverter) {
+		try {
+			CompletableFuture<T> future = supplier.get();
+			return get(future, timeout, exceptionConverter);
+		}
+		catch (Exception ex) {
+			DataAccessException converted = exceptionConverter.convert(ex);
+			if (converted != null) {
+				throw converted;
+			}
+			throw ex;
+		}
+	}
 
-    /**
-     * Functional interface for supplying a CompletableFuture.
-     *
-     * @param <T> The type of the result
-     */
-    @FunctionalInterface
-    public interface FutureSupplier<T> {
-        /**
-         * Get a CompletableFuture.
-         *
-         * @return The future
-         * @throws RuntimeException if an error occurs
-         */
-        CompletableFuture<T> get();
-    }
+	/**
+	 * Functional interface for supplying a CompletableFuture.
+	 *
+	 * @param <T> The type of the result
+	 */
+	@FunctionalInterface
+	public interface FutureSupplier<T> {
+
+		/**
+		 * Get a CompletableFuture.
+		 * @return The future
+		 * @throws RuntimeException if an error occurs
+		 */
+		CompletableFuture<T> get();
+
+	}
+
 }

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideGeoCommands.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideGeoCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,486 +46,480 @@ import glide.api.models.GlideString;
  */
 public class ValkeyGlideGeoCommands implements ValkeyGeoCommands {
 
-    private final ValkeyGlideConnection connection;
+	private final ValkeyGlideConnection connection;
 
-    /**
-     * Creates a new {@link ValkeyGlideGeoCommands}.
-     *
-     * @param connection must not be {@literal null}.
-     */
-    public ValkeyGlideGeoCommands(ValkeyGlideConnection connection) {
-        Assert.notNull(connection, "Connection must not be null!");
-        this.connection = connection;
-    }
+	/**
+	 * Creates a new {@link ValkeyGlideGeoCommands}.
+	 * @param connection must not be {@literal null}.
+	 */
+	public ValkeyGlideGeoCommands(ValkeyGlideConnection connection) {
+		Assert.notNull(connection, "Connection must not be null!");
+		this.connection = connection;
+	}
 
-    @Override
-    @Nullable
-    public Long geoAdd(byte[] key, Point point, byte[] member) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(point, "Point must not be null");
-        Assert.notNull(member, "Member must not be null");
+	@Override
+	@Nullable public Long geoAdd(byte[] key, Point point, byte[] member) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(point, "Point must not be null");
+		Assert.notNull(member, "Member must not be null");
 
-        try {
-            return connection.execute("GEOADD",
-                (Long glideResult) -> glideResult,
-                key, point.getX(), point.getY(), member);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		try {
+			return connection.execute("GEOADD", (Long glideResult) -> glideResult, key, point.getX(), point.getY(),
+					member);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    @Override
-    @Nullable
-    public Long geoAdd(byte[] key, Map<byte[], Point> memberCoordinateMap) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(memberCoordinateMap, "Member coordinate map must not be null");
+	@Override
+	@Nullable public Long geoAdd(byte[] key, Map<byte[], Point> memberCoordinateMap) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(memberCoordinateMap, "Member coordinate map must not be null");
 
-        try {
-            List<Object> commandArgs = new ArrayList<>();
-            commandArgs.add(key);
-            
-            for (Map.Entry<byte[], Point> entry : memberCoordinateMap.entrySet()) {
-                Point point = entry.getValue();
-                commandArgs.add(point.getX());
-                commandArgs.add(point.getY());
-                commandArgs.add(entry.getKey());
-            }
-            
-            return connection.execute("GEOADD",
-                (Long glideResult) -> glideResult,
-                commandArgs.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		try {
+			List<Object> commandArgs = new ArrayList<>();
+			commandArgs.add(key);
 
-    @Override
-    @Nullable
-    public Long geoAdd(byte[] key, Iterable<GeoLocation<byte[]>> locations) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(locations, "Locations must not be null");
+			for (Map.Entry<byte[], Point> entry : memberCoordinateMap.entrySet()) {
+				Point point = entry.getValue();
+				commandArgs.add(point.getX());
+				commandArgs.add(point.getY());
+				commandArgs.add(entry.getKey());
+			}
 
-        try {
-            List<Object> commandArgs = new ArrayList<>();
-            commandArgs.add(key);
-            
-            for (GeoLocation<byte[]> location : locations) {
-                Point point = location.getPoint();
-                commandArgs.add(point.getX());
-                commandArgs.add(point.getY());
-                commandArgs.add(location.getName());
-            }
-            return connection.execute("GEOADD",
-                (Long glideResult) -> glideResult,
-                commandArgs.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+			return connection.execute("GEOADD", (Long glideResult) -> glideResult, commandArgs.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    @Override
-    @Nullable
-    public Distance geoDist(byte[] key, byte[] member1, byte[] member2) {
-        return geoDist(key, member1, member2, DistanceUnit.METERS);
-    }
+	@Override
+	@Nullable public Long geoAdd(byte[] key, Iterable<GeoLocation<byte[]>> locations) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(locations, "Locations must not be null");
 
-    @Override
-    @Nullable
-    public Distance geoDist(byte[] key, byte[] member1, byte[] member2, Metric metric) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(member1, "Member1 must not be null");
-        Assert.notNull(member2, "Member2 must not be null");
-        Assert.notNull(metric, "Metric must not be null");
+		try {
+			List<Object> commandArgs = new ArrayList<>();
+			commandArgs.add(key);
 
-        try {
-            return connection.execute("GEODIST",
-                (Double glideResult) -> glideResult == null ? null : new Distance(glideResult, metric),
-                key, member1, member2, metric.getAbbreviation());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+			for (GeoLocation<byte[]> location : locations) {
+				Point point = location.getPoint();
+				commandArgs.add(point.getX());
+				commandArgs.add(point.getY());
+				commandArgs.add(location.getName());
+			}
+			return connection.execute("GEOADD", (Long glideResult) -> glideResult, commandArgs.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    @Override
-    @Nullable
-    public List<String> geoHash(byte[] key, byte[]... members) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(members, "Members must not be null");
-        Assert.noNullElements(members, "Members must not contain null elements");
+	@Override
+	@Nullable public Distance geoDist(byte[] key, byte[] member1, byte[] member2) {
+		return geoDist(key, member1, member2, DistanceUnit.METERS);
+	}
 
-        try {
-            Object[] args = new Object[members.length + 1];
-            args[0] = key;
-            System.arraycopy(members, 0, args, 1, members.length);
-            return connection.execute("GEOHASH",
-                (Object[] glideResult) -> {
-                    if (glideResult == null) {
-                        return null;
-                    }
-                    List<String> hashList = new ArrayList<>(glideResult.length);
-                    for (Object item : glideResult) {
-                        if (item == null) {
-                            hashList.add(null);
-                        }
-                        else {
-                            hashList.add(((GlideString) item).toString());
-                        }
-                    }
-                    return hashList;
-                },
-                args);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	@Override
+	@Nullable public Distance geoDist(byte[] key, byte[] member1, byte[] member2, Metric metric) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(member1, "Member1 must not be null");
+		Assert.notNull(member2, "Member2 must not be null");
+		Assert.notNull(metric, "Metric must not be null");
 
-    @Override
-    @Nullable
-    public List<Point> geoPos(byte[] key, byte[]... members) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(members, "Members must not be null");
-        Assert.noNullElements(members, "Members must not contain null elements");
+		try {
+			return connection.execute("GEODIST",
+					(Double glideResult) -> glideResult == null ? null : new Distance(glideResult, metric), key,
+					member1, member2, metric.getAbbreviation());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-        try {
-            Object[] args = new Object[members.length + 1];
-            args[0] = key;
-            System.arraycopy(members, 0, args, 1, members.length);
+	@Override
+	@Nullable public List<String> geoHash(byte[] key, byte[]... members) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(members, "Members must not be null");
+		Assert.noNullElements(members, "Members must not contain null elements");
 
-            
-            return connection.execute("GEOPOS",
-                (Object[] glideResult) -> {
-                    if (glideResult == null) {
-                        return new ArrayList<>();
-                    }
-                    
-                    List<Point> pointList = new ArrayList<>(glideResult.length);
-                    for (Object item : glideResult) {
-                        if (item == null) {
-                            pointList.add(null);
-                        } else {
-                            Point point = convertToPoint(item);
-                            pointList.add(point);
-                        }
-                    }
-                    return pointList;
-                },
-                args);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		try {
+			Object[] args = new Object[members.length + 1];
+			args[0] = key;
+			System.arraycopy(members, 0, args, 1, members.length);
+			return connection.execute("GEOHASH", (Object[] glideResult) -> {
+				if (glideResult == null) {
+					return null;
+				}
+				List<String> hashList = new ArrayList<>(glideResult.length);
+				for (Object item : glideResult) {
+					if (item == null) {
+						hashList.add(null);
+					}
+					else {
+						hashList.add(((GlideString) item).toString());
+					}
+				}
+				return hashList;
+			}, args);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    @Override
-    @Nullable
-    public GeoResults<GeoLocation<byte[]>> geoRadius(byte[] key, Circle within) {
-        return geoRadius(key, within, GeoRadiusCommandArgs.newGeoRadiusArgs());
-    }
+	@Override
+	@Nullable public List<Point> geoPos(byte[] key, byte[]... members) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(members, "Members must not be null");
+		Assert.noNullElements(members, "Members must not contain null elements");
 
-    @Override
-    @Nullable
-    public GeoResults<GeoLocation<byte[]>> geoRadiusByMember(byte[] key, byte[] member, Distance radius) {
-        return geoRadiusByMember(key, member, radius, GeoRadiusCommandArgs.newGeoRadiusArgs());
-    }
+		try {
+			Object[] args = new Object[members.length + 1];
+			args[0] = key;
+			System.arraycopy(members, 0, args, 1, members.length);
 
-    @Override
-    @Nullable
-    public GeoResults<GeoLocation<byte[]>> geoRadius(byte[] key, Circle within, GeoRadiusCommandArgs args) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(within, "Circle must not be null");
-        Assert.notNull(args, "GeoRadiusCommandArgs must not be null");
+			return connection.execute("GEOPOS", (Object[] glideResult) -> {
+				if (glideResult == null) {
+					return new ArrayList<>();
+				}
 
-        try {
-            List<Object> commandArgs = new ArrayList<>();
-            commandArgs.add(key);
-            commandArgs.add(within.getCenter().getX());
-            commandArgs.add(within.getCenter().getY());
-            commandArgs.add(within.getRadius().getValue());
-            commandArgs.add(within.getRadius().getMetric().getAbbreviation());
-            
-            appendGeoRadiusArgs(commandArgs, args);
-            
-            return connection.execute("GEORADIUS",
-                (Object[] glideResult) -> parseGeoResults(glideResult, args, within.getRadius().getMetric()),
-                commandArgs.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+				List<Point> pointList = new ArrayList<>(glideResult.length);
+				for (Object item : glideResult) {
+					if (item == null) {
+						pointList.add(null);
+					}
+					else {
+						Point point = convertToPoint(item);
+						pointList.add(point);
+					}
+				}
+				return pointList;
+			}, args);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    @Override
-    @Nullable
-    public GeoResults<GeoLocation<byte[]>> geoRadiusByMember(byte[] key, byte[] member, Distance radius,
-            GeoRadiusCommandArgs args) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(member, "Member must not be null");
-        Assert.notNull(radius, "Distance must not be null");
-        Assert.notNull(args, "GeoRadiusCommandArgs must not be null");
+	@Override
+	@Nullable public GeoResults<GeoLocation<byte[]>> geoRadius(byte[] key, Circle within) {
+		return geoRadius(key, within, GeoRadiusCommandArgs.newGeoRadiusArgs());
+	}
 
-        try {
-            List<Object> commandArgs = new ArrayList<>();
-            commandArgs.add(key);
-            commandArgs.add(member);
-            commandArgs.add(radius.getValue());
-            commandArgs.add(radius.getMetric().getAbbreviation());
-            
-            appendGeoRadiusArgs(commandArgs, args);
-            
-            return connection.execute("GEORADIUSBYMEMBER",
-                (Object[] glideResult) -> parseGeoResults(glideResult, args, radius.getMetric()),
-                commandArgs.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	@Override
+	@Nullable public GeoResults<GeoLocation<byte[]>> geoRadiusByMember(byte[] key, byte[] member, Distance radius) {
+		return geoRadiusByMember(key, member, radius, GeoRadiusCommandArgs.newGeoRadiusArgs());
+	}
 
-    @Override
-    @Nullable
-    public Long geoRemove(byte[] key, byte[]... members) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(members, "Members must not be null");
-        Assert.noNullElements(members, "Members must not contain null elements");
+	@Override
+	@Nullable public GeoResults<GeoLocation<byte[]>> geoRadius(byte[] key, Circle within, GeoRadiusCommandArgs args) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(within, "Circle must not be null");
+		Assert.notNull(args, "GeoRadiusCommandArgs must not be null");
 
-        try {
-            Object[] args = new Object[members.length + 1];
-            args[0] = key;
-            System.arraycopy(members, 0, args, 1, members.length);
+		try {
+			List<Object> commandArgs = new ArrayList<>();
+			commandArgs.add(key);
+			commandArgs.add(within.getCenter().getX());
+			commandArgs.add(within.getCenter().getY());
+			commandArgs.add(within.getRadius().getValue());
+			commandArgs.add(within.getRadius().getMetric().getAbbreviation());
 
+			appendGeoRadiusArgs(commandArgs, args);
 
-            return connection.execute("ZREM",
-                (Long glideResult) -> glideResult,
-                args);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+			return connection.execute("GEORADIUS",
+					(Object[] glideResult) -> parseGeoResults(glideResult, args, within.getRadius().getMetric()),
+					commandArgs.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    @Override
-    @Nullable
-    public GeoResults<GeoLocation<byte[]>> geoSearch(byte[] key, GeoReference<byte[]> reference, GeoShape predicate,
-            GeoSearchCommandArgs args) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(reference, "GeoReference must not be null");
-        Assert.notNull(predicate, "GeoShape must not be null");
-        Assert.notNull(args, "GeoSearchCommandArgs must not be null");
+	@Override
+	@Nullable public GeoResults<GeoLocation<byte[]>> geoRadiusByMember(byte[] key, byte[] member, Distance radius,
+			GeoRadiusCommandArgs args) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(member, "Member must not be null");
+		Assert.notNull(radius, "Distance must not be null");
+		Assert.notNull(args, "GeoRadiusCommandArgs must not be null");
 
-        try {
-            List<Object> commandArgs = new ArrayList<>();
-            commandArgs.add(key);
-            
-            appendGeoReference(commandArgs, reference);
-            appendGeoShape(commandArgs, predicate);
-            appendGeoSearchArgs(commandArgs, args);
-            
-            return connection.execute("GEOSEARCH",
-                (Object[] glideResult) -> parseGeoResults(glideResult, args, DistanceUnit.METERS),
-                commandArgs.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		try {
+			List<Object> commandArgs = new ArrayList<>();
+			commandArgs.add(key);
+			commandArgs.add(member);
+			commandArgs.add(radius.getValue());
+			commandArgs.add(radius.getMetric().getAbbreviation());
 
-    @Override
-    @Nullable
-    public Long geoSearchStore(byte[] destKey, byte[] key, GeoReference<byte[]> reference, GeoShape predicate,
-            GeoSearchStoreCommandArgs args) {
-        Assert.notNull(destKey, "Destination key must not be null");
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(reference, "GeoReference must not be null");
-        Assert.notNull(predicate, "GeoShape must not be null");
-        Assert.notNull(args, "GeoSearchStoreCommandArgs must not be null");
+			appendGeoRadiusArgs(commandArgs, args);
 
-        try {
-            List<Object> commandArgs = new ArrayList<>();
-            commandArgs.add(destKey);
-            commandArgs.add(key);
-            
-            appendGeoReference(commandArgs, reference);
-            appendGeoShape(commandArgs, predicate);
-            appendGeoSearchStoreArgs(commandArgs, args);
-            
-            return connection.execute("GEOSEARCHSTORE",
-                (Long glideResult) -> glideResult,
-                commandArgs.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+			return connection.execute("GEORADIUSBYMEMBER",
+					(Object[] glideResult) -> parseGeoResults(glideResult, args, radius.getMetric()),
+					commandArgs.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    // ==================== Helper Methods ====================
+	@Override
+	@Nullable public Long geoRemove(byte[] key, byte[]... members) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(members, "Members must not be null");
+		Assert.noNullElements(members, "Members must not contain null elements");
 
-    private Point convertToPoint(Object obj) {
-        if (obj == null) {
-            return null;
-        }
-        
-        Object[] coordinates = (Object[]) obj;
-        
-        if (coordinates.length >= 2 && coordinates[0] != null && coordinates[1] != null) {
-            double x = parseDouble(coordinates[0]);
-            double y = parseDouble(coordinates[1]);
-            return new Point(x, y);
-        }
-        
-        return null;
-    }
+		try {
+			Object[] args = new Object[members.length + 1];
+			args[0] = key;
+			System.arraycopy(members, 0, args, 1, members.length);
 
-    private double parseDouble(Object obj) {
-        if (obj instanceof Number) {
-            return ((Number) obj).doubleValue();
-        } else if (obj instanceof GlideString) {
-            return Double.parseDouble(((GlideString) obj).toString());
-        } else {
-            return Double.parseDouble(obj.toString());
-        }
-    }
+			return connection.execute("ZREM", (Long glideResult) -> glideResult, args);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    private void appendGeoRadiusArgs(List<Object> commandArgs, GeoRadiusCommandArgs args) {
-        if (args.getFlags().contains(GeoRadiusCommandArgs.Flag.WITHCOORD)) {
-            commandArgs.add("WITHCOORD");
-        }
-        if (args.getFlags().contains(GeoRadiusCommandArgs.Flag.WITHDIST)) {
-            commandArgs.add("WITHDIST");
-        }
-        if (args.hasLimit()) {
-            commandArgs.add("COUNT");
-            commandArgs.add(args.getLimit());
-            if (args.hasAnyLimit()) {
-                commandArgs.add("ANY");
-            }
-        }
-        if (args.hasSortDirection()) {
-            commandArgs.add(args.getSortDirection() == Direction.ASC ? "ASC" : "DESC");
-        }
-    }
+	@Override
+	@Nullable public GeoResults<GeoLocation<byte[]>> geoSearch(byte[] key, GeoReference<byte[]> reference, GeoShape predicate,
+			GeoSearchCommandArgs args) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(reference, "GeoReference must not be null");
+		Assert.notNull(predicate, "GeoShape must not be null");
+		Assert.notNull(args, "GeoSearchCommandArgs must not be null");
 
-    private void appendGeoSearchArgs(List<Object> commandArgs, GeoSearchCommandArgs args) {
-        if (args.getFlags().contains(GeoCommandArgs.GeoCommandFlag.withCord())) {
-            commandArgs.add("WITHCOORD");
-        }
-        if (args.getFlags().contains(GeoCommandArgs.GeoCommandFlag.withDist())) {
-            commandArgs.add("WITHDIST");
-        }
-        if (args.hasLimit()) {
-            commandArgs.add("COUNT");
-            commandArgs.add(args.getLimit());
-            if (args.hasAnyLimit()) {
-                commandArgs.add("ANY");
-            }
-        }
-        if (args.hasSortDirection()) {
-            commandArgs.add(args.getSortDirection() == Direction.ASC ? "ASC" : "DESC");
-        }
-    }
+		try {
+			List<Object> commandArgs = new ArrayList<>();
+			commandArgs.add(key);
 
-    private void appendGeoSearchStoreArgs(List<Object> commandArgs, GeoSearchStoreCommandArgs args) {
-        if (args.isStoreDistance()) {
-            commandArgs.add("STOREDIST");
-        }
-        if (args.hasLimit()) {
-            commandArgs.add("COUNT");
-            commandArgs.add(args.getLimit());
-            if (args.hasAnyLimit()) {
-                commandArgs.add("ANY");
-            }
-        }
-        if (args.hasSortDirection()) {
-            commandArgs.add(args.getSortDirection() == Direction.ASC ? "ASC" : "DESC");
-        }
-    }
+			appendGeoReference(commandArgs, reference);
+			appendGeoShape(commandArgs, predicate);
+			appendGeoSearchArgs(commandArgs, args);
 
-    private void appendGeoReference(List<Object> commandArgs, GeoReference<byte[]> reference) {
-        if (reference instanceof GeoReference.GeoMemberReference) {
-            commandArgs.add("FROMMEMBER");
-            commandArgs.add(((GeoReference.GeoMemberReference<byte[]>) reference).getMember());
-        } else if (reference instanceof GeoReference.GeoCoordinateReference) {
-            commandArgs.add("FROMLONLAT");
-            GeoReference.GeoCoordinateReference<?> coordRef = (GeoReference.GeoCoordinateReference<?>) reference;
-            commandArgs.add(coordRef.getLongitude());
-            commandArgs.add(coordRef.getLatitude());
-        }
-    }
+			return connection.execute("GEOSEARCH",
+					(Object[] glideResult) -> parseGeoResults(glideResult, args, DistanceUnit.METERS),
+					commandArgs.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    private void appendGeoShape(List<Object> commandArgs, GeoShape shape) {
-        if (shape instanceof RadiusShape) {
-            commandArgs.add("BYRADIUS");
-            RadiusShape radiusShape = (RadiusShape) shape;
-            commandArgs.add(radiusShape.getRadius().getValue());
-            commandArgs.add(radiusShape.getRadius().getMetric().getAbbreviation());
-        } else if (shape instanceof BoxShape) {
-            commandArgs.add("BYBOX");
-            BoxShape boxShape = (BoxShape) shape;
-            commandArgs.add(boxShape.getBoundingBox().getWidth().getValue());
-            commandArgs.add(boxShape.getBoundingBox().getHeight().getValue());
-            commandArgs.add(boxShape.getBoundingBox().getWidth().getMetric().getAbbreviation());
-        }
-    }
-    
-    private GeoResults<GeoLocation<byte[]>> parseGeoResults(Object[] result, GeoCommandArgs args, Metric defaultMetric) {
-        if (result == null) {
-            return new GeoResults<>(new ArrayList<>());
-        }
-        
-        List<GeoResult<GeoLocation<byte[]>>> geoResults = new ArrayList<>(result.length);
-        
-        boolean hasDistance = args.getFlags().contains(GeoCommandArgs.GeoCommandFlag.withDist());
-        boolean hasCoordinate = args.getFlags().contains(GeoCommandArgs.GeoCommandFlag.withCord());
-        
-        for (Object item : result) {
-            if (hasDistance || hasCoordinate) {
-                // Complex result format with additional information
-                Object[] itemArray;
-                if (item instanceof Object[]) {
-                    itemArray = (Object[]) item;
-                } else {
-                    continue;
-                }
-                
-                byte[] member = convertToBytes(itemArray[0]);
-                Distance distance = null;
-                Point point = null;
-                
-                int index = 1;
-                if (hasDistance && index < itemArray.length) {
-                    Object distObj = itemArray[index++];
-                    if (distObj != null) {
-                        try {
-                            double dist = parseDouble(distObj);
-                            distance = new Distance(dist, defaultMetric);
-                        } catch (Exception e) {
-                            distance = new Distance(0.0, defaultMetric);
-                        }
-                    } else {
-                        distance = new Distance(0.0, defaultMetric);
-                    }
-                }
-                if (hasCoordinate && index < itemArray.length) {
-                    Object coordObj = itemArray[index];
-                    point = convertToPoint(coordObj);
-                }
-                
-                GeoLocation<byte[]> location = new GeoLocation<>(member, point);
-                if (distance == null) {
-                    distance = new Distance(0.0, defaultMetric);
-                }
-                geoResults.add(new GeoResult<>(location, distance));
-            } else {
-                // Simple result format - just member names
-                byte[] member = convertToBytes(item);
-                GeoLocation<byte[]> location = new GeoLocation<>(member, null);
-                geoResults.add(new GeoResult<>(location, new Distance(0.0, defaultMetric)));
-            }
-        }
-        
-        return new GeoResults<>(geoResults);
-    }
+	@Override
+	@Nullable public Long geoSearchStore(byte[] destKey, byte[] key, GeoReference<byte[]> reference, GeoShape predicate,
+			GeoSearchStoreCommandArgs args) {
+		Assert.notNull(destKey, "Destination key must not be null");
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(reference, "GeoReference must not be null");
+		Assert.notNull(predicate, "GeoShape must not be null");
+		Assert.notNull(args, "GeoSearchStoreCommandArgs must not be null");
 
-    private byte[] convertToBytes(Object obj) {
-        if (obj instanceof GlideString) {
-            return ((GlideString) obj).getBytes();
-        } else if (obj instanceof byte[]) {
-            return (byte[]) obj;
-        } else {
-            return obj.toString().getBytes();
-        }
-    }
+		try {
+			List<Object> commandArgs = new ArrayList<>();
+			commandArgs.add(destKey);
+			commandArgs.add(key);
+
+			appendGeoReference(commandArgs, reference);
+			appendGeoShape(commandArgs, predicate);
+			appendGeoSearchStoreArgs(commandArgs, args);
+
+			return connection.execute("GEOSEARCHSTORE", (Long glideResult) -> glideResult, commandArgs.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	// ==================== Helper Methods ====================
+
+	private Point convertToPoint(Object obj) {
+		if (obj == null) {
+			return null;
+		}
+
+		Object[] coordinates = (Object[]) obj;
+
+		if (coordinates.length >= 2 && coordinates[0] != null && coordinates[1] != null) {
+			double x = parseDouble(coordinates[0]);
+			double y = parseDouble(coordinates[1]);
+			return new Point(x, y);
+		}
+
+		return null;
+	}
+
+	private double parseDouble(Object obj) {
+		if (obj instanceof Number) {
+			return ((Number) obj).doubleValue();
+		}
+		else if (obj instanceof GlideString) {
+			return Double.parseDouble(((GlideString) obj).toString());
+		}
+		else {
+			return Double.parseDouble(obj.toString());
+		}
+	}
+
+	private void appendGeoRadiusArgs(List<Object> commandArgs, GeoRadiusCommandArgs args) {
+		if (args.getFlags().contains(GeoRadiusCommandArgs.Flag.WITHCOORD)) {
+			commandArgs.add("WITHCOORD");
+		}
+		if (args.getFlags().contains(GeoRadiusCommandArgs.Flag.WITHDIST)) {
+			commandArgs.add("WITHDIST");
+		}
+		if (args.hasLimit()) {
+			commandArgs.add("COUNT");
+			commandArgs.add(args.getLimit());
+			if (args.hasAnyLimit()) {
+				commandArgs.add("ANY");
+			}
+		}
+		if (args.hasSortDirection()) {
+			commandArgs.add(args.getSortDirection() == Direction.ASC ? "ASC" : "DESC");
+		}
+	}
+
+	private void appendGeoSearchArgs(List<Object> commandArgs, GeoSearchCommandArgs args) {
+		if (args.getFlags().contains(GeoCommandArgs.GeoCommandFlag.withCord())) {
+			commandArgs.add("WITHCOORD");
+		}
+		if (args.getFlags().contains(GeoCommandArgs.GeoCommandFlag.withDist())) {
+			commandArgs.add("WITHDIST");
+		}
+		if (args.hasLimit()) {
+			commandArgs.add("COUNT");
+			commandArgs.add(args.getLimit());
+			if (args.hasAnyLimit()) {
+				commandArgs.add("ANY");
+			}
+		}
+		if (args.hasSortDirection()) {
+			commandArgs.add(args.getSortDirection() == Direction.ASC ? "ASC" : "DESC");
+		}
+	}
+
+	private void appendGeoSearchStoreArgs(List<Object> commandArgs, GeoSearchStoreCommandArgs args) {
+		if (args.isStoreDistance()) {
+			commandArgs.add("STOREDIST");
+		}
+		if (args.hasLimit()) {
+			commandArgs.add("COUNT");
+			commandArgs.add(args.getLimit());
+			if (args.hasAnyLimit()) {
+				commandArgs.add("ANY");
+			}
+		}
+		if (args.hasSortDirection()) {
+			commandArgs.add(args.getSortDirection() == Direction.ASC ? "ASC" : "DESC");
+		}
+	}
+
+	private void appendGeoReference(List<Object> commandArgs, GeoReference<byte[]> reference) {
+		if (reference instanceof GeoReference.GeoMemberReference) {
+			commandArgs.add("FROMMEMBER");
+			commandArgs.add(((GeoReference.GeoMemberReference<byte[]>) reference).getMember());
+		}
+		else if (reference instanceof GeoReference.GeoCoordinateReference) {
+			commandArgs.add("FROMLONLAT");
+			GeoReference.GeoCoordinateReference<?> coordRef = (GeoReference.GeoCoordinateReference<?>) reference;
+			commandArgs.add(coordRef.getLongitude());
+			commandArgs.add(coordRef.getLatitude());
+		}
+	}
+
+	private void appendGeoShape(List<Object> commandArgs, GeoShape shape) {
+		if (shape instanceof RadiusShape) {
+			commandArgs.add("BYRADIUS");
+			RadiusShape radiusShape = (RadiusShape) shape;
+			commandArgs.add(radiusShape.getRadius().getValue());
+			commandArgs.add(radiusShape.getRadius().getMetric().getAbbreviation());
+		}
+		else if (shape instanceof BoxShape) {
+			commandArgs.add("BYBOX");
+			BoxShape boxShape = (BoxShape) shape;
+			commandArgs.add(boxShape.getBoundingBox().getWidth().getValue());
+			commandArgs.add(boxShape.getBoundingBox().getHeight().getValue());
+			commandArgs.add(boxShape.getBoundingBox().getWidth().getMetric().getAbbreviation());
+		}
+	}
+
+	private GeoResults<GeoLocation<byte[]>> parseGeoResults(Object[] result, GeoCommandArgs args,
+			Metric defaultMetric) {
+		if (result == null) {
+			return new GeoResults<>(new ArrayList<>());
+		}
+
+		List<GeoResult<GeoLocation<byte[]>>> geoResults = new ArrayList<>(result.length);
+
+		boolean hasDistance = args.getFlags().contains(GeoCommandArgs.GeoCommandFlag.withDist());
+		boolean hasCoordinate = args.getFlags().contains(GeoCommandArgs.GeoCommandFlag.withCord());
+
+		for (Object item : result) {
+			if (hasDistance || hasCoordinate) {
+				// Complex result format with additional information
+				Object[] itemArray;
+				if (item instanceof Object[]) {
+					itemArray = (Object[]) item;
+				}
+				else {
+					continue;
+				}
+
+				byte[] member = convertToBytes(itemArray[0]);
+				Distance distance = null;
+				Point point = null;
+
+				int index = 1;
+				if (hasDistance && index < itemArray.length) {
+					Object distObj = itemArray[index++];
+					if (distObj != null) {
+						try {
+							double dist = parseDouble(distObj);
+							distance = new Distance(dist, defaultMetric);
+						}
+						catch (Exception e) {
+							distance = new Distance(0.0, defaultMetric);
+						}
+					}
+					else {
+						distance = new Distance(0.0, defaultMetric);
+					}
+				}
+				if (hasCoordinate && index < itemArray.length) {
+					Object coordObj = itemArray[index];
+					point = convertToPoint(coordObj);
+				}
+
+				GeoLocation<byte[]> location = new GeoLocation<>(member, point);
+				if (distance == null) {
+					distance = new Distance(0.0, defaultMetric);
+				}
+				geoResults.add(new GeoResult<>(location, distance));
+			}
+			else {
+				// Simple result format - just member names
+				byte[] member = convertToBytes(item);
+				GeoLocation<byte[]> location = new GeoLocation<>(member, null);
+				geoResults.add(new GeoResult<>(location, new Distance(0.0, defaultMetric)));
+			}
+		}
+
+		return new GeoResults<>(geoResults);
+	}
+
+	private byte[] convertToBytes(Object obj) {
+		if (obj instanceof GlideString) {
+			return ((GlideString) obj).getBytes();
+		}
+		else if (obj instanceof byte[]) {
+			return (byte[]) obj;
+		}
+		else {
+			return obj.toString().getBytes();
+		}
+	}
+
 }

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideHashCommands.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideHashCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,662 +47,654 @@ import glide.api.models.GlideString;
  */
 public class ValkeyGlideHashCommands implements ValkeyHashCommands {
 
-    private final ValkeyGlideConnection connection;
+	private final ValkeyGlideConnection connection;
 
-    /**
-     * Creates a new {@link ValkeyGlideHashCommands}.
-     *
-     * @param connection must not be {@literal null}.
-     */
-    public ValkeyGlideHashCommands(ValkeyGlideConnection connection) {
-        Assert.notNull(connection, "Connection must not be null!");
-        this.connection = connection;
-    }
-
-    @Override
-    public @Nullable Boolean hSet(byte[] key, byte[] field, byte[] value) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(field, "Field must not be null");
-        Assert.notNull(value, "Value must not be null");
-        
-        try {
-            return connection.execute("HSET",
-                (Number glideResult) -> glideResult != null ? glideResult.longValue() > 0 : null,
-                key,
-                field,
-                value);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public @Nullable Boolean hSetNX(byte[] key, byte[] field, byte[] value) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(field, "Field must not be null");
-        Assert.notNull(value, "Value must not be null");
-        
-        try {
-            return connection.execute("HSETNX",
-                (Boolean glideResult) -> glideResult,
-                key,
-                field,
-                value);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public @Nullable byte[] hGet(byte[] key, byte[] field) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(field, "Field must not be null");
-        
-        try {
-            return connection.execute("HGET",
-                (GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null,
-                key,
-                field);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public @Nullable List<byte[]> hMGet(byte[] key, byte[]... fields) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(fields, "Fields must not be null");
-        Assert.noNullElements(fields, "Fields must not contain null elements");
-        
-        try {
-            Object[] args = new Object[1 + fields.length];
-            args[0] = key;
-            System.arraycopy(fields, 0, args, 1, fields.length);
-            return connection.execute("HMGET",
-                (Object[] glideResult) -> ValkeyGlideConverters.toBytesList(glideResult),
-                args);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public void hMSet(byte[] key, Map<byte[], byte[]> hashes) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(hashes, "Hashes must not be null");
-        Assert.notEmpty(hashes, "Hashes must not be empty");
-        
-        try {
-            List<Object> args = new ArrayList<>();
-            args.add(key);
-            for (Map.Entry<byte[], byte[]> entry : hashes.entrySet()) {
-                args.add(entry.getKey());
-                args.add(entry.getValue());
-            }
-            connection.execute("HMSET",
-                // Valkey returns simple OK string for HMSET
-                (String glideResult) -> glideResult,
-                args.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public @Nullable Long hIncrBy(byte[] key, byte[] field, long delta) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(field, "Field must not be null");
-        
-        try {
-            return connection.execute("HINCRBY",
-                (Long glideResult) -> glideResult,
-                key,
-                field,
-                delta);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public @Nullable Double hIncrBy(byte[] key, byte[] field, double delta) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(field, "Field must not be null");
-        
-        try {
-            return connection.execute("HINCRBYFLOAT",
-                (Double glideResult) -> glideResult,
-                key,
-                field,
-                delta);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public @Nullable Boolean hExists(byte[] key, byte[] field) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(field, "Field must not be null");
-        
-        try {
-            return connection.execute("HEXISTS",
-                (Boolean glideResult) -> glideResult,
-                key, field);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public @Nullable Long hDel(byte[] key, byte[]... fields) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(fields, "Fields must not be null");
-        Assert.noNullElements(fields, "Fields must not contain null elements");
-        
-        try {
-            Object[] args = new Object[1 + fields.length];
-            args[0] = key;
-            System.arraycopy(fields, 0, args, 1, fields.length);
-
-            return connection.execute("HDEL",
-                (Long glideResult) -> glideResult,
-                args);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public @Nullable Long hLen(byte[] key) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("HLEN",
-                (Long glideResult) -> glideResult,
-                key);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public @Nullable Set<byte[]> hKeys(byte[] key) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("HKEYS",
-                (Object[] glideResult) -> ValkeyGlideConverters.toBytesSet(glideResult),
-                key);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public @Nullable List<byte[]> hVals(byte[] key) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("HVALS",
-                (Object[] glideResult) -> ValkeyGlideConverters.toBytesList(glideResult),
-                key);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public @Nullable Map<byte[], byte[]> hGetAll(byte[] key) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("HGETALL",
-                //(Map<GlideString, GlideString> glideResult) -> ValkeyGlideConverters.toBytesMap(glideResult),
-                glideResult -> ValkeyGlideConverters.toBytesMap(glideResult),
-                key);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public @Nullable byte[] hRandField(byte[] key) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("HRANDFIELD",
-                (GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null,
-                key);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public Map.Entry<byte[], byte[]> hRandFieldWithValues(byte[] key) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("HRANDFIELD",
-                glideResult -> ValkeyGlideConverters.toBytesMapEntry(glideResult),
-                key,
-                1,
-                "WITHVALUES");
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public @Nullable List<byte[]> hRandField(byte[] key, long count) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("HRANDFIELD",
-                (Object[] glideResult) -> ValkeyGlideConverters.toBytesList(glideResult),
-                key,
-                count);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public @Nullable List<Map.Entry<byte[], byte[]>> hRandFieldWithValues(byte[] key, long count) {
-        Assert.notNull(key, "Key must not be null");
-
-        try {
-            return connection.execute("HRANDFIELD",
-                glideResult -> ValkeyGlideConverters.toMapEntriesList(glideResult),
-                key,
-                count,
-                "WITHVALUES");
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public Cursor<Map.Entry<byte[], byte[]>> hScan(byte[] key, ScanOptions options) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(options, "ScanOptions must not be null");
-        
-        return new ValkeyGlideHashScanCursor(key, options, connection);
-    }
-    
-    /**
-     * Simple implementation of Cursor for HSCAN operation.
-     */
-    private static class ValkeyGlideHashScanCursor implements Cursor<Map.Entry<byte[], byte[]>> {
-        
-        private final byte[] key;
-        private final ScanOptions options;
-        private final ValkeyGlideConnection connection;
-        private long cursor = 0;
-        private List<Map.Entry<byte[], byte[]>> entries = new ArrayList<>();
-        private int currentIndex = 0;
-        private boolean finished = false;
-        
-        public ValkeyGlideHashScanCursor(byte[] key, ScanOptions options, ValkeyGlideConnection connection) {
-            this.key = key;
-            this.options = options;
-            this.connection = connection;
-            scanNext();
-        }
-        
-        @Override
-        public boolean hasNext() {
-            if (currentIndex < entries.size()) {
-                return true;
-            }
-            if (finished) {
-                return false;
-            }
-            scanNext();
-            return currentIndex < entries.size();
-        }
-        
-        @Override
-        public Map.Entry<byte[], byte[]> next() {
-            if (!hasNext()) {
-                throw new java.util.NoSuchElementException();
-            }
-            return entries.get(currentIndex++);
-        }
-
-        private void scanNext() {
-            if (connection.isQueueing() || connection.isPipelined()) {
-                throw new InvalidDataAccessApiUsageException("'HSCAN' cannot be called in pipeline / transaction mode");
-            }
-
-            try {
-                List<Object> args = new ArrayList<>();
-                args.add(key);
-                args.add(String.valueOf(cursor));
-                
-                if (options.getCount() != null) {
-                    args.add("COUNT");
-                    args.add(options.getCount());
-                }
-                
-                if (options.getPattern() != null) {
-                    args.add("MATCH");
-                    args.add(options.getPattern());
-                }
-                
-                connection.execute("HSCAN", (Object[] glideResult) -> {
-                    if (glideResult == null) {
-                        return null;
-                    }
-                    
-                    // First element is the new cursor and is byte[], need to convert to String first
-                    GlideString cursorStr = (GlideString) glideResult[0];
-                    cursor = Long.parseLong(cursorStr.getString());
-                    if (cursor == 0) {
-                        finished = true;
-                    }
-                        
-                    // Second element is the array of field-value pairs
-                    Object[] fieldValuePairs = (Object[]) glideResult[1];
-                        
-                    // Reset entries for this batch
-                    entries.clear();
-                    currentIndex = 0;
-                    for (int i = 0; i < fieldValuePairs.length; i += 2) {
-                        GlideString field = (GlideString) fieldValuePairs[i];
-                        GlideString value = (GlideString) fieldValuePairs[i + 1];
-                        entries.add(new HashMap.SimpleEntry<>(field.getBytes(), value.getBytes()));
-                    }
-
-                    return null; // We don't need to return anything from this mapper
-                },
-                args.toArray());
-
-            } catch (Exception ex) {
-                throw new ValkeyGlideExceptionConverter().convert(ex);
-            }
-        }
-        
-        @Override
-        public void close() {
-            // No resources to close for this implementation
-        }
-        
-        @Override
-        public boolean isClosed() {
-            return finished && currentIndex >= entries.size();
-        }
-        
-        @Override
-        public long getCursorId() {
-            return cursor;
-        }
-        
-        @Override
-        public long getPosition() {
-            return currentIndex;
-        }
-        
-        @Override
-        public CursorId getId() {
-            return CursorId.of(cursor);
-        }
-    }
-
-    @Override
-    public @Nullable Long hStrLen(byte[] key, byte[] field) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(field, "Field must not be null");
-        
-        try {
-            return connection.execute("HSTRLEN",
-            (Long glideResult) -> glideResult,
-            key,
-            field);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public @Nullable List<Long> hExpire(byte[] key, long seconds, ExpirationOptions.Condition condition, byte[]... fields) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(fields, "Fields must not be null");
-        Assert.noNullElements(fields, "Fields must not contain null elements");
-        
-        try {
-            List<Object> args = new ArrayList<>();
-            args.add(key);
-            args.add(seconds);
-            
-            // Add condition if not ALWAYS
-            if (condition != ExpirationOptions.Condition.ALWAYS) {
-                args.add(condition.name());
-            }
-            
-            // Add FIELDS keyword and numfields
-            args.add("FIELDS");
-            args.add(fields.length);
-            
-            // Add fields
-            for (byte[] field : fields) {
-                args.add(field);
-            }
-            
-            return connection.execute("HEXPIRE",
-                (Object[] glideResult) -> ValkeyGlideConverters.toLongsList(glideResult),
-                args.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public @Nullable List<Long> hpExpire(byte[] key, long millis, ExpirationOptions.Condition condition, byte[]... fields) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(fields, "Fields must not be null");
-        Assert.noNullElements(fields, "Fields must not contain null elements");
-        
-        try {
-            List<Object> args = new ArrayList<>();
-            args.add(key);
-            args.add(millis);
-            
-            // Add condition if not ALWAYS
-            if (condition != ExpirationOptions.Condition.ALWAYS) {
-                args.add(condition.name());
-            }
-            
-            // Add FIELDS keyword and numfields
-            args.add("FIELDS");
-            args.add(fields.length);
-            
-            // Add fields
-            for (byte[] field : fields) {
-                args.add(field);
-            }
-            
-            return connection.execute("HPEXPIRE",
-                (Object[] glideResult) -> ValkeyGlideConverters.toLongsList(glideResult),
-                args.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public @Nullable List<Long> hExpireAt(byte[] key, long unixTime, ExpirationOptions.Condition condition, byte[]... fields) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(fields, "Fields must not be null");
-        Assert.noNullElements(fields, "Fields must not contain null elements");
-        
-        try {
-            List<Object> args = new ArrayList<>();
-            args.add(key);
-            args.add(unixTime);
-            
-            // Add condition if not ALWAYS
-            if (condition != ExpirationOptions.Condition.ALWAYS) {
-                args.add(condition.name());
-            }
-            
-            // Add FIELDS keyword and numfields
-            args.add("FIELDS");
-            args.add(fields.length);
-            
-            // Add fields
-            for (byte[] field : fields) {
-                args.add(field);
-            }
-            
-            return connection.execute("HEXPIREAT",
-                (Object[] glideResult) -> ValkeyGlideConverters.toLongsList(glideResult),
-                args.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public @Nullable List<Long> hpExpireAt(byte[] key, long unixTimeInMillis, ExpirationOptions.Condition condition, byte[]... fields) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(fields, "Fields must not be null");
-        Assert.noNullElements(fields, "Fields must not contain null elements");
-        
-        try {
-            List<Object> args = new ArrayList<>();
-            args.add(key);
-            args.add(unixTimeInMillis);
-            
-            // Add condition if not ALWAYS
-            if (condition != ExpirationOptions.Condition.ALWAYS) {
-                args.add(condition.name());
-            }
-            
-            // Add FIELDS keyword and numfields
-            args.add("FIELDS");
-            args.add(fields.length);
-            
-            // Add fields
-            for (byte[] field : fields) {
-                args.add(field);
-            }
-            
-            return connection.execute("HPEXPIREAT",
-                (Object[] glideResult) -> ValkeyGlideConverters.toLongsList(glideResult),
-                args.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public @Nullable List<Long> hTtl(byte[] key, byte[]... fields) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(fields, "Fields must not be null");
-        Assert.noNullElements(fields, "Fields must not contain null elements");
-        
-        try {
-            List<Object> args = new ArrayList<>();
-            args.add(key);
-            args.add("FIELDS");
-            args.add(fields.length);
-            for (byte[] field : fields) {
-                args.add(field);
-            }
-            
-            return connection.execute("HTTL",
-                (Object[] glideResult) -> ValkeyGlideConverters.toLongsList(glideResult),
-                args.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public @Nullable List<Long> hTtl(byte[] key, TimeUnit timeUnit, byte[]... fields) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(timeUnit, "TimeUnit must not be null");
-        Assert.notNull(fields, "Fields must not be null");
-        Assert.noNullElements(fields, "Fields must not contain null elements");
-
-        try {
-            List<Object> args = new ArrayList<>();
-            args.add(key);
-            args.add("FIELDS");
-            args.add(fields.length);
-            for (byte[] field : fields) {
-                args.add(field);
-            }
-
-            return connection.execute("HTTL",
-                (Object[] glideResult) -> {
-                    List<Long> ttls = ValkeyGlideConverters.toLongsList(glideResult);
-                    List<Long> converted = new ArrayList<>(ttls.size());
-                    for (Long ttl : ttls) {
-                        if (ttl < 0) {
-                            converted.add(ttl);
-                        } else {
-                            converted.add(timeUnit.convert(ttl, TimeUnit.SECONDS));
-                        }
-                    }
-                    return converted;
-                },
-                args.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public @Nullable List<Long> hpTtl(byte[] key, byte[]... fields) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(fields, "Fields must not be null");
-        Assert.noNullElements(fields, "Fields must not contain null elements");
-        
-        try {
-            List<Object> args = new ArrayList<>();
-            args.add(key);
-            args.add("FIELDS");
-            args.add(fields.length);
-            for (byte[] field : fields) {
-                args.add(field);
-            }
-            
-            return connection.execute("HPTTL",
-                (Object[] glideResult) -> ValkeyGlideConverters.toLongsList(glideResult),
-                args.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public @Nullable List<Long> hPersist(byte[] key, byte[]... fields) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(fields, "Fields must not be null");
-        Assert.noNullElements(fields, "Fields must not contain null elements");
-        
-        try {
-            List<Object> args = new ArrayList<>();
-            args.add(key);
-            args.add("FIELDS");
-            args.add(fields.length);
-            for (byte[] field : fields) {
-                args.add(field);
-            }
-            
-            return connection.execute("HPERSIST",
-                (Object[] glideResult) -> ValkeyGlideConverters.toLongsList(glideResult),
-                args.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	/**
+	 * Creates a new {@link ValkeyGlideHashCommands}.
+	 * @param connection must not be {@literal null}.
+	 */
+	public ValkeyGlideHashCommands(ValkeyGlideConnection connection) {
+		Assert.notNull(connection, "Connection must not be null!");
+		this.connection = connection;
+	}
 
 	@Override
-	public Boolean hSetEx(byte[] key, Map<byte[], byte[]> fieldValueMap, ValkeyHashCommands.HashFieldSetOption option, Expiration expiration) {
+	public @Nullable Boolean hSet(byte[] key, byte[] field, byte[] value) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(field, "Field must not be null");
+		Assert.notNull(value, "Value must not be null");
+
+		try {
+			return connection.execute("HSET",
+					(Number glideResult) -> glideResult != null ? glideResult.longValue() > 0 : null, key, field,
+					value);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public @Nullable Boolean hSetNX(byte[] key, byte[] field, byte[] value) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(field, "Field must not be null");
+		Assert.notNull(value, "Value must not be null");
+
+		try {
+			return connection.execute("HSETNX", (Boolean glideResult) -> glideResult, key, field, value);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public @Nullable byte[] hGet(byte[] key, byte[] field) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(field, "Field must not be null");
+
+		try {
+			return connection.execute("HGET",
+					(GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null, key, field);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public @Nullable List<byte[]> hMGet(byte[] key, byte[]... fields) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(fields, "Fields must not be null");
+		Assert.noNullElements(fields, "Fields must not contain null elements");
+
+		try {
+			Object[] args = new Object[1 + fields.length];
+			args[0] = key;
+			System.arraycopy(fields, 0, args, 1, fields.length);
+			return connection.execute("HMGET", (Object[] glideResult) -> ValkeyGlideConverters.toBytesList(glideResult),
+					args);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public void hMSet(byte[] key, Map<byte[], byte[]> hashes) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(hashes, "Hashes must not be null");
+		Assert.notEmpty(hashes, "Hashes must not be empty");
+
+		try {
+			List<Object> args = new ArrayList<>();
+			args.add(key);
+			for (Map.Entry<byte[], byte[]> entry : hashes.entrySet()) {
+				args.add(entry.getKey());
+				args.add(entry.getValue());
+			}
+			connection.execute("HMSET",
+					// Valkey returns simple OK string for HMSET
+					(String glideResult) -> glideResult, args.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public @Nullable Long hIncrBy(byte[] key, byte[] field, long delta) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(field, "Field must not be null");
+
+		try {
+			return connection.execute("HINCRBY", (Long glideResult) -> glideResult, key, field, delta);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public @Nullable Double hIncrBy(byte[] key, byte[] field, double delta) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(field, "Field must not be null");
+
+		try {
+			return connection.execute("HINCRBYFLOAT", (Double glideResult) -> glideResult, key, field, delta);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public @Nullable Boolean hExists(byte[] key, byte[] field) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(field, "Field must not be null");
+
+		try {
+			return connection.execute("HEXISTS", (Boolean glideResult) -> glideResult, key, field);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public @Nullable Long hDel(byte[] key, byte[]... fields) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(fields, "Fields must not be null");
+		Assert.noNullElements(fields, "Fields must not contain null elements");
+
+		try {
+			Object[] args = new Object[1 + fields.length];
+			args[0] = key;
+			System.arraycopy(fields, 0, args, 1, fields.length);
+
+			return connection.execute("HDEL", (Long glideResult) -> glideResult, args);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public @Nullable Long hLen(byte[] key) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("HLEN", (Long glideResult) -> glideResult, key);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public @Nullable Set<byte[]> hKeys(byte[] key) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("HKEYS", (Object[] glideResult) -> ValkeyGlideConverters.toBytesSet(glideResult),
+					key);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public @Nullable List<byte[]> hVals(byte[] key) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("HVALS", (Object[] glideResult) -> ValkeyGlideConverters.toBytesList(glideResult),
+					key);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public @Nullable Map<byte[], byte[]> hGetAll(byte[] key) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("HGETALL",
+					// (Map<GlideString, GlideString> glideResult) ->
+					// ValkeyGlideConverters.toBytesMap(glideResult),
+					glideResult -> ValkeyGlideConverters.toBytesMap(glideResult), key);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public @Nullable byte[] hRandField(byte[] key) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("HRANDFIELD",
+					(GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null, key);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public Map.Entry<byte[], byte[]> hRandFieldWithValues(byte[] key) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("HRANDFIELD", glideResult -> ValkeyGlideConverters.toBytesMapEntry(glideResult),
+					key, 1, "WITHVALUES");
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public @Nullable List<byte[]> hRandField(byte[] key, long count) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("HRANDFIELD",
+					(Object[] glideResult) -> ValkeyGlideConverters.toBytesList(glideResult), key, count);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public @Nullable List<Map.Entry<byte[], byte[]>> hRandFieldWithValues(byte[] key, long count) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("HRANDFIELD", glideResult -> ValkeyGlideConverters.toMapEntriesList(glideResult),
+					key, count, "WITHVALUES");
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public Cursor<Map.Entry<byte[], byte[]>> hScan(byte[] key, ScanOptions options) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(options, "ScanOptions must not be null");
+
+		return new ValkeyGlideHashScanCursor(key, options, connection);
+	}
+
+	/**
+	 * Simple implementation of Cursor for HSCAN operation.
+	 */
+	private static class ValkeyGlideHashScanCursor implements Cursor<Map.Entry<byte[], byte[]>> {
+
+		private final byte[] key;
+
+		private final ScanOptions options;
+
+		private final ValkeyGlideConnection connection;
+
+		private long cursor = 0;
+
+		private List<Map.Entry<byte[], byte[]>> entries = new ArrayList<>();
+
+		private int currentIndex = 0;
+
+		private boolean finished = false;
+
+		public ValkeyGlideHashScanCursor(byte[] key, ScanOptions options, ValkeyGlideConnection connection) {
+			this.key = key;
+			this.options = options;
+			this.connection = connection;
+			scanNext();
+		}
+
+		@Override
+		public boolean hasNext() {
+			if (currentIndex < entries.size()) {
+				return true;
+			}
+			if (finished) {
+				return false;
+			}
+			scanNext();
+			return currentIndex < entries.size();
+		}
+
+		@Override
+		public Map.Entry<byte[], byte[]> next() {
+			if (!hasNext()) {
+				throw new java.util.NoSuchElementException();
+			}
+			return entries.get(currentIndex++);
+		}
+
+		private void scanNext() {
+			if (connection.isQueueing() || connection.isPipelined()) {
+				throw new InvalidDataAccessApiUsageException("'HSCAN' cannot be called in pipeline / transaction mode");
+			}
+
+			try {
+				List<Object> args = new ArrayList<>();
+				args.add(key);
+				args.add(String.valueOf(cursor));
+
+				if (options.getCount() != null) {
+					args.add("COUNT");
+					args.add(options.getCount());
+				}
+
+				if (options.getPattern() != null) {
+					args.add("MATCH");
+					args.add(options.getPattern());
+				}
+
+				connection.execute("HSCAN", (Object[] glideResult) -> {
+					if (glideResult == null) {
+						return null;
+					}
+
+					// First element is the new cursor and is byte[], need to convert to
+					// String first
+					GlideString cursorStr = (GlideString) glideResult[0];
+					cursor = Long.parseLong(cursorStr.getString());
+					if (cursor == 0) {
+						finished = true;
+					}
+
+					// Second element is the array of field-value pairs
+					Object[] fieldValuePairs = (Object[]) glideResult[1];
+
+					// Reset entries for this batch
+					entries.clear();
+					currentIndex = 0;
+					for (int i = 0; i < fieldValuePairs.length; i += 2) {
+						GlideString field = (GlideString) fieldValuePairs[i];
+						GlideString value = (GlideString) fieldValuePairs[i + 1];
+						entries.add(new HashMap.SimpleEntry<>(field.getBytes(), value.getBytes()));
+					}
+
+					return null; // We don't need to return anything from this mapper
+				}, args.toArray());
+
+			}
+			catch (Exception ex) {
+				throw new ValkeyGlideExceptionConverter().convert(ex);
+			}
+		}
+
+		@Override
+		public void close() {
+			// No resources to close for this implementation
+		}
+
+		@Override
+		public boolean isClosed() {
+			return finished && currentIndex >= entries.size();
+		}
+
+		@Override
+		public long getCursorId() {
+			return cursor;
+		}
+
+		@Override
+		public long getPosition() {
+			return currentIndex;
+		}
+
+		@Override
+		public CursorId getId() {
+			return CursorId.of(cursor);
+		}
+
+	}
+
+	@Override
+	public @Nullable Long hStrLen(byte[] key, byte[] field) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(field, "Field must not be null");
+
+		try {
+			return connection.execute("HSTRLEN", (Long glideResult) -> glideResult, key, field);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public @Nullable List<Long> hExpire(byte[] key, long seconds, ExpirationOptions.Condition condition,
+			byte[]... fields) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(fields, "Fields must not be null");
+		Assert.noNullElements(fields, "Fields must not contain null elements");
+
+		try {
+			List<Object> args = new ArrayList<>();
+			args.add(key);
+			args.add(seconds);
+
+			// Add condition if not ALWAYS
+			if (condition != ExpirationOptions.Condition.ALWAYS) {
+				args.add(condition.name());
+			}
+
+			// Add FIELDS keyword and numfields
+			args.add("FIELDS");
+			args.add(fields.length);
+
+			// Add fields
+			for (byte[] field : fields) {
+				args.add(field);
+			}
+
+			return connection.execute("HEXPIRE",
+					(Object[] glideResult) -> ValkeyGlideConverters.toLongsList(glideResult), args.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public @Nullable List<Long> hpExpire(byte[] key, long millis, ExpirationOptions.Condition condition,
+			byte[]... fields) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(fields, "Fields must not be null");
+		Assert.noNullElements(fields, "Fields must not contain null elements");
+
+		try {
+			List<Object> args = new ArrayList<>();
+			args.add(key);
+			args.add(millis);
+
+			// Add condition if not ALWAYS
+			if (condition != ExpirationOptions.Condition.ALWAYS) {
+				args.add(condition.name());
+			}
+
+			// Add FIELDS keyword and numfields
+			args.add("FIELDS");
+			args.add(fields.length);
+
+			// Add fields
+			for (byte[] field : fields) {
+				args.add(field);
+			}
+
+			return connection.execute("HPEXPIRE",
+					(Object[] glideResult) -> ValkeyGlideConverters.toLongsList(glideResult), args.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public @Nullable List<Long> hExpireAt(byte[] key, long unixTime, ExpirationOptions.Condition condition,
+			byte[]... fields) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(fields, "Fields must not be null");
+		Assert.noNullElements(fields, "Fields must not contain null elements");
+
+		try {
+			List<Object> args = new ArrayList<>();
+			args.add(key);
+			args.add(unixTime);
+
+			// Add condition if not ALWAYS
+			if (condition != ExpirationOptions.Condition.ALWAYS) {
+				args.add(condition.name());
+			}
+
+			// Add FIELDS keyword and numfields
+			args.add("FIELDS");
+			args.add(fields.length);
+
+			// Add fields
+			for (byte[] field : fields) {
+				args.add(field);
+			}
+
+			return connection.execute("HEXPIREAT",
+					(Object[] glideResult) -> ValkeyGlideConverters.toLongsList(glideResult), args.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public @Nullable List<Long> hpExpireAt(byte[] key, long unixTimeInMillis, ExpirationOptions.Condition condition,
+			byte[]... fields) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(fields, "Fields must not be null");
+		Assert.noNullElements(fields, "Fields must not contain null elements");
+
+		try {
+			List<Object> args = new ArrayList<>();
+			args.add(key);
+			args.add(unixTimeInMillis);
+
+			// Add condition if not ALWAYS
+			if (condition != ExpirationOptions.Condition.ALWAYS) {
+				args.add(condition.name());
+			}
+
+			// Add FIELDS keyword and numfields
+			args.add("FIELDS");
+			args.add(fields.length);
+
+			// Add fields
+			for (byte[] field : fields) {
+				args.add(field);
+			}
+
+			return connection.execute("HPEXPIREAT",
+					(Object[] glideResult) -> ValkeyGlideConverters.toLongsList(glideResult), args.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public @Nullable List<Long> hTtl(byte[] key, byte[]... fields) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(fields, "Fields must not be null");
+		Assert.noNullElements(fields, "Fields must not contain null elements");
+
+		try {
+			List<Object> args = new ArrayList<>();
+			args.add(key);
+			args.add("FIELDS");
+			args.add(fields.length);
+			for (byte[] field : fields) {
+				args.add(field);
+			}
+
+			return connection.execute("HTTL", (Object[] glideResult) -> ValkeyGlideConverters.toLongsList(glideResult),
+					args.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public @Nullable List<Long> hTtl(byte[] key, TimeUnit timeUnit, byte[]... fields) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(timeUnit, "TimeUnit must not be null");
+		Assert.notNull(fields, "Fields must not be null");
+		Assert.noNullElements(fields, "Fields must not contain null elements");
+
+		try {
+			List<Object> args = new ArrayList<>();
+			args.add(key);
+			args.add("FIELDS");
+			args.add(fields.length);
+			for (byte[] field : fields) {
+				args.add(field);
+			}
+
+			return connection.execute("HTTL", (Object[] glideResult) -> {
+				List<Long> ttls = ValkeyGlideConverters.toLongsList(glideResult);
+				List<Long> converted = new ArrayList<>(ttls.size());
+				for (Long ttl : ttls) {
+					if (ttl < 0) {
+						converted.add(ttl);
+					}
+					else {
+						converted.add(timeUnit.convert(ttl, TimeUnit.SECONDS));
+					}
+				}
+				return converted;
+			}, args.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public @Nullable List<Long> hpTtl(byte[] key, byte[]... fields) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(fields, "Fields must not be null");
+		Assert.noNullElements(fields, "Fields must not contain null elements");
+
+		try {
+			List<Object> args = new ArrayList<>();
+			args.add(key);
+			args.add("FIELDS");
+			args.add(fields.length);
+			for (byte[] field : fields) {
+				args.add(field);
+			}
+
+			return connection.execute("HPTTL", (Object[] glideResult) -> ValkeyGlideConverters.toLongsList(glideResult),
+					args.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public @Nullable List<Long> hPersist(byte[] key, byte[]... fields) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(fields, "Fields must not be null");
+		Assert.noNullElements(fields, "Fields must not contain null elements");
+
+		try {
+			List<Object> args = new ArrayList<>();
+			args.add(key);
+			args.add("FIELDS");
+			args.add(fields.length);
+			for (byte[] field : fields) {
+				args.add(field);
+			}
+
+			return connection.execute("HPERSIST",
+					(Object[] glideResult) -> ValkeyGlideConverters.toLongsList(glideResult), args.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public Boolean hSetEx(byte[] key, Map<byte[], byte[]> fieldValueMap, ValkeyHashCommands.HashFieldSetOption option,
+			Expiration expiration) {
 		Assert.notNull(key, "Key must not be null");
 		Assert.notNull(fieldValueMap, "FieldValueMap must not be null");
 		Assert.notNull(option, "Option must not be null");
@@ -713,19 +705,23 @@ public class ValkeyGlideHashCommands implements ValkeyHashCommands {
 			if (expiration != null && !expiration.isPersistent()) {
 				if (expiration.isKeepTtl()) {
 					args.add("KEEPTTL");
-				} else if (expiration.isUnixTimestamp()) {
+				}
+				else if (expiration.isUnixTimestamp()) {
 					if (expiration.getTimeUnit() == TimeUnit.MILLISECONDS) {
 						args.add("PXAT");
 						args.add(expiration.getExpirationTimeInMilliseconds());
-					} else {
+					}
+					else {
 						args.add("EXAT");
 						args.add(expiration.getExpirationTimeInSeconds());
 					}
-				} else {
+				}
+				else {
 					if (expiration.getTimeUnit() == TimeUnit.MILLISECONDS) {
 						args.add("PX");
 						args.add(expiration.getExpirationTimeInMilliseconds());
-					} else {
+					}
+					else {
 						args.add("EX");
 						args.add(expiration.getExpirationTimeInSeconds());
 					}
@@ -735,7 +731,8 @@ public class ValkeyGlideHashCommands implements ValkeyHashCommands {
 			switch (option) {
 				case IF_NONE_EXIST -> args.add("FNX");
 				case IF_ALL_EXIST -> args.add("FXX");
-				case UPSERT -> {} // no additional argument
+				case UPSERT -> {
+				} // no additional argument
 			}
 			// Add fields
 			args.add("FIELDS");
@@ -744,18 +741,17 @@ public class ValkeyGlideHashCommands implements ValkeyHashCommands {
 				args.add(entry.getKey());
 				args.add(entry.getValue());
 			}
-			return connection.execute("HSETEX",
-				(Object glideResult) -> {
-					if (glideResult instanceof String s) {
-						return "OK".equals(s);
-					}
-					if (glideResult instanceof Long l) {
-						return l > 0;
-					}
-					return Boolean.FALSE;
-				},
-				args.toArray());
-		} catch (Exception ex) {
+			return connection.execute("HSETEX", (Object glideResult) -> {
+				if (glideResult instanceof String s) {
+					return "OK".equals(s);
+				}
+				if (glideResult instanceof Long l) {
+					return l > 0;
+				}
+				return Boolean.FALSE;
+			}, args.toArray());
+		}
+		catch (Exception ex) {
 			throw new ValkeyGlideExceptionConverter().convert(ex);
 		}
 	}
@@ -771,20 +767,24 @@ public class ValkeyGlideHashCommands implements ValkeyHashCommands {
 			if (expiration != null) {
 				if (expiration.isPersistent()) {
 					args.add("PERSIST");
-				} else if (!expiration.isKeepTtl()) {
+				}
+				else if (!expiration.isKeepTtl()) {
 					if (expiration.isUnixTimestamp()) {
 						if (expiration.getTimeUnit() == TimeUnit.MILLISECONDS) {
 							args.add("PXAT");
 							args.add(expiration.getExpirationTimeInMilliseconds());
-						} else {
+						}
+						else {
 							args.add("EXAT");
 							args.add(expiration.getExpirationTimeInSeconds());
 						}
-					} else {
+					}
+					else {
 						if (expiration.getTimeUnit() == TimeUnit.MILLISECONDS) {
 							args.add("PX");
 							args.add(expiration.getExpirationTimeInMilliseconds());
-						} else {
+						}
+						else {
 							args.add("EX");
 							args.add(expiration.getExpirationTimeInSeconds());
 						}
@@ -797,16 +797,15 @@ public class ValkeyGlideHashCommands implements ValkeyHashCommands {
 			for (byte[] field : fields) {
 				args.add(field);
 			}
-			return connection.execute("HGETEX",
-				(Object[] glideResult) -> {
-					List<byte[]> result = new ArrayList<>(glideResult.length);
-					for (Object item : glideResult) {
-						result.add(item instanceof GlideString gs ? gs.getBytes() : (byte[]) item);
-					}
-					return result;
-				},
-				args.toArray());
-		} catch (Exception ex) {
+			return connection.execute("HGETEX", (Object[] glideResult) -> {
+				List<byte[]> result = new ArrayList<>(glideResult.length);
+				for (Object item : glideResult) {
+					result.add(item instanceof GlideString gs ? gs.getBytes() : (byte[]) item);
+				}
+				return result;
+			}, args.toArray());
+		}
+		catch (Exception ex) {
 			throw new ValkeyGlideExceptionConverter().convert(ex);
 		}
 	}
@@ -823,17 +822,17 @@ public class ValkeyGlideHashCommands implements ValkeyHashCommands {
 			for (byte[] field : fields) {
 				args.add(field);
 			}
-			return connection.execute("HGETDEL",
-				(Object[] glideResult) -> {
-					List<byte[]> result = new ArrayList<>(glideResult.length);
-					for (Object item : glideResult) {
-						result.add(item instanceof GlideString gs ? gs.getBytes() : (byte[]) item);
-					}
-					return result;
-				},
-				args.toArray());
-		} catch (Exception ex) {
+			return connection.execute("HGETDEL", (Object[] glideResult) -> {
+				List<byte[]> result = new ArrayList<>(glideResult.length);
+				for (Object item : glideResult) {
+					result.add(item instanceof GlideString gs ? gs.getBytes() : (byte[]) item);
+				}
+				return result;
+			}, args.toArray());
+		}
+		catch (Exception ex) {
 			throw new ValkeyGlideExceptionConverter().convert(ex);
 		}
 	}
+
 }

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideHyperLogLogCommands.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideHyperLogLogCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,72 +27,74 @@ import org.springframework.util.Assert;
  */
 public class ValkeyGlideHyperLogLogCommands implements ValkeyHyperLogLogCommands {
 
-    private final ValkeyGlideConnection connection;
+	private final ValkeyGlideConnection connection;
 
-    /**
-     * Creates a new {@link ValkeyGlideHyperLogLogCommands}.
-     *
-     * @param connection must not be {@literal null}.
-     */
-    public ValkeyGlideHyperLogLogCommands(ValkeyGlideConnection connection) {
-        Assert.notNull(connection, "Connection must not be null!");
-        this.connection = connection;
-    }
+	/**
+	 * Creates a new {@link ValkeyGlideHyperLogLogCommands}.
+	 * @param connection must not be {@literal null}.
+	 */
+	public ValkeyGlideHyperLogLogCommands(ValkeyGlideConnection connection) {
+		Assert.notNull(connection, "Connection must not be null!");
+		this.connection = connection;
+	}
 
-    @Override
-    @Nullable
-    public Long pfAdd(byte[] key, byte[]... values) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notEmpty(values, "PFADD requires at least one non 'null' value");
-        Assert.noNullElements(values, "Values for PFADD must not contain 'null'");
-        
-        try {
-            Object[] args = new Object[1 + values.length];
-            args[0] = key;
-            System.arraycopy(values, 0, args, 1, values.length);
-            
-            return connection.execute("PFADD",
-                (Boolean glideResult) -> glideResult ? 1L : 0L,
-                args);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	@Override
+	@Nullable public Long pfAdd(byte[] key, byte[]... values) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notEmpty(values, "PFADD requires at least one non 'null' value");
+		Assert.noNullElements(values, "Values for PFADD must not contain 'null'");
 
-    @Override
-    @Nullable
-    public Long pfCount(byte[]... keys) {
-        Assert.notEmpty(keys, "PFCOUNT requires at least one non 'null' key");
-        Assert.noNullElements(keys, "Keys for PFCOUNT must not contain 'null'");
-        
-        try {
-            Object[] args = new Object[keys.length];
-            System.arraycopy(keys, 0, args, 0, keys.length);
-            
-            return connection.execute("PFCOUNT",
-                (Long glideResult) -> glideResult,
-                args);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		try {
+			Object[] args = new Object[1 + values.length];
+			args[0] = key;
+			System.arraycopy(values, 0, args, 1, values.length);
 
-    @Override
-    public void pfMerge(byte[] destinationKey, byte[]... sourceKeys) {
-        Assert.notNull(destinationKey, "Destination key must not be null");
-        Assert.notNull(sourceKeys, "Source keys must not be null");
-        Assert.noNullElements(sourceKeys, "Keys for PFMERGE must not contain 'null'");
-        
-        try {
-            Object[] args = new Object[1 + sourceKeys.length];
-            args[0] = destinationKey;
-            System.arraycopy(sourceKeys, 0, args, 1, sourceKeys.length);
-            
-            connection.execute("PFMERGE",
-                (String glideResult) -> glideResult, // Return the "OK" response for pipeline/transaction correlation
-                args);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+			return connection.execute("PFADD", (Boolean glideResult) -> glideResult ? 1L : 0L, args);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Long pfCount(byte[]... keys) {
+		Assert.notEmpty(keys, "PFCOUNT requires at least one non 'null' key");
+		Assert.noNullElements(keys, "Keys for PFCOUNT must not contain 'null'");
+
+		try {
+			Object[] args = new Object[keys.length];
+			System.arraycopy(keys, 0, args, 0, keys.length);
+
+			return connection.execute("PFCOUNT", (Long glideResult) -> glideResult, args);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public void pfMerge(byte[] destinationKey, byte[]... sourceKeys) {
+		Assert.notNull(destinationKey, "Destination key must not be null");
+		Assert.notNull(sourceKeys, "Source keys must not be null");
+		Assert.noNullElements(sourceKeys, "Keys for PFMERGE must not contain 'null'");
+
+		try {
+			Object[] args = new Object[1 + sourceKeys.length];
+			args[0] = destinationKey;
+			System.arraycopy(sourceKeys, 0, args, 1, sourceKeys.length);
+
+			connection.execute("PFMERGE", (String glideResult) -> glideResult, // Return
+																				// the
+																				// "OK"
+																				// response
+																				// for
+																				// pipeline/transaction
+																				// correlation
+					args);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
 }

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideKeyCommands.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideKeyCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,657 +44,639 @@ import glide.api.models.GlideString;
  */
 public class ValkeyGlideKeyCommands implements ValkeyKeyCommands {
 
-    private final ValkeyGlideConnection connection;
+	private final ValkeyGlideConnection connection;
 
-    /**
-     * Creates a new {@link ValkeyGlideKeyCommands}.
-     *
-     * @param connection must not be {@literal null}.
-     */
-    public ValkeyGlideKeyCommands(ValkeyGlideConnection connection) {
-        Assert.notNull(connection, "Connection must not be null!");
-        this.connection = connection;
-    }
+	/**
+	 * Creates a new {@link ValkeyGlideKeyCommands}.
+	 * @param connection must not be {@literal null}.
+	 */
+	public ValkeyGlideKeyCommands(ValkeyGlideConnection connection) {
+		Assert.notNull(connection, "Connection must not be null!");
+		this.connection = connection;
+	}
 
-    @Override
-    @Nullable
-    public Boolean copy(byte[] sourceKey, byte[] targetKey, boolean replace) {
-        Assert.notNull(sourceKey, "Source key must not be null");
-        Assert.notNull(targetKey, "Target key must not be null");
-        
-        try {
-            if (replace) {
-                return connection.execute("COPY",
-                    (Boolean glideResult) -> glideResult,
-                    sourceKey, targetKey, "REPLACE");
-            } else {
-                return connection.execute("COPY",
-                    (Boolean glideResult) -> glideResult,
-                    sourceKey, targetKey);
-            }
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	@Override
+	@Nullable public Boolean copy(byte[] sourceKey, byte[] targetKey, boolean replace) {
+		Assert.notNull(sourceKey, "Source key must not be null");
+		Assert.notNull(targetKey, "Target key must not be null");
 
-    @Override
-    @Nullable
-    public Boolean exists(byte[] key) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("EXISTS",
-                (Long glideResult) -> glideResult != null ? glideResult > 0 : null,
-                key);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		try {
+			if (replace) {
+				return connection.execute("COPY", (Boolean glideResult) -> glideResult, sourceKey, targetKey,
+						"REPLACE");
+			}
+			else {
+				return connection.execute("COPY", (Boolean glideResult) -> glideResult, sourceKey, targetKey);
+			}
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    @Override
-    @Nullable
-    public Long exists(byte[]... keys) {
-        Assert.notEmpty(keys, "Keys must not be empty");
-        Assert.noNullElements(keys, "Keys must not contain null elements");
+	@Override
+	@Nullable public Boolean exists(byte[] key) {
+		Assert.notNull(key, "Key must not be null");
 
-        try {
-            Object[] args = new Object[keys.length];
-            System.arraycopy(keys, 0, args, 0, keys.length);
-            return connection.execute("EXISTS",
-                (Long glideResult) -> glideResult,
-                args);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		try {
+			return connection.execute("EXISTS", (Long glideResult) -> glideResult != null ? glideResult > 0 : null,
+					key);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    @Override
-    @Nullable
-    public Long del(byte[]... keys) {
-        Assert.notEmpty(keys, "Keys must not be empty");
-        Assert.noNullElements(keys, "Keys must not contain null elements");
-        try {
-            Object[] args = new Object[keys.length];
-            System.arraycopy(keys, 0, args, 0, keys.length);
+	@Override
+	@Nullable public Long exists(byte[]... keys) {
+		Assert.notEmpty(keys, "Keys must not be empty");
+		Assert.noNullElements(keys, "Keys must not contain null elements");
 
-            return connection.execute("DEL",
-                (Long glideResult) -> glideResult,
-                args);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		try {
+			Object[] args = new Object[keys.length];
+			System.arraycopy(keys, 0, args, 0, keys.length);
+			return connection.execute("EXISTS", (Long glideResult) -> glideResult, args);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    @Override
-    @Nullable
-    public Long unlink(byte[]... keys) {
-        Assert.notEmpty(keys, "Keys must not be empty");
-        Assert.noNullElements(keys, "Keys must not contain null elements");
+	@Override
+	@Nullable public Long del(byte[]... keys) {
+		Assert.notEmpty(keys, "Keys must not be empty");
+		Assert.noNullElements(keys, "Keys must not contain null elements");
+		try {
+			Object[] args = new Object[keys.length];
+			System.arraycopy(keys, 0, args, 0, keys.length);
 
-        try {
-            Object[] args = new Object[keys.length];
-            System.arraycopy(keys, 0, args, 0, keys.length);
+			return connection.execute("DEL", (Long glideResult) -> glideResult, args);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-            return connection.execute("UNLINK",
-                (Long glideResult) -> glideResult,
-                args);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	@Override
+	@Nullable public Long unlink(byte[]... keys) {
+		Assert.notEmpty(keys, "Keys must not be empty");
+		Assert.noNullElements(keys, "Keys must not contain null elements");
 
-    @Override
-    @Nullable
-    public DataType type(byte[] key) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("TYPE",
-                (GlideString glideResult) -> glideResult != null ? ValkeyGlideConverters.toDataType(glideResult.getBytes()) : null,
-                key);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		try {
+			Object[] args = new Object[keys.length];
+			System.arraycopy(keys, 0, args, 0, keys.length);
 
-    @Override
-    @Nullable
-    public Long touch(byte[]... keys) {
-        Assert.notEmpty(keys, "Keys must not be empty");
-        Assert.noNullElements(keys, "Keys must not contain null elements");
-        try {
-            Object[] args = new Object[keys.length];
-            System.arraycopy(keys, 0, args, 0, keys.length);
+			return connection.execute("UNLINK", (Long glideResult) -> glideResult, args);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-            return connection.execute("TOUCH",
-                (Long glideResult) -> glideResult,
-                args);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	@Override
+	@Nullable public DataType type(byte[] key) {
+		Assert.notNull(key, "Key must not be null");
 
-    @Override
-    @Nullable
-    public Set<byte[]> keys(byte[] pattern) {
-        Assert.notNull(pattern, "Pattern must not be null");
-        
-        try {
-            return connection.execute("KEYS",
-                (Object[] glideResult) -> ValkeyGlideConverters.toBytesSet(glideResult),
-                pattern);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		try {
+			return connection.execute("TYPE", (GlideString glideResult) -> glideResult != null
+					? ValkeyGlideConverters.toDataType(glideResult.getBytes()) : null, key);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    @Override
-    public Cursor<byte[]> scan(ScanOptions options) {
-        return new ValkeyGlideKeyScanCursor(connection, options != null ? options : ScanOptions.NONE);
-    }
+	@Override
+	@Nullable public Long touch(byte[]... keys) {
+		Assert.notEmpty(keys, "Keys must not be empty");
+		Assert.noNullElements(keys, "Keys must not contain null elements");
+		try {
+			Object[] args = new Object[keys.length];
+			System.arraycopy(keys, 0, args, 0, keys.length);
 
-    /**
-     * Simple implementation of a scan cursor for keys.
-     */
-    private static class ValkeyGlideKeyScanCursor implements Cursor<byte[]> {
-        
-        private final ValkeyGlideConnection connection;
-        private final ScanOptions scanOptions;
-        private String cursor = "0";
-        private java.util.Iterator<byte[]> currentBatch;
-        private boolean finished = false;
+			return connection.execute("TOUCH", (Long glideResult) -> glideResult, args);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-        public ValkeyGlideKeyScanCursor(ValkeyGlideConnection connection, ScanOptions scanOptions) {
-            this.connection = connection;
-            this.scanOptions = scanOptions;
-        }
+	@Override
+	@Nullable public Set<byte[]> keys(byte[] pattern) {
+		Assert.notNull(pattern, "Pattern must not be null");
 
-        @Override
-        public long getCursorId() {
-            try {
-                return Long.parseLong(cursor);
-            } catch (NumberFormatException e) {
-                return 0;
-            }
-        }
+		try {
+			return connection.execute("KEYS", (Object[] glideResult) -> ValkeyGlideConverters.toBytesSet(glideResult),
+					pattern);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-        @Override
-        public Cursor.CursorId getId() {
-            return Cursor.CursorId.of(cursor);
-        }
+	@Override
+	public Cursor<byte[]> scan(ScanOptions options) {
+		return new ValkeyGlideKeyScanCursor(connection, options != null ? options : ScanOptions.NONE);
+	}
 
-        @Override
-        public boolean hasNext() {
-            // First check if we have items in current batch
-            if (currentBatch != null && currentBatch.hasNext()) {
-                return true;
-            }
-            
-            // If we're finished and no more items in current batch, return false
-            if (finished) {
-                return false;
-            }
-            
-            // Try to load next batch
-            loadNextBatch();
-            
-            // Check if we have items after loading next batch
-            return currentBatch != null && currentBatch.hasNext();
-        }
+	/**
+	 * Simple implementation of a scan cursor for keys.
+	 */
+	private static class ValkeyGlideKeyScanCursor implements Cursor<byte[]> {
 
-        @Override
-        public byte[] next() {
-            if (!hasNext()) {
-                throw new java.util.NoSuchElementException();
-            }
-            return currentBatch.next();
-        }
+		private final ValkeyGlideConnection connection;
 
-        @Override
-        public void close() {
-            finished = true;
-            currentBatch = null;
-        }
+		private final ScanOptions scanOptions;
 
-        @Override
-        public long getPosition() {
-            return getCursorId();
-        }
+		private String cursor = "0";
 
-        @Override
-        public boolean isClosed() {
-            return finished;
-        }
+		private java.util.Iterator<byte[]> currentBatch;
 
-        private void loadNextBatch() {
-            if (connection.isQueueing() || connection.isPipelined()) {
-                throw new InvalidDataAccessApiUsageException("'SCAN' cannot be called in pipeline / transaction mode");
-            }
+		private boolean finished = false;
 
-            try {
-                List<Object> args = new ArrayList<>();
-                args.add(cursor);
-                
-                if (scanOptions.getPattern() != null) {
-                    args.add("MATCH");
-                    args.add(scanOptions.getPattern());
-                }
-                
-                if (scanOptions.getCount() != null) {
-                    args.add("COUNT");
-                    args.add(scanOptions.getCount());
-                }
-                
-                Object[] scanResult = connection.execute("SCAN",
-                    (Object[] glideResult) -> glideResult,
-                    args.toArray());
-                
-                if (scanResult != null && scanResult.length >= 2) {
-                    Object nextCursor = scanResult[0];
-                    Object keysResult = scanResult[1];
-                    
-                    // Handle cursor conversion
-                    if (nextCursor instanceof GlideString) {
-                        cursor = new String(((GlideString) nextCursor).getBytes(), StandardCharsets.UTF_8);
-                    } else if (nextCursor instanceof byte[]) {
-                        cursor = new String((byte[]) nextCursor, StandardCharsets.UTF_8);
-                    } else {
-                        cursor = nextCursor.toString();
-                    }
-                    
-                    if ("0".equals(cursor)) {
-                        finished = true;
-                    }
-                    
-                    // Convert keys result
-                    List<byte[]> keys = ValkeyGlideConverters.toBytesList(keysResult);
-                    currentBatch = keys.iterator();
-                }
-            } catch (Exception ex) {
-                throw new ValkeyGlideExceptionConverter().convert(ex);
-            }
-        }
-    }
+		public ValkeyGlideKeyScanCursor(ValkeyGlideConnection connection, ScanOptions scanOptions) {
+			this.connection = connection;
+			this.scanOptions = scanOptions;
+		}
 
-    @Override
-    @Nullable
-    public byte[] randomKey() {
-        try {
-            return connection.execute("RANDOMKEY",
-                (GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		@Override
+		public long getCursorId() {
+			try {
+				return Long.parseLong(cursor);
+			}
+			catch (NumberFormatException e) {
+				return 0;
+			}
+		}
 
-    @Override
-    public void rename(byte[] oldKey, byte[] newKey) {
-        Assert.notNull(oldKey, "Old key must not be null");
-        Assert.notNull(newKey, "New key must not be null");
-        
-        try {
-            connection.execute("RENAME",
-                (String glideResult) -> glideResult, // Return the "OK" response for pipeline/transaction modes
-                oldKey, newKey);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		@Override
+		public Cursor.CursorId getId() {
+			return Cursor.CursorId.of(cursor);
+		}
 
-    @Override
-    @Nullable
-    public Boolean renameNX(byte[] oldKey, byte[] newKey) {
-        Assert.notNull(oldKey, "Old key must not be null");
-        Assert.notNull(newKey, "New key must not be null");
-        
-        try {
-            return connection.execute("RENAMENX",
-                (Boolean glideResult) -> glideResult,
-                oldKey, newKey);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		@Override
+		public boolean hasNext() {
+			// First check if we have items in current batch
+			if (currentBatch != null && currentBatch.hasNext()) {
+				return true;
+			}
 
-    @Override
-    @Nullable
-    public Boolean expire(byte[] key, long seconds, ExpirationOptions.Condition condition) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            if (condition == ExpirationOptions.Condition.ALWAYS) {
-                return connection.execute("EXPIRE",
-                    (Boolean glideResult) -> glideResult,
-                    key, seconds);
-            } else {
-                String conditionStr = switch (condition) {
-                    case XX -> "XX";
-                    case NX -> "NX";
-                    case GT -> "GT";
-                    case LT -> "LT";
-                    default -> throw new IllegalArgumentException("Unsupported expiration condition: " + condition);
-                };
-                return connection.execute("EXPIRE",
-                    (Boolean glideResult) -> glideResult,
-                    key, seconds, conditionStr);
-            }
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+			// If we're finished and no more items in current batch, return false
+			if (finished) {
+				return false;
+			}
 
-    @Override
-    @Nullable
-    public Boolean pExpire(byte[] key, long millis, ExpirationOptions.Condition condition) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            if (condition == ExpirationOptions.Condition.ALWAYS) {
-                return connection.execute("PEXPIRE",
-                    (Boolean glideResult) -> glideResult,
-                    key, millis);
-            } else {
-                String conditionStr = switch (condition) {
-                    case XX -> "XX";
-                    case NX -> "NX";
-                    case GT -> "GT";
-                    case LT -> "LT";
-                    default -> throw new IllegalArgumentException("Unsupported expiration condition: " + condition);
-                };
-                return connection.execute("PEXPIRE",
-                    (Boolean glideResult) -> glideResult,
-                    key, millis, conditionStr);
-            }
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+			// Try to load next batch
+			loadNextBatch();
 
-    @Override
-    @Nullable
-    public Boolean expireAt(byte[] key, long unixTime, ExpirationOptions.Condition condition) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            if (condition == ExpirationOptions.Condition.ALWAYS) {
-                return connection.execute("EXPIREAT",
-                    (Boolean glideResult) -> glideResult,
-                    key, unixTime);
-            } else {
-                String conditionStr = switch (condition) {
-                    case XX -> "XX";
-                    case NX -> "NX";
-                    case GT -> "GT";
-                    case LT -> "LT";
-                    default -> throw new IllegalArgumentException("Unsupported expiration condition: " + condition);
-                };
-                return connection.execute("EXPIREAT",
-                    (Boolean glideResult) -> glideResult,
-                    key, unixTime, conditionStr);
-            }
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+			// Check if we have items after loading next batch
+			return currentBatch != null && currentBatch.hasNext();
+		}
 
-    @Override
-    @Nullable
-    public Boolean pExpireAt(byte[] key, long unixTimeInMillis, ExpirationOptions.Condition condition) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            if (condition == ExpirationOptions.Condition.ALWAYS) {
-                return connection.execute("PEXPIREAT",
-                    (Boolean glideResult) -> glideResult,
-                    key, unixTimeInMillis);
-            } else {
-                String conditionStr = switch (condition) {
-                    case XX -> "XX";
-                    case NX -> "NX";
-                    case GT -> "GT";
-                    case LT -> "LT";
-                    default -> throw new IllegalArgumentException("Unsupported expiration condition: " + condition);
-                };
-                return connection.execute("PEXPIREAT",
-                    (Boolean glideResult) -> glideResult,
-                    key, unixTimeInMillis, conditionStr);
-            }
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		@Override
+		public byte[] next() {
+			if (!hasNext()) {
+				throw new java.util.NoSuchElementException();
+			}
+			return currentBatch.next();
+		}
 
-    @Override
-    @Nullable
-    public Boolean persist(byte[] key) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("PERSIST",
-                (Boolean glideResult) -> glideResult,
-                key);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		@Override
+		public void close() {
+			finished = true;
+			currentBatch = null;
+		}
 
-    @Override
-    @Nullable
-    public Boolean move(byte[] key, int dbIndex) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("MOVE",
-                (Boolean glideResult) -> glideResult,
-                key, dbIndex);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		@Override
+		public long getPosition() {
+			return getCursorId();
+		}
 
-    @Override
-    @Nullable
-    public Long ttl(byte[] key) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("TTL",
-                (Long glideResult) -> glideResult,
-                key);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		@Override
+		public boolean isClosed() {
+			return finished;
+		}
 
-    @Override
-    @Nullable
-    public Long ttl(byte[] key, TimeUnit timeUnit) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(timeUnit, "TimeUnit must not be null");
-        
-        try {
-            return connection.execute("TTL",
-                (Long ttlSeconds) -> {
-                    if (ttlSeconds == null) {
-                        return null;
-                    }
-                    
-                    // Valkey TTL semantics: -2 = key doesn't exist, -1 = key exists but no expiration
-                    // These are special values, not actual time values, so don't convert them
-                    if (ttlSeconds < 0) {
-                        return ttlSeconds;
-                    }
-                    
-                    return timeUnit.convert(ttlSeconds, TimeUnit.SECONDS);
-                },
-                key);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		private void loadNextBatch() {
+			if (connection.isQueueing() || connection.isPipelined()) {
+				throw new InvalidDataAccessApiUsageException("'SCAN' cannot be called in pipeline / transaction mode");
+			}
 
-    @Override
-    @Nullable
-    public Long pTtl(byte[] key) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("PTTL",
-                (Long glideResult) -> glideResult,
-                key);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+			try {
+				List<Object> args = new ArrayList<>();
+				args.add(cursor);
 
-    @Override
-    @Nullable
-    public Long pTtl(byte[] key, TimeUnit timeUnit) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(timeUnit, "TimeUnit must not be null");
-        
-        try {
-            return connection.execute("PTTL",
-                (Long pTtlMillis) -> {
-                    if (pTtlMillis == null) {
-                        return null;
-                    }
-                    
-                    // Valkey PTTL semantics: -2 = key doesn't exist, -1 = key exists but no expiration
-                    // These are special values, not actual time values, so don't convert them
-                    if (pTtlMillis < 0) {
-                        return pTtlMillis;
-                    }
-                    
-                    return timeUnit.convert(pTtlMillis, TimeUnit.MILLISECONDS);
-                },
-                key);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+				if (scanOptions.getPattern() != null) {
+					args.add("MATCH");
+					args.add(scanOptions.getPattern());
+				}
 
-    @Override
-    @Nullable
-    public List<byte[]> sort(byte[] key, SortParameters params) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            List<Object> args = new ArrayList<>();
-            args.add(key);
-            
-            if (params != null) {
-                ValkeyGlideConverters.appendSortParameters(args, params);
-            }
-            
-            return connection.execute("SORT",
-                (Object[] glideResult) -> ValkeyGlideConverters.toBytesList(glideResult),
-                args.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+				if (scanOptions.getCount() != null) {
+					args.add("COUNT");
+					args.add(scanOptions.getCount());
+				}
 
-    @Override
-    @Nullable
-    public Long sort(byte[] key, SortParameters params, byte[] storeKey) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(storeKey, "Store key must not be null");
-        
-        try {
-            List<Object> args = new ArrayList<>();
-            args.add(key);
-            
-            if (params != null) {
-                ValkeyGlideConverters.appendSortParameters(args, params);
-            }
-            
-            args.add("STORE");
-            args.add(storeKey);
-            
-            return connection.execute("SORT",
-                (Long glideResult) -> glideResult,
-                args.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+				Object[] scanResult = connection.execute("SCAN", (Object[] glideResult) -> glideResult, args.toArray());
 
-    @Override
-    @Nullable
-    public byte[] dump(byte[] key) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("DUMP",
-                (GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null,
-                key);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+				if (scanResult != null && scanResult.length >= 2) {
+					Object nextCursor = scanResult[0];
+					Object keysResult = scanResult[1];
 
-    @Override
-    public void restore(byte[] key, long ttlInMillis, byte[] serializedValue, boolean replace) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(serializedValue, "Serialized value must not be null");
-        
-        try {
-            if (replace) {
-                connection.execute("RESTORE",
-                    (String glideResult) -> glideResult, // Return the "OK" response for pipeline/transaction modes
-                    key, ttlInMillis, serializedValue, "REPLACE");
-            } else {
-                connection.execute("RESTORE",
-                    (String glideResult) -> glideResult, // Return the "OK" response for pipeline/transaction modes
-                    key, ttlInMillis, serializedValue);
-            }
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+					// Handle cursor conversion
+					if (nextCursor instanceof GlideString) {
+						cursor = new String(((GlideString) nextCursor).getBytes(), StandardCharsets.UTF_8);
+					}
+					else if (nextCursor instanceof byte[]) {
+						cursor = new String((byte[]) nextCursor, StandardCharsets.UTF_8);
+					}
+					else {
+						cursor = nextCursor.toString();
+					}
 
-    @Override
-    @Nullable
-    public ValueEncoding encodingOf(byte[] key) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("OBJECT",
-                (GlideString glideResult) -> ValkeyGlideConverters.toValueEncoding(glideResult),
-                "ENCODING", key);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+					if ("0".equals(cursor)) {
+						finished = true;
+					}
 
-    @Override
-    @Nullable
-    public Duration idletime(byte[] key) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("OBJECT",
-                (Long glideResult) -> glideResult != null ? Duration.ofSeconds(glideResult) : null,
-                "IDLETIME", key);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+					// Convert keys result
+					List<byte[]> keys = ValkeyGlideConverters.toBytesList(keysResult);
+					currentBatch = keys.iterator();
+				}
+			}
+			catch (Exception ex) {
+				throw new ValkeyGlideExceptionConverter().convert(ex);
+			}
+		}
 
-    @Override
-    @Nullable
-    public Long refcount(byte[] key) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("OBJECT",
-                (Long glideResult) -> glideResult,
-                "REFCOUNT", key);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	}
+
+	@Override
+	@Nullable public byte[] randomKey() {
+		try {
+			return connection.execute("RANDOMKEY",
+					(GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public void rename(byte[] oldKey, byte[] newKey) {
+		Assert.notNull(oldKey, "Old key must not be null");
+		Assert.notNull(newKey, "New key must not be null");
+
+		try {
+			connection.execute("RENAME", (String glideResult) -> glideResult, // Return
+																				// the
+																				// "OK"
+																				// response
+																				// for
+																				// pipeline/transaction
+																				// modes
+					oldKey, newKey);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Boolean renameNX(byte[] oldKey, byte[] newKey) {
+		Assert.notNull(oldKey, "Old key must not be null");
+		Assert.notNull(newKey, "New key must not be null");
+
+		try {
+			return connection.execute("RENAMENX", (Boolean glideResult) -> glideResult, oldKey, newKey);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Boolean expire(byte[] key, long seconds, ExpirationOptions.Condition condition) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			if (condition == ExpirationOptions.Condition.ALWAYS) {
+				return connection.execute("EXPIRE", (Boolean glideResult) -> glideResult, key, seconds);
+			}
+			else {
+				String conditionStr = switch (condition) {
+					case XX -> "XX";
+					case NX -> "NX";
+					case GT -> "GT";
+					case LT -> "LT";
+					default -> throw new IllegalArgumentException("Unsupported expiration condition: " + condition);
+				};
+				return connection.execute("EXPIRE", (Boolean glideResult) -> glideResult, key, seconds, conditionStr);
+			}
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Boolean pExpire(byte[] key, long millis, ExpirationOptions.Condition condition) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			if (condition == ExpirationOptions.Condition.ALWAYS) {
+				return connection.execute("PEXPIRE", (Boolean glideResult) -> glideResult, key, millis);
+			}
+			else {
+				String conditionStr = switch (condition) {
+					case XX -> "XX";
+					case NX -> "NX";
+					case GT -> "GT";
+					case LT -> "LT";
+					default -> throw new IllegalArgumentException("Unsupported expiration condition: " + condition);
+				};
+				return connection.execute("PEXPIRE", (Boolean glideResult) -> glideResult, key, millis, conditionStr);
+			}
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Boolean expireAt(byte[] key, long unixTime, ExpirationOptions.Condition condition) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			if (condition == ExpirationOptions.Condition.ALWAYS) {
+				return connection.execute("EXPIREAT", (Boolean glideResult) -> glideResult, key, unixTime);
+			}
+			else {
+				String conditionStr = switch (condition) {
+					case XX -> "XX";
+					case NX -> "NX";
+					case GT -> "GT";
+					case LT -> "LT";
+					default -> throw new IllegalArgumentException("Unsupported expiration condition: " + condition);
+				};
+				return connection.execute("EXPIREAT", (Boolean glideResult) -> glideResult, key, unixTime,
+						conditionStr);
+			}
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Boolean pExpireAt(byte[] key, long unixTimeInMillis, ExpirationOptions.Condition condition) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			if (condition == ExpirationOptions.Condition.ALWAYS) {
+				return connection.execute("PEXPIREAT", (Boolean glideResult) -> glideResult, key, unixTimeInMillis);
+			}
+			else {
+				String conditionStr = switch (condition) {
+					case XX -> "XX";
+					case NX -> "NX";
+					case GT -> "GT";
+					case LT -> "LT";
+					default -> throw new IllegalArgumentException("Unsupported expiration condition: " + condition);
+				};
+				return connection.execute("PEXPIREAT", (Boolean glideResult) -> glideResult, key, unixTimeInMillis,
+						conditionStr);
+			}
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Boolean persist(byte[] key) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("PERSIST", (Boolean glideResult) -> glideResult, key);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Boolean move(byte[] key, int dbIndex) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("MOVE", (Boolean glideResult) -> glideResult, key, dbIndex);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Long ttl(byte[] key) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("TTL", (Long glideResult) -> glideResult, key);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Long ttl(byte[] key, TimeUnit timeUnit) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(timeUnit, "TimeUnit must not be null");
+
+		try {
+			return connection.execute("TTL", (Long ttlSeconds) -> {
+				if (ttlSeconds == null) {
+					return null;
+				}
+
+				// Valkey TTL semantics: -2 = key doesn't exist, -1 = key exists but no
+				// expiration
+				// These are special values, not actual time values, so don't convert them
+				if (ttlSeconds < 0) {
+					return ttlSeconds;
+				}
+
+				return timeUnit.convert(ttlSeconds, TimeUnit.SECONDS);
+			}, key);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Long pTtl(byte[] key) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("PTTL", (Long glideResult) -> glideResult, key);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Long pTtl(byte[] key, TimeUnit timeUnit) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(timeUnit, "TimeUnit must not be null");
+
+		try {
+			return connection.execute("PTTL", (Long pTtlMillis) -> {
+				if (pTtlMillis == null) {
+					return null;
+				}
+
+				// Valkey PTTL semantics: -2 = key doesn't exist, -1 = key exists but no
+				// expiration
+				// These are special values, not actual time values, so don't convert them
+				if (pTtlMillis < 0) {
+					return pTtlMillis;
+				}
+
+				return timeUnit.convert(pTtlMillis, TimeUnit.MILLISECONDS);
+			}, key);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public List<byte[]> sort(byte[] key, SortParameters params) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			List<Object> args = new ArrayList<>();
+			args.add(key);
+
+			if (params != null) {
+				ValkeyGlideConverters.appendSortParameters(args, params);
+			}
+
+			return connection.execute("SORT", (Object[] glideResult) -> ValkeyGlideConverters.toBytesList(glideResult),
+					args.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Long sort(byte[] key, SortParameters params, byte[] storeKey) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(storeKey, "Store key must not be null");
+
+		try {
+			List<Object> args = new ArrayList<>();
+			args.add(key);
+
+			if (params != null) {
+				ValkeyGlideConverters.appendSortParameters(args, params);
+			}
+
+			args.add("STORE");
+			args.add(storeKey);
+
+			return connection.execute("SORT", (Long glideResult) -> glideResult, args.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public byte[] dump(byte[] key) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("DUMP",
+					(GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null, key);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public void restore(byte[] key, long ttlInMillis, byte[] serializedValue, boolean replace) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(serializedValue, "Serialized value must not be null");
+
+		try {
+			if (replace) {
+				connection.execute("RESTORE", (String glideResult) -> glideResult, // Return
+																					// the
+																					// "OK"
+																					// response
+																					// for
+																					// pipeline/transaction
+																					// modes
+						key, ttlInMillis, serializedValue, "REPLACE");
+			}
+			else {
+				connection.execute("RESTORE", (String glideResult) -> glideResult, // Return
+																					// the
+																					// "OK"
+																					// response
+																					// for
+																					// pipeline/transaction
+																					// modes
+						key, ttlInMillis, serializedValue);
+			}
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public ValueEncoding encodingOf(byte[] key) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("OBJECT",
+					(GlideString glideResult) -> ValkeyGlideConverters.toValueEncoding(glideResult), "ENCODING", key);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Duration idletime(byte[] key) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("OBJECT",
+					(Long glideResult) -> glideResult != null ? Duration.ofSeconds(glideResult) : null, "IDLETIME",
+					key);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Long refcount(byte[] key) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("OBJECT", (Long glideResult) -> glideResult, "REFCOUNT", key);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
 	@Override
 	public Boolean delex(byte[] key, CompareCondition condition) {
@@ -708,7 +690,8 @@ public class ValkeyGlideKeyCommands implements ValkeyKeyCommands {
 				case VALUE -> {
 					if (condition.getOperator() == CompareCondition.ComparisonOperator.EQUALS) {
 						args.add("IFEQ");
-					} else {
+					}
+					else {
 						args.add("IFNE");
 					}
 					args.add(condition.getValue().asBytes());
@@ -716,26 +699,28 @@ public class ValkeyGlideKeyCommands implements ValkeyKeyCommands {
 				case DIGEST -> {
 					if (condition.getOperator() == CompareCondition.ComparisonOperator.EQUALS) {
 						args.add("IFDEQ");
-					} else {
+					}
+					else {
 						args.add("IFDNE");
 					}
 					args.add(condition.getValue().asBytes());
 				}
 			}
-			return connection.execute("DELEX",
-				(Object glideResult) -> {
-					if (glideResult == null) return false;
-					if (glideResult instanceof Long l) return l > 0;
-					if (glideResult instanceof GlideString gs) {
-						throw new InvalidDataAccessApiUsageException(gs.getString());
-					}
-					if (glideResult instanceof String s) {
-						throw new InvalidDataAccessApiUsageException(s);
-					}
-					throw new IllegalStateException("Unexpected DELEX reply: " + glideResult);
-				},
-				args.toArray());
-		} catch (Exception ex) {
+			return connection.execute("DELEX", (Object glideResult) -> {
+				if (glideResult == null)
+					return false;
+				if (glideResult instanceof Long l)
+					return l > 0;
+				if (glideResult instanceof GlideString gs) {
+					throw new InvalidDataAccessApiUsageException(gs.getString());
+				}
+				if (glideResult instanceof String s) {
+					throw new InvalidDataAccessApiUsageException(s);
+				}
+				throw new IllegalStateException("Unexpected DELEX reply: " + glideResult);
+			}, args.toArray());
+		}
+		catch (Exception ex) {
 			throw new ValkeyGlideExceptionConverter().convert(ex);
 		}
 	}
@@ -745,10 +730,11 @@ public class ValkeyGlideKeyCommands implements ValkeyKeyCommands {
 		Assert.notNull(key, "Key must not be null");
 		try {
 			return connection.execute("DIGEST",
-				(GlideString glideResult) -> glideResult != null ? glideResult.getString() : null,
-				key);
-		} catch (Exception ex) {
+					(GlideString glideResult) -> glideResult != null ? glideResult.getString() : null, key);
+		}
+		catch (Exception ex) {
 			throw new ValkeyGlideExceptionConverter().convert(ex);
 		}
 	}
+
 }

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideListCommands.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideListCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,424 +32,405 @@ import glide.api.models.GlideString;
  */
 public class ValkeyGlideListCommands implements ValkeyListCommands {
 
-    private final ValkeyGlideConnection connection;
+	private final ValkeyGlideConnection connection;
 
-    /**
-     * Creates a new {@link ValkeyGlideListCommands}.
-     *
-     * @param connection must not be {@literal null}.
-     */
-    public ValkeyGlideListCommands(ValkeyGlideConnection connection) {
-        Assert.notNull(connection, "Connection must not be null!");
-        this.connection = connection;
-    }
+	/**
+	 * Creates a new {@link ValkeyGlideListCommands}.
+	 * @param connection must not be {@literal null}.
+	 */
+	public ValkeyGlideListCommands(ValkeyGlideConnection connection) {
+		Assert.notNull(connection, "Connection must not be null!");
+		this.connection = connection;
+	}
 
-    @Override
-    @Nullable
-    public Long rPush(byte[] key, byte[]... values) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(values, "Values must not be null");
-        Assert.noNullElements(values, "Values must not contain null elements");
-        
-        try {
-            Object[] args = new Object[values.length + 1];
-            args[0] = key;
-            System.arraycopy(values, 0, args, 1, values.length);
-            
-            return connection.execute("RPUSH",
-                (Long glideResult) -> glideResult,
-                args);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	@Override
+	@Nullable public Long rPush(byte[] key, byte[]... values) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(values, "Values must not be null");
+		Assert.noNullElements(values, "Values must not contain null elements");
 
-    @Override
-    @Nullable
-    public List<Long> lPos(byte[] key, byte[] element, @Nullable Integer rank, @Nullable Integer count) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(element, "Element must not be null");
-        
-        try {
-            List<Object> args = new ArrayList<>();
-            args.add(key);
-            args.add(element);
-            
-            if (rank != null) {
-                args.add("RANK");
-                args.add(rank);
-            }
-            
-            if (count != null) {
-                args.add("COUNT");
-                args.add(count);
-            }
-            
-            return connection.execute("LPOS",
-                (Object glideResult) -> {
-                    if (glideResult == null) {
-                        return new ArrayList<>();
-                    }
+		try {
+			Object[] args = new Object[values.length + 1];
+			args[0] = key;
+			System.arraycopy(values, 0, args, 1, values.length);
 
-                    // glideResult can be a single Long or an array of Longs
-                    if (glideResult instanceof Long) {
-                        List<Long> singleResult = new ArrayList<>();
-                        singleResult.add((Long) glideResult);
-                        return singleResult;
-                    }
-                    return ValkeyGlideConverters.toLongsList((Object[]) glideResult);
-                },
-                args.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+			return connection.execute("RPUSH", (Long glideResult) -> glideResult, args);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    @Override
-    @Nullable
-    public Long lPush(byte[] key, byte[]... values) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(values, "Values must not be null");
-        Assert.noNullElements(values, "Values must not contain null elements");
-        
-        try {
-            Object[] args = new Object[values.length + 1];
-            args[0] = key;
-            System.arraycopy(values, 0, args, 1, values.length);
-            
-            return connection.execute("LPUSH",
-                (Long glideResult) -> glideResult,
-                args);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	@Override
+	@Nullable public List<Long> lPos(byte[] key, byte[] element, @Nullable Integer rank, @Nullable Integer count) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(element, "Element must not be null");
 
-    @Override
-    @Nullable
-    public Long rPushX(byte[] key, byte[] value) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(value, "Value must not be null");
-        
-        try {
-            return connection.execute("RPUSHX",
-                (Long glideResult) -> glideResult,
-                key, value);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		try {
+			List<Object> args = new ArrayList<>();
+			args.add(key);
+			args.add(element);
 
-    @Override
-    @Nullable
-    public Long lPushX(byte[] key, byte[] value) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(value, "Value must not be null");
-        
-        try {
-            return connection.execute("LPUSHX",
-                (Long glideResult) -> glideResult,
-                key, value);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+			if (rank != null) {
+				args.add("RANK");
+				args.add(rank);
+			}
 
-    @Override
-    @Nullable
-    public Long lLen(byte[] key) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("LLEN",
-                (Long glideResult) -> glideResult,
-                key);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+			if (count != null) {
+				args.add("COUNT");
+				args.add(count);
+			}
 
-    @Override
-    @Nullable
-    public List<byte[]> lRange(byte[] key, long start, long end) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("LRANGE",
-                (Object[] glideResult) -> ValkeyGlideConverters.toBytesList(glideResult),
-                key, start, end);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+			return connection.execute("LPOS", (Object glideResult) -> {
+				if (glideResult == null) {
+					return new ArrayList<>();
+				}
 
-    @Override
-    public void lTrim(byte[] key, long start, long end) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            connection.execute("LTRIM",
-                (String glideResult) -> glideResult, // Return the "OK" response for pipeline/transaction modes
-                key, start, end);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+				// glideResult can be a single Long or an array of Longs
+				if (glideResult instanceof Long) {
+					List<Long> singleResult = new ArrayList<>();
+					singleResult.add((Long) glideResult);
+					return singleResult;
+				}
+				return ValkeyGlideConverters.toLongsList((Object[]) glideResult);
+			}, args.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    @Override
-    @Nullable
-    public byte[] lIndex(byte[] key, long index) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("LINDEX",
-                (GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null,
-                key, index);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	@Override
+	@Nullable public Long lPush(byte[] key, byte[]... values) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(values, "Values must not be null");
+		Assert.noNullElements(values, "Values must not contain null elements");
 
-    @Override
-    @Nullable
-    public Long lInsert(byte[] key, Position where, byte[] pivot, byte[] value) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(where, "Position must not be null");
-        Assert.notNull(pivot, "Pivot must not be null");
-        Assert.notNull(value, "Value must not be null");
-        
-        try {
-            String position = (where == Position.BEFORE) ? "BEFORE" : "AFTER";
-            return connection.execute("LINSERT",
-                (Long glideResult) -> glideResult,
-                key, position, pivot, value);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		try {
+			Object[] args = new Object[values.length + 1];
+			args[0] = key;
+			System.arraycopy(values, 0, args, 1, values.length);
 
-    @Override
-    @Nullable
-    public byte[] lMove(byte[] sourceKey, byte[] destinationKey, Direction from, Direction to) {
-        Assert.notNull(sourceKey, "Source key must not be null");
-        Assert.notNull(destinationKey, "Destination key must not be null");
-        Assert.notNull(from, "From direction must not be null");
-        Assert.notNull(to, "To direction must not be null");
-        
-        try {
-            String fromStr = (from == Direction.LEFT) ? "LEFT" : "RIGHT";
-            String toStr = (to == Direction.LEFT) ? "LEFT" : "RIGHT";
-            return connection.execute("LMOVE",
-                (GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null,
-                sourceKey, destinationKey, fromStr, toStr);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+			return connection.execute("LPUSH", (Long glideResult) -> glideResult, args);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    @Override
-    @Nullable
-    public byte[] bLMove(byte[] sourceKey, byte[] destinationKey, Direction from, Direction to, double timeout) {
-        Assert.notNull(sourceKey, "Source key must not be null");
-        Assert.notNull(destinationKey, "Destination key must not be null");
-        Assert.notNull(from, "From direction must not be null");
-        Assert.notNull(to, "To direction must not be null");
-        
-        try {
-            String fromStr = (from == Direction.LEFT) ? "LEFT" : "RIGHT";
-            String toStr = (to == Direction.LEFT) ? "LEFT" : "RIGHT";
-            return connection.execute("BLMOVE",
-                (GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null,
-                sourceKey, destinationKey, fromStr, toStr, timeout);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	@Override
+	@Nullable public Long rPushX(byte[] key, byte[] value) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(value, "Value must not be null");
 
-    @Override
-    public void lSet(byte[] key, long index, byte[] value) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(value, "Value must not be null");
-        
-        try {
-            connection.execute("LSET",
-                (String glideResult) -> glideResult, // Return the "OK" response for pipeline/transaction modes
-                key, index, value);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		try {
+			return connection.execute("RPUSHX", (Long glideResult) -> glideResult, key, value);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    @Override
-    @Nullable
-    public Long lRem(byte[] key, long count, byte[] value) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(value, "Value must not be null");
-        
-        try {
-            return connection.execute("LREM",
-                (Long glideResult) -> glideResult,
-                key, count, value);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	@Override
+	@Nullable public Long lPushX(byte[] key, byte[] value) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(value, "Value must not be null");
 
-    @Override
-    @Nullable
-    public byte[] lPop(byte[] key) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("LPOP",
-                (GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null,
-                key);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		try {
+			return connection.execute("LPUSHX", (Long glideResult) -> glideResult, key, value);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    @Override
-    @Nullable
-    public List<byte[]> lPop(byte[] key, long count) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("LPOP",
-                (Object glideResult) -> {
-                    if (glideResult == null) {
-                        return null;
-                    }
+	@Override
+	@Nullable public Long lLen(byte[] key) {
+		Assert.notNull(key, "Key must not be null");
 
-                    // glideResult can be a single Long or an array of Longs
-                    if (glideResult instanceof GlideString) {
-                        List<byte[]> singleResult = new ArrayList<>();
-                        singleResult.add(((GlideString) glideResult).getBytes());
-                        return singleResult;
-                    }
-                    return ValkeyGlideConverters.toBytesList((Object[]) glideResult);
-                },
-                key, count);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		try {
+			return connection.execute("LLEN", (Long glideResult) -> glideResult, key);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    @Override
-    @Nullable
-    public byte[] rPop(byte[] key) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("RPOP",
-                (GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null,
-                key);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	@Override
+	@Nullable public List<byte[]> lRange(byte[] key, long start, long end) {
+		Assert.notNull(key, "Key must not be null");
 
-    @Override
-    @Nullable
-    public List<byte[]> rPop(byte[] key, long count) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("RPOP",
-                (Object glideResult) -> {
-                    if (glideResult == null) {
-                        return null;
-                    }
+		try {
+			return connection.execute("LRANGE",
+					(Object[] glideResult) -> ValkeyGlideConverters.toBytesList(glideResult), key, start, end);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-                    // glideResult can be a single Long or an array of Longs
-                    if (glideResult instanceof GlideString) {
-                        List<byte[]> singleResult = new ArrayList<>();
-                        singleResult.add(((GlideString) glideResult).getBytes());
-                        return singleResult;
-                    }
-                    return ValkeyGlideConverters.toBytesList((Object[]) glideResult);
-                },
-                key, count);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	@Override
+	public void lTrim(byte[] key, long start, long end) {
+		Assert.notNull(key, "Key must not be null");
 
-    @Override
-    @Nullable
-    public List<byte[]> bLPop(int timeout, byte[]... keys) {
-        Assert.notNull(keys, "Keys must not be null");
-        Assert.noNullElements(keys, "Keys must not contain null elements");
-        
-        try {
-            Object[] args = new Object[keys.length + 1];
-            System.arraycopy(keys, 0, args, 0, keys.length);
-            args[keys.length] = timeout;
-            
-            return connection.execute("BLPOP",
-                (Object glideResult) -> {
-                    if (glideResult == null) {
-                        return new ArrayList<>();
-                    }
-                    return ValkeyGlideConverters.toBytesList((Object[]) glideResult);
-                },
-                args);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		try {
+			connection.execute("LTRIM", (String glideResult) -> glideResult, // Return the
+																				// "OK"
+																				// response
+																				// for
+																				// pipeline/transaction
+																				// modes
+					key, start, end);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    @Override
-    @Nullable
-    public List<byte[]> bRPop(int timeout, byte[]... keys) {
-        Assert.notNull(keys, "Keys must not be null");
-        Assert.noNullElements(keys, "Keys must not contain null elements");
-        
-        try {
-            Object[] args = new Object[keys.length + 1];
-            System.arraycopy(keys, 0, args, 0, keys.length);
-            args[keys.length] = timeout;
-            
-            return connection.execute("BRPOP",
-                (Object glideResult) -> {
-                    if (glideResult == null) {
-                        return new ArrayList<>();
-                    }
-                    return ValkeyGlideConverters.toBytesList((Object[]) glideResult);
-                },
-                args);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	@Override
+	@Nullable public byte[] lIndex(byte[] key, long index) {
+		Assert.notNull(key, "Key must not be null");
 
-    @Override
-    @Nullable
-    public byte[] rPopLPush(byte[] srcKey, byte[] dstKey) {
-        Assert.notNull(srcKey, "Source key must not be null");
-        Assert.notNull(dstKey, "Destination key must not be null");
-        
-        try {
-            return connection.execute("RPOPLPUSH",
-                (GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null,
-                srcKey, dstKey);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		try {
+			return connection.execute("LINDEX",
+					(GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null, key, index);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    @Override
-    @Nullable
-    public byte[] bRPopLPush(int timeout, byte[] srcKey, byte[] dstKey) {
-        Assert.notNull(srcKey, "Source key must not be null");
-        Assert.notNull(dstKey, "Destination key must not be null");
-        
-        try {
-            return connection.execute("BRPOPLPUSH",
-                (GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null,
-                srcKey, dstKey, timeout);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	@Override
+	@Nullable public Long lInsert(byte[] key, Position where, byte[] pivot, byte[] value) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(where, "Position must not be null");
+		Assert.notNull(pivot, "Pivot must not be null");
+		Assert.notNull(value, "Value must not be null");
+
+		try {
+			String position = (where == Position.BEFORE) ? "BEFORE" : "AFTER";
+			return connection.execute("LINSERT", (Long glideResult) -> glideResult, key, position, pivot, value);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public byte[] lMove(byte[] sourceKey, byte[] destinationKey, Direction from, Direction to) {
+		Assert.notNull(sourceKey, "Source key must not be null");
+		Assert.notNull(destinationKey, "Destination key must not be null");
+		Assert.notNull(from, "From direction must not be null");
+		Assert.notNull(to, "To direction must not be null");
+
+		try {
+			String fromStr = (from == Direction.LEFT) ? "LEFT" : "RIGHT";
+			String toStr = (to == Direction.LEFT) ? "LEFT" : "RIGHT";
+			return connection.execute("LMOVE",
+					(GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null, sourceKey,
+					destinationKey, fromStr, toStr);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public byte[] bLMove(byte[] sourceKey, byte[] destinationKey, Direction from, Direction to, double timeout) {
+		Assert.notNull(sourceKey, "Source key must not be null");
+		Assert.notNull(destinationKey, "Destination key must not be null");
+		Assert.notNull(from, "From direction must not be null");
+		Assert.notNull(to, "To direction must not be null");
+
+		try {
+			String fromStr = (from == Direction.LEFT) ? "LEFT" : "RIGHT";
+			String toStr = (to == Direction.LEFT) ? "LEFT" : "RIGHT";
+			return connection.execute("BLMOVE",
+					(GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null, sourceKey,
+					destinationKey, fromStr, toStr, timeout);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public void lSet(byte[] key, long index, byte[] value) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(value, "Value must not be null");
+
+		try {
+			connection.execute("LSET", (String glideResult) -> glideResult, // Return the
+																			// "OK"
+																			// response
+																			// for
+																			// pipeline/transaction
+																			// modes
+					key, index, value);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Long lRem(byte[] key, long count, byte[] value) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(value, "Value must not be null");
+
+		try {
+			return connection.execute("LREM", (Long glideResult) -> glideResult, key, count, value);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public byte[] lPop(byte[] key) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("LPOP",
+					(GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null, key);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public List<byte[]> lPop(byte[] key, long count) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("LPOP", (Object glideResult) -> {
+				if (glideResult == null) {
+					return null;
+				}
+
+				// glideResult can be a single Long or an array of Longs
+				if (glideResult instanceof GlideString) {
+					List<byte[]> singleResult = new ArrayList<>();
+					singleResult.add(((GlideString) glideResult).getBytes());
+					return singleResult;
+				}
+				return ValkeyGlideConverters.toBytesList((Object[]) glideResult);
+			}, key, count);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public byte[] rPop(byte[] key) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("RPOP",
+					(GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null, key);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public List<byte[]> rPop(byte[] key, long count) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("RPOP", (Object glideResult) -> {
+				if (glideResult == null) {
+					return null;
+				}
+
+				// glideResult can be a single Long or an array of Longs
+				if (glideResult instanceof GlideString) {
+					List<byte[]> singleResult = new ArrayList<>();
+					singleResult.add(((GlideString) glideResult).getBytes());
+					return singleResult;
+				}
+				return ValkeyGlideConverters.toBytesList((Object[]) glideResult);
+			}, key, count);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public List<byte[]> bLPop(int timeout, byte[]... keys) {
+		Assert.notNull(keys, "Keys must not be null");
+		Assert.noNullElements(keys, "Keys must not contain null elements");
+
+		try {
+			Object[] args = new Object[keys.length + 1];
+			System.arraycopy(keys, 0, args, 0, keys.length);
+			args[keys.length] = timeout;
+
+			return connection.execute("BLPOP", (Object glideResult) -> {
+				if (glideResult == null) {
+					return new ArrayList<>();
+				}
+				return ValkeyGlideConverters.toBytesList((Object[]) glideResult);
+			}, args);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public List<byte[]> bRPop(int timeout, byte[]... keys) {
+		Assert.notNull(keys, "Keys must not be null");
+		Assert.noNullElements(keys, "Keys must not contain null elements");
+
+		try {
+			Object[] args = new Object[keys.length + 1];
+			System.arraycopy(keys, 0, args, 0, keys.length);
+			args[keys.length] = timeout;
+
+			return connection.execute("BRPOP", (Object glideResult) -> {
+				if (glideResult == null) {
+					return new ArrayList<>();
+				}
+				return ValkeyGlideConverters.toBytesList((Object[]) glideResult);
+			}, args);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public byte[] rPopLPush(byte[] srcKey, byte[] dstKey) {
+		Assert.notNull(srcKey, "Source key must not be null");
+		Assert.notNull(dstKey, "Destination key must not be null");
+
+		try {
+			return connection.execute("RPOPLPUSH",
+					(GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null, srcKey, dstKey);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public byte[] bRPopLPush(int timeout, byte[] srcKey, byte[] dstKey) {
+		Assert.notNull(srcKey, "Source key must not be null");
+		Assert.notNull(dstKey, "Destination key must not be null");
+
+		try {
+			return connection.execute("BRPOPLPUSH",
+					(GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null, srcKey, dstKey,
+					timeout);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
 }

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideScriptingCommands.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideScriptingCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,199 +34,199 @@ import glide.api.models.GlideString;
  */
 public class ValkeyGlideScriptingCommands implements ValkeyScriptingCommands {
 
-    private final ValkeyGlideConnection connection;
+	private final ValkeyGlideConnection connection;
 
-    /**
-     * Creates a new {@link ValkeyGlideScriptingCommands}.
-     *
-     * @param connection must not be {@literal null}.
-     */
-    public ValkeyGlideScriptingCommands(ValkeyGlideConnection connection) {
-        Assert.notNull(connection, "Connection must not be null!");
-        this.connection = connection;
-    }
+	/**
+	 * Creates a new {@link ValkeyGlideScriptingCommands}.
+	 * @param connection must not be {@literal null}.
+	 */
+	public ValkeyGlideScriptingCommands(ValkeyGlideConnection connection) {
+		Assert.notNull(connection, "Connection must not be null!");
+		this.connection = connection;
+	}
 
-    @Override
-    @Nullable
-    public <T> T eval(byte[] script, ReturnType returnType, int numKeys, byte[]... keysAndArgs) {
-        Assert.notNull(script, "Script must not be null");
-        Assert.notNull(returnType, "ReturnType must not be null");
-        Assert.notNull(keysAndArgs, "Keys and args must not be null");
-        
-        try {
-            Object[] args = new Object[2 + keysAndArgs.length];
-            args[0] = script;
-            args[1] = String.valueOf(numKeys);
-            System.arraycopy(keysAndArgs, 0, args, 2, keysAndArgs.length);
+	@Override
+	@Nullable public <T> T eval(byte[] script, ReturnType returnType, int numKeys, byte[]... keysAndArgs) {
+		Assert.notNull(script, "Script must not be null");
+		Assert.notNull(returnType, "ReturnType must not be null");
+		Assert.notNull(keysAndArgs, "Keys and args must not be null");
 
-            return connection.execute("EVAL",
-                (Object glideResult) -> {
-                    return convertResult(glideResult, returnType);
-                },
-                args);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		try {
+			Object[] args = new Object[2 + keysAndArgs.length];
+			args[0] = script;
+			args[1] = String.valueOf(numKeys);
+			System.arraycopy(keysAndArgs, 0, args, 2, keysAndArgs.length);
 
-    @Override
-    @Nullable
-    public <T> T evalSha(String scriptSha1, ReturnType returnType, int numKeys, byte[]... keysAndArgs) {
-        Assert.notNull(scriptSha1, "Script SHA1 must not be null");
-        Assert.notNull(returnType, "ReturnType must not be null");
-        Assert.notNull(keysAndArgs, "Keys and args must not be null");
-        
-        try {
-            Object[] args = new Object[2 + keysAndArgs.length];
-            args[0] = scriptSha1;
-            args[1] = String.valueOf(numKeys);
-            System.arraycopy(keysAndArgs, 0, args, 2, keysAndArgs.length);
+			return connection.execute("EVAL", (Object glideResult) -> {
+				return convertResult(glideResult, returnType);
+			}, args);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-            return connection.execute("EVALSHA",
-                (Object glideResult) -> {
-                    return convertResult(glideResult, returnType);
-                },
-                args);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	@Override
+	@Nullable public <T> T evalSha(String scriptSha1, ReturnType returnType, int numKeys, byte[]... keysAndArgs) {
+		Assert.notNull(scriptSha1, "Script SHA1 must not be null");
+		Assert.notNull(returnType, "ReturnType must not be null");
+		Assert.notNull(keysAndArgs, "Keys and args must not be null");
 
-    @Override
-    @Nullable
-    public <T> T evalSha(byte[] scriptSha1, ReturnType returnType, int numKeys, byte[]... keysAndArgs) {
-        Assert.notNull(scriptSha1, "Script SHA1 must not be null");
-        return evalSha(new String(scriptSha1), returnType, numKeys, keysAndArgs);
-    }
+		try {
+			Object[] args = new Object[2 + keysAndArgs.length];
+			args[0] = scriptSha1;
+			args[1] = String.valueOf(numKeys);
+			System.arraycopy(keysAndArgs, 0, args, 2, keysAndArgs.length);
 
-    @Override
-    public void scriptFlush() {
-        try {
-            connection.execute("SCRIPT",
-                glideResult -> glideResult, // Return "OK" for pipeline/transaction correlation
-                "FLUSH");
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+			return connection.execute("EVALSHA", (Object glideResult) -> {
+				return convertResult(glideResult, returnType);
+			}, args);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    @Override
-    @Nullable
-    public List<Boolean> scriptExists(String... scriptSha1s) {
-        Assert.notNull(scriptSha1s, "Script SHA1s must not be null");
+	@Override
+	@Nullable public <T> T evalSha(byte[] scriptSha1, ReturnType returnType, int numKeys, byte[]... keysAndArgs) {
+		Assert.notNull(scriptSha1, "Script SHA1 must not be null");
+		return evalSha(new String(scriptSha1), returnType, numKeys, keysAndArgs);
+	}
 
-        try {
-            Object[] args = new Object[1 + scriptSha1s.length];
-            args[0] = "EXISTS";
-            System.arraycopy(scriptSha1s, 0, args, 1, scriptSha1s.length);
+	@Override
+	public void scriptFlush() {
+		try {
+			connection.execute("SCRIPT", glideResult -> glideResult, // Return "OK" for
+																		// pipeline/transaction
+																		// correlation
+					"FLUSH");
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-            return connection.execute("SCRIPT",
-                (Object[] glideResult) -> {
-                    if (glideResult == null) {
-                        return null;
-                    }
-                    List<Boolean> exists = new ArrayList<>(glideResult.length);
-                    for (Object value : glideResult) {
-                        exists.add((Boolean) value);
-                    }
-                    return exists;
-                },
-                args);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	@Override
+	@Nullable public List<Boolean> scriptExists(String... scriptSha1s) {
+		Assert.notNull(scriptSha1s, "Script SHA1s must not be null");
 
-    @Nullable
-    public List<Boolean> scriptExists(byte[]... scriptSha1s) {
-        Assert.notNull(scriptSha1s, "Script SHA1s must not be null");
-        
-        String[] sha1s = new String[scriptSha1s.length];
-        for (int i = 0; i < scriptSha1s.length; i++) {
-            sha1s[i] = new String(scriptSha1s[i]);
-        }
-        return scriptExists(sha1s);
-    }
+		try {
+			Object[] args = new Object[1 + scriptSha1s.length];
+			args[0] = "EXISTS";
+			System.arraycopy(scriptSha1s, 0, args, 1, scriptSha1s.length);
 
-    @Override
-    @Nullable
-    public String scriptLoad(byte[] script) {
-        Assert.notNull(script, "Script must not be null");
+			return connection.execute("SCRIPT", (Object[] glideResult) -> {
+				if (glideResult == null) {
+					return null;
+				}
+				List<Boolean> exists = new ArrayList<>(glideResult.length);
+				for (Object value : glideResult) {
+					exists.add((Boolean) value);
+				}
+				return exists;
+			}, args);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-        try {
-            return connection.execute("SCRIPT",
-                (GlideString glideResult) -> glideResult != null ? glideResult.toString() : null,
-                "LOAD", script);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	@Nullable public List<Boolean> scriptExists(byte[]... scriptSha1s) {
+		Assert.notNull(scriptSha1s, "Script SHA1s must not be null");
 
-    @Override
-    public void scriptKill() {
-        try {
-            connection.execute("SCRIPT",
-                (String glideResult) -> glideResult, // Return "OK" for pipeline/transaction correlation
-                "KILL");
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-    
-    @SuppressWarnings("unchecked")
-    private <T> T convertResult(Object result, ReturnType returnType) {
-        switch (returnType) {
-            case BOOLEAN:
-                // Lua false comes back as a null bulk reply
-                if (result == null) {
-                    return (T) Boolean.FALSE;
-                }
-                if (result instanceof Number) {
-                    return (T) Boolean.valueOf(((Number) result).longValue() == 1L);
-                }
-                return (T) Boolean.valueOf("1".equals(result.toString()));
-            case INTEGER:
-                if (result instanceof Number) {
-                    return (T) Long.valueOf(((Number) result).longValue());
-                }
-                return (T) Long.valueOf(result.toString());
-            case STATUS:
-                // STATUS should return String, following Jedis pattern
-                if (result instanceof GlideString) {
-                    return (T) new String(((GlideString) result).toString());
-                }
-                if (result instanceof byte[]) {
-                    return (T) new String((byte[]) result, StandardCharsets.UTF_8);
-                }
-                return (T) result.toString();
-            case VALUE:
-                // VALUE should return byte[] for simple values, complex objects as-is
-                if (result instanceof GlideString) {
-                    return (T) ((GlideString) result).getBytes();
-                }
-                // if (result instanceof String) {
-                //     return (T) ((String) result).getBytes(StandardCharsets.UTF_8);
-                // }
-                // Return complex objects (Maps, Lists, etc.) as-is
-                // If caller expects byte[] but gets complex object, they'll get ClassCastException
-                return (T) result;
-            case MULTI:
-                // Assume the result is Object[] for MULTI
-                Object[] resultArray = (Object[]) result;
-                Object[] convertedArray = new Object[resultArray.length];
-                for (int i = 0; i < resultArray.length; i++) {
-                    Object item = resultArray[i];
-                    if (item instanceof GlideString) {
-                        convertedArray[i] = ((GlideString) item).getBytes();
-                    } else if (item instanceof String) {
-                        convertedArray[i] = ((String) item).getBytes(StandardCharsets.UTF_8);
-                    } else {
-                        convertedArray[i] = item;
-                    }
-                }
-                return (T) convertedArray;
-            default:
-                throw new IllegalArgumentException("Unsupported return type: " + returnType);
-        }
-    }
+		String[] sha1s = new String[scriptSha1s.length];
+		for (int i = 0; i < scriptSha1s.length; i++) {
+			sha1s[i] = new String(scriptSha1s[i]);
+		}
+		return scriptExists(sha1s);
+	}
+
+	@Override
+	@Nullable public String scriptLoad(byte[] script) {
+		Assert.notNull(script, "Script must not be null");
+
+		try {
+			return connection.execute("SCRIPT",
+					(GlideString glideResult) -> glideResult != null ? glideResult.toString() : null, "LOAD", script);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public void scriptKill() {
+		try {
+			connection.execute("SCRIPT", (String glideResult) -> glideResult, // Return
+																				// "OK"
+																				// for
+																				// pipeline/transaction
+																				// correlation
+					"KILL");
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private <T> T convertResult(Object result, ReturnType returnType) {
+		switch (returnType) {
+			case BOOLEAN:
+				// Lua false comes back as a null bulk reply
+				if (result == null) {
+					return (T) Boolean.FALSE;
+				}
+				if (result instanceof Number) {
+					return (T) Boolean.valueOf(((Number) result).longValue() == 1L);
+				}
+				return (T) Boolean.valueOf("1".equals(result.toString()));
+			case INTEGER:
+				if (result instanceof Number) {
+					return (T) Long.valueOf(((Number) result).longValue());
+				}
+				return (T) Long.valueOf(result.toString());
+			case STATUS:
+				// STATUS should return String, following Jedis pattern
+				if (result instanceof GlideString) {
+					return (T) new String(((GlideString) result).toString());
+				}
+				if (result instanceof byte[]) {
+					return (T) new String((byte[]) result, StandardCharsets.UTF_8);
+				}
+				return (T) result.toString();
+			case VALUE:
+				// VALUE should return byte[] for simple values, complex objects as-is
+				if (result instanceof GlideString) {
+					return (T) ((GlideString) result).getBytes();
+				}
+				// if (result instanceof String) {
+				// return (T) ((String) result).getBytes(StandardCharsets.UTF_8);
+				// }
+				// Return complex objects (Maps, Lists, etc.) as-is
+				// If caller expects byte[] but gets complex object, they'll get
+				// ClassCastException
+				return (T) result;
+			case MULTI:
+				// Assume the result is Object[] for MULTI
+				Object[] resultArray = (Object[]) result;
+				Object[] convertedArray = new Object[resultArray.length];
+				for (int i = 0; i < resultArray.length; i++) {
+					Object item = resultArray[i];
+					if (item instanceof GlideString) {
+						convertedArray[i] = ((GlideString) item).getBytes();
+					}
+					else if (item instanceof String) {
+						convertedArray[i] = ((String) item).getBytes(StandardCharsets.UTF_8);
+					}
+					else {
+						convertedArray[i] = item;
+					}
+				}
+				return (T) convertedArray;
+			default:
+				throw new IllegalArgumentException("Unsupported return type: " + returnType);
+		}
+	}
+
 }

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideServerCommands.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideServerCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,562 +36,546 @@ import glide.api.models.GlideString;
  */
 public class ValkeyGlideServerCommands implements ValkeyServerCommands {
 
-    private final ValkeyGlideConnection connection;
+	private final ValkeyGlideConnection connection;
 
-    /**
-     * Creates a new {@link ValkeyGlideServerCommands}.
-     *
-     * @param connection must not be {@literal null}.
-     */
-    public ValkeyGlideServerCommands(ValkeyGlideConnection connection) {
-        Assert.notNull(connection, "Connection must not be null!");
-        this.connection = connection;
-    }
+	/**
+	 * Creates a new {@link ValkeyGlideServerCommands}.
+	 * @param connection must not be {@literal null}.
+	 */
+	public ValkeyGlideServerCommands(ValkeyGlideConnection connection) {
+		Assert.notNull(connection, "Connection must not be null!");
+		this.connection = connection;
+	}
 
-    @Override
-    public void bgReWriteAof() {
-        try {
-            connection.execute("BGREWRITEAOF",
-                glideResult -> glideResult);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	@Override
+	public void bgReWriteAof() {
+		try {
+			connection.execute("BGREWRITEAOF", glideResult -> glideResult);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    @Override
-    public void bgSave() {
-        try {
-            connection.execute("BGSAVE",
-                glideResult -> glideResult);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	@Override
+	public void bgSave() {
+		try {
+			connection.execute("BGSAVE", glideResult -> glideResult);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    @Override
-    @Nullable
-    public Long lastSave() {
-        try {
-            return connection.execute("LASTSAVE",
-                (Long glideResult) -> glideResult);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	@Override
+	@Nullable public Long lastSave() {
+		try {
+			return connection.execute("LASTSAVE", (Long glideResult) -> glideResult);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    @Override
-    public void save() {
-        try {
-            connection.execute("SAVE",
-                glideResult -> glideResult); // Return the "OK" response for pipeline/transaction modes
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	@Override
+	public void save() {
+		try {
+			connection.execute("SAVE", glideResult -> glideResult); // Return the "OK"
+																	// response for
+																	// pipeline/transaction
+																	// modes
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    @Override
-    @Nullable
-    public Long dbSize() {
-        try {
-            return connection.execute("DBSIZE",
-                (Long glideResult) -> glideResult);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	@Override
+	@Nullable public Long dbSize() {
+		try {
+			return connection.execute("DBSIZE", (Long glideResult) -> glideResult);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    @Override
-    public void flushDb() {
-        try {
-            connection.execute("FLUSHDB",
-                glideResult -> glideResult);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	@Override
+	public void flushDb() {
+		try {
+			connection.execute("FLUSHDB", glideResult -> glideResult);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    @Override
-    public void flushDb(FlushOption option) {
-        Assert.notNull(option, "FlushOption must not be null");
-        
-        try {
-            connection.execute("FLUSHDB",
-                glideResult -> glideResult,
-                option.name());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	@Override
+	public void flushDb(FlushOption option) {
+		Assert.notNull(option, "FlushOption must not be null");
 
-    @Override
-    public void flushAll() {
-        try {
-            connection.execute("FLUSHALL",
-                glideResult -> glideResult);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		try {
+			connection.execute("FLUSHDB", glideResult -> glideResult, option.name());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    @Override
-    public void flushAll(FlushOption option) {
-        Assert.notNull(option, "FlushOption must not be null");
-        
-        try {
-            connection.execute("FLUSHALL",
-                glideResult -> glideResult,
-                option.name());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	@Override
+	public void flushAll() {
+		try {
+			connection.execute("FLUSHALL", glideResult -> glideResult);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    @Override
-    @Nullable
-    public Properties info() {
-        try {
-            return connection.execute("INFO",
-                (GlideString glideResult) -> {
-                    if (glideResult == null) {
-                        return null;
-                    }
-                    return parseInfoResponse(glideResult.toString());
-                });
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	@Override
+	public void flushAll(FlushOption option) {
+		Assert.notNull(option, "FlushOption must not be null");
 
-    @Override
-    @Nullable
-    public Properties info(String section) {
-        Assert.notNull(section, "Section must not be null");
-        
-        try {
-            return connection.execute("INFO",
-                (GlideString glideResult) -> {
-                    if (glideResult == null) {
-                        return null;
-                    }
-                    return parseInfoResponse(glideResult.toString());
-                },
-                section);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		try {
+			connection.execute("FLUSHALL", glideResult -> glideResult, option.name());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    /**
-     * Converts the command result to a String, handling both GlideString and other types.
-     * 
-     * @param result the result from the command execution
-     * @return String representation of the result
-     */
-    private String convertResultToString(Object result) {
-        if (result == null) {
-            return null;
-        }
-        
-        if (result instanceof GlideString) {
-            return ValkeyGlideConverters.toString(((GlideString) result).getBytes());
-        }
-        
-        Object convertedResult = ValkeyGlideConverters.defaultFromGlideResult(result);
-        if (convertedResult instanceof byte[]) {
-            return ValkeyGlideConverters.toString((byte[]) convertedResult);
-        } else if (convertedResult instanceof String) {
-            return (String) convertedResult;
-        } else if (convertedResult == null) {
-            return null;
-        } else {
-            return convertedResult.toString();
-        }
-    }
+	@Override
+	@Nullable public Properties info() {
+		try {
+			return connection.execute("INFO", (GlideString glideResult) -> {
+				if (glideResult == null) {
+					return null;
+				}
+				return parseInfoResponse(glideResult.toString());
+			});
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    /**
-     * Parses the INFO command response string into Properties.
-     * 
-     * @param infoResponse the response from the INFO command
-     * @return Properties containing the parsed key-value pairs
-     */
-    private Properties parseInfoResponse(String infoResponse) {
-        Properties properties = new Properties();
-        
-        if (infoResponse == null) {
-            return properties;
-        }
-        
-        String[] lines = infoResponse.split("\r?\n");
-        
-        for (String line : lines) {
-            line = line.trim();
-            
-            // Skip empty lines and comments (lines starting with #)
-            if (line.isEmpty() || line.startsWith("#")) {
-                continue;
-            }
-            
-            // Parse key:value pairs
-            int colonIndex = line.indexOf(':');
-            if (colonIndex > 0 && colonIndex < line.length() - 1) {
-                String key = line.substring(0, colonIndex).trim();
-                String value = line.substring(colonIndex + 1).trim();
-                properties.setProperty(key, value);
-            }
-        }
-        
-        return properties;
-    }
+	@Override
+	@Nullable public Properties info(String section) {
+		Assert.notNull(section, "Section must not be null");
 
-    /**
-     * Parses the CONFIG GET command response into Properties.
-     * 
-     * @param result the result from the CONFIG GET command
-     * @return Properties containing the parsed key-value pairs
-     */
-    private Properties parseConfigResponse(Object result) {
-        Properties properties = new Properties();
-        
-        if (result == null) {
-            return properties;
-        }
-        
-        // CONFIG GET can return either a Map or a List depending on the implementation
-        if (result instanceof java.util.Map) {
-            java.util.Map<?, ?> map = (java.util.Map<?, ?>) result;
-            for (java.util.Map.Entry<?, ?> entry : map.entrySet()) {
-                String key = convertResultToString(ValkeyGlideConverters.defaultFromGlideResult(entry.getKey()));
-                String value = convertResultToString(ValkeyGlideConverters.defaultFromGlideResult(entry.getValue()));
-                if (key != null && value != null) {
-                    properties.setProperty(key, value);
-                }
-            }
-        } else {
-            List<Object> list = convertToList(result);
-            
-            // CONFIG GET returns key-value pairs as a flat list
-            for (int i = 0; i < list.size(); i += 2) {
-                if (i + 1 < list.size()) {
-                    String key = convertResultToString(ValkeyGlideConverters.defaultFromGlideResult(list.get(i)));
-                    String value = convertResultToString(ValkeyGlideConverters.defaultFromGlideResult(list.get(i + 1)));
-                    if (key != null && value != null) {
-                        properties.setProperty(key, value);
-                    }
-                }
-            }
-        }
-        
-        return properties;
-    }
+		try {
+			return connection.execute("INFO", (GlideString glideResult) -> {
+				if (glideResult == null) {
+					return null;
+				}
+				return parseInfoResponse(glideResult.toString());
+			}, section);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    /**
-     * Parses the TIME command response into a Long value in the specified TimeUnit.
-     * 
-     * @param result the result from the TIME command (Object[] from Glide)
-     * @param timeUnit the desired time unit
-     * @return the time in the specified unit
-     */
-    private Long parseTimeResponse(Object[] result, TimeUnit timeUnit) {
-        if (result == null || result.length < 2) {
-            return null;
-        }
-        
-        // TIME returns [seconds, microseconds] as Object[]
-        Object secondsObj = ValkeyGlideConverters.defaultFromGlideResult(result[0]);
-        Object microsecondsObj = ValkeyGlideConverters.defaultFromGlideResult(result[1]);
-        
-        long seconds = parseNumber(secondsObj).longValue();
-        long microseconds = parseNumber(microsecondsObj).longValue();
-        
-        // Convert to milliseconds first
-        long milliseconds = seconds * 1000 + microseconds / 1000;
-        
-        return timeUnit.convert(milliseconds, TimeUnit.MILLISECONDS);
-    }
+	/**
+	 * Converts the command result to a String, handling both GlideString and other types.
+	 * @param result the result from the command execution
+	 * @return String representation of the result
+	 */
+	private String convertResultToString(Object result) {
+		if (result == null) {
+			return null;
+		}
 
-    /**
-     * Converts an object to a List.
-     * 
-     * @param obj the object to convert
-     * @return the converted list
-     */
-    @SuppressWarnings("unchecked")
-    private List<Object> convertToList(Object obj) {
-        if (obj instanceof List) {
-            return (List<Object>) obj;
-        } else if (obj instanceof Object[]) {
-            Object[] array = (Object[]) obj;
-            List<Object> list = new java.util.ArrayList<>(array.length);
-            for (Object item : array) {
-                list.add(item);
-            }
-            return list;
-        } else {
-            throw new IllegalArgumentException("Cannot convert " + obj.getClass() + " to List");
-        }
-    }
+		if (result instanceof GlideString) {
+			return ValkeyGlideConverters.toString(((GlideString) result).getBytes());
+		}
 
-    /**
-     * Parses a number from an object.
-     * 
-     * @param obj the object to parse
-     * @return the parsed number
-     */
-    private Number parseNumber(Object obj) {
-        if (obj instanceof Number) {
-            return (Number) obj;
-        } else if (obj instanceof String) {
-            return Long.parseLong((String) obj);
-        } else if (obj instanceof byte[]) {
-            return Long.parseLong(new String((byte[]) obj));
-        } else {
-            throw new IllegalArgumentException("Cannot parse number from " + obj.getClass());
-        }
-    }
+		Object convertedResult = ValkeyGlideConverters.defaultFromGlideResult(result);
+		if (convertedResult instanceof byte[]) {
+			return ValkeyGlideConverters.toString((byte[]) convertedResult);
+		}
+		else if (convertedResult instanceof String) {
+			return (String) convertedResult;
+		}
+		else if (convertedResult == null) {
+			return null;
+		}
+		else {
+			return convertedResult.toString();
+		}
+	}
 
-    @Override
-    public void shutdown() {
-        try {
-            connection.execute("SHUTDOWN",
-                glideResult -> glideResult);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	/**
+	 * Parses the INFO command response string into Properties.
+	 * @param infoResponse the response from the INFO command
+	 * @return Properties containing the parsed key-value pairs
+	 */
+	private Properties parseInfoResponse(String infoResponse) {
+		Properties properties = new Properties();
 
-    @Override
-    public void shutdown(ShutdownOption option) {
-        Assert.notNull(option, "ShutdownOption must not be null");
-        
-        try {
-            connection.execute("SHUTDOWN",
-                glideResult -> glideResult,
-                option.name());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		if (infoResponse == null) {
+			return properties;
+		}
 
-    @Override
-    @Nullable
-    public Properties getConfig(String pattern) {
-        Assert.notNull(pattern, "Pattern must not be null");
-        
-        try {
-            return connection.execute("CONFIG",
-                (Object glideResult) -> parseConfigResponse(glideResult),
-        "GET", pattern);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		String[] lines = infoResponse.split("\r?\n");
 
-    @Override
-    public void setConfig(String param, String value) {
-        Assert.notNull(param, "Parameter must not be null");
-        Assert.notNull(value, "Value must not be null");
-        
-        try {
-            connection.execute("CONFIG",
-                glideResult -> glideResult,
-        "SET", param, value);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		for (String line : lines) {
+			line = line.trim();
 
-    @Override
-    public void resetConfigStats() {
-        try {
-            connection.execute("CONFIG",
-                glideResult -> glideResult,
-        "RESETSTAT");
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+			// Skip empty lines and comments (lines starting with #)
+			if (line.isEmpty() || line.startsWith("#")) {
+				continue;
+			}
 
-    @Override
-    public void rewriteConfig() {
-        try {
-            connection.execute("CONFIG",
-                glideResult -> glideResult,
-        "REWRITE");
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+			// Parse key:value pairs
+			int colonIndex = line.indexOf(':');
+			if (colonIndex > 0 && colonIndex < line.length() - 1) {
+				String key = line.substring(0, colonIndex).trim();
+				String value = line.substring(colonIndex + 1).trim();
+				properties.setProperty(key, value);
+			}
+		}
 
-    @Override
-    @Nullable
-    public Long time(TimeUnit timeUnit) {
-        Assert.notNull(timeUnit, "TimeUnit must not be null");
-        
-        try {
-            return connection.execute("TIME",
-                (Object[] glideResult) -> parseTimeResponse(glideResult, timeUnit));
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		return properties;
+	}
 
-    @Override
-    public void killClient(String host, int port) {
-        Assert.notNull(host, "Host must not be null");
-        
-        try {
-            connection.execute("CLIENT",
-                glideResult -> glideResult,
-        "KILL", host + ":" + port);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	/**
+	 * Parses the CONFIG GET command response into Properties.
+	 * @param result the result from the CONFIG GET command
+	 * @return Properties containing the parsed key-value pairs
+	 */
+	private Properties parseConfigResponse(Object result) {
+		Properties properties = new Properties();
 
-    @Override
-    public void setClientName(byte[] name) {
-        Assert.notNull(name, "Name must not be null");
-        
-        try {
-            connection.execute("CLIENT",
-                glideResult -> glideResult,
-        "SETNAME", name);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		if (result == null) {
+			return properties;
+		}
 
-    @Override
-    @Nullable
-    public String getClientName() {
-        try {
-            return connection.execute("CLIENT",
-                (GlideString glideResult) -> glideResult != null ? glideResult.toString() : null,
-        "GETNAME");
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		// CONFIG GET can return either a Map or a List depending on the implementation
+		if (result instanceof java.util.Map) {
+			java.util.Map<?, ?> map = (java.util.Map<?, ?>) result;
+			for (java.util.Map.Entry<?, ?> entry : map.entrySet()) {
+				String key = convertResultToString(ValkeyGlideConverters.defaultFromGlideResult(entry.getKey()));
+				String value = convertResultToString(ValkeyGlideConverters.defaultFromGlideResult(entry.getValue()));
+				if (key != null && value != null) {
+					properties.setProperty(key, value);
+				}
+			}
+		}
+		else {
+			List<Object> list = convertToList(result);
 
-    @Override
-    @Nullable
-    public List<ValkeyClientInfo> getClientList() {
-        try {
-            return connection.execute("CLIENT",
-                (GlideString glideResult) -> glideResult != null ? parseClientListResponse(glideResult.toString()) : null,
-        "LIST");
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+			// CONFIG GET returns key-value pairs as a flat list
+			for (int i = 0; i < list.size(); i += 2) {
+				if (i + 1 < list.size()) {
+					String key = convertResultToString(ValkeyGlideConverters.defaultFromGlideResult(list.get(i)));
+					String value = convertResultToString(ValkeyGlideConverters.defaultFromGlideResult(list.get(i + 1)));
+					if (key != null && value != null) {
+						properties.setProperty(key, value);
+					}
+				}
+			}
+		}
 
-    @Override
-    public void replicaOf(String host, int port) {
-        Assert.notNull(host, "Host must not be null");
-        
-        try {
-            connection.execute("REPLICAOF",
-                glideResult -> glideResult,
-                host, String.valueOf(port));
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		return properties;
+	}
 
-    @Override
-    public void replicaOfNoOne() {
-        try {
-            connection.execute("REPLICAOF",
-                glideResult -> glideResult,
-        "NO", "ONE");
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	/**
+	 * Parses the TIME command response into a Long value in the specified TimeUnit.
+	 * @param result the result from the TIME command (Object[] from Glide)
+	 * @param timeUnit the desired time unit
+	 * @return the time in the specified unit
+	 */
+	private Long parseTimeResponse(Object[] result, TimeUnit timeUnit) {
+		if (result == null || result.length < 2) {
+			return null;
+		}
 
-    @Override
-    public void migrate(byte[] key, ValkeyNode target, int dbIndex, @Nullable MigrateOption option) {
-        migrate(key, target, dbIndex, option, 0);
-    }
+		// TIME returns [seconds, microseconds] as Object[]
+		Object secondsObj = ValkeyGlideConverters.defaultFromGlideResult(result[0]);
+		Object microsecondsObj = ValkeyGlideConverters.defaultFromGlideResult(result[1]);
 
-    @Override
-    public void migrate(byte[] key, ValkeyNode target, int dbIndex, @Nullable MigrateOption option, long timeout) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(target, "Target must not be null");
-        
-        try {
-            List<Object> args = new ArrayList<>();
-            args.add(target.getHost());
-            args.add(String.valueOf(target.getPort()));
-            args.add(key);
-            args.add(String.valueOf(dbIndex));
-            args.add(String.valueOf(timeout));
-            
-            if (option != null) {
-                args.add(option.name());
-            }
-            
-            connection.execute("MIGRATE",
-                glideResult -> glideResult,
-                args.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		long seconds = parseNumber(secondsObj).longValue();
+		long microseconds = parseNumber(microsecondsObj).longValue();
 
-    /**
-     * Parses the CLIENT LIST command response into a list of ValkeyClientInfo objects.
-     * 
-     * @param clientListResponse the response from the CLIENT LIST command
-     * @return List of ValkeyClientInfo objects
-     */
-    private List<ValkeyClientInfo> parseClientListResponse(String clientListResponse) {
-        List<ValkeyClientInfo> clientInfos = new ArrayList<>();
-        
-        if (clientListResponse == null || clientListResponse.isEmpty()) {
-            return clientInfos;
-        }
-        
-        String[] lines = clientListResponse.split("\r?\n");
-        
-        for (String line : lines) {
-            line = line.trim();
-            
-            if (line.isEmpty()) {
-                continue;
-            }
-            
-            // Parse client info line into a ValkeyClientInfo object
-            ValkeyClientInfo clientInfo = parseClientInfoLine(line);
-            if (clientInfo != null) {
-                clientInfos.add(clientInfo);
-            }
-        }
-        
-        return clientInfos;
-    }
+		// Convert to milliseconds first
+		long milliseconds = seconds * 1000 + microseconds / 1000;
 
-    /**
-     * Parses a single client info line into a ValkeyClientInfo object.
-     * 
-     * @param line the client info line
-     * @return ValkeyClientInfo object or null if parsing fails
-     */
-    private ValkeyClientInfo parseClientInfoLine(String line) {
-        Properties properties = new Properties();
-        
-        // Parse space-separated key=value pairs
-        String[] parts = line.split("\\s+");
-        
-        for (String part : parts) {
-            int equalsIndex = part.indexOf('=');
-            if (equalsIndex > 0 && equalsIndex < part.length() - 1) {
-                String key = part.substring(0, equalsIndex).trim();
-                String value = part.substring(equalsIndex + 1).trim();
-                properties.setProperty(key, value);
-            }
-        }
-        
-        return new ValkeyClientInfo(properties);
-    }
+		return timeUnit.convert(milliseconds, TimeUnit.MILLISECONDS);
+	}
+
+	/**
+	 * Converts an object to a List.
+	 * @param obj the object to convert
+	 * @return the converted list
+	 */
+	@SuppressWarnings("unchecked")
+	private List<Object> convertToList(Object obj) {
+		if (obj instanceof List) {
+			return (List<Object>) obj;
+		}
+		else if (obj instanceof Object[]) {
+			Object[] array = (Object[]) obj;
+			List<Object> list = new java.util.ArrayList<>(array.length);
+			for (Object item : array) {
+				list.add(item);
+			}
+			return list;
+		}
+		else {
+			throw new IllegalArgumentException("Cannot convert " + obj.getClass() + " to List");
+		}
+	}
+
+	/**
+	 * Parses a number from an object.
+	 * @param obj the object to parse
+	 * @return the parsed number
+	 */
+	private Number parseNumber(Object obj) {
+		if (obj instanceof Number) {
+			return (Number) obj;
+		}
+		else if (obj instanceof String) {
+			return Long.parseLong((String) obj);
+		}
+		else if (obj instanceof byte[]) {
+			return Long.parseLong(new String((byte[]) obj));
+		}
+		else {
+			throw new IllegalArgumentException("Cannot parse number from " + obj.getClass());
+		}
+	}
+
+	@Override
+	public void shutdown() {
+		try {
+			connection.execute("SHUTDOWN", glideResult -> glideResult);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public void shutdown(ShutdownOption option) {
+		Assert.notNull(option, "ShutdownOption must not be null");
+
+		try {
+			connection.execute("SHUTDOWN", glideResult -> glideResult, option.name());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Properties getConfig(String pattern) {
+		Assert.notNull(pattern, "Pattern must not be null");
+
+		try {
+			return connection.execute("CONFIG", (Object glideResult) -> parseConfigResponse(glideResult), "GET",
+					pattern);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public void setConfig(String param, String value) {
+		Assert.notNull(param, "Parameter must not be null");
+		Assert.notNull(value, "Value must not be null");
+
+		try {
+			connection.execute("CONFIG", glideResult -> glideResult, "SET", param, value);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public void resetConfigStats() {
+		try {
+			connection.execute("CONFIG", glideResult -> glideResult, "RESETSTAT");
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public void rewriteConfig() {
+		try {
+			connection.execute("CONFIG", glideResult -> glideResult, "REWRITE");
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Long time(TimeUnit timeUnit) {
+		Assert.notNull(timeUnit, "TimeUnit must not be null");
+
+		try {
+			return connection.execute("TIME", (Object[] glideResult) -> parseTimeResponse(glideResult, timeUnit));
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public void killClient(String host, int port) {
+		Assert.notNull(host, "Host must not be null");
+
+		try {
+			connection.execute("CLIENT", glideResult -> glideResult, "KILL", host + ":" + port);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public void setClientName(byte[] name) {
+		Assert.notNull(name, "Name must not be null");
+
+		try {
+			connection.execute("CLIENT", glideResult -> glideResult, "SETNAME", name);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public String getClientName() {
+		try {
+			return connection.execute("CLIENT",
+					(GlideString glideResult) -> glideResult != null ? glideResult.toString() : null, "GETNAME");
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public List<ValkeyClientInfo> getClientList() {
+		try {
+			return connection.execute("CLIENT", (GlideString glideResult) -> glideResult != null
+					? parseClientListResponse(glideResult.toString()) : null, "LIST");
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public void replicaOf(String host, int port) {
+		Assert.notNull(host, "Host must not be null");
+
+		try {
+			connection.execute("REPLICAOF", glideResult -> glideResult, host, String.valueOf(port));
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public void replicaOfNoOne() {
+		try {
+			connection.execute("REPLICAOF", glideResult -> glideResult, "NO", "ONE");
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public void migrate(byte[] key, ValkeyNode target, int dbIndex, @Nullable MigrateOption option) {
+		migrate(key, target, dbIndex, option, 0);
+	}
+
+	@Override
+	public void migrate(byte[] key, ValkeyNode target, int dbIndex, @Nullable MigrateOption option, long timeout) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(target, "Target must not be null");
+
+		try {
+			List<Object> args = new ArrayList<>();
+			args.add(target.getHost());
+			args.add(String.valueOf(target.getPort()));
+			args.add(key);
+			args.add(String.valueOf(dbIndex));
+			args.add(String.valueOf(timeout));
+
+			if (option != null) {
+				args.add(option.name());
+			}
+
+			connection.execute("MIGRATE", glideResult -> glideResult, args.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	/**
+	 * Parses the CLIENT LIST command response into a list of ValkeyClientInfo objects.
+	 * @param clientListResponse the response from the CLIENT LIST command
+	 * @return List of ValkeyClientInfo objects
+	 */
+	private List<ValkeyClientInfo> parseClientListResponse(String clientListResponse) {
+		List<ValkeyClientInfo> clientInfos = new ArrayList<>();
+
+		if (clientListResponse == null || clientListResponse.isEmpty()) {
+			return clientInfos;
+		}
+
+		String[] lines = clientListResponse.split("\r?\n");
+
+		for (String line : lines) {
+			line = line.trim();
+
+			if (line.isEmpty()) {
+				continue;
+			}
+
+			// Parse client info line into a ValkeyClientInfo object
+			ValkeyClientInfo clientInfo = parseClientInfoLine(line);
+			if (clientInfo != null) {
+				clientInfos.add(clientInfo);
+			}
+		}
+
+		return clientInfos;
+	}
+
+	/**
+	 * Parses a single client info line into a ValkeyClientInfo object.
+	 * @param line the client info line
+	 * @return ValkeyClientInfo object or null if parsing fails
+	 */
+	private ValkeyClientInfo parseClientInfoLine(String line) {
+		Properties properties = new Properties();
+
+		// Parse space-separated key=value pairs
+		String[] parts = line.split("\\s+");
+
+		for (String part : parts) {
+			int equalsIndex = part.indexOf('=');
+			if (equalsIndex > 0 && equalsIndex < part.length() - 1) {
+				String key = part.substring(0, equalsIndex).trim();
+				String value = part.substring(equalsIndex + 1).trim();
+				properties.setProperty(key, value);
+			}
+		}
+
+		return new ValkeyClientInfo(properties);
+	}
+
 }

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideSetCommands.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideSetCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,469 +38,445 @@ import glide.api.models.GlideString;
  */
 public class ValkeyGlideSetCommands implements ValkeySetCommands {
 
-    private final ValkeyGlideConnection connection;
+	private final ValkeyGlideConnection connection;
 
-    /**
-     * Creates a new {@link ValkeyGlideSetCommands}.
-     *
-     * @param connection must not be {@literal null}.
-     */
-    public ValkeyGlideSetCommands(ValkeyGlideConnection connection) {
-        Assert.notNull(connection, "Connection must not be null!");
-        this.connection = connection;
-    }
+	/**
+	 * Creates a new {@link ValkeyGlideSetCommands}.
+	 * @param connection must not be {@literal null}.
+	 */
+	public ValkeyGlideSetCommands(ValkeyGlideConnection connection) {
+		Assert.notNull(connection, "Connection must not be null!");
+		this.connection = connection;
+	}
 
-    @Override
-    @Nullable
-    public Long sAdd(byte[] key, byte[]... values) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(values, "Values must not be null");
-        Assert.noNullElements(values, "Values must not contain null elements");
-        
-        try {
-            Object[] args = new Object[values.length + 1];
-            args[0] = key;
-            System.arraycopy(values, 0, args, 1, values.length);
-            
-            return connection.execute("SADD",
-                (Long glideResult) -> glideResult,
-                args);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	@Override
+	@Nullable public Long sAdd(byte[] key, byte[]... values) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(values, "Values must not be null");
+		Assert.noNullElements(values, "Values must not contain null elements");
 
-    @Override
-    @Nullable
-    public Long sRem(byte[] key, byte[]... values) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(values, "Values must not be null");
-        Assert.noNullElements(values, "Values must not contain null elements");
-        
-        try {
-            Object[] args = new Object[values.length + 1];
-            args[0] = key;
-            System.arraycopy(values, 0, args, 1, values.length);
-            
-            return connection.execute("SREM",
-                (Long glideResult) -> glideResult,
-                args);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		try {
+			Object[] args = new Object[values.length + 1];
+			args[0] = key;
+			System.arraycopy(values, 0, args, 1, values.length);
 
-    @Override
-    @Nullable
-    public byte[] sPop(byte[] key) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("SPOP",
-                (GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null,
-                key);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+			return connection.execute("SADD", (Long glideResult) -> glideResult, args);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    @Override
-    @Nullable
-    public List<byte[]> sPop(byte[] key, long count) {
-        Assert.notNull(key, "Key must not be null");
+	@Override
+	@Nullable public Long sRem(byte[] key, byte[]... values) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(values, "Values must not be null");
+		Assert.noNullElements(values, "Values must not contain null elements");
 
-        try {
-            return connection.execute("SPOP",
-                (HashSet<GlideString> glideResult) -> {
-                    if (glideResult == null) {
-                        return null;
-                    }
-                    List<byte[]> resultList = new ArrayList<>();
-                    for (GlideString gs : glideResult) {
-                        resultList.add(gs.getBytes());
-                    }
-                    return resultList;
-            },
-            key, count);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		try {
+			Object[] args = new Object[values.length + 1];
+			args[0] = key;
+			System.arraycopy(values, 0, args, 1, values.length);
 
-    @Override
-    @Nullable
-    public Boolean sMove(byte[] srcKey, byte[] destKey, byte[] value) {
-        Assert.notNull(srcKey, "Source key must not be null");
-        Assert.notNull(destKey, "Destination key must not be null");
-        Assert.notNull(value, "Value must not be null");
-        
-        try {
-            return connection.execute("SMOVE",
-                (Boolean glideResult) -> glideResult,
-                srcKey, destKey, value);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+			return connection.execute("SREM", (Long glideResult) -> glideResult, args);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    @Override
-    @Nullable
-    public Long sCard(byte[] key) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("SCARD",
-                (Long glideResult) -> glideResult,
-                key);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	@Override
+	@Nullable public byte[] sPop(byte[] key) {
+		Assert.notNull(key, "Key must not be null");
 
-    @Override
-    @Nullable
-    public Boolean sIsMember(byte[] key, byte[] value) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(value, "Value must not be null");
-        
-        try {
-            return connection.execute("SISMEMBER",
-                (Boolean glideResult) -> glideResult,
-                key, value);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		try {
+			return connection.execute("SPOP",
+					(GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null, key);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    @Override
-    @Nullable
-    public List<Boolean> sMIsMember(byte[] key, byte[]... values) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(values, "Values must not be null");
-        Assert.noNullElements(values, "Values must not contain null elements");
-        
-        try {
-            Object[] args = new Object[values.length + 1];
-            args[0] = key;
-            System.arraycopy(values, 0, args, 1, values.length);
-            
-            return connection.execute("SMISMEMBER",
-                (Object[] glideResult) -> ValkeyGlideConverters.toBooleansList(glideResult),
-                args);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	@Override
+	@Nullable public List<byte[]> sPop(byte[] key, long count) {
+		Assert.notNull(key, "Key must not be null");
 
-    @Override
-    @Nullable
-    public Set<byte[]> sDiff(byte[]... keys) {
-        Assert.notNull(keys, "Keys must not be null");
-        Assert.noNullElements(keys, "Keys must not contain null elements");
-        
-        try {
-            Object[] args = new Object[keys.length];
-            System.arraycopy(keys, 0, args, 0, keys.length);
-            return connection.execute("SDIFF",
-                (HashSet<GlideString> glideResult) -> {
-                    if (glideResult == null) {
-                        return null;
-                    }
-                    Set<byte[]> resultSet = new HashSet<>();
-                    for (GlideString gs : glideResult) {
-                        resultSet.add(gs.getBytes());
-                    }
-                    return resultSet;
-                },
-                args);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		try {
+			return connection.execute("SPOP", (HashSet<GlideString> glideResult) -> {
+				if (glideResult == null) {
+					return null;
+				}
+				List<byte[]> resultList = new ArrayList<>();
+				for (GlideString gs : glideResult) {
+					resultList.add(gs.getBytes());
+				}
+				return resultList;
+			}, key, count);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    @Override
-    @Nullable
-    public Long sDiffStore(byte[] destKey, byte[]... keys) {
-        Assert.notNull(destKey, "Destination key must not be null");
-        Assert.notNull(keys, "Keys must not be null");
-        Assert.noNullElements(keys, "Keys must not contain null elements");
-        
-        try {
-            Object[] args = new Object[keys.length + 1];
-            args[0] = destKey;
-            System.arraycopy(keys, 0, args, 1, keys.length);
-            
-            return connection.execute("SDIFFSTORE",
-                (Long glideResult) -> glideResult,
-                args);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	@Override
+	@Nullable public Boolean sMove(byte[] srcKey, byte[] destKey, byte[] value) {
+		Assert.notNull(srcKey, "Source key must not be null");
+		Assert.notNull(destKey, "Destination key must not be null");
+		Assert.notNull(value, "Value must not be null");
 
-    @Override
-    @Nullable
-    public Set<byte[]> sInter(byte[]... keys) {
-        Assert.notNull(keys, "Keys must not be null");
-        Assert.noNullElements(keys, "Keys must not contain null elements");
-        
-        try {
-            Object[] args = new Object[keys.length];
-            System.arraycopy(keys, 0, args, 0, keys.length);
-            return connection.execute("SINTER",
-                (HashSet<GlideString> glideResult) -> {
-                    if (glideResult == null) {
-                        return null;
-                    }
-                    Set<byte[]> resultSet = new HashSet<>();
-                    for (GlideString gs : glideResult) {
-                        resultSet.add(gs.getBytes());
-                    }
-                    return resultSet;
-                },
-                args);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		try {
+			return connection.execute("SMOVE", (Boolean glideResult) -> glideResult, srcKey, destKey, value);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    @Override
-    @Nullable
-    public Long sInterStore(byte[] destKey, byte[]... keys) {
-        Assert.notNull(destKey, "Destination key must not be null");
-        Assert.notNull(keys, "Keys must not be null");
-        Assert.noNullElements(keys, "Keys must not contain null elements");
-        
-        try {
-            Object[] args = new Object[keys.length + 1];
-            args[0] = destKey;
-            System.arraycopy(keys, 0, args, 1, keys.length);
-            
-            return connection.execute("SINTERSTORE",
-                (Long glideResult) -> glideResult,
-                args);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	@Override
+	@Nullable public Long sCard(byte[] key) {
+		Assert.notNull(key, "Key must not be null");
 
-    @Override
-    @Nullable
-    public Set<byte[]> sUnion(byte[]... keys) {
-        Assert.notNull(keys, "Keys must not be null");
-        Assert.noNullElements(keys, "Keys must not contain null elements");
-        
-        try {
-            Object[] args = new Object[keys.length];
-            System.arraycopy(keys, 0, args, 0, keys.length);
+		try {
+			return connection.execute("SCARD", (Long glideResult) -> glideResult, key);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-            return connection.execute("SUNION",
-                (HashSet<GlideString> glideResult) -> {
-                    if (glideResult == null) {
-                        return null;
-                    }
-                    Set<byte[]> resultSet = new HashSet<>();
-                    for (GlideString gs : glideResult) {
-                        resultSet.add(gs.getBytes());
-                    }
-                    return resultSet;
-                },
-                args);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	@Override
+	@Nullable public Boolean sIsMember(byte[] key, byte[] value) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(value, "Value must not be null");
 
-    @Override
-    @Nullable
-    public Long sUnionStore(byte[] destKey, byte[]... keys) {
-        Assert.notNull(destKey, "Destination key must not be null");
-        Assert.notNull(keys, "Keys must not be null");
-        Assert.noNullElements(keys, "Keys must not contain null elements");
-        
-        try {
-            Object[] args = new Object[keys.length + 1];
-            args[0] = destKey;
-            System.arraycopy(keys, 0, args, 1, keys.length);
-            
-            return connection.execute("SUNIONSTORE",
-                (Long glideResult) -> glideResult,
-                args);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		try {
+			return connection.execute("SISMEMBER", (Boolean glideResult) -> glideResult, key, value);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    @Override
-    @Nullable
-    public Set<byte[]> sMembers(byte[] key) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("SMEMBERS",
-                (HashSet<GlideString> glideResult) -> {
-                    if (glideResult == null) {
-                        return null;
-                    }
-                    Set<byte[]> resultSet = new HashSet<>();
-                    for (GlideString gs : glideResult) {
-                        resultSet.add(gs.getBytes());
-                    }
-                    return resultSet;
-                },
-                key);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	@Override
+	@Nullable public List<Boolean> sMIsMember(byte[] key, byte[]... values) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(values, "Values must not be null");
+		Assert.noNullElements(values, "Values must not contain null elements");
 
-    @Override
-    @Nullable
-    public byte[] sRandMember(byte[] key) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("SRANDMEMBER",
-                (GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null,
-                key);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+		try {
+			Object[] args = new Object[values.length + 1];
+			args[0] = key;
+			System.arraycopy(values, 0, args, 1, values.length);
 
-    @Override
-    @Nullable
-    public List<byte[]> sRandMember(byte[] key, long count) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("SRANDMEMBER",
-                (Object[] glideResult) -> ValkeyGlideConverters.toBytesList(glideResult),
-                key, count);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+			return connection.execute("SMISMEMBER",
+					(Object[] glideResult) -> ValkeyGlideConverters.toBooleansList(glideResult), args);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
 
-    @Override
-    public Cursor<byte[]> sScan(byte[] key, ScanOptions options) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(options, "ScanOptions must not be null");
-        
-        return new ValkeyGlideSetScanCursor(key, options, connection);
-    }
-    
-    /**
-     * Simple implementation of Cursor for SSCAN operation.
-     */
-    private static class ValkeyGlideSetScanCursor implements Cursor<byte[]> {
-        
-        private final byte[] key;
-        private final ScanOptions options;
-        private final ValkeyGlideConnection connection;
-        private long cursor = 0;
-        private List<byte[]> members = new ArrayList<>();
-        private int currentIndex = 0;
-        private boolean finished = false;
-        
-        public ValkeyGlideSetScanCursor(byte[] key, ScanOptions options, ValkeyGlideConnection connection) {
-            this.key = key;
-            this.options = options;
-            this.connection = connection;
-            scanNext();
-        }
-        
-        @Override
-        public boolean hasNext() {
-            if (currentIndex < members.size()) {
-                return true;
-            }
-            if (finished) {
-                return false;
-            }
-            scanNext();
-            return currentIndex < members.size();
-        }
-        
-        @Override
-        public byte[] next() {
-            if (!hasNext()) {
-                throw new java.util.NoSuchElementException();
-            }
-            return members.get(currentIndex++);
-        }
-        
-        private void scanNext() {
-            if (connection.isQueueing() || connection.isPipelined()) {
-                throw new InvalidDataAccessApiUsageException("'SSCAN' cannot be called in pipeline / transaction mode");
-            }
+	@Override
+	@Nullable public Set<byte[]> sDiff(byte[]... keys) {
+		Assert.notNull(keys, "Keys must not be null");
+		Assert.noNullElements(keys, "Keys must not contain null elements");
 
-            try {
-                List<Object> args = new ArrayList<>();
-                args.add(key);
-                args.add(String.valueOf(cursor));
-                
-                if (options.getPattern() != null) {
-                    args.add("MATCH");
-                    args.add(options.getPattern());
-                }
-                
-                if (options.getCount() != null) {
-                    args.add("COUNT");
-                    args.add(options.getCount());
-                }
-                
-                connection.execute("SSCAN",
-                    (Object[] glideResult) -> {
-                        if (glideResult == null) {
-                            return null;
-                        }
-                    
-                        // First element is the new cursor and is byte[], need to convert to String first
-                        GlideString cursorStr = (GlideString) glideResult[0];
-                        cursor = Long.parseLong(cursorStr.getString());
-                        if (cursor == 0) {
-                            finished = true;
-                        }
-                        
-                        // Reset members for this batch
-                        members.clear();
-                        currentIndex = 0;
-                        
-                        members.addAll(ValkeyGlideConverters.toBytesList((Object[]) glideResult[1]));
-                        return null; // We don't need to return anything from this mapper
-                    },
-                    args.toArray());
-            } catch (Exception ex) {
-                throw new ValkeyGlideExceptionConverter().convert(ex);
-            }
-        }
-        
-        @Override
-        public void close() {
-            // No resources to close for this implementation
-        }
-        
-        @Override
-        public boolean isClosed() {
-            return finished && currentIndex >= members.size();
-        }
-        
-        @Override
-        public long getCursorId() {
-            return cursor;
-        }
-        
-        @Override
-        public long getPosition() {
-            return currentIndex;
-        }
-        
-        @Override
-        public CursorId getId() {
-            return CursorId.of(cursor);
-        }
-    }
+		try {
+			Object[] args = new Object[keys.length];
+			System.arraycopy(keys, 0, args, 0, keys.length);
+			return connection.execute("SDIFF", (HashSet<GlideString> glideResult) -> {
+				if (glideResult == null) {
+					return null;
+				}
+				Set<byte[]> resultSet = new HashSet<>();
+				for (GlideString gs : glideResult) {
+					resultSet.add(gs.getBytes());
+				}
+				return resultSet;
+			}, args);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Long sDiffStore(byte[] destKey, byte[]... keys) {
+		Assert.notNull(destKey, "Destination key must not be null");
+		Assert.notNull(keys, "Keys must not be null");
+		Assert.noNullElements(keys, "Keys must not contain null elements");
+
+		try {
+			Object[] args = new Object[keys.length + 1];
+			args[0] = destKey;
+			System.arraycopy(keys, 0, args, 1, keys.length);
+
+			return connection.execute("SDIFFSTORE", (Long glideResult) -> glideResult, args);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Set<byte[]> sInter(byte[]... keys) {
+		Assert.notNull(keys, "Keys must not be null");
+		Assert.noNullElements(keys, "Keys must not contain null elements");
+
+		try {
+			Object[] args = new Object[keys.length];
+			System.arraycopy(keys, 0, args, 0, keys.length);
+			return connection.execute("SINTER", (HashSet<GlideString> glideResult) -> {
+				if (glideResult == null) {
+					return null;
+				}
+				Set<byte[]> resultSet = new HashSet<>();
+				for (GlideString gs : glideResult) {
+					resultSet.add(gs.getBytes());
+				}
+				return resultSet;
+			}, args);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Long sInterStore(byte[] destKey, byte[]... keys) {
+		Assert.notNull(destKey, "Destination key must not be null");
+		Assert.notNull(keys, "Keys must not be null");
+		Assert.noNullElements(keys, "Keys must not contain null elements");
+
+		try {
+			Object[] args = new Object[keys.length + 1];
+			args[0] = destKey;
+			System.arraycopy(keys, 0, args, 1, keys.length);
+
+			return connection.execute("SINTERSTORE", (Long glideResult) -> glideResult, args);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Set<byte[]> sUnion(byte[]... keys) {
+		Assert.notNull(keys, "Keys must not be null");
+		Assert.noNullElements(keys, "Keys must not contain null elements");
+
+		try {
+			Object[] args = new Object[keys.length];
+			System.arraycopy(keys, 0, args, 0, keys.length);
+
+			return connection.execute("SUNION", (HashSet<GlideString> glideResult) -> {
+				if (glideResult == null) {
+					return null;
+				}
+				Set<byte[]> resultSet = new HashSet<>();
+				for (GlideString gs : glideResult) {
+					resultSet.add(gs.getBytes());
+				}
+				return resultSet;
+			}, args);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Long sUnionStore(byte[] destKey, byte[]... keys) {
+		Assert.notNull(destKey, "Destination key must not be null");
+		Assert.notNull(keys, "Keys must not be null");
+		Assert.noNullElements(keys, "Keys must not contain null elements");
+
+		try {
+			Object[] args = new Object[keys.length + 1];
+			args[0] = destKey;
+			System.arraycopy(keys, 0, args, 1, keys.length);
+
+			return connection.execute("SUNIONSTORE", (Long glideResult) -> glideResult, args);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Set<byte[]> sMembers(byte[] key) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("SMEMBERS", (HashSet<GlideString> glideResult) -> {
+				if (glideResult == null) {
+					return null;
+				}
+				Set<byte[]> resultSet = new HashSet<>();
+				for (GlideString gs : glideResult) {
+					resultSet.add(gs.getBytes());
+				}
+				return resultSet;
+			}, key);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public byte[] sRandMember(byte[] key) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("SRANDMEMBER",
+					(GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null, key);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public List<byte[]> sRandMember(byte[] key, long count) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("SRANDMEMBER",
+					(Object[] glideResult) -> ValkeyGlideConverters.toBytesList(glideResult), key, count);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public Cursor<byte[]> sScan(byte[] key, ScanOptions options) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(options, "ScanOptions must not be null");
+
+		return new ValkeyGlideSetScanCursor(key, options, connection);
+	}
+
+	/**
+	 * Simple implementation of Cursor for SSCAN operation.
+	 */
+	private static class ValkeyGlideSetScanCursor implements Cursor<byte[]> {
+
+		private final byte[] key;
+
+		private final ScanOptions options;
+
+		private final ValkeyGlideConnection connection;
+
+		private long cursor = 0;
+
+		private List<byte[]> members = new ArrayList<>();
+
+		private int currentIndex = 0;
+
+		private boolean finished = false;
+
+		public ValkeyGlideSetScanCursor(byte[] key, ScanOptions options, ValkeyGlideConnection connection) {
+			this.key = key;
+			this.options = options;
+			this.connection = connection;
+			scanNext();
+		}
+
+		@Override
+		public boolean hasNext() {
+			if (currentIndex < members.size()) {
+				return true;
+			}
+			if (finished) {
+				return false;
+			}
+			scanNext();
+			return currentIndex < members.size();
+		}
+
+		@Override
+		public byte[] next() {
+			if (!hasNext()) {
+				throw new java.util.NoSuchElementException();
+			}
+			return members.get(currentIndex++);
+		}
+
+		private void scanNext() {
+			if (connection.isQueueing() || connection.isPipelined()) {
+				throw new InvalidDataAccessApiUsageException("'SSCAN' cannot be called in pipeline / transaction mode");
+			}
+
+			try {
+				List<Object> args = new ArrayList<>();
+				args.add(key);
+				args.add(String.valueOf(cursor));
+
+				if (options.getPattern() != null) {
+					args.add("MATCH");
+					args.add(options.getPattern());
+				}
+
+				if (options.getCount() != null) {
+					args.add("COUNT");
+					args.add(options.getCount());
+				}
+
+				connection.execute("SSCAN", (Object[] glideResult) -> {
+					if (glideResult == null) {
+						return null;
+					}
+
+					// First element is the new cursor and is byte[], need to convert to
+					// String first
+					GlideString cursorStr = (GlideString) glideResult[0];
+					cursor = Long.parseLong(cursorStr.getString());
+					if (cursor == 0) {
+						finished = true;
+					}
+
+					// Reset members for this batch
+					members.clear();
+					currentIndex = 0;
+
+					members.addAll(ValkeyGlideConverters.toBytesList((Object[]) glideResult[1]));
+					return null; // We don't need to return anything from this mapper
+				}, args.toArray());
+			}
+			catch (Exception ex) {
+				throw new ValkeyGlideExceptionConverter().convert(ex);
+			}
+		}
+
+		@Override
+		public void close() {
+			// No resources to close for this implementation
+		}
+
+		@Override
+		public boolean isClosed() {
+			return finished && currentIndex >= members.size();
+		}
+
+		@Override
+		public long getCursorId() {
+			return cursor;
+		}
+
+		@Override
+		public long getPosition() {
+			return currentIndex;
+		}
+
+		@Override
+		public CursorId getId() {
+			return CursorId.of(cursor);
+		}
+
+	}
 
 	@Override
 	public Long sInterCard(byte[]... keys) {
@@ -512,11 +488,11 @@ public class ValkeyGlideSetCommands implements ValkeySetCommands {
 			for (byte[] key : keys) {
 				args.add(key);
 			}
-			return connection.execute("SINTERCARD",
-				(Long glideResult) -> glideResult,
-				args.toArray());
-		} catch (Exception ex) {
+			return connection.execute("SINTERCARD", (Long glideResult) -> glideResult, args.toArray());
+		}
+		catch (Exception ex) {
 			throw new ValkeyGlideExceptionConverter().convert(ex);
 		}
 	}
+
 }

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideStreamCommands.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideStreamCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,980 +42,1013 @@ import glide.api.models.GlideString;
  */
 public class ValkeyGlideStreamCommands implements ValkeyStreamCommands {
 
-    private final ValkeyGlideConnection connection;
-
-    /**
-     * Creates a new {@link ValkeyGlideStreamCommands}.
-     *
-     * @param connection must not be {@literal null}.
-     */
-    public ValkeyGlideStreamCommands(ValkeyGlideConnection connection) {
-        Assert.notNull(connection, "Connection must not be null!");
-        this.connection = connection;
-    }
-
-    @Override
-    public Long xAck(byte[] key, String group, RecordId... recordIds) {
-        Assert.notNull(key, "Key must not be null!");
-        Assert.notNull(group, "Group must not be null!");
-        Assert.notNull(recordIds, "Record IDs must not be null!");
-
-        try {
-            Object[] params = new Object[recordIds.length + 2];
-            params[0] = key;
-            params[1] = group;
-
-            for (int i = 0; i < recordIds.length; i++) {
-                params[i + 2] = recordIds[i].getValue();
-            }
-
-            return connection.execute("XACK",
-                (Long glideResult) -> glideResult,
-                params);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public RecordId xAdd(MapRecord<byte[], byte[], byte[]> record) {
-        return xAdd(record, XAddOptions.none());
-    }
-
-    @Override
-    public RecordId xAdd(MapRecord<byte[], byte[], byte[]> record, XAddOptions options) {
-        Assert.notNull(record, "Record must not be null!");
-        Assert.notNull(options, "Options must not be null!");
-
-        byte[] key = record.getStream();
-        RecordId recordId = record.getId();
-        Map<byte[], byte[]> body = record.getValue();
-
-        Assert.notNull(key, "Key must not be null!");
-        Assert.notEmpty(body, "Body must not be empty!");
-
-        try {
-            List<Object> params = new ArrayList<>(2 + body.size() * 2 + 4);
-            params.add(key);
-
-            if (options.isNoMkStream()) {
-                params.add("NOMKSTREAM");
-            }
-
-            if (options.hasMaxlen()) {
-                params.add("MAXLEN");
-                if (options.isApproximateTrimming()) {
-                    params.add("~");
-                }
-                params.add(String.valueOf(options.getMaxlen()));
-            }
-
-            if (options.hasMinId()) {
-                params.add("MINID");
-                if (options.isApproximateTrimming()) {
-                    params.add("~");
-                }
-                params.add(options.getMinId().getValue());
-            }
-
-            // Add LIMIT if present (valid with approximate trimming)
-            if (options.getTrimOptions() != null && options.getTrimOptions().hasLimit()) {
-                params.add("LIMIT");
-                params.add(String.valueOf(options.getTrimOptions().getLimit()));
-            }
-
-            if (recordId == null || recordId.equals(RecordId.autoGenerate())) {
-                params.add("*");
-            } else {
-                params.add(recordId.getValue());
-            }
-
-            for (Map.Entry<byte[], byte[]> entry : body.entrySet()) {
-                params.add(entry.getKey());
-                params.add(entry.getValue());
-            }
-
-            return connection.execute("XADD",
-                (GlideString glideResult) -> glideResult != null ? RecordId.of(glideResult.toString()) : null,
-                params.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public List<RecordId> xClaimJustId(byte[] key, String group, String newOwner, XClaimOptions options) {
-        Assert.notNull(key, "Key must not be null!");
-        Assert.hasText(group, "Group must not be null or empty!");
-        Assert.hasText(newOwner, "New owner must not be null or empty!");
-        Assert.notNull(options, "Options must not be null!");
-
-        try {
-            List<Object> args = buildXClaimArgs(key, group, newOwner, options);
-            args.add("JUSTID");
-            
-            return connection.execute("XCLAIM",
-                (Object[] glideResult) -> {
-                    if (glideResult == null) {
-                        return Collections.emptyList();
-                    }
-                    List<RecordId> recordIds = new ArrayList<>(glideResult.length);
-                    for (Object item : glideResult) {
-                        recordIds.add(RecordId.of(((GlideString) item).toString()));
-                    }
-                    return recordIds;
-                },
-                args.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public List<ByteRecord> xClaim(byte[] key, String group, String newOwner, XClaimOptions options) {
-        Assert.notNull(key, "Key must not be null!");
-        Assert.hasText(group, "Group must not be null or empty!");
-        Assert.hasText(newOwner, "New owner must not be null or empty!");
-        Assert.notNull(options, "Options must not be null!");
-
-        try {
-            List<Object> args = buildXClaimArgs(key, group, newOwner, options);
-            
-            return connection.execute("XCLAIM",
-                (Map<?, ?> glideResult) -> {
-                    return parseByteRecords(glideResult, key, false);
-                },
-                args.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public Long xDel(byte[] key, RecordId... recordIds) {
-        Assert.notNull(key, "Key must not be null!");
-        Assert.notNull(recordIds, "Record IDs must not be null!");
-        
-        try {
-            Object[] params = new Object[recordIds.length + 1];
-            params[0] = key;
-            
-            for (int i = 0; i < recordIds.length; i++) {
-                params[i + 1] = recordIds[i].getValue();
-            }
-            
-            return connection.execute("XDEL",
-                (Long glideResult) -> glideResult,
-                params);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public String xGroupCreate(byte[] key, String groupName, ReadOffset readOffset) {
-        return xGroupCreate(key, groupName, readOffset, false);
-    }
-
-    @Override
-    public String xGroupCreate(byte[] key, String groupName, ReadOffset readOffset, boolean makeStream) {
-        Assert.notNull(key, "Key must not be null!");
-        Assert.hasText(groupName, "Group name must not be null or empty!");
-        Assert.notNull(readOffset, "ReadOffset must not be null!");
-
-        try {
-            List<Object> args = new ArrayList<>(6);
-            args.add("CREATE");
-            args.add(key);
-            args.add(groupName);
-            args.add(readOffset.getOffset());
-            
-            if (makeStream) {
-                args.add("MKSTREAM");
-            }
-
-            return connection.execute("XGROUP",
-                (String glideResult) -> glideResult,
-                args.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-    
-    @Override
-    public Boolean xGroupDelConsumer(byte[] key, Consumer consumer) {
-        Assert.notNull(key, "Key must not be null!");
-        Assert.notNull(consumer, "Consumer must not be null!");
-
-        try {
-            return connection.execute("XGROUP",
-                (Long glideResult) -> glideResult != null ? glideResult > 0 : null,
-            "DELCONSUMER", key, consumer.getGroup(), consumer.getName());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public Boolean xGroupDestroy(byte[] key, String groupName) {
-        Assert.notNull(key, "Key must not be null!");
-        Assert.hasText(groupName, "Group name must not be null or empty!");
-
-        try {
-            return connection.execute("XGROUP",
-                (Boolean glideResult) -> glideResult,
-                "DESTROY", key, groupName);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public XInfoStream xInfo(byte[] key) {
-        Assert.notNull(key, "Key must not be null!");
-
-        try {
-            return connection.execute("XINFO",
-                (Map<?, ?> glideResult) -> {
-                    if (glideResult == null) {
-                        return null;
-                    }
-
-                    // Convert the result to a List<Object>
-                    // XInfoStream.fromList() expects a List<Object> with alternating keys and values
-                    // Valkey-Glide returns a Map, so we need to convert it
-                    // first-entry and last-entry are special cases with nested structures and need to be converted to Map
-                    List<Object> list = new ArrayList<>(glideResult.size() * 2);
-
-                    for (Map.Entry<?, ?> entry : glideResult.entrySet()) {
-                        list.add(entry.getKey().toString());
-                        if (entry.getKey().toString().equals("first-entry") || entry.getKey().toString().equals("last-entry")) {
-                            Object[] entryObjects = (Object[]) entry.getValue();
-                            Map<byte[], Map<byte[], byte[]>> entryMap = new HashMap<>();
-                            for (int i = 0; i < entryObjects.length; i += 2) {
-                                byte[] recordIdString = ((GlideString) entryObjects[i]).getBytes();
-                                Map<byte[], byte[]> fields = new HashMap<>();
-                                Object[] fieldsArr = (Object[]) entryObjects[i + 1];
-                                for (int j = 0; j < fieldsArr.length; j += 2) {
-                                    byte[] field = ((GlideString) fieldsArr[j]).getBytes();
-                                    byte[] value = ((GlideString) fieldsArr[j + 1]).getBytes();
-                                    fields.put(field, value);
-                                }
-                                entryMap.put(recordIdString, fields);
-                            }
-                            list.add(entryMap);
-                        } else {
-                            list.add(ValkeyGlideConverters.defaultFromGlideResult(entry.getValue()));
-                        }
-                    }
-                    return XInfoStream.fromList(list);
-                },
-                "STREAM", key);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public XInfoGroups xInfoGroups(byte[] key) {
-        Assert.notNull(key, "Key must not be null!");
-
-        try {
-            return connection.execute("XINFO",
-                (Object[] glideResult) -> {
-                    if (glideResult == null) {
-                        return null;
-                    }
-
-                    // XInfoGroups.fromList expects a list where each group is represented as a separate List
-                    // Format: [group1List, group2List, ...] where each groupList is [key1, value1, key2, value2, ...]
-                    List<Object> groupsList = new ArrayList<>(glideResult.length);
-
-                    for (Object groupInfo : glideResult) {
-                        Map<?, ?> groupMap = (Map<?, ?>) groupInfo;
-                        List<Object> singleGroupList = new ArrayList<>(groupMap.size() * 2);
-                        for (Map.Entry<?, ?> entry : groupMap.entrySet()) {
-                            singleGroupList.add(entry.getKey().toString());
-                            if (entry.getValue() == null) {
-                                singleGroupList.add(null);
-                            } else if (entry.getValue() instanceof Number n) {
-                                // convert to long
-                                singleGroupList.add(n.longValue());
-                            } else {
-                                singleGroupList.add(entry.getValue().toString());
-                            }
-                        }
-                        groupsList.add(singleGroupList);
-                    }
-                    return XInfoGroups.fromList(groupsList);
-                },
-                "GROUPS", key);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public XInfoConsumers xInfoConsumers(byte[] key, String groupName) {
-        Assert.notNull(key, "Key must not be null!");
-        Assert.hasText(groupName, "Group name must not be null or empty!");
-
-        try {
-            return connection.execute("XINFO",
-                (Object[] glideResult) -> {
-                    if (glideResult == null) {
-                        return null;
-                    }
-
-                    List<Object> consumersList = new ArrayList<>(glideResult.length);
-                    for (Object groupInfo : glideResult) {
-                        Map<?, ?> groupMap = (Map<?, ?>) groupInfo;
-                        List<Object> singleConsumerList = new ArrayList<>(groupMap.size() * 2);
-                        for (Map.Entry<?, ?> entry : groupMap.entrySet()) {
-                            singleConsumerList.add(entry.getKey().toString());
-                            if (entry.getValue() == null) {
-                                singleConsumerList.add(null);
-                            } else if (entry.getValue() instanceof Number n) {
-                                // convert to long
-                                singleConsumerList.add(n.longValue());
-                            } else {
-                                singleConsumerList.add(entry.getValue().toString());
-                            }
-                        }
-                        consumersList.add(singleConsumerList);
-                    }
-                    return XInfoConsumers.fromList("", consumersList);
-                },
-                "CONSUMERS", key, groupName);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public Long xLen(byte[] key) {
-        Assert.notNull(key, "Key must not be null!");
-        
-        try {
-            return connection.execute("XLEN",
-                (Long glideResult) -> glideResult,
-                key);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public PendingMessagesSummary xPending(byte[] key, String groupName) {
-        Assert.notNull(key, "Key must not be null!");
-        Assert.hasText(groupName, "Group name must not be null or empty!");
-
-        try {
-            return connection.execute("XPENDING",
-                (Object glideResult) -> glideResult != null ? parsePendingMessagesSummary(glideResult) : null,
-                key, groupName);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public PendingMessages xPending(byte[] key, String groupName, XPendingOptions options) {
-        Assert.notNull(key, "Key must not be null!");
-        Assert.hasText(groupName, "Group name must not be null or empty!");
-        Assert.notNull(options, "Options must not be null!");
-
-        try {
-            List<Object> args = new ArrayList<>();
-            args.add(key);
-            args.add(groupName);
-
-            if (options.isLimited()) {
-                Range<?> range = options.getRange();
-                Object lowerBound = range.getLowerBound().getValue().map(Object.class::cast).orElse("-");
-                Object upperBound = range.getUpperBound().getValue().map(Object.class::cast).orElse("+");
-                
-                args.add(lowerBound);
-                args.add(upperBound);
-                args.add(options.getCount());
-
-                if (options.hasConsumer()) {
-                    args.add(options.getConsumerName());
-                }
-            }
-
-            return connection.execute("XPENDING",
-                (Object glideResult) -> glideResult != null ? parsePendingMessages(glideResult, groupName) : null,
-                args.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    // Convenience method for getting pending messages for a specific consumer
-    public PendingMessages xPending(byte[] key, String groupName, String consumerName) {
-        Assert.notNull(key, "Key must not be null!");
-        Assert.hasText(groupName, "Group name must not be null or empty!");
-        Assert.hasText(consumerName, "Consumer name must not be null or empty!");
-
-        ValkeyStreamCommands.XPendingOptions options = ValkeyStreamCommands.XPendingOptions
-                .range(Range.unbounded(), 100L)
-                .consumer(consumerName);
-        
-        return xPending(key, groupName, options);
-    }
-
-    @Override
-    public List<ByteRecord> xRange(byte[] key, Range<String> range, Limit limit) {
-        Assert.notNull(key, "Key must not be null!");
-        Assert.notNull(range, "Range must not be null!");
-        Assert.notNull(limit, "Limit must not be null!");
-
-        try {
-            List<Object> args = new ArrayList<>();
-            args.add(key);
-            
-            // Handle lower bound with exclusive/inclusive semantics
-            Object lowerBound;
-            if (range.getLowerBound().isBounded()) {
-                Object value = range.getLowerBound().getValue().orElse("-");
-                lowerBound = range.getLowerBound().isInclusive() ? String.valueOf(value) : "(" + String.valueOf(value);
-            } else {
-                lowerBound = "-";
-            }
-            
-            // Handle upper bound with exclusive/inclusive semantics  
-            Object upperBound;
-            if (range.getUpperBound().isBounded()) {
-                Object value = range.getUpperBound().getValue().orElse("+");
-                upperBound = range.getUpperBound().isInclusive() ? String.valueOf(value) : "(" + String.valueOf(value);
-            } else {
-                upperBound = "+";
-            }
-            
-            args.add(lowerBound);
-            args.add(upperBound);
-
-            if (limit.isLimited()) {
-                args.add("COUNT");
-                args.add(limit.getCount());
-            }
-
-            return connection.execute("XRANGE",
-                (Map<?, ?> glideResult) -> {
-                    return parseByteRecords(glideResult, key, false);
-                },
-                args.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public List<ByteRecord> xRead(StreamReadOptions readOptions, StreamOffset<byte[]>... streams) {
-        Assert.notNull(readOptions, "Read options must not be null!");
-        Assert.notNull(streams, "Streams must not be null!");
-        Assert.notEmpty(streams, "Streams must not be empty!");
-
-        try {
-            List<Object> args = new ArrayList<>();
-
-            if (readOptions.getCount() != null && readOptions.getCount() > 0) {
-                args.add("COUNT");
-                args.add(readOptions.getCount());
-            }
-
-            if (readOptions.getBlock() != null && readOptions.getBlock() >= 0) {
-                args.add("BLOCK");
-                args.add(readOptions.getBlock());
-            }
-
-            args.add("STREAMS");
-
-            for (StreamOffset<byte[]> stream : streams) {
-                args.add(stream.getKey());
-            }
-
-            for (StreamOffset<byte[]> stream : streams) {
-                args.add(stream.getOffset().getOffset());
-            }
-
-            // Extract stream keys for workaround to ClusterValue.of() bug
-            byte[][] streamKeys = new byte[streams.length][];
-            for (int i = 0; i < streams.length; i++) {
-                streamKeys[i] = streams[i].getKey();
-            }
-
-            return connection.execute("XREAD",
-                (Object glideResult) -> {
-                    return parseMultiStreamByteRecords(glideResult, streamKeys);
-                },
-                args.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public List<ByteRecord> xReadGroup(Consumer consumer, StreamReadOptions readOptions, StreamOffset<byte[]>... streams) {
-        Assert.notNull(consumer, "Consumer must not be null!");
-        Assert.notNull(readOptions, "Read options must not be null!");
-        Assert.notNull(streams, "Streams must not be null!");
-        Assert.notEmpty(streams, "Streams must not be empty!");
-
-        try {
-            List<Object> args = new ArrayList<>();
-            args.add("GROUP");
-            args.add(consumer.getGroup());
-            args.add(consumer.getName());
-
-            if (readOptions.getCount() != null && readOptions.getCount() > 0) {
-                args.add("COUNT");
-                args.add(readOptions.getCount());
-            }
-
-            if (readOptions.getBlock() != null && readOptions.getBlock() >= 0) {
-                args.add("BLOCK");
-                args.add(readOptions.getBlock());
-            }
-
-            if (readOptions.isNoack()) {
-                args.add("NOACK");
-            }
-
-            args.add("STREAMS");
-
-            for (StreamOffset<byte[]> stream : streams) {
-                args.add(stream.getKey());
-            }
-
-            for (StreamOffset<byte[]> stream : streams) {
-                args.add(stream.getOffset().getOffset());
-            }
-
-            // Extract stream keys for workaround to ClusterValue.of() bug
-            byte[][] streamKeys = new byte[streams.length][];
-            for (int i = 0; i < streams.length; i++) {
-                streamKeys[i] = streams[i].getKey();
-            }
-
-            return connection.execute("XREADGROUP",
-                (Object glideResult) -> {
-                    return parseMultiStreamByteRecords(glideResult, streamKeys);
-                },
-                args.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public List<ByteRecord> xRevRange(byte[] key, Range<String> range, Limit limit) {
-        Assert.notNull(key, "Key must not be null!");
-        Assert.notNull(range, "Range must not be null!");
-        Assert.notNull(limit, "Limit must not be null!");
-
-        try {
-            List<Object> args = new ArrayList<>();
-            args.add(key);
-            
-            // Handle upper bound with exclusive/inclusive semantics (note: xRevRange has reversed argument order)
-            Object upperBound;
-            if (range.getUpperBound().isBounded()) {
-                Object value = range.getUpperBound().getValue().orElse("+");
-                upperBound = range.getUpperBound().isInclusive() ? String.valueOf(value) : "(" + String.valueOf(value);
-            } else {
-                upperBound = "+";
-            }
-            
-            // Handle lower bound with exclusive/inclusive semantics
-            Object lowerBound;
-            if (range.getLowerBound().isBounded()) {
-                Object value = range.getLowerBound().getValue().orElse("-");
-                lowerBound = range.getLowerBound().isInclusive() ? String.valueOf(value) : "(" + String.valueOf(value);
-            } else {
-                lowerBound = "-";
-            }
-            
-            args.add(upperBound);
-            args.add(lowerBound);
-
-            if (limit.isLimited()) {
-                args.add("COUNT");
-                args.add(limit.getCount());
-            }
-
-            return connection.execute("XREVRANGE",
-                (Map<?, ?> glideResult) -> {
-                    return parseByteRecords(glideResult, key, true);
-                },
-                args.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public Long xTrim(byte[] key, long count) {
-        return xTrim(key, count, false);
-    }
-
-    @Override
-    public Long xTrim(byte[] key, long count, boolean approximateTrimming) {
-        Assert.notNull(key, "Key must not be null!");
-
-        try {
-            List<Object> args = new ArrayList<>(4);
-            args.add(key);
-            args.add("MAXLEN");
-            
-            if (approximateTrimming) {
-                args.add("~");
-            }
-            
-            args.add(String.valueOf(count));
-
-            return connection.execute("XTRIM",
-                (Long glideResult) -> glideResult,
-                args.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    // ==================== Helper Methods ====================
-
-    private String convertResultToString(Object result) {
-        if (result instanceof byte[]) {
-            return new String((byte[]) result, StandardCharsets.UTF_8);
-        } else if (result instanceof String) {
-            return (String) result;
-        } else if (result == null) {
-            return null;
-        } else {
-            return result.toString();
-        }
-    }
-
-    private List<Object> buildXClaimArgs(byte[] key, String group, String newOwner, XClaimOptions options) {
-        List<Object> args = new ArrayList<>();
-        args.add(key);
-        args.add(group);
-        args.add(newOwner);
-        args.add(options.getMinIdleTime().toMillis());
-        
-        if (options.getIds() != null) {
-            for (RecordId recordId : options.getIds()) {
-                args.add(recordId.getValue());
-            }
-        }
-        
-        if (options.getIdleTime() != null) {
-            args.add("IDLE");
-            args.add(options.getIdleTime().toMillis());
-        }
-        
-        if (options.getUnixTime() != null) {
-            args.add("TIME");
-            args.add(options.getUnixTime().toEpochMilli());
-        }
-        
-        if (options.getRetryCount() != null) {
-            args.add("RETRYCOUNT");
-            args.add(options.getRetryCount());
-        }
-        
-        if (options.isForce()) {
-            args.add("FORCE");
-        }
-        
-        return args;
-    }
-
-    @SuppressWarnings("unchecked")
-    private List<Object> convertToList(Object obj) {
-        if (obj instanceof List) {
-            return (List<Object>) obj;
-        } else if (obj instanceof Object[]) {
-            Object[] array = (Object[]) obj;
-            List<Object> list = new ArrayList<>(array.length);
-            for (Object item : array) {
-                list.add(item);
-            }
-            return list;
-        } else if (obj instanceof Map) {
-            Map<?, ?> map = (Map<?, ?>) obj;
-            if (map.isEmpty()) {
-                return new ArrayList<>();
-            } else {
-                List<Object> list = new ArrayList<>(map.size() * 2);
-                for (Map.Entry<?, ?> entry : map.entrySet()) {
-                    list.add(entry.getKey());
-                    list.add(entry.getValue());
-                }
-                return list;
-            }
-        } else if (obj == null) {
-            return new ArrayList<>();
-        } else {
-            throw new IllegalArgumentException("Cannot convert " + obj.getClass() + " to List");
-        }
-    }
-
-    private List<ByteRecord> parseByteRecords(Map<?, ?> result, byte[] streamKey, boolean reverseOrder) {
-        if (result == null) {
-            return new ArrayList<>();
-        }
-
-        List<ByteRecord> byteRecords = new ArrayList<>(result.size());
-        
-        // Sort entries by record ID (timestamp-sequence) to maintain correct order
-        List<Map.Entry<?, ?>> sortedEntries = new ArrayList<>(result.entrySet());
-        sortedEntries.sort((e1, e2) -> {
-            // WORKAROUND: ClusterValue.of() bug converts GlideString to String
-            String id1;
-            if (e1.getKey() instanceof GlideString) {
-                id1 = ((GlideString) e1.getKey()).toString();
-            } else {
-                id1 = e1.getKey().toString();
-            }
-            
-            String id2;
-            if (e2.getKey() instanceof GlideString) {
-                id2 = ((GlideString) e2.getKey()).toString();
-            } else {
-                id2 = e2.getKey().toString();
-            }
-            
-            // Compare full record IDs: "timestamp-sequence"
-            String[] parts1 = id1.split("-");
-            String[] parts2 = id2.split("-");
-            
-            long timestamp1 = Long.parseLong(parts1[0]);
-            long timestamp2 = Long.parseLong(parts2[0]);
-            
-            int comparison = Long.compare(timestamp1, timestamp2);
-            
-            // If timestamps are equal, compare sequence numbers
-            if (comparison == 0 && parts1.length > 1 && parts2.length > 1) {
-                long seq1 = Long.parseLong(parts1[1]);
-                long seq2 = Long.parseLong(parts2[1]);
-                comparison = Long.compare(seq1, seq2);
-            }
-            
-            return reverseOrder ? -comparison : comparison;
-        });
-
-        // Parse Valkey-Glide stream record format using converter patterns
-        for (Map.Entry<?, ?> entry : sortedEntries) {
-            // WORKAROUND: ClusterValue.of() bug converts GlideString to String
-            String recordIdString;
-            Object keyObj = entry.getKey();
-            if (keyObj instanceof GlideString) {
-                recordIdString = ((GlideString) keyObj).toString();
-            } else if (keyObj instanceof String) {
-                recordIdString = (String) keyObj;
-            } else {
-                recordIdString = keyObj.toString();
-            }
-            
-            Map<byte[], byte[]> fields = new HashMap<>();
-            Object[] fieldsArr = (Object[]) entry.getValue();
-            
-            for (int i = 0; i < fieldsArr.length; i++) {
-                Object[] itemArr = (Object[]) fieldsArr[i];
-                GlideString field = (GlideString) itemArr[0];
-                GlideString value = (GlideString) itemArr[1];
-                fields.put(field.getBytes(), value.getBytes());
-            }
-            ByteRecord byteRecord = StreamRecords.newRecord()
-                    .in(streamKey)
-                    .withId(RecordId.of(recordIdString))
-                    .ofBytes(fields);
-            byteRecords.add(byteRecord);
-        }
-        return byteRecords;
-    }
-
-    private List<ByteRecord> parseMultiStreamByteRecords(Object result, byte[][] originalStreamKeys) {
-        if (result == null) {
-            return new ArrayList<>();
-        }
-
-        List<ByteRecord> allRecords = new ArrayList<>();
-
-        // Handle both List and Map formats from Valkey-Glide XREAD/XREADGROUP responses
-        if (result instanceof Map) {
-            // When Valkey-Glide returns Map format: {streamKey: recordsData}
-            Map<?, ?> streamsMap = (Map<?, ?>) result;
-            
-            // WORKAROUND: Since ClusterValue.of() bug converts GlideString keys to Strings,
-            // we cannot rely on the map keys. For single-stream case, use the original key directly.
-            if (originalStreamKeys != null && streamsMap.size() == 1 && originalStreamKeys.length == 1) {
-                // Single stream case - use the original key directly
-                Map.Entry<?, ?> streamEntry = streamsMap.entrySet().iterator().next();
-                Map<?, ?> streamRecordsObj = (Map<?, ?>) streamEntry.getValue();
-                byte[] streamKey = originalStreamKeys[0];
-                List<ByteRecord> streamRecords = parseByteRecords(streamRecordsObj, streamKey, false);
-                allRecords.addAll(streamRecords);
-            } else {
-                // Multiple streams or fallback to old behavior
-                for (Map.Entry<?, ?> streamEntry : streamsMap.entrySet()) {
-                    Object streamKeyObj = streamEntry.getKey();
-                    Map<?, ?> streamRecordsObj = (Map<?, ?>) streamEntry.getValue();
-                    
-                    byte[] streamKey;
-                    if (streamKeyObj instanceof byte[]) {
-                        streamKey = (byte[]) streamKeyObj;
-                    } else if (streamKeyObj instanceof GlideString) {
-                        streamKey = ((GlideString) streamKeyObj).getBytes();
-                    } else {
-                        // Fallback: Convert String to UTF-8 bytes (may have issues with JDK serialization)
-                        streamKey = streamKeyObj.toString().getBytes(StandardCharsets.UTF_8);
-                    }
-                    
-                    List<ByteRecord> streamRecords = parseByteRecords(streamRecordsObj, streamKey, false);
-                    allRecords.addAll(streamRecords);
-                }
-            }
-        } 
-        return allRecords;
-    }
-
-
-    // This is a LLM-generated code and it's so hellish i cant even think to refactor it. I am ashemed to show it here, but it works.
-    private PendingMessagesSummary parsePendingMessagesSummary(Object result) {
-        if (result == null) {
-            return new PendingMessagesSummary("", 0L, Range.closed("", ""), Collections.emptyMap());
-        }
-
-        try {
-            List<Object> list = convertToList(result);
-            
-            if (list.size() >= 4) {
-                Object totalObj = ValkeyGlideConverters.defaultFromGlideResult(list.get(0));
-                Long totalPendingMessages = 0L;
-                if (totalObj instanceof Number) {
-                    totalPendingMessages = ((Number) totalObj).longValue();
-                } else if (totalObj instanceof List) {
-                    // Handle case where result is nested - extract the actual number
-                    List<?> nested = (List<?>) totalObj;
-                    if (!nested.isEmpty() && nested.get(0) instanceof Number) {
-                        totalPendingMessages = ((Number) nested.get(0)).longValue();
-                    }
-                }
-                
-                String lowestId = convertResultToString(ValkeyGlideConverters.defaultFromGlideResult(list.get(1)));
-                String highestId = convertResultToString(ValkeyGlideConverters.defaultFromGlideResult(list.get(2)));
-                Range<String> range = Range.closed(lowestId, highestId);
-                
-                Map<String, Long> consumerMessageCount = new HashMap<>();
-                Object consumersObj = list.get(3);
-                
-                
-                if (consumersObj instanceof Object[]) {
-                    // Handle Object[] format: [[consumerName, count], [consumerName, count], ...]
-                    Object[] consumersArray = (Object[]) consumersObj;
-                    
-                    for (Object consumerPair : consumersArray) {
-                        if (consumerPair instanceof Object[]) {
-                            Object[] pair = (Object[]) consumerPair;
-                            if (pair.length >= 2) {
-                                Object consumerNameObj = ValkeyGlideConverters.defaultFromGlideResult(pair[0]);
-                                Object countObj = ValkeyGlideConverters.defaultFromGlideResult(pair[1]);
-                                
-                                String consumerName = convertResultToString(consumerNameObj);
-                                
-                                Long messageCount = 0L;
-                                if (countObj instanceof Number) {
-                                    messageCount = ((Number) countObj).longValue();
-                                } else if (countObj != null) {
-                                    try {
-                                        // Use convertResultToString to handle byte[] properly
-                                        String countStr = convertResultToString(countObj);
-                                        messageCount = Long.parseLong(countStr);
-                                    } catch (NumberFormatException e) {
-                                        messageCount = 0L;
-                                    }
-                                }
-                                
-                                consumerMessageCount.put(consumerName, messageCount);
-                            }
-                        }
-                    }
-                } else if (consumersObj instanceof List) {
-                    @SuppressWarnings("unchecked")
-                    List<Object> consumers = (List<Object>) consumersObj;
-                    
-                    // Handle flat list format: [consumerName1, count1, consumerName2, count2, ...]
-                    for (int i = 0; i < consumers.size(); i += 2) {
-                        if (i + 1 < consumers.size()) {
-                            Object consumerNameObj = ValkeyGlideConverters.defaultFromGlideResult(consumers.get(i));
-                            Object countObj = ValkeyGlideConverters.defaultFromGlideResult(consumers.get(i + 1));
-                            
-                            String consumerName = convertResultToString(consumerNameObj);
-                            
-                            Long messageCount = 0L;
-                            if (countObj instanceof Number) {
-                                messageCount = ((Number) countObj).longValue();
-                            } else if (countObj != null) {
-                                try {
-                                    messageCount = Long.parseLong(countObj.toString());
-                                } catch (NumberFormatException e) {
-                                    messageCount = 0L;
-                                }
-                            }
-                            
-                            consumerMessageCount.put(consumerName, messageCount);
-                        }
-                    }
-                }
-                
-                return new PendingMessagesSummary("", totalPendingMessages, range, consumerMessageCount);
-            }
-            
-            return new PendingMessagesSummary("", 0L, Range.closed("", ""), Collections.emptyMap());
-        } catch (Exception e) {
-            throw new ValkeyGlideExceptionConverter().convert(e);
-        }
-    }
-
-    // This is a LLM-generated code and it's so hellish i cant even think to refactor it. I am ashemed to show it here, but it works.
-    private PendingMessages parsePendingMessages(Object result, String groupName) {
-        if (result == null) {
-            return new PendingMessages(groupName, Collections.emptyList());
-        }
-
-        try {
-            List<Object> list = convertToList(result);
-            List<PendingMessage> pendingMessages = new ArrayList<>();
-
-            for (Object item : list) {
-                Object convertedItem = ValkeyGlideConverters.defaultFromGlideResult(item);
-                if (convertedItem instanceof List) {
-                    @SuppressWarnings("unchecked")
-                    List<Object> messageData = (List<Object>) convertedItem;
-                    if (messageData.size() >= 4) {
-                        String recordId = convertResultToString(ValkeyGlideConverters.defaultFromGlideResult(messageData.get(0)));
-                        String consumerName = convertResultToString(ValkeyGlideConverters.defaultFromGlideResult(messageData.get(1)));
-                        Long idleTime = ((Number) ValkeyGlideConverters.defaultFromGlideResult(messageData.get(2))).longValue();
-                        Long deliveryCount = ((Number) ValkeyGlideConverters.defaultFromGlideResult(messageData.get(3))).longValue();
-                        
-                        PendingMessage pendingMessage = new PendingMessage(
-                            RecordId.of(recordId), 
-                            Consumer.from(groupName, consumerName), 
-                            Duration.ofMillis(idleTime), 
-                            deliveryCount
-                        );
-                        pendingMessages.add(pendingMessage);
-                    }
-                }
-            }
-            return new PendingMessages(groupName, pendingMessages);
-        } catch (Exception e) {
-            throw new ValkeyGlideExceptionConverter().convert(e);
-        }
-    }
+	private final ValkeyGlideConnection connection;
+
+	/**
+	 * Creates a new {@link ValkeyGlideStreamCommands}.
+	 * @param connection must not be {@literal null}.
+	 */
+	public ValkeyGlideStreamCommands(ValkeyGlideConnection connection) {
+		Assert.notNull(connection, "Connection must not be null!");
+		this.connection = connection;
+	}
+
+	@Override
+	public Long xAck(byte[] key, String group, RecordId... recordIds) {
+		Assert.notNull(key, "Key must not be null!");
+		Assert.notNull(group, "Group must not be null!");
+		Assert.notNull(recordIds, "Record IDs must not be null!");
+
+		try {
+			Object[] params = new Object[recordIds.length + 2];
+			params[0] = key;
+			params[1] = group;
+
+			for (int i = 0; i < recordIds.length; i++) {
+				params[i + 2] = recordIds[i].getValue();
+			}
+
+			return connection.execute("XACK", (Long glideResult) -> glideResult, params);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public RecordId xAdd(MapRecord<byte[], byte[], byte[]> record) {
+		return xAdd(record, XAddOptions.none());
+	}
+
+	@Override
+	public RecordId xAdd(MapRecord<byte[], byte[], byte[]> record, XAddOptions options) {
+		Assert.notNull(record, "Record must not be null!");
+		Assert.notNull(options, "Options must not be null!");
+
+		byte[] key = record.getStream();
+		RecordId recordId = record.getId();
+		Map<byte[], byte[]> body = record.getValue();
+
+		Assert.notNull(key, "Key must not be null!");
+		Assert.notEmpty(body, "Body must not be empty!");
+
+		try {
+			List<Object> params = new ArrayList<>(2 + body.size() * 2 + 4);
+			params.add(key);
+
+			if (options.isNoMkStream()) {
+				params.add("NOMKSTREAM");
+			}
+
+			if (options.hasMaxlen()) {
+				params.add("MAXLEN");
+				if (options.isApproximateTrimming()) {
+					params.add("~");
+				}
+				params.add(String.valueOf(options.getMaxlen()));
+			}
+
+			if (options.hasMinId()) {
+				params.add("MINID");
+				if (options.isApproximateTrimming()) {
+					params.add("~");
+				}
+				params.add(options.getMinId().getValue());
+			}
+
+			// Add LIMIT if present (valid with approximate trimming)
+			if (options.getTrimOptions() != null && options.getTrimOptions().hasLimit()) {
+				params.add("LIMIT");
+				params.add(String.valueOf(options.getTrimOptions().getLimit()));
+			}
+
+			if (recordId == null || recordId.equals(RecordId.autoGenerate())) {
+				params.add("*");
+			}
+			else {
+				params.add(recordId.getValue());
+			}
+
+			for (Map.Entry<byte[], byte[]> entry : body.entrySet()) {
+				params.add(entry.getKey());
+				params.add(entry.getValue());
+			}
+
+			return connection.execute("XADD",
+					(GlideString glideResult) -> glideResult != null ? RecordId.of(glideResult.toString()) : null,
+					params.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public List<RecordId> xClaimJustId(byte[] key, String group, String newOwner, XClaimOptions options) {
+		Assert.notNull(key, "Key must not be null!");
+		Assert.hasText(group, "Group must not be null or empty!");
+		Assert.hasText(newOwner, "New owner must not be null or empty!");
+		Assert.notNull(options, "Options must not be null!");
+
+		try {
+			List<Object> args = buildXClaimArgs(key, group, newOwner, options);
+			args.add("JUSTID");
+
+			return connection.execute("XCLAIM", (Object[] glideResult) -> {
+				if (glideResult == null) {
+					return Collections.emptyList();
+				}
+				List<RecordId> recordIds = new ArrayList<>(glideResult.length);
+				for (Object item : glideResult) {
+					recordIds.add(RecordId.of(((GlideString) item).toString()));
+				}
+				return recordIds;
+			}, args.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public List<ByteRecord> xClaim(byte[] key, String group, String newOwner, XClaimOptions options) {
+		Assert.notNull(key, "Key must not be null!");
+		Assert.hasText(group, "Group must not be null or empty!");
+		Assert.hasText(newOwner, "New owner must not be null or empty!");
+		Assert.notNull(options, "Options must not be null!");
+
+		try {
+			List<Object> args = buildXClaimArgs(key, group, newOwner, options);
+
+			return connection.execute("XCLAIM", (Map<?, ?> glideResult) -> {
+				return parseByteRecords(glideResult, key, false);
+			}, args.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public Long xDel(byte[] key, RecordId... recordIds) {
+		Assert.notNull(key, "Key must not be null!");
+		Assert.notNull(recordIds, "Record IDs must not be null!");
+
+		try {
+			Object[] params = new Object[recordIds.length + 1];
+			params[0] = key;
+
+			for (int i = 0; i < recordIds.length; i++) {
+				params[i + 1] = recordIds[i].getValue();
+			}
+
+			return connection.execute("XDEL", (Long glideResult) -> glideResult, params);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public String xGroupCreate(byte[] key, String groupName, ReadOffset readOffset) {
+		return xGroupCreate(key, groupName, readOffset, false);
+	}
+
+	@Override
+	public String xGroupCreate(byte[] key, String groupName, ReadOffset readOffset, boolean makeStream) {
+		Assert.notNull(key, "Key must not be null!");
+		Assert.hasText(groupName, "Group name must not be null or empty!");
+		Assert.notNull(readOffset, "ReadOffset must not be null!");
+
+		try {
+			List<Object> args = new ArrayList<>(6);
+			args.add("CREATE");
+			args.add(key);
+			args.add(groupName);
+			args.add(readOffset.getOffset());
+
+			if (makeStream) {
+				args.add("MKSTREAM");
+			}
+
+			return connection.execute("XGROUP", (String glideResult) -> glideResult, args.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public Boolean xGroupDelConsumer(byte[] key, Consumer consumer) {
+		Assert.notNull(key, "Key must not be null!");
+		Assert.notNull(consumer, "Consumer must not be null!");
+
+		try {
+			return connection.execute("XGROUP", (Long glideResult) -> glideResult != null ? glideResult > 0 : null,
+					"DELCONSUMER", key, consumer.getGroup(), consumer.getName());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public Boolean xGroupDestroy(byte[] key, String groupName) {
+		Assert.notNull(key, "Key must not be null!");
+		Assert.hasText(groupName, "Group name must not be null or empty!");
+
+		try {
+			return connection.execute("XGROUP", (Boolean glideResult) -> glideResult, "DESTROY", key, groupName);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public XInfoStream xInfo(byte[] key) {
+		Assert.notNull(key, "Key must not be null!");
+
+		try {
+			return connection.execute("XINFO", (Map<?, ?> glideResult) -> {
+				if (glideResult == null) {
+					return null;
+				}
+
+				// Convert the result to a List<Object>
+				// XInfoStream.fromList() expects a List<Object> with alternating keys and
+				// values
+				// Valkey-Glide returns a Map, so we need to convert it
+				// first-entry and last-entry are special cases with nested structures and
+				// need to be converted to Map
+				List<Object> list = new ArrayList<>(glideResult.size() * 2);
+
+				for (Map.Entry<?, ?> entry : glideResult.entrySet()) {
+					list.add(entry.getKey().toString());
+					if (entry.getKey().toString().equals("first-entry")
+							|| entry.getKey().toString().equals("last-entry")) {
+						Object[] entryObjects = (Object[]) entry.getValue();
+						Map<byte[], Map<byte[], byte[]>> entryMap = new HashMap<>();
+						for (int i = 0; i < entryObjects.length; i += 2) {
+							byte[] recordIdString = ((GlideString) entryObjects[i]).getBytes();
+							Map<byte[], byte[]> fields = new HashMap<>();
+							Object[] fieldsArr = (Object[]) entryObjects[i + 1];
+							for (int j = 0; j < fieldsArr.length; j += 2) {
+								byte[] field = ((GlideString) fieldsArr[j]).getBytes();
+								byte[] value = ((GlideString) fieldsArr[j + 1]).getBytes();
+								fields.put(field, value);
+							}
+							entryMap.put(recordIdString, fields);
+						}
+						list.add(entryMap);
+					}
+					else {
+						list.add(ValkeyGlideConverters.defaultFromGlideResult(entry.getValue()));
+					}
+				}
+				return XInfoStream.fromList(list);
+			}, "STREAM", key);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public XInfoGroups xInfoGroups(byte[] key) {
+		Assert.notNull(key, "Key must not be null!");
+
+		try {
+			return connection.execute("XINFO", (Object[] glideResult) -> {
+				if (glideResult == null) {
+					return null;
+				}
+
+				// XInfoGroups.fromList expects a list where each group is represented as
+				// a separate List
+				// Format: [group1List, group2List, ...] where each groupList is [key1,
+				// value1, key2, value2, ...]
+				List<Object> groupsList = new ArrayList<>(glideResult.length);
+
+				for (Object groupInfo : glideResult) {
+					Map<?, ?> groupMap = (Map<?, ?>) groupInfo;
+					List<Object> singleGroupList = new ArrayList<>(groupMap.size() * 2);
+					for (Map.Entry<?, ?> entry : groupMap.entrySet()) {
+						singleGroupList.add(entry.getKey().toString());
+						if (entry.getValue() == null) {
+							singleGroupList.add(null);
+						}
+						else if (entry.getValue() instanceof Number n) {
+							// convert to long
+							singleGroupList.add(n.longValue());
+						}
+						else {
+							singleGroupList.add(entry.getValue().toString());
+						}
+					}
+					groupsList.add(singleGroupList);
+				}
+				return XInfoGroups.fromList(groupsList);
+			}, "GROUPS", key);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public XInfoConsumers xInfoConsumers(byte[] key, String groupName) {
+		Assert.notNull(key, "Key must not be null!");
+		Assert.hasText(groupName, "Group name must not be null or empty!");
+
+		try {
+			return connection.execute("XINFO", (Object[] glideResult) -> {
+				if (glideResult == null) {
+					return null;
+				}
+
+				List<Object> consumersList = new ArrayList<>(glideResult.length);
+				for (Object groupInfo : glideResult) {
+					Map<?, ?> groupMap = (Map<?, ?>) groupInfo;
+					List<Object> singleConsumerList = new ArrayList<>(groupMap.size() * 2);
+					for (Map.Entry<?, ?> entry : groupMap.entrySet()) {
+						singleConsumerList.add(entry.getKey().toString());
+						if (entry.getValue() == null) {
+							singleConsumerList.add(null);
+						}
+						else if (entry.getValue() instanceof Number n) {
+							// convert to long
+							singleConsumerList.add(n.longValue());
+						}
+						else {
+							singleConsumerList.add(entry.getValue().toString());
+						}
+					}
+					consumersList.add(singleConsumerList);
+				}
+				return XInfoConsumers.fromList("", consumersList);
+			}, "CONSUMERS", key, groupName);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public Long xLen(byte[] key) {
+		Assert.notNull(key, "Key must not be null!");
+
+		try {
+			return connection.execute("XLEN", (Long glideResult) -> glideResult, key);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public PendingMessagesSummary xPending(byte[] key, String groupName) {
+		Assert.notNull(key, "Key must not be null!");
+		Assert.hasText(groupName, "Group name must not be null or empty!");
+
+		try {
+			return connection.execute("XPENDING",
+					(Object glideResult) -> glideResult != null ? parsePendingMessagesSummary(glideResult) : null, key,
+					groupName);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public PendingMessages xPending(byte[] key, String groupName, XPendingOptions options) {
+		Assert.notNull(key, "Key must not be null!");
+		Assert.hasText(groupName, "Group name must not be null or empty!");
+		Assert.notNull(options, "Options must not be null!");
+
+		try {
+			List<Object> args = new ArrayList<>();
+			args.add(key);
+			args.add(groupName);
+
+			if (options.isLimited()) {
+				Range<?> range = options.getRange();
+				Object lowerBound = range.getLowerBound().getValue().map(Object.class::cast).orElse("-");
+				Object upperBound = range.getUpperBound().getValue().map(Object.class::cast).orElse("+");
+
+				args.add(lowerBound);
+				args.add(upperBound);
+				args.add(options.getCount());
+
+				if (options.hasConsumer()) {
+					args.add(options.getConsumerName());
+				}
+			}
+
+			return connection.execute("XPENDING",
+					(Object glideResult) -> glideResult != null ? parsePendingMessages(glideResult, groupName) : null,
+					args.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	// Convenience method for getting pending messages for a specific consumer
+	public PendingMessages xPending(byte[] key, String groupName, String consumerName) {
+		Assert.notNull(key, "Key must not be null!");
+		Assert.hasText(groupName, "Group name must not be null or empty!");
+		Assert.hasText(consumerName, "Consumer name must not be null or empty!");
+
+		ValkeyStreamCommands.XPendingOptions options = ValkeyStreamCommands.XPendingOptions
+			.range(Range.unbounded(), 100L)
+			.consumer(consumerName);
+
+		return xPending(key, groupName, options);
+	}
+
+	@Override
+	public List<ByteRecord> xRange(byte[] key, Range<String> range, Limit limit) {
+		Assert.notNull(key, "Key must not be null!");
+		Assert.notNull(range, "Range must not be null!");
+		Assert.notNull(limit, "Limit must not be null!");
+
+		try {
+			List<Object> args = new ArrayList<>();
+			args.add(key);
+
+			// Handle lower bound with exclusive/inclusive semantics
+			Object lowerBound;
+			if (range.getLowerBound().isBounded()) {
+				Object value = range.getLowerBound().getValue().orElse("-");
+				lowerBound = range.getLowerBound().isInclusive() ? String.valueOf(value) : "(" + String.valueOf(value);
+			}
+			else {
+				lowerBound = "-";
+			}
+
+			// Handle upper bound with exclusive/inclusive semantics
+			Object upperBound;
+			if (range.getUpperBound().isBounded()) {
+				Object value = range.getUpperBound().getValue().orElse("+");
+				upperBound = range.getUpperBound().isInclusive() ? String.valueOf(value) : "(" + String.valueOf(value);
+			}
+			else {
+				upperBound = "+";
+			}
+
+			args.add(lowerBound);
+			args.add(upperBound);
+
+			if (limit.isLimited()) {
+				args.add("COUNT");
+				args.add(limit.getCount());
+			}
+
+			return connection.execute("XRANGE", (Map<?, ?> glideResult) -> {
+				return parseByteRecords(glideResult, key, false);
+			}, args.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public List<ByteRecord> xRead(StreamReadOptions readOptions, StreamOffset<byte[]>... streams) {
+		Assert.notNull(readOptions, "Read options must not be null!");
+		Assert.notNull(streams, "Streams must not be null!");
+		Assert.notEmpty(streams, "Streams must not be empty!");
+
+		try {
+			List<Object> args = new ArrayList<>();
+
+			if (readOptions.getCount() != null && readOptions.getCount() > 0) {
+				args.add("COUNT");
+				args.add(readOptions.getCount());
+			}
+
+			if (readOptions.getBlock() != null && readOptions.getBlock() >= 0) {
+				args.add("BLOCK");
+				args.add(readOptions.getBlock());
+			}
+
+			args.add("STREAMS");
+
+			for (StreamOffset<byte[]> stream : streams) {
+				args.add(stream.getKey());
+			}
+
+			for (StreamOffset<byte[]> stream : streams) {
+				args.add(stream.getOffset().getOffset());
+			}
+
+			// Extract stream keys for workaround to ClusterValue.of() bug
+			byte[][] streamKeys = new byte[streams.length][];
+			for (int i = 0; i < streams.length; i++) {
+				streamKeys[i] = streams[i].getKey();
+			}
+
+			return connection.execute("XREAD", (Object glideResult) -> {
+				return parseMultiStreamByteRecords(glideResult, streamKeys);
+			}, args.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public List<ByteRecord> xReadGroup(Consumer consumer, StreamReadOptions readOptions,
+			StreamOffset<byte[]>... streams) {
+		Assert.notNull(consumer, "Consumer must not be null!");
+		Assert.notNull(readOptions, "Read options must not be null!");
+		Assert.notNull(streams, "Streams must not be null!");
+		Assert.notEmpty(streams, "Streams must not be empty!");
+
+		try {
+			List<Object> args = new ArrayList<>();
+			args.add("GROUP");
+			args.add(consumer.getGroup());
+			args.add(consumer.getName());
+
+			if (readOptions.getCount() != null && readOptions.getCount() > 0) {
+				args.add("COUNT");
+				args.add(readOptions.getCount());
+			}
+
+			if (readOptions.getBlock() != null && readOptions.getBlock() >= 0) {
+				args.add("BLOCK");
+				args.add(readOptions.getBlock());
+			}
+
+			if (readOptions.isNoack()) {
+				args.add("NOACK");
+			}
+
+			args.add("STREAMS");
+
+			for (StreamOffset<byte[]> stream : streams) {
+				args.add(stream.getKey());
+			}
+
+			for (StreamOffset<byte[]> stream : streams) {
+				args.add(stream.getOffset().getOffset());
+			}
+
+			// Extract stream keys for workaround to ClusterValue.of() bug
+			byte[][] streamKeys = new byte[streams.length][];
+			for (int i = 0; i < streams.length; i++) {
+				streamKeys[i] = streams[i].getKey();
+			}
+
+			return connection.execute("XREADGROUP", (Object glideResult) -> {
+				return parseMultiStreamByteRecords(glideResult, streamKeys);
+			}, args.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public List<ByteRecord> xRevRange(byte[] key, Range<String> range, Limit limit) {
+		Assert.notNull(key, "Key must not be null!");
+		Assert.notNull(range, "Range must not be null!");
+		Assert.notNull(limit, "Limit must not be null!");
+
+		try {
+			List<Object> args = new ArrayList<>();
+			args.add(key);
+
+			// Handle upper bound with exclusive/inclusive semantics (note: xRevRange has
+			// reversed argument order)
+			Object upperBound;
+			if (range.getUpperBound().isBounded()) {
+				Object value = range.getUpperBound().getValue().orElse("+");
+				upperBound = range.getUpperBound().isInclusive() ? String.valueOf(value) : "(" + String.valueOf(value);
+			}
+			else {
+				upperBound = "+";
+			}
+
+			// Handle lower bound with exclusive/inclusive semantics
+			Object lowerBound;
+			if (range.getLowerBound().isBounded()) {
+				Object value = range.getLowerBound().getValue().orElse("-");
+				lowerBound = range.getLowerBound().isInclusive() ? String.valueOf(value) : "(" + String.valueOf(value);
+			}
+			else {
+				lowerBound = "-";
+			}
+
+			args.add(upperBound);
+			args.add(lowerBound);
+
+			if (limit.isLimited()) {
+				args.add("COUNT");
+				args.add(limit.getCount());
+			}
+
+			return connection.execute("XREVRANGE", (Map<?, ?> glideResult) -> {
+				return parseByteRecords(glideResult, key, true);
+			}, args.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public Long xTrim(byte[] key, long count) {
+		return xTrim(key, count, false);
+	}
+
+	@Override
+	public Long xTrim(byte[] key, long count, boolean approximateTrimming) {
+		Assert.notNull(key, "Key must not be null!");
+
+		try {
+			List<Object> args = new ArrayList<>(4);
+			args.add(key);
+			args.add("MAXLEN");
+
+			if (approximateTrimming) {
+				args.add("~");
+			}
+
+			args.add(String.valueOf(count));
+
+			return connection.execute("XTRIM", (Long glideResult) -> glideResult, args.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	// ==================== Helper Methods ====================
+
+	private String convertResultToString(Object result) {
+		if (result instanceof byte[]) {
+			return new String((byte[]) result, StandardCharsets.UTF_8);
+		}
+		else if (result instanceof String) {
+			return (String) result;
+		}
+		else if (result == null) {
+			return null;
+		}
+		else {
+			return result.toString();
+		}
+	}
+
+	private List<Object> buildXClaimArgs(byte[] key, String group, String newOwner, XClaimOptions options) {
+		List<Object> args = new ArrayList<>();
+		args.add(key);
+		args.add(group);
+		args.add(newOwner);
+		args.add(options.getMinIdleTime().toMillis());
+
+		if (options.getIds() != null) {
+			for (RecordId recordId : options.getIds()) {
+				args.add(recordId.getValue());
+			}
+		}
+
+		if (options.getIdleTime() != null) {
+			args.add("IDLE");
+			args.add(options.getIdleTime().toMillis());
+		}
+
+		if (options.getUnixTime() != null) {
+			args.add("TIME");
+			args.add(options.getUnixTime().toEpochMilli());
+		}
+
+		if (options.getRetryCount() != null) {
+			args.add("RETRYCOUNT");
+			args.add(options.getRetryCount());
+		}
+
+		if (options.isForce()) {
+			args.add("FORCE");
+		}
+
+		return args;
+	}
+
+	@SuppressWarnings("unchecked")
+	private List<Object> convertToList(Object obj) {
+		if (obj instanceof List) {
+			return (List<Object>) obj;
+		}
+		else if (obj instanceof Object[]) {
+			Object[] array = (Object[]) obj;
+			List<Object> list = new ArrayList<>(array.length);
+			for (Object item : array) {
+				list.add(item);
+			}
+			return list;
+		}
+		else if (obj instanceof Map) {
+			Map<?, ?> map = (Map<?, ?>) obj;
+			if (map.isEmpty()) {
+				return new ArrayList<>();
+			}
+			else {
+				List<Object> list = new ArrayList<>(map.size() * 2);
+				for (Map.Entry<?, ?> entry : map.entrySet()) {
+					list.add(entry.getKey());
+					list.add(entry.getValue());
+				}
+				return list;
+			}
+		}
+		else if (obj == null) {
+			return new ArrayList<>();
+		}
+		else {
+			throw new IllegalArgumentException("Cannot convert " + obj.getClass() + " to List");
+		}
+	}
+
+	private List<ByteRecord> parseByteRecords(Map<?, ?> result, byte[] streamKey, boolean reverseOrder) {
+		if (result == null) {
+			return new ArrayList<>();
+		}
+
+		List<ByteRecord> byteRecords = new ArrayList<>(result.size());
+
+		// Sort entries by record ID (timestamp-sequence) to maintain correct order
+		List<Map.Entry<?, ?>> sortedEntries = new ArrayList<>(result.entrySet());
+		sortedEntries.sort((e1, e2) -> {
+			// WORKAROUND: ClusterValue.of() bug converts GlideString to String
+			String id1;
+			if (e1.getKey() instanceof GlideString) {
+				id1 = ((GlideString) e1.getKey()).toString();
+			}
+			else {
+				id1 = e1.getKey().toString();
+			}
+
+			String id2;
+			if (e2.getKey() instanceof GlideString) {
+				id2 = ((GlideString) e2.getKey()).toString();
+			}
+			else {
+				id2 = e2.getKey().toString();
+			}
+
+			// Compare full record IDs: "timestamp-sequence"
+			String[] parts1 = id1.split("-");
+			String[] parts2 = id2.split("-");
+
+			long timestamp1 = Long.parseLong(parts1[0]);
+			long timestamp2 = Long.parseLong(parts2[0]);
+
+			int comparison = Long.compare(timestamp1, timestamp2);
+
+			// If timestamps are equal, compare sequence numbers
+			if (comparison == 0 && parts1.length > 1 && parts2.length > 1) {
+				long seq1 = Long.parseLong(parts1[1]);
+				long seq2 = Long.parseLong(parts2[1]);
+				comparison = Long.compare(seq1, seq2);
+			}
+
+			return reverseOrder ? -comparison : comparison;
+		});
+
+		// Parse Valkey-Glide stream record format using converter patterns
+		for (Map.Entry<?, ?> entry : sortedEntries) {
+			// WORKAROUND: ClusterValue.of() bug converts GlideString to String
+			String recordIdString;
+			Object keyObj = entry.getKey();
+			if (keyObj instanceof GlideString) {
+				recordIdString = ((GlideString) keyObj).toString();
+			}
+			else if (keyObj instanceof String) {
+				recordIdString = (String) keyObj;
+			}
+			else {
+				recordIdString = keyObj.toString();
+			}
+
+			Map<byte[], byte[]> fields = new HashMap<>();
+			Object[] fieldsArr = (Object[]) entry.getValue();
+
+			for (int i = 0; i < fieldsArr.length; i++) {
+				Object[] itemArr = (Object[]) fieldsArr[i];
+				GlideString field = (GlideString) itemArr[0];
+				GlideString value = (GlideString) itemArr[1];
+				fields.put(field.getBytes(), value.getBytes());
+			}
+			ByteRecord byteRecord = StreamRecords.newRecord()
+				.in(streamKey)
+				.withId(RecordId.of(recordIdString))
+				.ofBytes(fields);
+			byteRecords.add(byteRecord);
+		}
+		return byteRecords;
+	}
+
+	private List<ByteRecord> parseMultiStreamByteRecords(Object result, byte[][] originalStreamKeys) {
+		if (result == null) {
+			return new ArrayList<>();
+		}
+
+		List<ByteRecord> allRecords = new ArrayList<>();
+
+		// Handle both List and Map formats from Valkey-Glide XREAD/XREADGROUP responses
+		if (result instanceof Map) {
+			// When Valkey-Glide returns Map format: {streamKey: recordsData}
+			Map<?, ?> streamsMap = (Map<?, ?>) result;
+
+			// WORKAROUND: Since ClusterValue.of() bug converts GlideString keys to
+			// Strings,
+			// we cannot rely on the map keys. For single-stream case, use the original
+			// key directly.
+			if (originalStreamKeys != null && streamsMap.size() == 1 && originalStreamKeys.length == 1) {
+				// Single stream case - use the original key directly
+				Map.Entry<?, ?> streamEntry = streamsMap.entrySet().iterator().next();
+				Map<?, ?> streamRecordsObj = (Map<?, ?>) streamEntry.getValue();
+				byte[] streamKey = originalStreamKeys[0];
+				List<ByteRecord> streamRecords = parseByteRecords(streamRecordsObj, streamKey, false);
+				allRecords.addAll(streamRecords);
+			}
+			else {
+				// Multiple streams or fallback to old behavior
+				for (Map.Entry<?, ?> streamEntry : streamsMap.entrySet()) {
+					Object streamKeyObj = streamEntry.getKey();
+					Map<?, ?> streamRecordsObj = (Map<?, ?>) streamEntry.getValue();
+
+					byte[] streamKey;
+					if (streamKeyObj instanceof byte[]) {
+						streamKey = (byte[]) streamKeyObj;
+					}
+					else if (streamKeyObj instanceof GlideString) {
+						streamKey = ((GlideString) streamKeyObj).getBytes();
+					}
+					else {
+						// Fallback: Convert String to UTF-8 bytes (may have issues with
+						// JDK serialization)
+						streamKey = streamKeyObj.toString().getBytes(StandardCharsets.UTF_8);
+					}
+
+					List<ByteRecord> streamRecords = parseByteRecords(streamRecordsObj, streamKey, false);
+					allRecords.addAll(streamRecords);
+				}
+			}
+		}
+		return allRecords;
+	}
+
+	// This is a LLM-generated code and it's so hellish i cant even think to refactor it.
+	// I am ashemed to show it here, but it works.
+	private PendingMessagesSummary parsePendingMessagesSummary(Object result) {
+		if (result == null) {
+			return new PendingMessagesSummary("", 0L, Range.closed("", ""), Collections.emptyMap());
+		}
+
+		try {
+			List<Object> list = convertToList(result);
+
+			if (list.size() >= 4) {
+				Object totalObj = ValkeyGlideConverters.defaultFromGlideResult(list.get(0));
+				Long totalPendingMessages = 0L;
+				if (totalObj instanceof Number) {
+					totalPendingMessages = ((Number) totalObj).longValue();
+				}
+				else if (totalObj instanceof List) {
+					// Handle case where result is nested - extract the actual number
+					List<?> nested = (List<?>) totalObj;
+					if (!nested.isEmpty() && nested.get(0) instanceof Number) {
+						totalPendingMessages = ((Number) nested.get(0)).longValue();
+					}
+				}
+
+				String lowestId = convertResultToString(ValkeyGlideConverters.defaultFromGlideResult(list.get(1)));
+				String highestId = convertResultToString(ValkeyGlideConverters.defaultFromGlideResult(list.get(2)));
+				Range<String> range = Range.closed(lowestId, highestId);
+
+				Map<String, Long> consumerMessageCount = new HashMap<>();
+				Object consumersObj = list.get(3);
+
+				if (consumersObj instanceof Object[]) {
+					// Handle Object[] format: [[consumerName, count], [consumerName,
+					// count], ...]
+					Object[] consumersArray = (Object[]) consumersObj;
+
+					for (Object consumerPair : consumersArray) {
+						if (consumerPair instanceof Object[]) {
+							Object[] pair = (Object[]) consumerPair;
+							if (pair.length >= 2) {
+								Object consumerNameObj = ValkeyGlideConverters.defaultFromGlideResult(pair[0]);
+								Object countObj = ValkeyGlideConverters.defaultFromGlideResult(pair[1]);
+
+								String consumerName = convertResultToString(consumerNameObj);
+
+								Long messageCount = 0L;
+								if (countObj instanceof Number) {
+									messageCount = ((Number) countObj).longValue();
+								}
+								else if (countObj != null) {
+									try {
+										// Use convertResultToString to handle byte[]
+										// properly
+										String countStr = convertResultToString(countObj);
+										messageCount = Long.parseLong(countStr);
+									}
+									catch (NumberFormatException e) {
+										messageCount = 0L;
+									}
+								}
+
+								consumerMessageCount.put(consumerName, messageCount);
+							}
+						}
+					}
+				}
+				else if (consumersObj instanceof List) {
+					@SuppressWarnings("unchecked")
+					List<Object> consumers = (List<Object>) consumersObj;
+
+					// Handle flat list format: [consumerName1, count1, consumerName2,
+					// count2, ...]
+					for (int i = 0; i < consumers.size(); i += 2) {
+						if (i + 1 < consumers.size()) {
+							Object consumerNameObj = ValkeyGlideConverters.defaultFromGlideResult(consumers.get(i));
+							Object countObj = ValkeyGlideConverters.defaultFromGlideResult(consumers.get(i + 1));
+
+							String consumerName = convertResultToString(consumerNameObj);
+
+							Long messageCount = 0L;
+							if (countObj instanceof Number) {
+								messageCount = ((Number) countObj).longValue();
+							}
+							else if (countObj != null) {
+								try {
+									messageCount = Long.parseLong(countObj.toString());
+								}
+								catch (NumberFormatException e) {
+									messageCount = 0L;
+								}
+							}
+
+							consumerMessageCount.put(consumerName, messageCount);
+						}
+					}
+				}
+
+				return new PendingMessagesSummary("", totalPendingMessages, range, consumerMessageCount);
+			}
+
+			return new PendingMessagesSummary("", 0L, Range.closed("", ""), Collections.emptyMap());
+		}
+		catch (Exception e) {
+			throw new ValkeyGlideExceptionConverter().convert(e);
+		}
+	}
+
+	// This is a LLM-generated code and it's so hellish i cant even think to refactor it.
+	// I am ashemed to show it here, but it works.
+	private PendingMessages parsePendingMessages(Object result, String groupName) {
+		if (result == null) {
+			return new PendingMessages(groupName, Collections.emptyList());
+		}
+
+		try {
+			List<Object> list = convertToList(result);
+			List<PendingMessage> pendingMessages = new ArrayList<>();
+
+			for (Object item : list) {
+				Object convertedItem = ValkeyGlideConverters.defaultFromGlideResult(item);
+				if (convertedItem instanceof List) {
+					@SuppressWarnings("unchecked")
+					List<Object> messageData = (List<Object>) convertedItem;
+					if (messageData.size() >= 4) {
+						String recordId = convertResultToString(
+								ValkeyGlideConverters.defaultFromGlideResult(messageData.get(0)));
+						String consumerName = convertResultToString(
+								ValkeyGlideConverters.defaultFromGlideResult(messageData.get(1)));
+						Long idleTime = ((Number) ValkeyGlideConverters.defaultFromGlideResult(messageData.get(2)))
+							.longValue();
+						Long deliveryCount = ((Number) ValkeyGlideConverters.defaultFromGlideResult(messageData.get(3)))
+							.longValue();
+
+						PendingMessage pendingMessage = new PendingMessage(RecordId.of(recordId),
+								Consumer.from(groupName, consumerName), Duration.ofMillis(idleTime), deliveryCount);
+						pendingMessages.add(pendingMessage);
+					}
+				}
+			}
+			return new PendingMessages(groupName, pendingMessages);
+		}
+		catch (Exception e) {
+			throw new ValkeyGlideExceptionConverter().convert(e);
+		}
+	}
 
 	@Override
 	public Long xTrim(byte[] key, ValkeyStreamCommands.XTrimOptions options) {
@@ -1032,7 +1065,8 @@ public class ValkeyGlideStreamCommands implements ValkeyStreamCommands {
 					args.add("~");
 				}
 				args.add(String.valueOf(maxLen.threshold()));
-			} else if (trimOptions.getTrimStrategy() instanceof ValkeyStreamCommands.MinIdTrimStrategy minId) {
+			}
+			else if (trimOptions.getTrimStrategy() instanceof ValkeyStreamCommands.MinIdTrimStrategy minId) {
 				args.add("MINID");
 				if (trimOptions.getTrimOperator() == ValkeyStreamCommands.TrimOperator.APPROXIMATE) {
 					args.add("~");
@@ -1052,16 +1086,16 @@ public class ValkeyGlideStreamCommands implements ValkeyStreamCommands {
 					case ACKNOWLEDGED -> args.add("ACKED");
 				}
 			}
-			return connection.execute("XTRIM",
-				(Long glideResult) -> glideResult,
-				args.toArray());
-		} catch (Exception ex) {
+			return connection.execute("XTRIM", (Long glideResult) -> glideResult, args.toArray());
+		}
+		catch (Exception ex) {
 			throw new ValkeyGlideExceptionConverter().convert(ex);
 		}
 	}
 
 	@Override
-	public List<ValkeyStreamCommands.StreamEntryDeletionResult> xAckDel(byte[] key, String group, ValkeyStreamCommands.XDelOptions options, RecordId... recordIds) {
+	public List<ValkeyStreamCommands.StreamEntryDeletionResult> xAckDel(byte[] key, String group,
+			ValkeyStreamCommands.XDelOptions options, RecordId... recordIds) {
 		Assert.notNull(key, "Key must not be null");
 		Assert.notNull(group, "Group must not be null");
 		Assert.notNull(options, "Options must not be null");
@@ -1082,23 +1116,23 @@ public class ValkeyGlideStreamCommands implements ValkeyStreamCommands {
 			for (RecordId id : recordIds) {
 				args.add(id.getValue());
 			}
-			return connection.execute("XACKDEL",
-				(Object[] glideResult) -> {
-					List<ValkeyStreamCommands.StreamEntryDeletionResult> results = new ArrayList<>(glideResult.length);
-					for (Object item : glideResult) {
-						long code = item instanceof Long l ? l : Long.parseLong(item.toString());
-						results.add(ValkeyStreamCommands.StreamEntryDeletionResult.fromCode(code));
-					}
-					return results;
-				},
-				args.toArray());
-		} catch (Exception ex) {
+			return connection.execute("XACKDEL", (Object[] glideResult) -> {
+				List<ValkeyStreamCommands.StreamEntryDeletionResult> results = new ArrayList<>(glideResult.length);
+				for (Object item : glideResult) {
+					long code = item instanceof Long l ? l : Long.parseLong(item.toString());
+					results.add(ValkeyStreamCommands.StreamEntryDeletionResult.fromCode(code));
+				}
+				return results;
+			}, args.toArray());
+		}
+		catch (Exception ex) {
 			throw new ValkeyGlideExceptionConverter().convert(ex);
 		}
 	}
 
 	@Override
-	public List<ValkeyStreamCommands.StreamEntryDeletionResult> xDelEx(byte[] key, ValkeyStreamCommands.XDelOptions options, RecordId... recordIds) {
+	public List<ValkeyStreamCommands.StreamEntryDeletionResult> xDelEx(byte[] key,
+			ValkeyStreamCommands.XDelOptions options, RecordId... recordIds) {
 		Assert.notNull(key, "Key must not be null");
 		Assert.notNull(options, "Options must not be null");
 		Assert.notNull(recordIds, "RecordIds must not be null");
@@ -1117,18 +1151,18 @@ public class ValkeyGlideStreamCommands implements ValkeyStreamCommands {
 			for (RecordId id : recordIds) {
 				args.add(id.getValue());
 			}
-			return connection.execute("XDELEX",
-				(Object[] glideResult) -> {
-					List<ValkeyStreamCommands.StreamEntryDeletionResult> results = new ArrayList<>(glideResult.length);
-					for (Object item : glideResult) {
-						long code = item instanceof Long l ? l : Long.parseLong(item.toString());
-						results.add(ValkeyStreamCommands.StreamEntryDeletionResult.fromCode(code));
-					}
-					return results;
-				},
-				args.toArray());
-		} catch (Exception ex) {
+			return connection.execute("XDELEX", (Object[] glideResult) -> {
+				List<ValkeyStreamCommands.StreamEntryDeletionResult> results = new ArrayList<>(glideResult.length);
+				for (Object item : glideResult) {
+					long code = item instanceof Long l ? l : Long.parseLong(item.toString());
+					results.add(ValkeyStreamCommands.StreamEntryDeletionResult.fromCode(code));
+				}
+				return results;
+			}, args.toArray());
+		}
+		catch (Exception ex) {
 			throw new ValkeyGlideExceptionConverter().convert(ex);
 		}
 	}
+
 }

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideStringCommands.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideStringCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,669 +37,623 @@ import glide.api.models.GlideString;
  */
 public class ValkeyGlideStringCommands implements ValkeyStringCommands {
 
-    private final ValkeyGlideConnection connection;
+	private final ValkeyGlideConnection connection;
 
-    /**
-     * Creates a new {@link ValkeyGlideStringCommands}.
-     *
-     * @param connection must not be {@literal null}.
-     */
-    public ValkeyGlideStringCommands(ValkeyGlideConnection connection) {
-        Assert.notNull(connection, "Connection must not be null!");
-        this.connection = connection;
-    }
-
-    @Override
-    @Nullable
-    public byte[] get(byte[] key) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("GET",
-                (GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null,
-                key);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Boolean setNX(byte[] key, byte[] value) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(value, "Value must not be null");
-        
-        try {
-            return connection.execute("SETNX",
-                (Long glideResult) -> glideResult != null ? glideResult != 0 : null,
-                key,
-                value);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public byte[] getDel(byte[] key) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("GETDEL",
-                (GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null,
-                key);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public byte[] getEx(byte[] key, Expiration expiration) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(expiration, "Expiration must not be null");
-        
-        try {
-            if (expiration.isPersistent()) {
-                return connection.execute("GETEX",
-                    (GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null,
-                    key, "PERSIST");
-            } else if (expiration.isKeepTtl()) {
-                return connection.execute("GETEX",
-                    (GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null,
-                    key);
-            } else if (expiration.isUnixTimestamp()) {
-                if (expiration.getTimeUnit() == TimeUnit.SECONDS) {
-                    return connection.execute("GETEX",
-                        (GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null,
-                        key, "EXAT", expiration.getExpirationTime());
-                } else {
-                    return connection.execute("GETEX",
-                        (GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null,
-                        key, "PXAT", expiration.getExpirationTime());
-                }
-            } else {
-                if (expiration.getTimeUnit() == TimeUnit.SECONDS) {
-                    return connection.execute("GETEX",
-                        (GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null,
-                        key, "EX", expiration.getExpirationTime());
-                } else {
-                    return connection.execute("GETEX",
-                        (GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null,
-                        key, "PX", expiration.getExpirationTime());
-                }
-            }
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public byte[] getSet(byte[] key, byte[] value) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(value, "Value must not be null");
-        
-        try {
-            return connection.execute("GETSET",
-                (GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null,
-                key,
-                value);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public List<byte[]> mGet(byte[]... keys) {
-        Assert.notNull(keys, "Keys must not be null");
-        Assert.noNullElements(keys, "Keys must not contain null elements");
-        
-        try {
-            Object[] args = new Object[keys.length];
-            System.arraycopy(keys, 0, args, 0, keys.length);
-            return connection.execute("MGET",
-                (Object[] glideResult) -> ValkeyGlideConverters.toBytesList(glideResult),
-                args);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Boolean set(byte[] key, byte[] value) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(value, "Value must not be null");
-        
-        try {
-            return connection.execute("SET",
-                (String glideResult) -> glideResult != null ? "OK".equals(glideResult) : null,
-                key,
-                value);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Boolean set(byte[] key, byte[] value, Expiration expiration, SetOption option) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(value, "Value must not be null");
-        
-        try {
-            List<Object> args = new ArrayList<>();
-            args.add(key);
-            args.add(value);
-            
-            if (expiration != null && !expiration.isPersistent()) {
-                if (expiration.isKeepTtl()) {
-                    args.add("KEEPTTL");
-                } else if (expiration.isUnixTimestamp()) {
-                    if (expiration.getTimeUnit() == TimeUnit.MILLISECONDS) {
-                        args.add("PXAT");
-                        args.add(expiration.getExpirationTimeInMilliseconds());
-                    } else {
-                        args.add("EXAT");
-                        args.add(expiration.getExpirationTimeInSeconds());
-                    }
-                } else {
-                    if (expiration.getTimeUnit() == TimeUnit.MILLISECONDS) {
-                        args.add("PX");
-                        args.add(expiration.getExpirationTimeInMilliseconds());
-                    } else {
-                        args.add("EX");
-                        args.add(expiration.getExpirationTimeInSeconds());
-                    }
-                }
-            }
-            
-            final boolean hasConditionalOption;
-            if (option != null) {
-                switch (option) {
-                    case SET_IF_ABSENT:
-                        args.add("NX");
-                        hasConditionalOption = true;
-                        break;
-                    case SET_IF_PRESENT:
-                        args.add("XX");
-                        hasConditionalOption = true;
-                        break;
-                    case UPSERT:
-                        // No additional argument needed
-                        hasConditionalOption = false;
-                        break;
-                    default:
-                        hasConditionalOption = false;
-                        break;
-                }
-            } else {
-                hasConditionalOption = false;
-            }
-            
-            return connection.execute("SET",
-                (String glideResult) -> {
-                    if (glideResult == null) {
-                        return hasConditionalOption ? Boolean.FALSE : null;
-                    }
-                    return "OK".equals(glideResult) ? Boolean.TRUE : null;
-                },
-                args.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public byte[] setGet(byte[] key, byte[] value, Expiration expiration, SetOption option) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(value, "Value must not be null");
-        
-        try {
-            List<Object> args = new ArrayList<>();
-            args.add(key);
-            args.add(value);
-            args.add("GET");
-            
-            if (expiration != null && !expiration.isPersistent()) {
-                if (expiration.isUnixTimestamp()) {
-                    if (expiration.getTimeUnit() == TimeUnit.SECONDS) {
-                        args.add("EXAT");
-                    } else {
-                        args.add("PXAT");
-                    }
-                } else {
-                    if (expiration.getTimeUnit() == TimeUnit.SECONDS) {
-                        args.add("EX");
-                    } else {
-                        args.add("PX");
-                    }
-                }
-                args.add(expiration.getExpirationTime());
-            }
-            
-            if (option != null) {
-                switch (option) {
-                    case SET_IF_ABSENT:
-                        args.add("NX");
-                        break;
-                    case SET_IF_PRESENT:
-                        args.add("XX");
-                        break;
-                    case UPSERT:
-                        // No additional argument needed
-                        break;
-                }
-            }
-            
-            return connection.execute("SET",
-                (GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null,
-                args.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Boolean setEx(byte[] key, long seconds, byte[] value) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(value, "Value must not be null");
-        
-        try {
-            return connection.execute("SETEX",
-                (String glideResult) -> glideResult != null ? "OK".equals(glideResult) : null,
-                key,
-                seconds,
-                value);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Boolean pSetEx(byte[] key, long milliseconds, byte[] value) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(value, "Value must not be null");
-        
-        try {
-            return connection.execute("PSETEX",
-                (String glideResult) -> glideResult != null ? "OK".equals(glideResult) : null,
-                key,
-                milliseconds,
-                value);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Boolean mSet(Map<byte[], byte[]> tuple) {
-        Assert.notNull(tuple, "Tuple must not be null");
-        
-        try {
-            List<Object> args = new ArrayList<>();
-            for (Map.Entry<byte[], byte[]> entry : tuple.entrySet()) {
-                args.add(entry.getKey());
-                args.add(entry.getValue());
-            }
-            
-            return connection.execute("MSET",
-                (String glideResult) -> glideResult != null ? "OK".equals(glideResult) : null,
-                args.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Boolean mSetNX(Map<byte[], byte[]> tuple) {
-        Assert.notNull(tuple, "Tuple must not be null");
-        
-        try {
-            List<Object> args = new ArrayList<>();
-            for (Map.Entry<byte[], byte[]> entry : tuple.entrySet()) {
-                args.add(entry.getKey());
-                args.add(entry.getValue());
-            }
-            
-            return connection.execute("MSETNX",
-                (Boolean glideResult) -> glideResult,
-                args.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Long incr(byte[] key) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("INCR",
-                (Long glideResult) -> glideResult,
-                key);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Long incrBy(byte[] key, long value) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("INCRBY",
-                (Long glideResult) -> glideResult,
-                key,
-                value);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Double incrBy(byte[] key, double value) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("INCRBYFLOAT",
-                (Double glideResult) -> glideResult,
-                key,
-                value);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Long decr(byte[] key) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("DECR",
-                (Long glideResult) -> glideResult,
-                key);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Long decrBy(byte[] key, long value) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("DECRBY",
-                (Long glideResult) -> glideResult,
-                key,
-                value);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Long append(byte[] key, byte[] value) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(value, "Value must not be null");
-        
-        try {
-            return connection.execute("APPEND",
-                (Long glideResult) -> glideResult,
-                key,
-                value);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public byte[] getRange(byte[] key, long start, long end) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("GETRANGE",
-                (GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null,
-                key,
-                start,
-                end);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public void setRange(byte[] key, byte[] value, long offset) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(value, "Value must not be null");
-        
-        try {
-            connection.execute("SETRANGE",
-                (Long glideResult) -> glideResult,
-                key,
-                offset,
-                value);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Boolean getBit(byte[] key, long offset) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("GETBIT",
-                (Long glideResult) -> glideResult != null ? glideResult != 0 : null,
-                key,
-                offset);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Boolean setBit(byte[] key, long offset, boolean value) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("SETBIT",
-                (Long glideResult) -> glideResult != null ? glideResult != 0 : null,
-                key,
-                offset,
-                value ? 1 : 0);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Long bitCount(byte[] key) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("BITCOUNT",
-                (Long glideResult) -> glideResult,
-                key);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Long bitCount(byte[] key, long start, long end) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("BITCOUNT",
-                (Long glideResult) -> glideResult,
-                key,
-                start,
-                end);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public List<Long> bitField(byte[] key, BitFieldSubCommands subCommands) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(subCommands, "SubCommands must not be null");
-        
-        try {
-            List<Object> args = new ArrayList<>();
-            args.add(key);
-            
-            for (BitFieldSubCommands.BitFieldSubCommand subCommand : subCommands.getSubCommands()) {
-                if (subCommand instanceof BitFieldSubCommands.BitFieldGet) {
-                    BitFieldSubCommands.BitFieldGet get = (BitFieldSubCommands.BitFieldGet) subCommand;
-                    args.add("GET");
-                    args.add(get.getType().asString());
-                    args.add(get.getOffset().asString());
-                } else if (subCommand instanceof BitFieldSubCommands.BitFieldSet) {
-                    BitFieldSubCommands.BitFieldSet set = (BitFieldSubCommands.BitFieldSet) subCommand;
-                    args.add("SET");
-                    args.add(set.getType().asString());
-                    args.add(set.getOffset().asString());
-                    args.add(set.getValue());
-                } else if (subCommand instanceof BitFieldSubCommands.BitFieldIncrBy) {
-                    BitFieldSubCommands.BitFieldIncrBy incrBy = (BitFieldSubCommands.BitFieldIncrBy) subCommand;
-                    
-                    // Add OVERFLOW command if specified
-                    // The OVERFLOW command must be sent before the INCRBY/SET commands it affects
-                    if (incrBy.getOverflow() != null) {
-                        args.add("OVERFLOW");
-                        args.add(incrBy.getOverflow().name());
-                    }
-                    
-                    args.add("INCRBY");
-                    args.add(incrBy.getType().asString());
-                    args.add(incrBy.getOffset().asString());
-                    args.add(incrBy.getValue());
-                }
-            }
-            
-            return connection.execute("BITFIELD",
-                (Object[] glideResult) -> toBitFieldLongsList(glideResult),
-                args.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    /**
-     * Dedicated mapper for BITFIELD command results that handles null values.
-     * BITFIELD is unique in that it can return NULL elements in the array when
-     * OVERFLOW FAIL is used and an overflow/underflow is detected.
-     *
-     * @param glideResult The raw result from Glide
-     * @return List of Long values, with nulls preserved for failed overflow operations
-     */
-    @Nullable
-    private static List<Long> toBitFieldLongsList(@Nullable Object[] glideResult) {
-        if (glideResult == null) {
-            return null;
-        }
-        
-        List<Long> resultList = new ArrayList<>(glideResult.length);
-        for (Object item : glideResult) {
-            // Handle null (from OVERFLOW FAIL) - preserve it in the result
-            if (item == null) {
-                resultList.add(null);
-            } else {
-                resultList.add(((Number) item).longValue());
-            }
-        }
-        return resultList;
-    }
-
-    @Override
-    @Nullable
-    public Long bitOp(BitOperation op, byte[] destination, byte[]... keys) {
-        Assert.notNull(op, "BitOperation must not be null");
-        Assert.notNull(destination, "Destination key must not be null");
-        Assert.notNull(keys, "Keys must not be null");
-        Assert.noNullElements(keys, "Keys must not contain null elements");
-        
-        try {
-            List<Object> args = new ArrayList<>();
-            args.add(op.name());
-            args.add(destination);
-            for (byte[] key : keys) {
-                args.add(key);
-            }
-            
-            return connection.execute("BITOP",
-                (Long glideResult) -> glideResult,
-                args.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Long bitPos(byte[] key, boolean bit, Range<Long> range) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            List<Object> args = new ArrayList<>();
-            args.add(key);
-            args.add(bit ? 1 : 0);
-            
-            if (range != null) {
-                if (range.getLowerBound().isBounded()) {
-                    args.add(range.getLowerBound().getValue().get());
-                }
-                if (range.getUpperBound().isBounded()) {
-                    args.add(range.getUpperBound().getValue().get());
-                }
-            }
-            
-            return connection.execute("BITPOS",
-                (Long glideResult) -> glideResult,
-                args.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Long strLen(byte[] key) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("STRLEN",
-                (Long glideResult) -> glideResult,
-                key);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
+	/**
+	 * Creates a new {@link ValkeyGlideStringCommands}.
+	 * @param connection must not be {@literal null}.
+	 */
+	public ValkeyGlideStringCommands(ValkeyGlideConnection connection) {
+		Assert.notNull(connection, "Connection must not be null!");
+		this.connection = connection;
+	}
 
 	@Override
-	@Nullable
-	public byte[] setGet(byte[] key, byte[] value, io.valkey.springframework.data.valkey.connection.SetCondition condition, io.valkey.springframework.data.valkey.core.types.Expiration expiration) {
+	@Nullable public byte[] get(byte[] key) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("GET",
+					(GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null, key);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Boolean setNX(byte[] key, byte[] value) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(value, "Value must not be null");
+
+		try {
+			return connection.execute("SETNX", (Long glideResult) -> glideResult != null ? glideResult != 0 : null, key,
+					value);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public byte[] getDel(byte[] key) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("GETDEL",
+					(GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null, key);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public byte[] getEx(byte[] key, Expiration expiration) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(expiration, "Expiration must not be null");
+
+		try {
+			if (expiration.isPersistent()) {
+				return connection.execute("GETEX",
+						(GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null, key,
+						"PERSIST");
+			}
+			else if (expiration.isKeepTtl()) {
+				return connection.execute("GETEX",
+						(GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null, key);
+			}
+			else if (expiration.isUnixTimestamp()) {
+				if (expiration.getTimeUnit() == TimeUnit.SECONDS) {
+					return connection.execute("GETEX",
+							(GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null, key,
+							"EXAT", expiration.getExpirationTime());
+				}
+				else {
+					return connection.execute("GETEX",
+							(GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null, key,
+							"PXAT", expiration.getExpirationTime());
+				}
+			}
+			else {
+				if (expiration.getTimeUnit() == TimeUnit.SECONDS) {
+					return connection.execute("GETEX",
+							(GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null, key, "EX",
+							expiration.getExpirationTime());
+				}
+				else {
+					return connection.execute("GETEX",
+							(GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null, key, "PX",
+							expiration.getExpirationTime());
+				}
+			}
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public byte[] getSet(byte[] key, byte[] value) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(value, "Value must not be null");
+
+		try {
+			return connection.execute("GETSET",
+					(GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null, key, value);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public List<byte[]> mGet(byte[]... keys) {
+		Assert.notNull(keys, "Keys must not be null");
+		Assert.noNullElements(keys, "Keys must not contain null elements");
+
+		try {
+			Object[] args = new Object[keys.length];
+			System.arraycopy(keys, 0, args, 0, keys.length);
+			return connection.execute("MGET", (Object[] glideResult) -> ValkeyGlideConverters.toBytesList(glideResult),
+					args);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Boolean set(byte[] key, byte[] value) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(value, "Value must not be null");
+
+		try {
+			return connection.execute("SET",
+					(String glideResult) -> glideResult != null ? "OK".equals(glideResult) : null, key, value);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Boolean set(byte[] key, byte[] value, Expiration expiration, SetOption option) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(value, "Value must not be null");
+
+		try {
+			List<Object> args = new ArrayList<>();
+			args.add(key);
+			args.add(value);
+
+			if (expiration != null && !expiration.isPersistent()) {
+				if (expiration.isKeepTtl()) {
+					args.add("KEEPTTL");
+				}
+				else if (expiration.isUnixTimestamp()) {
+					if (expiration.getTimeUnit() == TimeUnit.MILLISECONDS) {
+						args.add("PXAT");
+						args.add(expiration.getExpirationTimeInMilliseconds());
+					}
+					else {
+						args.add("EXAT");
+						args.add(expiration.getExpirationTimeInSeconds());
+					}
+				}
+				else {
+					if (expiration.getTimeUnit() == TimeUnit.MILLISECONDS) {
+						args.add("PX");
+						args.add(expiration.getExpirationTimeInMilliseconds());
+					}
+					else {
+						args.add("EX");
+						args.add(expiration.getExpirationTimeInSeconds());
+					}
+				}
+			}
+
+			final boolean hasConditionalOption;
+			if (option != null) {
+				switch (option) {
+					case SET_IF_ABSENT:
+						args.add("NX");
+						hasConditionalOption = true;
+						break;
+					case SET_IF_PRESENT:
+						args.add("XX");
+						hasConditionalOption = true;
+						break;
+					case UPSERT:
+						// No additional argument needed
+						hasConditionalOption = false;
+						break;
+					default:
+						hasConditionalOption = false;
+						break;
+				}
+			}
+			else {
+				hasConditionalOption = false;
+			}
+
+			return connection.execute("SET", (String glideResult) -> {
+				if (glideResult == null) {
+					return hasConditionalOption ? Boolean.FALSE : null;
+				}
+				return "OK".equals(glideResult) ? Boolean.TRUE : null;
+			}, args.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public byte[] setGet(byte[] key, byte[] value, Expiration expiration, SetOption option) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(value, "Value must not be null");
+
+		try {
+			List<Object> args = new ArrayList<>();
+			args.add(key);
+			args.add(value);
+			args.add("GET");
+
+			if (expiration != null && !expiration.isPersistent()) {
+				if (expiration.isUnixTimestamp()) {
+					if (expiration.getTimeUnit() == TimeUnit.SECONDS) {
+						args.add("EXAT");
+					}
+					else {
+						args.add("PXAT");
+					}
+				}
+				else {
+					if (expiration.getTimeUnit() == TimeUnit.SECONDS) {
+						args.add("EX");
+					}
+					else {
+						args.add("PX");
+					}
+				}
+				args.add(expiration.getExpirationTime());
+			}
+
+			if (option != null) {
+				switch (option) {
+					case SET_IF_ABSENT:
+						args.add("NX");
+						break;
+					case SET_IF_PRESENT:
+						args.add("XX");
+						break;
+					case UPSERT:
+						// No additional argument needed
+						break;
+				}
+			}
+
+			return connection.execute("SET",
+					(GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null, args.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Boolean setEx(byte[] key, long seconds, byte[] value) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(value, "Value must not be null");
+
+		try {
+			return connection.execute("SETEX",
+					(String glideResult) -> glideResult != null ? "OK".equals(glideResult) : null, key, seconds, value);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Boolean pSetEx(byte[] key, long milliseconds, byte[] value) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(value, "Value must not be null");
+
+		try {
+			return connection.execute("PSETEX",
+					(String glideResult) -> glideResult != null ? "OK".equals(glideResult) : null, key, milliseconds,
+					value);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Boolean mSet(Map<byte[], byte[]> tuple) {
+		Assert.notNull(tuple, "Tuple must not be null");
+
+		try {
+			List<Object> args = new ArrayList<>();
+			for (Map.Entry<byte[], byte[]> entry : tuple.entrySet()) {
+				args.add(entry.getKey());
+				args.add(entry.getValue());
+			}
+
+			return connection.execute("MSET",
+					(String glideResult) -> glideResult != null ? "OK".equals(glideResult) : null, args.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Boolean mSetNX(Map<byte[], byte[]> tuple) {
+		Assert.notNull(tuple, "Tuple must not be null");
+
+		try {
+			List<Object> args = new ArrayList<>();
+			for (Map.Entry<byte[], byte[]> entry : tuple.entrySet()) {
+				args.add(entry.getKey());
+				args.add(entry.getValue());
+			}
+
+			return connection.execute("MSETNX", (Boolean glideResult) -> glideResult, args.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Long incr(byte[] key) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("INCR", (Long glideResult) -> glideResult, key);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Long incrBy(byte[] key, long value) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("INCRBY", (Long glideResult) -> glideResult, key, value);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Double incrBy(byte[] key, double value) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("INCRBYFLOAT", (Double glideResult) -> glideResult, key, value);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Long decr(byte[] key) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("DECR", (Long glideResult) -> glideResult, key);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Long decrBy(byte[] key, long value) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("DECRBY", (Long glideResult) -> glideResult, key, value);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Long append(byte[] key, byte[] value) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(value, "Value must not be null");
+
+		try {
+			return connection.execute("APPEND", (Long glideResult) -> glideResult, key, value);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public byte[] getRange(byte[] key, long start, long end) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("GETRANGE",
+					(GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null, key, start, end);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public void setRange(byte[] key, byte[] value, long offset) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(value, "Value must not be null");
+
+		try {
+			connection.execute("SETRANGE", (Long glideResult) -> glideResult, key, offset, value);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Boolean getBit(byte[] key, long offset) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("GETBIT", (Long glideResult) -> glideResult != null ? glideResult != 0 : null,
+					key, offset);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Boolean setBit(byte[] key, long offset, boolean value) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("SETBIT", (Long glideResult) -> glideResult != null ? glideResult != 0 : null,
+					key, offset, value ? 1 : 0);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Long bitCount(byte[] key) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("BITCOUNT", (Long glideResult) -> glideResult, key);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Long bitCount(byte[] key, long start, long end) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("BITCOUNT", (Long glideResult) -> glideResult, key, start, end);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public List<Long> bitField(byte[] key, BitFieldSubCommands subCommands) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(subCommands, "SubCommands must not be null");
+
+		try {
+			List<Object> args = new ArrayList<>();
+			args.add(key);
+
+			for (BitFieldSubCommands.BitFieldSubCommand subCommand : subCommands.getSubCommands()) {
+				if (subCommand instanceof BitFieldSubCommands.BitFieldGet) {
+					BitFieldSubCommands.BitFieldGet get = (BitFieldSubCommands.BitFieldGet) subCommand;
+					args.add("GET");
+					args.add(get.getType().asString());
+					args.add(get.getOffset().asString());
+				}
+				else if (subCommand instanceof BitFieldSubCommands.BitFieldSet) {
+					BitFieldSubCommands.BitFieldSet set = (BitFieldSubCommands.BitFieldSet) subCommand;
+					args.add("SET");
+					args.add(set.getType().asString());
+					args.add(set.getOffset().asString());
+					args.add(set.getValue());
+				}
+				else if (subCommand instanceof BitFieldSubCommands.BitFieldIncrBy) {
+					BitFieldSubCommands.BitFieldIncrBy incrBy = (BitFieldSubCommands.BitFieldIncrBy) subCommand;
+
+					// Add OVERFLOW command if specified
+					// The OVERFLOW command must be sent before the INCRBY/SET commands it
+					// affects
+					if (incrBy.getOverflow() != null) {
+						args.add("OVERFLOW");
+						args.add(incrBy.getOverflow().name());
+					}
+
+					args.add("INCRBY");
+					args.add(incrBy.getType().asString());
+					args.add(incrBy.getOffset().asString());
+					args.add(incrBy.getValue());
+				}
+			}
+
+			return connection.execute("BITFIELD", (Object[] glideResult) -> toBitFieldLongsList(glideResult),
+					args.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	/**
+	 * Dedicated mapper for BITFIELD command results that handles null values. BITFIELD is
+	 * unique in that it can return NULL elements in the array when OVERFLOW FAIL is used
+	 * and an overflow/underflow is detected.
+	 * @param glideResult The raw result from Glide
+	 * @return List of Long values, with nulls preserved for failed overflow operations
+	 */
+	@Nullable private static List<Long> toBitFieldLongsList(@Nullable Object[] glideResult) {
+		if (glideResult == null) {
+			return null;
+		}
+
+		List<Long> resultList = new ArrayList<>(glideResult.length);
+		for (Object item : glideResult) {
+			// Handle null (from OVERFLOW FAIL) - preserve it in the result
+			if (item == null) {
+				resultList.add(null);
+			}
+			else {
+				resultList.add(((Number) item).longValue());
+			}
+		}
+		return resultList;
+	}
+
+	@Override
+	@Nullable public Long bitOp(BitOperation op, byte[] destination, byte[]... keys) {
+		Assert.notNull(op, "BitOperation must not be null");
+		Assert.notNull(destination, "Destination key must not be null");
+		Assert.notNull(keys, "Keys must not be null");
+		Assert.noNullElements(keys, "Keys must not contain null elements");
+
+		try {
+			List<Object> args = new ArrayList<>();
+			args.add(op.name());
+			args.add(destination);
+			for (byte[] key : keys) {
+				args.add(key);
+			}
+
+			return connection.execute("BITOP", (Long glideResult) -> glideResult, args.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Long bitPos(byte[] key, boolean bit, Range<Long> range) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			List<Object> args = new ArrayList<>();
+			args.add(key);
+			args.add(bit ? 1 : 0);
+
+			if (range != null) {
+				if (range.getLowerBound().isBounded()) {
+					args.add(range.getLowerBound().getValue().get());
+				}
+				if (range.getUpperBound().isBounded()) {
+					args.add(range.getUpperBound().getValue().get());
+				}
+			}
+
+			return connection.execute("BITPOS", (Long glideResult) -> glideResult, args.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Long strLen(byte[] key) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("STRLEN", (Long glideResult) -> glideResult, key);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public byte[] setGet(byte[] key, byte[] value,
+			io.valkey.springframework.data.valkey.connection.SetCondition condition,
+			io.valkey.springframework.data.valkey.core.types.Expiration expiration) {
 		Assert.notNull(key, "Key must not be null");
 		Assert.notNull(value, "Value must not be null");
 		Assert.notNull(condition, "SetCondition must not be null");
@@ -713,19 +667,23 @@ public class ValkeyGlideStringCommands implements ValkeyStringCommands {
 			if (expiration != null && !expiration.isPersistent()) {
 				if (expiration.isKeepTtl()) {
 					args.add("KEEPTTL");
-				} else if (expiration.isUnixTimestamp()) {
+				}
+				else if (expiration.isUnixTimestamp()) {
 					if (expiration.getTimeUnit() == TimeUnit.MILLISECONDS) {
 						args.add("PXAT");
 						args.add(expiration.getExpirationTimeInMilliseconds());
-					} else {
+					}
+					else {
 						args.add("EXAT");
 						args.add(expiration.getExpirationTimeInSeconds());
 					}
-				} else {
+				}
+				else {
 					if (expiration.getTimeUnit() == TimeUnit.MILLISECONDS) {
 						args.add("PX");
 						args.add(expiration.getExpirationTimeInMilliseconds());
-					} else {
+					}
+					else {
 						args.add("EX");
 						args.add(expiration.getExpirationTimeInSeconds());
 					}
@@ -743,30 +701,36 @@ public class ValkeyGlideStringCommands implements ValkeyStringCommands {
 					break;
 			}
 
-			io.valkey.springframework.data.valkey.connection.CompareCondition compareCondition = condition.getCompareCondition();
+			io.valkey.springframework.data.valkey.connection.CompareCondition compareCondition = condition
+				.getCompareCondition();
 			if (compareCondition != null) {
 				switch (compareCondition.getComparison()) {
 					case VALUE:
-						args.add(compareCondition.getOperator() == io.valkey.springframework.data.valkey.connection.CompareCondition.ComparisonOperator.EQUALS ? "IFEQ" : "IFNE");
+						args.add(compareCondition
+							.getOperator() == io.valkey.springframework.data.valkey.connection.CompareCondition.ComparisonOperator.EQUALS
+									? "IFEQ" : "IFNE");
 						break;
 					case DIGEST:
-						args.add(compareCondition.getOperator() == io.valkey.springframework.data.valkey.connection.CompareCondition.ComparisonOperator.EQUALS ? "IFDEQ" : "IFDNE");
+						args.add(compareCondition
+							.getOperator() == io.valkey.springframework.data.valkey.connection.CompareCondition.ComparisonOperator.EQUALS
+									? "IFDEQ" : "IFDNE");
 						break;
 				}
 				args.add(compareCondition.getValue().asBytes());
 			}
 
 			return connection.execute("SET",
-				(GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null,
-				args.toArray());
-		} catch (Exception ex) {
+					(GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null, args.toArray());
+		}
+		catch (Exception ex) {
 			throw new ValkeyGlideExceptionConverter().convert(ex);
 		}
 	}
 
 	@Override
-	@Nullable
-	public Boolean set(byte[] key, byte[] value, io.valkey.springframework.data.valkey.connection.SetCondition condition, io.valkey.springframework.data.valkey.core.types.Expiration expiration) {
+	@Nullable public Boolean set(byte[] key, byte[] value,
+			io.valkey.springframework.data.valkey.connection.SetCondition condition,
+			io.valkey.springframework.data.valkey.core.types.Expiration expiration) {
 		Assert.notNull(key, "Key must not be null");
 		Assert.notNull(value, "Value must not be null");
 		Assert.notNull(condition, "SetCondition must not be null");
@@ -779,19 +743,23 @@ public class ValkeyGlideStringCommands implements ValkeyStringCommands {
 			if (expiration != null && !expiration.isPersistent()) {
 				if (expiration.isKeepTtl()) {
 					args.add("KEEPTTL");
-				} else if (expiration.isUnixTimestamp()) {
+				}
+				else if (expiration.isUnixTimestamp()) {
 					if (expiration.getTimeUnit() == TimeUnit.MILLISECONDS) {
 						args.add("PXAT");
 						args.add(expiration.getExpirationTimeInMilliseconds());
-					} else {
+					}
+					else {
 						args.add("EXAT");
 						args.add(expiration.getExpirationTimeInSeconds());
 					}
-				} else {
+				}
+				else {
 					if (expiration.getTimeUnit() == TimeUnit.MILLISECONDS) {
 						args.add("PX");
 						args.add(expiration.getExpirationTimeInMilliseconds());
-					} else {
+					}
+					else {
 						args.add("EX");
 						args.add(expiration.getExpirationTimeInSeconds());
 					}
@@ -814,30 +782,35 @@ public class ValkeyGlideStringCommands implements ValkeyStringCommands {
 					break;
 			}
 
-			io.valkey.springframework.data.valkey.connection.CompareCondition compareCondition = condition.getCompareCondition();
+			io.valkey.springframework.data.valkey.connection.CompareCondition compareCondition = condition
+				.getCompareCondition();
 			final boolean hasCompareCondition = compareCondition != null;
 			if (compareCondition != null) {
 				switch (compareCondition.getComparison()) {
 					case VALUE:
-						args.add(compareCondition.getOperator() == io.valkey.springframework.data.valkey.connection.CompareCondition.ComparisonOperator.EQUALS ? "IFEQ" : "IFNE");
+						args.add(compareCondition
+							.getOperator() == io.valkey.springframework.data.valkey.connection.CompareCondition.ComparisonOperator.EQUALS
+									? "IFEQ" : "IFNE");
 						break;
 					case DIGEST:
-						args.add(compareCondition.getOperator() == io.valkey.springframework.data.valkey.connection.CompareCondition.ComparisonOperator.EQUALS ? "IFDEQ" : "IFDNE");
+						args.add(compareCondition
+							.getOperator() == io.valkey.springframework.data.valkey.connection.CompareCondition.ComparisonOperator.EQUALS
+									? "IFDEQ" : "IFDNE");
 						break;
 				}
 				args.add(compareCondition.getValue().asBytes());
 			}
 
-			return connection.execute("SET",
-				(String glideResult) -> {
-					if (glideResult == null) {
-						return (hasConditionalOption || hasCompareCondition) ? Boolean.FALSE : null;
-					}
-					return "OK".equals(glideResult) ? Boolean.TRUE : null;
-				},
-				args.toArray());
-		} catch (Exception ex) {
+			return connection.execute("SET", (String glideResult) -> {
+				if (glideResult == null) {
+					return (hasConditionalOption || hasCompareCondition) ? Boolean.FALSE : null;
+				}
+				return "OK".equals(glideResult) ? Boolean.TRUE : null;
+			}, args.toArray());
+		}
+		catch (Exception ex) {
 			throw new ValkeyGlideExceptionConverter().convert(ex);
 		}
 	}
+
 }

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideSubscription.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,125 +29,130 @@ import org.springframework.util.Assert;
  */
 class ValkeyGlideSubscription extends AbstractSubscription {
 
-    private final UnifiedGlideClient client;
-    private final DelegatingPubSubListener pubSubListener;
-    private final SubscriptionListener subscriptionListener;
+	private final UnifiedGlideClient client;
 
-    ValkeyGlideSubscription(MessageListener listener, UnifiedGlideClient client,
-            DelegatingPubSubListener pubSubListener) {
-        super(listener);
-        
-        Assert.notNull(client, "UnifiedGlideClient must not be null");
-        Assert.notNull(pubSubListener, "DelegatingPubSubListener must not be null");
-        
-        this.client = client;
-        this.pubSubListener = pubSubListener;
-        this.subscriptionListener = listener instanceof SubscriptionListener
-            ? (SubscriptionListener) listener
-            : SubscriptionListener.NO_OP_SUBSCRIPTION_LISTENER;
-    }
+	private final DelegatingPubSubListener pubSubListener;
 
-    @Override
-    protected void doSubscribe(byte[]... channels) {
-        sendPubsubCommand("SUBSCRIBE_BLOCKING", channels);
+	private final SubscriptionListener subscriptionListener;
 
-        for (byte[] channel : channels) {
-            subscriptionListener.onChannelSubscribed(channel, getChannels().size());
-        }
-    }
+	ValkeyGlideSubscription(MessageListener listener, UnifiedGlideClient client,
+			DelegatingPubSubListener pubSubListener) {
+		super(listener);
 
-    @Override
-    protected void doPsubscribe(byte[]... patterns) {
-        sendPubsubCommand("PSUBSCRIBE_BLOCKING", patterns);
+		Assert.notNull(client, "UnifiedGlideClient must not be null");
+		Assert.notNull(pubSubListener, "DelegatingPubSubListener must not be null");
 
-        for (byte[] pattern : patterns) {
-            subscriptionListener.onPatternSubscribed(pattern, getPatterns().size());
-        }
-    }
+		this.client = client;
+		this.pubSubListener = pubSubListener;
+		this.subscriptionListener = listener instanceof SubscriptionListener ? (SubscriptionListener) listener
+				: SubscriptionListener.NO_OP_SUBSCRIPTION_LISTENER;
+	}
 
-    @Override
-    protected void doUnsubscribe(boolean all, byte[]... channels) {
-        byte[][] toNotify;
-        
-        if (all) {
-            toNotify = getChannels().toArray(new byte[0][]);
-            sendPubsubCommand("UNSUBSCRIBE_BLOCKING");
-        } else {
-            toNotify = channels;
-            sendPubsubCommand("UNSUBSCRIBE_BLOCKING", channels);
-        }
+	@Override
+	protected void doSubscribe(byte[]... channels) {
+		sendPubsubCommand("SUBSCRIBE_BLOCKING", channels);
 
-        for (byte[] channel : toNotify) {
-            subscriptionListener.onChannelUnsubscribed(channel, getChannels().size());
-        }
-    }
+		for (byte[] channel : channels) {
+			subscriptionListener.onChannelSubscribed(channel, getChannels().size());
+		}
+	}
 
-    @Override
-    protected void doPUnsubscribe(boolean all, byte[]... patterns) {
-        byte[][] toNotify;
-        
-        if (all) {
-            toNotify = getPatterns().toArray(new byte[0][]);
-            sendPubsubCommand("PUNSUBSCRIBE_BLOCKING");
-        } else {
-            toNotify = patterns;
-            sendPubsubCommand("PUNSUBSCRIBE_BLOCKING", patterns);
-        }
+	@Override
+	protected void doPsubscribe(byte[]... patterns) {
+		sendPubsubCommand("PSUBSCRIBE_BLOCKING", patterns);
 
-        for (byte[] pattern : toNotify) {
-            subscriptionListener.onPatternUnsubscribed(pattern, getPatterns().size());
-        }
-    }
+		for (byte[] pattern : patterns) {
+			subscriptionListener.onPatternSubscribed(pattern, getPatterns().size());
+		}
+	}
 
-    @Override
-    protected void doClose() {
-        // Clear listener first to prevent stale messages
-        pubSubListener.clearListener();
-        
-        // Capture channels/patterns BEFORE unsubscribing (they get cleared by parent)
-        byte[][] channelsToNotify = getChannels().toArray(new byte[0][]);
-        byte[][] patternsToNotify = getPatterns().toArray(new byte[0][]);
-        
-        // Unsubscribe from SPECIFIC channels we subscribed to, not ALL
-        if (channelsToNotify.length > 0) {
-            sendPubsubCommand("UNSUBSCRIBE_BLOCKING");
-        }
-        
-        if (patternsToNotify.length > 0) {
-            sendPubsubCommand("PUNSUBSCRIBE_BLOCKING");
-        }
-        
-        // Notify subscription callbacks
-        for (byte[] channel : channelsToNotify) {
-            subscriptionListener.onChannelUnsubscribed(channel, 0);
-        }
-        for (byte[] pattern : patternsToNotify) {
-            subscriptionListener.onPatternUnsubscribed(pattern, 0);
-        }
-    }
+	@Override
+	protected void doUnsubscribe(boolean all, byte[]... channels) {
+		byte[][] toNotify;
 
-    /**
-     * Send a pub/sub command directly to the client using GlideString.
-     */
-    private void sendPubsubCommand(String command, byte[]... channels) {
-        GlideString[] cmd = new GlideString[channels.length + 2];
+		if (all) {
+			toNotify = getChannels().toArray(new byte[0][]);
+			sendPubsubCommand("UNSUBSCRIBE_BLOCKING");
+		}
+		else {
+			toNotify = channels;
+			sendPubsubCommand("UNSUBSCRIBE_BLOCKING", channels);
+		}
 
-        int i = 0;
-        cmd[i++] = GlideString.of(command);
-        for (byte[] channel : channels) {
-            cmd[i++] = GlideString.of(channel);
-        }
+		for (byte[] channel : toNotify) {
+			subscriptionListener.onChannelUnsubscribed(channel, getChannels().size());
+		}
+	}
 
-        // Always append timeout = 0
-        cmd[i] = GlideString.of("0");
+	@Override
+	protected void doPUnsubscribe(boolean all, byte[]... patterns) {
+		byte[][] toNotify;
 
-        try {
-            client.customCommand(cmd);
-        } catch (Exception e) {
-            if (e instanceof InterruptedException) {
-                Thread.currentThread().interrupt();
-            }
-            throw new ValkeyGlideExceptionConverter().convert(e);
-        }
-    }
+		if (all) {
+			toNotify = getPatterns().toArray(new byte[0][]);
+			sendPubsubCommand("PUNSUBSCRIBE_BLOCKING");
+		}
+		else {
+			toNotify = patterns;
+			sendPubsubCommand("PUNSUBSCRIBE_BLOCKING", patterns);
+		}
+
+		for (byte[] pattern : toNotify) {
+			subscriptionListener.onPatternUnsubscribed(pattern, getPatterns().size());
+		}
+	}
+
+	@Override
+	protected void doClose() {
+		// Clear listener first to prevent stale messages
+		pubSubListener.clearListener();
+
+		// Capture channels/patterns BEFORE unsubscribing (they get cleared by parent)
+		byte[][] channelsToNotify = getChannels().toArray(new byte[0][]);
+		byte[][] patternsToNotify = getPatterns().toArray(new byte[0][]);
+
+		// Unsubscribe from SPECIFIC channels we subscribed to, not ALL
+		if (channelsToNotify.length > 0) {
+			sendPubsubCommand("UNSUBSCRIBE_BLOCKING");
+		}
+
+		if (patternsToNotify.length > 0) {
+			sendPubsubCommand("PUNSUBSCRIBE_BLOCKING");
+		}
+
+		// Notify subscription callbacks
+		for (byte[] channel : channelsToNotify) {
+			subscriptionListener.onChannelUnsubscribed(channel, 0);
+		}
+		for (byte[] pattern : patternsToNotify) {
+			subscriptionListener.onPatternUnsubscribed(pattern, 0);
+		}
+	}
+
+	/**
+	 * Send a pub/sub command directly to the client using GlideString.
+	 */
+	private void sendPubsubCommand(String command, byte[]... channels) {
+		GlideString[] cmd = new GlideString[channels.length + 2];
+
+		int i = 0;
+		cmd[i++] = GlideString.of(command);
+		for (byte[] channel : channels) {
+			cmd[i++] = GlideString.of(channel);
+		}
+
+		// Always append timeout = 0
+		cmd[i] = GlideString.of("0");
+
+		try {
+			client.customCommand(cmd);
+		}
+		catch (Exception e) {
+			if (e instanceof InterruptedException) {
+				Thread.currentThread().interrupt();
+			}
+			throw new ValkeyGlideExceptionConverter().convert(e);
+		}
+	}
+
 }

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideUtils.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,37 +26,36 @@ import org.springframework.util.Assert;
  */
 public abstract class ValkeyGlideUtils {
 
-    /**
-     * Convert a range min value to a string representation.
-     *
-     * @param range the range
-     * @return string representation of the range min value
-     */
-    public static String convertRangeMinValue(Range<?> range) {
-        Assert.notNull(range, "Range must not be null!");
-        
-        if (range.getLowerBound().isBounded()) {
-            Object value = range.getLowerBound().getValue();
-            return range.getLowerBound().isInclusive() ? String.valueOf(value) : "(" + String.valueOf(value);
-        }
-        
-        return "-inf";
-    }
+	/**
+	 * Convert a range min value to a string representation.
+	 * @param range the range
+	 * @return string representation of the range min value
+	 */
+	public static String convertRangeMinValue(Range<?> range) {
+		Assert.notNull(range, "Range must not be null!");
 
-    /**
-     * Convert a range max value to a string representation.
-     *
-     * @param range the range
-     * @return string representation of the range max value
-     */
-    public static String convertRangeMaxValue(Range<?> range) {
-        Assert.notNull(range, "Range must not be null!");
-        
-        if (range.getUpperBound().isBounded()) {
-            Object value = range.getUpperBound().getValue();
-            return range.getUpperBound().isInclusive() ? String.valueOf(value) : "(" + String.valueOf(value);
-        }
-        
-        return "+inf";
-    }
+		if (range.getLowerBound().isBounded()) {
+			Object value = range.getLowerBound().getValue();
+			return range.getLowerBound().isInclusive() ? String.valueOf(value) : "(" + String.valueOf(value);
+		}
+
+		return "-inf";
+	}
+
+	/**
+	 * Convert a range max value to a string representation.
+	 * @param range the range
+	 * @return string representation of the range max value
+	 */
+	public static String convertRangeMaxValue(Range<?> range) {
+		Assert.notNull(range, "Range must not be null!");
+
+		if (range.getUpperBound().isBounded()) {
+			Object value = range.getUpperBound().getValue();
+			return range.getUpperBound().isInclusive() ? String.valueOf(value) : "(" + String.valueOf(value);
+		}
+
+		return "+inf";
+	}
+
 }

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideWatchConflictException.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideWatchConflictException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,31 +18,30 @@ package io.valkey.springframework.data.valkey.connection.valkeyglide;
 import org.springframework.dao.DataAccessException;
 
 /**
- * Exception thrown when a Valkey transaction is aborted due to a WATCH conflict.
- * This exception is used to signal that a watched key was modified between
- * the WATCH command and the EXEC command, causing the transaction to be aborted.
+ * Exception thrown when a Valkey transaction is aborted due to a WATCH conflict. This
+ * exception is used to signal that a watched key was modified between the WATCH command
+ * and the EXEC command, causing the transaction to be aborted.
  *
  * @author Ilia Kolominsky
  * @since 2.0
  */
 public class ValkeyGlideWatchConflictException extends DataAccessException {
 
-    /**
-     * Constructor for ValkeyGlideWatchConflictException.
-     *
-     * @param msg the detail message
-     */
-    public ValkeyGlideWatchConflictException(String msg) {
-        super(msg);
-    }
+	/**
+	 * Constructor for ValkeyGlideWatchConflictException.
+	 * @param msg the detail message
+	 */
+	public ValkeyGlideWatchConflictException(String msg) {
+		super(msg);
+	}
 
-    /**
-     * Constructor for ValkeyGlideWatchConflictException.
-     *
-     * @param msg the detail message
-     * @param cause the root cause from the underlying data access API
-     */
-    public ValkeyGlideWatchConflictException(String msg, Throwable cause) {
-        super(msg, cause);
-    }
+	/**
+	 * Constructor for ValkeyGlideWatchConflictException.
+	 * @param msg the detail message
+	 * @param cause the root cause from the underlying data access API
+	 */
+	public ValkeyGlideWatchConflictException(String msg, Throwable cause) {
+		super(msg, cause);
+	}
+
 }

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideZSetCommands.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideZSetCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,1680 +44,1607 @@ import glide.api.models.GlideString;
  */
 public class ValkeyGlideZSetCommands implements ValkeyZSetCommands {
 
-    private final ValkeyGlideConnection connection;
-
-    /**
-     * Creates a new {@link ValkeyGlideZSetCommands}.
-     *
-     * @param connection must not be {@literal null}.
-     */
-    public ValkeyGlideZSetCommands(ValkeyGlideConnection connection) {
-        Assert.notNull(connection, "Connection must not be null!");
-        this.connection = connection;
-    }
-
-    @Override
-    @Nullable
-    public Boolean zAdd(byte[] key, double score, byte[] value, ZAddArgs args) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(value, "Value must not be null");
-        Assert.notNull(args, "ZAddArgs must not be null");
-        
-        try {
-            List<Object> commandArgs = new ArrayList<>();
-            commandArgs.add(key);
-            
-            // Add arguments based on ZAddArgs
-            if (args.contains(ZAddArgs.Flag.NX)) {
-                commandArgs.add("NX");
-            }
-            if (args.contains(ZAddArgs.Flag.XX)) {
-                commandArgs.add("XX");
-            }
-            if (args.contains(ZAddArgs.Flag.GT)) {
-                commandArgs.add("GT");
-            }
-            if (args.contains(ZAddArgs.Flag.LT)) {
-                commandArgs.add("LT");
-            }
-            if (args.contains(ZAddArgs.Flag.CH)) {
-                commandArgs.add("CH");
-            }
-            
-            commandArgs.add(score);
-            commandArgs.add(value);
-            
-            return connection.execute("ZADD",
-                (Long glideResult) -> glideResult == null ? null : glideResult > 0,
-                commandArgs.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Long zAdd(byte[] key, Set<Tuple> tuples, ZAddArgs args) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(tuples, "Tuples must not be null");
-        Assert.notNull(args, "ZAddArgs must not be null");
-        
-        if (tuples.isEmpty()) {
-            return 0L;
-        }
-        
-        try {
-            List<Object> commandArgs = new ArrayList<>();
-            commandArgs.add(key);
-            
-            // Add arguments based on ZAddArgs
-            if (args.contains(ZAddArgs.Flag.NX)) {
-                commandArgs.add("NX");
-            }
-            if (args.contains(ZAddArgs.Flag.XX)) {
-                commandArgs.add("XX");
-            }
-            if (args.contains(ZAddArgs.Flag.GT)) {
-                commandArgs.add("GT");
-            }
-            if (args.contains(ZAddArgs.Flag.LT)) {
-                commandArgs.add("LT");
-            }
-            if (args.contains(ZAddArgs.Flag.CH)) {
-                commandArgs.add("CH");
-            }
-            
-            // Add score-value pairs
-            for (Tuple tuple : tuples) {
-                commandArgs.add(tuple.getScore());
-                commandArgs.add(tuple.getValue());
-            }
-            
-            return connection.execute("ZADD",
-                (Long glideResult) -> glideResult,
-                commandArgs.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Long zRem(byte[] key, byte[]... values) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(values, "Values must not be null");
-        Assert.noNullElements(values, "Values must not contain null elements");
-        
-        try {
-            Object[] args = new Object[values.length + 1];
-            args[0] = key;
-            System.arraycopy(values, 0, args, 1, values.length);
-            
-            return connection.execute("ZREM",
-                (Long glideResult) -> glideResult,
-                args);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Double zIncrBy(byte[] key, double increment, byte[] value) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(value, "Value must not be null");
-        
-        try {
-            return connection.execute("ZINCRBY",
-                (Double glideResult) -> glideResult,
-                key, increment, value);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public byte[] zRandMember(byte[] key) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("ZRANDMEMBER",
-                (GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null,
-                key);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public List<byte[]> zRandMember(byte[] key, long count) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("ZRANDMEMBER",
-                (Object glideResult) -> {
-                    if (glideResult == null) {
-                        return new ArrayList<>();
-                    }
-                    if (glideResult instanceof GlideString) {
-                        // Single result case
-                        List<byte[]> singleResultList = new ArrayList<>(1);
-                        singleResultList.add(((GlideString) glideResult).getBytes());
-                        return singleResultList;
-                    }
-                    Object[] glideResultArray = (Object[]) glideResult;
-                    List<byte[]> resultList = new ArrayList<>(glideResultArray.length);
-                    for (Object item : glideResultArray) {
-                        resultList.add(((GlideString) item).getBytes());
-                    }
-                    return resultList;
-                },
-                key, count);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Tuple zRandMemberWithScore(byte[] key) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("ZRANDMEMBER",
-                (Object[] glideResult) -> {
-                    if (glideResult == null) {
-                        return null;
-                    }
-
-                    Object[] firstElement = (Object[]) glideResult[0];
-                    byte[] value = ((GlideString) firstElement[0]).getBytes();
-                    Double score = (Double) firstElement[1];
-                    return new DefaultTuple(value, score);
-                },
-                key, 1, "WITHSCORES");
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public List<Tuple> zRandMemberWithScore(byte[] key, long count) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("ZRANDMEMBER",
-                (Object[] glideResult) -> {
-                    if (glideResult == null) {
-                        return new ArrayList<>();
-                    }
-                    
-                    List<Tuple> resultList = new ArrayList<>();
-                    for (Object item : glideResult) {
-                        Object[] pair = (Object[]) item;
-                        byte[] value = ((GlideString) pair[0]).getBytes();
-                        Double score = (Double) pair[1];
-                        resultList.add(new DefaultTuple(value, score));
-                    }
-                    return resultList;
-                },
-                key, count, "WITHSCORES");
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Long zRank(byte[] key, byte[] value) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(value, "Value must not be null");
-        
-        try {
-            return connection.execute("ZRANK",
-                (Long glideResult) -> glideResult,
-                key, value);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Long zRevRank(byte[] key, byte[] value) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(value, "Value must not be null");
-        
-        try {
-            return connection.execute("ZREVRANK",
-                (Long glideResult) -> glideResult,
-                key, value);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Set<byte[]> zRange(byte[] key, long start, long end) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("ZRANGE",
-                (Object[] glideResult) -> {
-                    if (glideResult == null) {
-                        return null;
-                    }
-                    Set<byte[]> resultSet = new LinkedHashSet<>(glideResult.length);
-                    for (Object item : glideResult) {
-                        resultSet.add(((GlideString) item).getBytes());
-                    }
-                    return resultSet;
-                },
-                key, start, end);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Set<Tuple> zRangeWithScores(byte[] key, long start, long end) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("ZRANGE",
-                (Map<?, ?>  glideResult) -> {
-                    if (glideResult == null || glideResult.isEmpty()) {
-                        return null;
-                    }
-
-                    Set<Tuple> resultSet = new LinkedHashSet<>();
-                    for (Map.Entry<?, ?> entry : glideResult.entrySet()) {
-                        byte[] value = ((GlideString) entry.getKey()).getBytes();
-                        Double score = ((Number) entry.getValue()).doubleValue();
-                        resultSet.add(new DefaultTuple(value, score));
-                    }
-                    return resultSet;
-                },
-
-                key, start, end, "WITHSCORES");
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Set<byte[]> zRangeByScore(byte[] key, org.springframework.data.domain.Range<? extends Number> range,
-            io.valkey.springframework.data.valkey.connection.Limit limit) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(range, "Range must not be null");
-        Assert.notNull(limit, "Limit must not be null");
-        
-        try {
-            List<Object> commandArgs = new ArrayList<>();
-            commandArgs.add(key);
-            
-            // Add range bounds
-            commandArgs.add(formatRangeBound(range.getLowerBound(), true));
-            commandArgs.add(formatRangeBound(range.getUpperBound(), false));
-            
-            // Add limit if specified
-            if (limit.isLimited()) {
-                commandArgs.add("LIMIT");
-                commandArgs.add(limit.getOffset());
-                commandArgs.add(limit.getCount());
-            }
-            
-            return connection.execute("ZRANGEBYSCORE",
-                (Object[] glideResult) -> {
-                    if (glideResult == null) {
-                        return null;
-                    }
-                    Set<byte[]> resultSet = new LinkedHashSet<>(glideResult.length);
-                    for (Object item : glideResult) {
-                        resultSet.add(((GlideString) item).getBytes());
-                    }
-                    return resultSet;
-                },
-                commandArgs.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Set<byte[]> zRangeByScore(byte[] key, String min, String max, long offset, long count) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(min, "Min must not be null");
-        Assert.notNull(max, "Max must not be null");
-        
-        try {
-            List<Object> commandArgs = new ArrayList<>();
-            commandArgs.add(key);
-            commandArgs.add(min);
-            commandArgs.add(max);
-            commandArgs.add("LIMIT");
-            commandArgs.add(offset);
-            commandArgs.add(count);
-            
-            return connection.execute("ZRANGEBYSCORE",
-                (Object[] glideResult) -> {
-                    if (glideResult == null) {
-                        return null;
-                    }
-                    Set<byte[]> resultSet = new LinkedHashSet<>(glideResult.length);
-                    for (Object item : glideResult) {
-                        resultSet.add(((GlideString) item).getBytes());
-                    }
-                    return resultSet;
-                },
-                commandArgs.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Set<Tuple> zRangeByScoreWithScores(byte[] key, org.springframework.data.domain.Range<? extends Number> range,
-            io.valkey.springframework.data.valkey.connection.Limit limit) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(range, "Range must not be null");
-        Assert.notNull(limit, "Limit must not be null");
-        
-        try {
-            List<Object> commandArgs = new ArrayList<>();
-            commandArgs.add(key);
-            
-            // Add range bounds
-            commandArgs.add(formatRangeBound(range.getLowerBound(), true));
-            commandArgs.add(formatRangeBound(range.getUpperBound(), false));
-            
-            commandArgs.add("WITHSCORES");
-            
-            // Add limit if specified
-            if (limit.isLimited()) {
-                commandArgs.add("LIMIT");
-                commandArgs.add(limit.getOffset());
-                commandArgs.add(limit.getCount());
-            }
-            
-            return connection.execute("ZRANGEBYSCORE",
-                (Object[] glideResult) -> {
-                    if (glideResult == null) {
-                        return null;
-                    }
-                    Set<Tuple> resultSet = new LinkedHashSet<>();
-                    for (Object item : glideResult) {
-                        Object[] valueScorePair = (Object[]) item;
-                        byte[] value = ((GlideString) valueScorePair[0]).getBytes();
-                        Double score = ((Number) valueScorePair[1]).doubleValue();
-                        resultSet.add(new DefaultTuple(value, score));
-                    }
-                    return resultSet;
-                },
-                commandArgs.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Set<byte[]> zRevRange(byte[] key, long start, long end) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("ZREVRANGE",
-                (Object[] glideResult) -> {
-                    if (glideResult == null) {
-                        return null;
-                    }
-                    Set<byte[]> resultSet = new LinkedHashSet<>(glideResult.length);
-                    for (Object item : glideResult) {
-                        resultSet.add(((GlideString) item).getBytes());
-                    }
-                    return resultSet;
-                },
-                key, start, end);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Set<Tuple> zRevRangeWithScores(byte[] key, long start, long end) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("ZREVRANGE",
-                (Object[] glideResult) -> {
-                    if (glideResult == null) {
-                        return null;
-                    }
-                    Set<Tuple> resultSet = new LinkedHashSet<>();
-                    for (Object item : glideResult) {
-                        Object[] valueScorePair = (Object[]) item;
-                        byte[] value = ((GlideString) valueScorePair[0]).getBytes();
-                        Double score = ((Number) valueScorePair[1]).doubleValue();
-                        resultSet.add(new DefaultTuple(value, score));
-                    }
-                    return resultSet;
-                },
-                key, start, end, "WITHSCORES");
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Set<byte[]> zRevRangeByScore(byte[] key, org.springframework.data.domain.Range<? extends Number> range,
-            io.valkey.springframework.data.valkey.connection.Limit limit) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(range, "Range must not be null");
-        Assert.notNull(limit, "Limit must not be null");
-        
-        try {
-            List<Object> commandArgs = new ArrayList<>();
-            commandArgs.add(key);
-            
-            // Add range bounds (reversed for ZREVRANGEBYSCORE)
-            commandArgs.add(formatRangeBound(range.getUpperBound(), true));
-            commandArgs.add(formatRangeBound(range.getLowerBound(), false));
-            
-            // Add limit if specified
-            if (limit.isLimited()) {
-                commandArgs.add("LIMIT");
-                commandArgs.add(limit.getOffset());
-                commandArgs.add(limit.getCount());
-            }
-            
-            return connection.execute("ZREVRANGEBYSCORE",
-                (Object[] glideResult) -> {
-                    if (glideResult == null) {
-                        return null;
-                    }
-                    Set<byte[]> resultSet = new LinkedHashSet<>(glideResult.length);
-                    for (Object item : glideResult) {
-                        resultSet.add(((GlideString) item).getBytes());
-                    }
-                    return resultSet;
-                },
-                commandArgs.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Set<Tuple> zRevRangeByScoreWithScores(byte[] key, org.springframework.data.domain.Range<? extends Number> range,
-            io.valkey.springframework.data.valkey.connection.Limit limit) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(range, "Range must not be null");
-        Assert.notNull(limit, "Limit must not be null");
-        
-        try {
-            List<Object> commandArgs = new ArrayList<>();
-            commandArgs.add(key);
-            
-            // Add range bounds (reversed for ZREVRANGEBYSCORE)
-            commandArgs.add(formatRangeBound(range.getUpperBound(), true));
-            commandArgs.add(formatRangeBound(range.getLowerBound(), false));
-            
-            commandArgs.add("WITHSCORES");
-            
-            // Add limit if specified
-            if (limit.isLimited()) {
-                commandArgs.add("LIMIT");
-                commandArgs.add(limit.getOffset());
-                commandArgs.add(limit.getCount());
-            }
-            
-            return connection.execute("ZREVRANGEBYSCORE",
-                (Object[] glideResult) -> {
-                    if (glideResult == null) {
-                        return null;
-                    }
-                    Set<Tuple> resultSet = new LinkedHashSet<>();
-                    for (Object item : glideResult) {
-                        // Each item is expected to be an array: [value, score]
-                        Object[] valueScorePair = (Object[]) item;
-                        byte[] value = ((GlideString) valueScorePair[0]).getBytes();
-                        Double score = ((Number) valueScorePair[1]).doubleValue();
-                        resultSet.add(new DefaultTuple(value, score));
-                    }
-                    return resultSet;
-                },
-                commandArgs.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Long zCount(byte[] key, org.springframework.data.domain.Range<? extends Number> range) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(range, "Range must not be null");
-        
-        try {
-            return connection.execute("ZCOUNT",
-                (Long glideResult) -> glideResult,
-                key, 
-                formatRangeBound(range.getLowerBound(), true), 
-                formatRangeBound(range.getUpperBound(), false));
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Long zLexCount(byte[] key, org.springframework.data.domain.Range<byte[]> range) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(range, "Range must not be null");
-        
-        try {
-            return connection.execute("ZLEXCOUNT",
-                (Long glideResult) -> glideResult,
-                key, 
-                formatLexRangeBound(range.getLowerBound(), true), 
-                formatLexRangeBound(range.getUpperBound(), false));
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Tuple zPopMin(byte[] key) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("ZPOPMIN",
-                (Map<?, ?>  glideResult) -> {
-                    if (glideResult == null || glideResult.isEmpty()) {
-                        return null;
-                    }
-                    Map.Entry<?, ?> entry = glideResult.entrySet().iterator().next();
-                    byte[] value = ((GlideString) entry.getKey()).getBytes();
-                    Double score = ((Number) entry.getValue()).doubleValue();
-                    return new DefaultTuple(value, score);
-                },
-                key);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Set<Tuple> zPopMin(byte[] key, long count) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("ZPOPMIN",
-                (Object glideResult) -> glideResult != null ? convertToTupleSetForPop(glideResult, true) : null,
-                key, count);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Tuple bZPopMin(byte[] key, long timeout, TimeUnit unit) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(unit, "TimeUnit must not be null");
-        
-        try {
-            long timeoutInSeconds = unit.toSeconds(timeout);
-            
-            return connection.execute("BZPOPMIN",
-                (Object[] glideResult) -> {
-                    if (glideResult == null) {
-                        return null;
-                    }
-                    byte[] value = ((GlideString) glideResult[1]).getBytes();
-                    Double score = ((Number) glideResult[2]).doubleValue();
-                    return new DefaultTuple(value, score);
-                },
-                key, timeoutInSeconds);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Tuple zPopMax(byte[] key) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("ZPOPMAX",
-                (Map<?, ?>  glideResult) -> {
-                    if (glideResult == null || glideResult.isEmpty()) {
-                        return null;
-                    }
-                    Map.Entry<?, ?> entry = glideResult.entrySet().iterator().next();
-                    byte[] value = ((GlideString) entry.getKey()).getBytes();
-                    Double score = ((Number) entry.getValue()).doubleValue();
-                    return new DefaultTuple(value, score);
-                },
-                key);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Set<Tuple> zPopMax(byte[] key, long count) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("ZPOPMAX",
-                (Object glideResult) -> glideResult != null ? convertToTupleSetForPop(glideResult, false) : null,
-                key, count);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Tuple bZPopMax(byte[] key, long timeout, TimeUnit unit) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(unit, "TimeUnit must not be null");
-        
-        try {
-            long timeoutInSeconds = unit.toSeconds(timeout);
-            
-            return connection.execute("BZPOPMAX",
-                (Object[] glideResult) -> {
-                    if (glideResult == null) {
-                        return null;
-                    }
-                    byte[] value = ((GlideString) glideResult[1]).getBytes();
-                    Double score = ((Number) glideResult[2]).doubleValue();
-                    return new DefaultTuple(value, score);
-                },
-                key, timeoutInSeconds);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Long zCard(byte[] key) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("ZCARD",
-                (Long glideResult) -> glideResult,
-                key);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Double zScore(byte[] key, byte[] value) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(value, "Value must not be null");
-        
-        try {
-            return connection.execute("ZSCORE",
-                (Double glideResult) -> glideResult,
-                key, value);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public List<Double> zMScore(byte[] key, byte[]... values) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(values, "Values must not be null");
-        Assert.noNullElements(values, "Values must not contain null elements");
-        
-        try {
-            Object[] args = new Object[values.length + 1];
-            args[0] = key;
-            System.arraycopy(values, 0, args, 1, values.length);
-            
-            return connection.execute("ZMSCORE",
-                (Object[] glideResult) -> {
-                    if (glideResult == null) {
-                        return null;
-                    }
-                    List<Double> resultList = new ArrayList<>(glideResult.length);
-                    for (Object item : glideResult) {
-                        resultList.add((Double) item);
-                    }
-                    return resultList;
-                },
-                args);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Long zRemRange(byte[] key, long start, long end) {
-        Assert.notNull(key, "Key must not be null");
-        
-        try {
-            return connection.execute("ZREMRANGEBYRANK",
-                (Long glideResult) -> glideResult,
-                key, start, end);
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Long zRemRangeByLex(byte[] key, org.springframework.data.domain.Range<byte[]> range) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(range, "Range must not be null");
-        
-        try {
-            return connection.execute("ZREMRANGEBYLEX",
-                (Long glideResult) -> glideResult,
-                key, 
-                formatLexRangeBound(range.getLowerBound(), true), 
-                formatLexRangeBound(range.getUpperBound(), false));
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Long zRemRangeByScore(byte[] key, org.springframework.data.domain.Range<? extends Number> range) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(range, "Range must not be null");
-        
-        try {
-            return connection.execute("ZREMRANGEBYSCORE",
-                (Long glideResult) -> glideResult,
-                key, 
-                formatRangeBound(range.getLowerBound(), true), 
-                formatRangeBound(range.getUpperBound(), false));
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Set<byte[]> zDiff(byte[]... sets) {
-        Assert.notNull(sets, "Sets must not be null");
-        Assert.noNullElements(sets, "Sets must not contain null elements");
-        
-        try {
-            List<Object> commandArgs = new ArrayList<>();
-            commandArgs.add(sets.length);
-            for (byte[] set : sets) {
-                commandArgs.add(set);
-            }
-            
-            return connection.execute("ZDIFF",
-                (Object[] glideResult) -> {
-                    if (glideResult == null) {
-                        return null;
-                    }
-                    Set<byte[]> resultSet = new LinkedHashSet<>(glideResult.length);
-                    for (Object item : glideResult) {
-                        resultSet.add(((GlideString) item).getBytes());
-                    }
-                    return resultSet;
-                },
-                commandArgs.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Set<Tuple> zDiffWithScores(byte[]... sets) {
-        Assert.notNull(sets, "Sets must not be null");
-        Assert.noNullElements(sets, "Sets must not contain null elements");
-        
-        try {
-            List<Object> commandArgs = new ArrayList<>();
-            commandArgs.add(sets.length);
-            for (byte[] set : sets) {
-                commandArgs.add(set);
-            }
-            commandArgs.add("WITHSCORES");
-            
-            return connection.execute("ZDIFF",
-                (Map<?, ?>  glideResult) -> {
-                    if (glideResult == null || glideResult.isEmpty()) {
-                        return null;
-                    }
-
-                    Set<Tuple> resultSet = new LinkedHashSet<>();
-                    for (Map.Entry<?, ?> entry : glideResult.entrySet()) {
-                        byte[] value = ((GlideString) entry.getKey()).getBytes();
-                        Double score = ((Number) entry.getValue()).doubleValue();
-                        resultSet.add(new DefaultTuple(value, score));
-                    }
-                    return resultSet;
-                },
-                commandArgs.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Long zDiffStore(byte[] destKey, byte[]... sets) {
-        Assert.notNull(destKey, "Destination key must not be null");
-        Assert.notNull(sets, "Sets must not be null");
-        Assert.noNullElements(sets, "Sets must not contain null elements");
-        
-        try {
-            List<Object> commandArgs = new ArrayList<>();
-            commandArgs.add(destKey);
-            commandArgs.add(sets.length);
-            for (byte[] set : sets) {
-                commandArgs.add(set);
-            }
-            
-            return connection.execute("ZDIFFSTORE",
-                (Long glideResult) -> glideResult,
-                commandArgs.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Set<byte[]> zInter(byte[]... sets) {
-        Assert.notNull(sets, "Sets must not be null");
-        Assert.noNullElements(sets, "Sets must not contain null elements");
-        
-        try {
-            List<Object> commandArgs = new ArrayList<>();
-            commandArgs.add(sets.length);
-            for (byte[] set : sets) {
-                commandArgs.add(set);
-            }
-            
-            return connection.execute("ZINTER",
-                (Object[] glideResult) -> {
-                    if (glideResult == null) {
-                        return null;
-                    }
-                    Set<byte[]> resultSet = new LinkedHashSet<>(glideResult.length);
-                    for (Object item : glideResult) {
-                        resultSet.add(((GlideString) item).getBytes());
-                    }
-                    return resultSet;
-                },
-                commandArgs.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Set<Tuple> zInterWithScores(byte[]... sets) {
-        Assert.notNull(sets, "Sets must not be null");
-        Assert.noNullElements(sets, "Sets must not contain null elements");
-        
-        try {
-            List<Object> commandArgs = new ArrayList<>();
-            commandArgs.add(sets.length);
-            for (byte[] set : sets) {
-                commandArgs.add(set);
-            }
-            commandArgs.add("WITHSCORES");
-            
-            return connection.execute("ZINTER",
-                (Map<?, ?>  glideResult) -> {
-                    if (glideResult == null || glideResult.isEmpty()) {
-                        return null;
-                    }
-
-                    Set<Tuple> resultSet = new LinkedHashSet<>();
-                    for (Map.Entry<?, ?> entry : glideResult.entrySet()) {
-                        byte[] value = ((GlideString) entry.getKey()).getBytes();
-                        Double score = ((Number) entry.getValue()).doubleValue();
-                        resultSet.add(new DefaultTuple(value, score));
-                    }
-                    return resultSet;
-                },
-                commandArgs.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Set<Tuple> zInterWithScores(Aggregate aggregate, Weights weights, byte[]... sets) {
-        Assert.notNull(aggregate, "Aggregate must not be null");
-        Assert.notNull(weights, "Weights must not be null");
-        Assert.notNull(sets, "Sets must not be null");
-        Assert.noNullElements(sets, "Sets must not contain null elements");
-        
-        try {
-            List<Object> commandArgs = new ArrayList<>();
-            commandArgs.add(sets.length);
-            for (byte[] set : sets) {
-                commandArgs.add(set);
-            }
-            
-            // Add WEIGHTS
-            commandArgs.add("WEIGHTS");
-            for (double weight : weights.toArray()) {
-                commandArgs.add(weight);
-            }
-            
-            // Add AGGREGATE
-            commandArgs.add("AGGREGATE");
-            commandArgs.add(aggregate.name());
-            
-            commandArgs.add("WITHSCORES");
-            
-            return connection.execute("ZINTER",
-                (Map<?, ?>  glideResult) -> {
-                    if (glideResult == null || glideResult.isEmpty()) {
-                        return null;
-                    }
-
-                    Set<Tuple> resultSet = new LinkedHashSet<>();
-                    for (Map.Entry<?, ?> entry : glideResult.entrySet()) {
-                        byte[] value = ((GlideString) entry.getKey()).getBytes();
-                        Double score = ((Number) entry.getValue()).doubleValue();
-                        resultSet.add(new DefaultTuple(value, score));
-                    }
-                    return resultSet;
-                },
-                commandArgs.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Long zInterStore(byte[] destKey, byte[]... sets) {
-        Assert.notNull(destKey, "Destination key must not be null");
-        Assert.notNull(sets, "Sets must not be null");
-        Assert.noNullElements(sets, "Sets must not contain null elements");
-        
-        try {
-            List<Object> commandArgs = new ArrayList<>();
-            commandArgs.add(destKey);
-            commandArgs.add(sets.length);
-            for (byte[] set : sets) {
-                commandArgs.add(set);
-            }
-            
-            return connection.execute("ZINTERSTORE",
-                (Long glideResult) -> glideResult,
-                commandArgs.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Long zInterStore(byte[] destKey, Aggregate aggregate, Weights weights, byte[]... sets) {
-        Assert.notNull(destKey, "Destination key must not be null");
-        Assert.notNull(aggregate, "Aggregate must not be null");
-        Assert.notNull(weights, "Weights must not be null");
-        Assert.notNull(sets, "Sets must not be null");
-        Assert.noNullElements(sets, "Sets must not contain null elements");
-        
-        try {
-            List<Object> commandArgs = new ArrayList<>();
-            commandArgs.add(destKey);
-            commandArgs.add(sets.length);
-            for (byte[] set : sets) {
-                commandArgs.add(set);
-            }
-            
-            // Add WEIGHTS
-            commandArgs.add("WEIGHTS");
-            for (double weight : weights.toArray()) {
-                commandArgs.add(weight);
-            }
-            
-            // Add AGGREGATE
-            commandArgs.add("AGGREGATE");
-            commandArgs.add(aggregate.name());
-            
-            return connection.execute("ZINTERSTORE",
-                (Long glideResult) -> glideResult,
-                commandArgs.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Set<byte[]> zUnion(byte[]... sets) {
-        Assert.notNull(sets, "Sets must not be null");
-        Assert.noNullElements(sets, "Sets must not contain null elements");
-        
-        try {
-            List<Object> commandArgs = new ArrayList<>();
-            commandArgs.add(sets.length);
-            for (byte[] set : sets) {
-                commandArgs.add(set);
-            }
-            
-            return connection.execute("ZUNION",
-                (Object[] glideResult) -> {
-                    if (glideResult == null) {
-                        return null;
-                    }
-                    Set<byte[]> resultSet = new LinkedHashSet<>(glideResult.length);
-                    for (Object item : glideResult) {
-                        resultSet.add(((GlideString) item).getBytes());
-                    }
-                    return resultSet;
-                },
-                commandArgs.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Set<Tuple> zUnionWithScores(byte[]... sets) {
-        Assert.notNull(sets, "Sets must not be null");
-        Assert.noNullElements(sets, "Sets must not contain null elements");
-        
-        try {
-            List<Object> commandArgs = new ArrayList<>();
-            commandArgs.add(sets.length);
-            for (byte[] set : sets) {
-                commandArgs.add(set);
-            }
-            commandArgs.add("WITHSCORES");
-            
-            return connection.execute("ZUNION",
-                (Map<?, ?>  glideResult) -> {
-                    if (glideResult == null || glideResult.isEmpty()) {
-                        return null;
-                    }
-
-                    Set<Tuple> resultSet = new LinkedHashSet<>();
-                    for (Map.Entry<?, ?> entry : glideResult.entrySet()) {
-                        byte[] value = ((GlideString) entry.getKey()).getBytes();
-                        Double score = ((Number) entry.getValue()).doubleValue();
-                        resultSet.add(new DefaultTuple(value, score));
-                    }
-                    return resultSet;
-                },
-                commandArgs.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Set<Tuple> zUnionWithScores(Aggregate aggregate, Weights weights, byte[]... sets) {
-        Assert.notNull(aggregate, "Aggregate must not be null");
-        Assert.notNull(weights, "Weights must not be null");
-        Assert.notNull(sets, "Sets must not be null");
-        Assert.noNullElements(sets, "Sets must not contain null elements");
-        
-        try {
-            List<Object> commandArgs = new ArrayList<>();
-            commandArgs.add(sets.length);
-            for (byte[] set : sets) {
-                commandArgs.add(set);
-            }
-            
-            // Add WEIGHTS
-            commandArgs.add("WEIGHTS");
-            for (double weight : weights.toArray()) {
-                commandArgs.add(weight);
-            }
-            
-            // Add AGGREGATE
-            commandArgs.add("AGGREGATE");
-            commandArgs.add(aggregate.name());
-            
-            commandArgs.add("WITHSCORES");
-            
-            return connection.execute("ZUNION",
-                (Map<?, ?>  glideResult) -> {
-                    if (glideResult == null || glideResult.isEmpty()) {
-                        return null;
-                    }
-
-                    Set<Tuple> resultSet = new LinkedHashSet<>();
-                    for (Map.Entry<?, ?> entry : glideResult.entrySet()) {
-                        byte[] value = ((GlideString) entry.getKey()).getBytes();
-                        Double score = ((Number) entry.getValue()).doubleValue();
-                        resultSet.add(new DefaultTuple(value, score));
-                    }
-                    return resultSet;
-                },
-                commandArgs.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Long zUnionStore(byte[] destKey, byte[]... sets) {
-        Assert.notNull(destKey, "Destination key must not be null");
-        Assert.notNull(sets, "Sets must not be null");
-        Assert.noNullElements(sets, "Sets must not contain null elements");
-        
-        try {
-            List<Object> commandArgs = new ArrayList<>();
-            commandArgs.add(destKey);
-            commandArgs.add(sets.length);
-            for (byte[] set : sets) {
-                commandArgs.add(set);
-            }
-            
-            return connection.execute("ZUNIONSTORE",
-                (Long glideResult) -> glideResult,
-                commandArgs.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Long zUnionStore(byte[] destKey, Aggregate aggregate, Weights weights, byte[]... sets) {
-        Assert.notNull(destKey, "Destination key must not be null");
-        Assert.notNull(aggregate, "Aggregate must not be null");
-        Assert.notNull(weights, "Weights must not be null");
-        Assert.notNull(sets, "Sets must not be null");
-        Assert.noNullElements(sets, "Sets must not contain null elements");
-        
-        try {
-            List<Object> commandArgs = new ArrayList<>();
-            commandArgs.add(destKey);
-            commandArgs.add(sets.length);
-            for (byte[] set : sets) {
-                commandArgs.add(set);
-            }
-            
-            // Add WEIGHTS
-            commandArgs.add("WEIGHTS");
-            for (double weight : weights.toArray()) {
-                commandArgs.add(weight);
-            }
-            
-            // Add AGGREGATE
-            commandArgs.add("AGGREGATE");
-            commandArgs.add(aggregate.name());
-            
-            return connection.execute("ZUNIONSTORE",
-                (Long glideResult) -> glideResult,
-                commandArgs.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Set<byte[]> zRangeByLex(byte[] key, org.springframework.data.domain.Range<byte[]> range,
-            io.valkey.springframework.data.valkey.connection.Limit limit) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(range, "Range must not be null");
-        Assert.notNull(limit, "Limit must not be null");
-        
-        try {
-            List<Object> commandArgs = new ArrayList<>();
-            commandArgs.add(key);
-            commandArgs.add(formatLexRangeBound(range.getLowerBound(), true));
-            commandArgs.add(formatLexRangeBound(range.getUpperBound(), false));
-            
-            if (limit.isLimited()) {
-                commandArgs.add("LIMIT");
-                commandArgs.add(limit.getOffset());
-                commandArgs.add(limit.getCount());
-            }
-            
-            return connection.execute("ZRANGEBYLEX",
-                (Object[] glideResult) -> {
-                    if (glideResult == null) {
-                        return null;
-                    }
-                    Set<byte[]> resultSet = new LinkedHashSet<>(glideResult.length);
-                    for (Object item : glideResult) {
-                        resultSet.add(((GlideString) item).getBytes());
-                    }
-                    return resultSet;
-                },
-                commandArgs.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Set<byte[]> zRevRangeByLex(byte[] key, org.springframework.data.domain.Range<byte[]> range,
-            io.valkey.springframework.data.valkey.connection.Limit limit) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(range, "Range must not be null");
-        Assert.notNull(limit, "Limit must not be null");
-        
-        try {
-            List<Object> commandArgs = new ArrayList<>();
-            commandArgs.add(key);
-            commandArgs.add(formatLexRangeBound(range.getUpperBound(), false));
-            commandArgs.add(formatLexRangeBound(range.getLowerBound(), true));
-            
-            if (limit.isLimited()) {
-                commandArgs.add("LIMIT");
-                commandArgs.add(limit.getOffset());
-                commandArgs.add(limit.getCount());
-            }
-            
-            return connection.execute("ZREVRANGEBYLEX",
-                (Object[] glideResult) -> {
-                    if (glideResult == null) {
-                        return null;
-                    }
-                    Set<byte[]> resultSet = new LinkedHashSet<>(glideResult.length);
-                    for (Object item : glideResult) {
-                        resultSet.add(((GlideString) item).getBytes());
-                    }
-                    return resultSet;
-                },
-                commandArgs.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Long zRangeStoreByLex(byte[] dstKey, byte[] srcKey, org.springframework.data.domain.Range<byte[]> range,
-            io.valkey.springframework.data.valkey.connection.Limit limit) {
-        Assert.notNull(dstKey, "Destination key must not be null");
-        Assert.notNull(srcKey, "Source key must not be null");
-        Assert.notNull(range, "Range must not be null");
-        Assert.notNull(limit, "Limit must not be null");
-        
-        try {
-            List<Object> commandArgs = new ArrayList<>();
-            commandArgs.add(dstKey);
-            commandArgs.add(srcKey);
-            commandArgs.add(formatLexRangeBound(range.getLowerBound(), true));
-            commandArgs.add(formatLexRangeBound(range.getUpperBound(), false));
-            commandArgs.add("BYLEX");
-            
-            if (limit.isLimited()) {
-                commandArgs.add("LIMIT");
-                commandArgs.add(limit.getOffset());
-                commandArgs.add(limit.getCount());
-            }
-            
-            return connection.execute("ZRANGESTORE",
-                (Long glideResult) -> glideResult,
-                commandArgs.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Long zRangeStoreRevByLex(byte[] dstKey, byte[] srcKey, org.springframework.data.domain.Range<byte[]> range,
-            io.valkey.springframework.data.valkey.connection.Limit limit) {
-        Assert.notNull(dstKey, "Destination key must not be null");
-        Assert.notNull(srcKey, "Source key must not be null");
-        Assert.notNull(range, "Range must not be null");
-        Assert.notNull(limit, "Limit must not be null");
-        
-        try {
-            List<Object> commandArgs = new ArrayList<>();
-            commandArgs.add(dstKey);
-            commandArgs.add(srcKey);
-            commandArgs.add(formatLexRangeBound(range.getUpperBound(), false));
-            commandArgs.add(formatLexRangeBound(range.getLowerBound(), true));
-            commandArgs.add("BYLEX");
-            commandArgs.add("REV");
-            
-            if (limit.isLimited()) {
-                commandArgs.add("LIMIT");
-                commandArgs.add(limit.getOffset());
-                commandArgs.add(limit.getCount());
-            }
-            
-            return connection.execute("ZRANGESTORE",
-                (Long glideResult) -> glideResult,
-                commandArgs.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Long zRangeStoreByScore(byte[] dstKey, byte[] srcKey, 
-            org.springframework.data.domain.Range<? extends Number> range,
-            io.valkey.springframework.data.valkey.connection.Limit limit) {
-        Assert.notNull(dstKey, "Destination key must not be null");
-        Assert.notNull(srcKey, "Source key must not be null");
-        Assert.notNull(range, "Range must not be null");
-        Assert.notNull(limit, "Limit must not be null");
-        
-        try {
-            List<Object> commandArgs = new ArrayList<>();
-            commandArgs.add(dstKey);
-            commandArgs.add(srcKey);
-            commandArgs.add(formatRangeBound(range.getLowerBound(), true));
-            commandArgs.add(formatRangeBound(range.getUpperBound(), false));
-            commandArgs.add("BYSCORE");
-            
-            if (limit.isLimited()) {
-                commandArgs.add("LIMIT");
-                commandArgs.add(limit.getOffset());
-                commandArgs.add(limit.getCount());
-            }
-            
-            return connection.execute("ZRANGESTORE",
-                (Long glideResult) -> glideResult,
-                commandArgs.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    @Nullable
-    public Long zRangeStoreRevByScore(byte[] dstKey, byte[] srcKey, 
-            org.springframework.data.domain.Range<? extends Number> range,
-            io.valkey.springframework.data.valkey.connection.Limit limit) {
-        Assert.notNull(dstKey, "Destination key must not be null");
-        Assert.notNull(srcKey, "Source key must not be null");
-        Assert.notNull(range, "Range must not be null");
-        Assert.notNull(limit, "Limit must not be null");
-        
-        try {
-            List<Object> commandArgs = new ArrayList<>();
-            commandArgs.add(dstKey);
-            commandArgs.add(srcKey);
-            commandArgs.add(formatRangeBound(range.getUpperBound(), true));
-            commandArgs.add(formatRangeBound(range.getLowerBound(), false));
-            commandArgs.add("BYSCORE");
-            commandArgs.add("REV");
-            
-            if (limit.isLimited()) {
-                commandArgs.add("LIMIT");
-                commandArgs.add(limit.getOffset());
-                commandArgs.add(limit.getCount());
-            }
-            
-            return connection.execute("ZRANGESTORE",
-                (Long glideResult) -> glideResult,
-                commandArgs.toArray());
-        } catch (Exception ex) {
-            throw new ValkeyGlideExceptionConverter().convert(ex);
-        }
-    }
-
-    @Override
-    public Cursor<Tuple> zScan(byte[] key, ScanOptions options) {
-        Assert.notNull(key, "Key must not be null");
-        Assert.notNull(options, "ScanOptions must not be null");
-       return new ValkeyGlideZSetScanCursor(key, options, connection);
-    }
-
-    // ==================== Helper Methods ====================
-
-    /**
-     * Unified method to convert pop operation results to tuple sets with configurable sort order.
-     * 
-     * @param result the result from ZPOPMIN/ZPOPMAX operation
-     * @param ascending true for ascending order (lowest first), false for descending order (highest first)
-     * @return set of tuples in the specified order
-     */
-    private Set<Tuple> convertToTupleSetForPop(Object result, boolean ascending) {
-        Object converted = ValkeyGlideConverters.defaultFromGlideResult(result);
-        List<Tuple> tuples = new ArrayList<>();
-        
-        // Handle HashMap format returned by Valkey-Glide for pop operations
-        Map<?, ?> map = (Map<?, ?>) converted;
-        
-        // Convert map entries to tuples
-        for (Map.Entry<?, ?> entry : map.entrySet()) {
-            byte[] value = (byte[]) entry.getKey();
-            Double score = ((Number) entry.getValue()).doubleValue();
-            tuples.add(new DefaultTuple(value, score));
-        }
-        
-        // Sort tuples based on the specified order
-        tuples.sort(ascending ? 
-            (t1, t2) -> Double.compare(t1.getScore(), t2.getScore()) :  // ascending: lowest first
-            (t1, t2) -> Double.compare(t2.getScore(), t1.getScore()));   // descending: highest first
-        
-        // Convert to LinkedHashSet to maintain order
-        Set<Tuple> resultSet = new LinkedHashSet<>();
-        resultSet.addAll(tuples);
-        
-        return resultSet;
-    }
-
-    private String formatRangeBound(org.springframework.data.domain.Range.Bound<? extends Number> bound, boolean isLowerBound) {
-        if (bound == null || !bound.getValue().isPresent()) {
-            return isLowerBound ? "-inf" : "+inf";
-        }
-        
-        String value = bound.getValue().get().toString();
-        return bound.isInclusive() ? value : "(" + value;
-    }
-
-    private String formatLexRangeBound(org.springframework.data.domain.Range.Bound<?> bound, boolean isLowerBound) {
-        if (bound == null || !bound.getValue().isPresent()) {
-            return isLowerBound ? "-" : "+";
-        }
-        
-        Object val = bound.getValue().get();
-        String value;
-        if (val instanceof byte[]) {
-            value = new String((byte[]) val, StandardCharsets.UTF_8);
-        } else if (val instanceof String) {
-            value = (String) val;
-        } else {
-            value = val.toString();
-        }
-        
-        return bound.isInclusive() ? "[" + value : "(" + value;
-    }
-
-    /**
-     * Simple implementation of Cursor for ZSCAN operation.
-     */
-    private static class ValkeyGlideZSetScanCursor implements Cursor<Tuple> {
-        
-        private final byte[] key;
-        private final ScanOptions options;
-        private final ValkeyGlideConnection connection;
-        private long cursor = 0;
-        private List<Tuple> tuples = new ArrayList<>();
-        private int currentIndex = 0;
-        private boolean finished = false;
-        
-        public ValkeyGlideZSetScanCursor(byte[] key, ScanOptions options, ValkeyGlideConnection connection) {
-            this.key = key;
-            this.options = options;
-            this.connection = connection;
-            scanNext();
-        }
-        
-        @Override
-        public boolean hasNext() {
-            if (currentIndex < tuples.size()) {
-                return true;
-            }
-            if (finished) {
-                return false;
-            }
-            scanNext();
-            return currentIndex < tuples.size();
-        }
-        
-        @Override
-        public Tuple next() {
-            if (!hasNext()) {
-                throw new java.util.NoSuchElementException();
-            }
-            return tuples.get(currentIndex++);
-        }
-        
-        private void scanNext() {
-            if (connection.isQueueing() || connection.isPipelined()) {
-                throw new InvalidDataAccessApiUsageException("'ZSCAN' cannot be called in pipeline / transaction mode");
-            }
-
-            try {
-                List<Object> args = new ArrayList<>();
-                args.add(key);
-                args.add(String.valueOf(cursor));
-                
-                if (options.getPattern() != null) {
-                    args.add("MATCH");
-                    args.add(options.getPattern());
-                }
-                
-                if (options.getCount() != null) {
-                    args.add("COUNT");
-                    args.add(options.getCount());
-                }
-                
-                Object result = connection.execute("ZSCAN", rawResult -> ValkeyGlideConverters.defaultFromGlideResult(rawResult), args.toArray());
-                Object converted = ValkeyGlideConverters.defaultFromGlideResult(result);
-                
-                if (converted == null) {
-                    finished = true;
-                    return;
-                }
-                
-                List<Object> scanResult = convertToList(converted);
-                if (scanResult.size() >= 2) {
-                    // First element is the cursor, second is the result array
-                    Object cursorObj = ValkeyGlideConverters.defaultFromGlideResult(scanResult.get(0));
-                    if (cursorObj instanceof String) {
-                        cursor = Long.parseLong((String) cursorObj);
-                    } else if (cursorObj instanceof Number) {
-                        cursor = ((Number) cursorObj).longValue();
-                    } else if (cursorObj instanceof byte[]) {
-                        cursor = Long.parseLong(new String((byte[]) cursorObj));
-                    } else {
-                        cursor = Long.parseLong(cursorObj.toString());
-                    }
-                    
-                    if (cursor == 0) {
-                        finished = true;
-                    }
-                    
-                    Object resultArray = scanResult.get(1);
-                    if (resultArray != null) {
-                        List<Object> tupleList = convertToList(resultArray);
-                        tuples.clear();
-                        currentIndex = 0;
-                        
-                        for (int i = 0; i < tupleList.size(); i += 2) {
-                            if (i + 1 < tupleList.size()) {
-                                byte[] value = (byte[]) ValkeyGlideConverters.defaultFromGlideResult(tupleList.get(i));
-                                Double score = parseScore(ValkeyGlideConverters.defaultFromGlideResult(tupleList.get(i + 1)));
-                                tuples.add(new DefaultTuple(value, score));
-                            }
-                        }
-                    }
-                }
-            } catch (Exception ex) {
-                finished = true;
-                throw new ValkeyGlideExceptionConverter().convert(ex);
-            }
-        }
-        
-        @Override
-        public void close() {
-            finished = true;
-        }
-        
-        @Override
-        public boolean isClosed() {
-            return finished;
-        }
-        
-        @Override
-        public long getCursorId() {
-            return cursor;
-        }
-        
-        @Override
-        public long getPosition() {
-            return currentIndex;
-        }
-        
-        @Override
-        public Cursor.CursorId getId() {
-            return Cursor.CursorId.of(cursor);
-        }
-        
-        // Helper methods for convertToList and parseScore
-        @SuppressWarnings("unchecked")
-        private List<Object> convertToList(Object obj) {
-            if (obj instanceof List) {
-                return (List<Object>) obj;
-            } else if (obj instanceof Object[]) {
-                Object[] array = (Object[]) obj;
-                List<Object> list = new ArrayList<>(array.length);
-                for (Object item : array) {
-                    list.add(item);
-                }
-                return list;
-            } else {
-                throw new IllegalArgumentException("Cannot convert " + obj.getClass() + " to List");
-            }
-        }
-        
-        private Double parseScore(Object obj) {
-            if (obj instanceof Number) {
-                return ((Number) obj).doubleValue();
-            } else if (obj instanceof String) {
-                return Double.parseDouble((String) obj);
-            } else if (obj instanceof byte[]) {
-                return Double.parseDouble(new String((byte[]) obj));
-            } else {
-                throw new IllegalArgumentException("Cannot parse score from " + obj.getClass());
-            }
-        }
-    }
+	private final ValkeyGlideConnection connection;
+
+	/**
+	 * Creates a new {@link ValkeyGlideZSetCommands}.
+	 * @param connection must not be {@literal null}.
+	 */
+	public ValkeyGlideZSetCommands(ValkeyGlideConnection connection) {
+		Assert.notNull(connection, "Connection must not be null!");
+		this.connection = connection;
+	}
+
+	@Override
+	@Nullable public Boolean zAdd(byte[] key, double score, byte[] value, ZAddArgs args) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(value, "Value must not be null");
+		Assert.notNull(args, "ZAddArgs must not be null");
+
+		try {
+			List<Object> commandArgs = new ArrayList<>();
+			commandArgs.add(key);
+
+			// Add arguments based on ZAddArgs
+			if (args.contains(ZAddArgs.Flag.NX)) {
+				commandArgs.add("NX");
+			}
+			if (args.contains(ZAddArgs.Flag.XX)) {
+				commandArgs.add("XX");
+			}
+			if (args.contains(ZAddArgs.Flag.GT)) {
+				commandArgs.add("GT");
+			}
+			if (args.contains(ZAddArgs.Flag.LT)) {
+				commandArgs.add("LT");
+			}
+			if (args.contains(ZAddArgs.Flag.CH)) {
+				commandArgs.add("CH");
+			}
+
+			commandArgs.add(score);
+			commandArgs.add(value);
+
+			return connection.execute("ZADD", (Long glideResult) -> glideResult == null ? null : glideResult > 0,
+					commandArgs.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Long zAdd(byte[] key, Set<Tuple> tuples, ZAddArgs args) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(tuples, "Tuples must not be null");
+		Assert.notNull(args, "ZAddArgs must not be null");
+
+		if (tuples.isEmpty()) {
+			return 0L;
+		}
+
+		try {
+			List<Object> commandArgs = new ArrayList<>();
+			commandArgs.add(key);
+
+			// Add arguments based on ZAddArgs
+			if (args.contains(ZAddArgs.Flag.NX)) {
+				commandArgs.add("NX");
+			}
+			if (args.contains(ZAddArgs.Flag.XX)) {
+				commandArgs.add("XX");
+			}
+			if (args.contains(ZAddArgs.Flag.GT)) {
+				commandArgs.add("GT");
+			}
+			if (args.contains(ZAddArgs.Flag.LT)) {
+				commandArgs.add("LT");
+			}
+			if (args.contains(ZAddArgs.Flag.CH)) {
+				commandArgs.add("CH");
+			}
+
+			// Add score-value pairs
+			for (Tuple tuple : tuples) {
+				commandArgs.add(tuple.getScore());
+				commandArgs.add(tuple.getValue());
+			}
+
+			return connection.execute("ZADD", (Long glideResult) -> glideResult, commandArgs.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Long zRem(byte[] key, byte[]... values) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(values, "Values must not be null");
+		Assert.noNullElements(values, "Values must not contain null elements");
+
+		try {
+			Object[] args = new Object[values.length + 1];
+			args[0] = key;
+			System.arraycopy(values, 0, args, 1, values.length);
+
+			return connection.execute("ZREM", (Long glideResult) -> glideResult, args);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Double zIncrBy(byte[] key, double increment, byte[] value) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(value, "Value must not be null");
+
+		try {
+			return connection.execute("ZINCRBY", (Double glideResult) -> glideResult, key, increment, value);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public byte[] zRandMember(byte[] key) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("ZRANDMEMBER",
+					(GlideString glideResult) -> glideResult != null ? glideResult.getBytes() : null, key);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public List<byte[]> zRandMember(byte[] key, long count) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("ZRANDMEMBER", (Object glideResult) -> {
+				if (glideResult == null) {
+					return new ArrayList<>();
+				}
+				if (glideResult instanceof GlideString) {
+					// Single result case
+					List<byte[]> singleResultList = new ArrayList<>(1);
+					singleResultList.add(((GlideString) glideResult).getBytes());
+					return singleResultList;
+				}
+				Object[] glideResultArray = (Object[]) glideResult;
+				List<byte[]> resultList = new ArrayList<>(glideResultArray.length);
+				for (Object item : glideResultArray) {
+					resultList.add(((GlideString) item).getBytes());
+				}
+				return resultList;
+			}, key, count);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Tuple zRandMemberWithScore(byte[] key) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("ZRANDMEMBER", (Object[] glideResult) -> {
+				if (glideResult == null) {
+					return null;
+				}
+
+				Object[] firstElement = (Object[]) glideResult[0];
+				byte[] value = ((GlideString) firstElement[0]).getBytes();
+				Double score = (Double) firstElement[1];
+				return new DefaultTuple(value, score);
+			}, key, 1, "WITHSCORES");
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public List<Tuple> zRandMemberWithScore(byte[] key, long count) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("ZRANDMEMBER", (Object[] glideResult) -> {
+				if (glideResult == null) {
+					return new ArrayList<>();
+				}
+
+				List<Tuple> resultList = new ArrayList<>();
+				for (Object item : glideResult) {
+					Object[] pair = (Object[]) item;
+					byte[] value = ((GlideString) pair[0]).getBytes();
+					Double score = (Double) pair[1];
+					resultList.add(new DefaultTuple(value, score));
+				}
+				return resultList;
+			}, key, count, "WITHSCORES");
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Long zRank(byte[] key, byte[] value) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(value, "Value must not be null");
+
+		try {
+			return connection.execute("ZRANK", (Long glideResult) -> glideResult, key, value);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Long zRevRank(byte[] key, byte[] value) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(value, "Value must not be null");
+
+		try {
+			return connection.execute("ZREVRANK", (Long glideResult) -> glideResult, key, value);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Set<byte[]> zRange(byte[] key, long start, long end) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("ZRANGE", (Object[] glideResult) -> {
+				if (glideResult == null) {
+					return null;
+				}
+				Set<byte[]> resultSet = new LinkedHashSet<>(glideResult.length);
+				for (Object item : glideResult) {
+					resultSet.add(((GlideString) item).getBytes());
+				}
+				return resultSet;
+			}, key, start, end);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Set<Tuple> zRangeWithScores(byte[] key, long start, long end) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("ZRANGE", (Map<?, ?> glideResult) -> {
+				if (glideResult == null || glideResult.isEmpty()) {
+					return null;
+				}
+
+				Set<Tuple> resultSet = new LinkedHashSet<>();
+				for (Map.Entry<?, ?> entry : glideResult.entrySet()) {
+					byte[] value = ((GlideString) entry.getKey()).getBytes();
+					Double score = ((Number) entry.getValue()).doubleValue();
+					resultSet.add(new DefaultTuple(value, score));
+				}
+				return resultSet;
+			},
+
+					key, start, end, "WITHSCORES");
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Set<byte[]> zRangeByScore(byte[] key, org.springframework.data.domain.Range<? extends Number> range,
+			io.valkey.springframework.data.valkey.connection.Limit limit) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(range, "Range must not be null");
+		Assert.notNull(limit, "Limit must not be null");
+
+		try {
+			List<Object> commandArgs = new ArrayList<>();
+			commandArgs.add(key);
+
+			// Add range bounds
+			commandArgs.add(formatRangeBound(range.getLowerBound(), true));
+			commandArgs.add(formatRangeBound(range.getUpperBound(), false));
+
+			// Add limit if specified
+			if (limit.isLimited()) {
+				commandArgs.add("LIMIT");
+				commandArgs.add(limit.getOffset());
+				commandArgs.add(limit.getCount());
+			}
+
+			return connection.execute("ZRANGEBYSCORE", (Object[] glideResult) -> {
+				if (glideResult == null) {
+					return null;
+				}
+				Set<byte[]> resultSet = new LinkedHashSet<>(glideResult.length);
+				for (Object item : glideResult) {
+					resultSet.add(((GlideString) item).getBytes());
+				}
+				return resultSet;
+			}, commandArgs.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Set<byte[]> zRangeByScore(byte[] key, String min, String max, long offset, long count) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(min, "Min must not be null");
+		Assert.notNull(max, "Max must not be null");
+
+		try {
+			List<Object> commandArgs = new ArrayList<>();
+			commandArgs.add(key);
+			commandArgs.add(min);
+			commandArgs.add(max);
+			commandArgs.add("LIMIT");
+			commandArgs.add(offset);
+			commandArgs.add(count);
+
+			return connection.execute("ZRANGEBYSCORE", (Object[] glideResult) -> {
+				if (glideResult == null) {
+					return null;
+				}
+				Set<byte[]> resultSet = new LinkedHashSet<>(glideResult.length);
+				for (Object item : glideResult) {
+					resultSet.add(((GlideString) item).getBytes());
+				}
+				return resultSet;
+			}, commandArgs.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Set<Tuple> zRangeByScoreWithScores(byte[] key, org.springframework.data.domain.Range<? extends Number> range,
+			io.valkey.springframework.data.valkey.connection.Limit limit) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(range, "Range must not be null");
+		Assert.notNull(limit, "Limit must not be null");
+
+		try {
+			List<Object> commandArgs = new ArrayList<>();
+			commandArgs.add(key);
+
+			// Add range bounds
+			commandArgs.add(formatRangeBound(range.getLowerBound(), true));
+			commandArgs.add(formatRangeBound(range.getUpperBound(), false));
+
+			commandArgs.add("WITHSCORES");
+
+			// Add limit if specified
+			if (limit.isLimited()) {
+				commandArgs.add("LIMIT");
+				commandArgs.add(limit.getOffset());
+				commandArgs.add(limit.getCount());
+			}
+
+			return connection.execute("ZRANGEBYSCORE", (Object[] glideResult) -> {
+				if (glideResult == null) {
+					return null;
+				}
+				Set<Tuple> resultSet = new LinkedHashSet<>();
+				for (Object item : glideResult) {
+					Object[] valueScorePair = (Object[]) item;
+					byte[] value = ((GlideString) valueScorePair[0]).getBytes();
+					Double score = ((Number) valueScorePair[1]).doubleValue();
+					resultSet.add(new DefaultTuple(value, score));
+				}
+				return resultSet;
+			}, commandArgs.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Set<byte[]> zRevRange(byte[] key, long start, long end) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("ZREVRANGE", (Object[] glideResult) -> {
+				if (glideResult == null) {
+					return null;
+				}
+				Set<byte[]> resultSet = new LinkedHashSet<>(glideResult.length);
+				for (Object item : glideResult) {
+					resultSet.add(((GlideString) item).getBytes());
+				}
+				return resultSet;
+			}, key, start, end);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Set<Tuple> zRevRangeWithScores(byte[] key, long start, long end) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("ZREVRANGE", (Object[] glideResult) -> {
+				if (glideResult == null) {
+					return null;
+				}
+				Set<Tuple> resultSet = new LinkedHashSet<>();
+				for (Object item : glideResult) {
+					Object[] valueScorePair = (Object[]) item;
+					byte[] value = ((GlideString) valueScorePair[0]).getBytes();
+					Double score = ((Number) valueScorePair[1]).doubleValue();
+					resultSet.add(new DefaultTuple(value, score));
+				}
+				return resultSet;
+			}, key, start, end, "WITHSCORES");
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Set<byte[]> zRevRangeByScore(byte[] key, org.springframework.data.domain.Range<? extends Number> range,
+			io.valkey.springframework.data.valkey.connection.Limit limit) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(range, "Range must not be null");
+		Assert.notNull(limit, "Limit must not be null");
+
+		try {
+			List<Object> commandArgs = new ArrayList<>();
+			commandArgs.add(key);
+
+			// Add range bounds (reversed for ZREVRANGEBYSCORE)
+			commandArgs.add(formatRangeBound(range.getUpperBound(), true));
+			commandArgs.add(formatRangeBound(range.getLowerBound(), false));
+
+			// Add limit if specified
+			if (limit.isLimited()) {
+				commandArgs.add("LIMIT");
+				commandArgs.add(limit.getOffset());
+				commandArgs.add(limit.getCount());
+			}
+
+			return connection.execute("ZREVRANGEBYSCORE", (Object[] glideResult) -> {
+				if (glideResult == null) {
+					return null;
+				}
+				Set<byte[]> resultSet = new LinkedHashSet<>(glideResult.length);
+				for (Object item : glideResult) {
+					resultSet.add(((GlideString) item).getBytes());
+				}
+				return resultSet;
+			}, commandArgs.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Set<Tuple> zRevRangeByScoreWithScores(byte[] key,
+			org.springframework.data.domain.Range<? extends Number> range,
+			io.valkey.springframework.data.valkey.connection.Limit limit) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(range, "Range must not be null");
+		Assert.notNull(limit, "Limit must not be null");
+
+		try {
+			List<Object> commandArgs = new ArrayList<>();
+			commandArgs.add(key);
+
+			// Add range bounds (reversed for ZREVRANGEBYSCORE)
+			commandArgs.add(formatRangeBound(range.getUpperBound(), true));
+			commandArgs.add(formatRangeBound(range.getLowerBound(), false));
+
+			commandArgs.add("WITHSCORES");
+
+			// Add limit if specified
+			if (limit.isLimited()) {
+				commandArgs.add("LIMIT");
+				commandArgs.add(limit.getOffset());
+				commandArgs.add(limit.getCount());
+			}
+
+			return connection.execute("ZREVRANGEBYSCORE", (Object[] glideResult) -> {
+				if (glideResult == null) {
+					return null;
+				}
+				Set<Tuple> resultSet = new LinkedHashSet<>();
+				for (Object item : glideResult) {
+					// Each item is expected to be an array: [value, score]
+					Object[] valueScorePair = (Object[]) item;
+					byte[] value = ((GlideString) valueScorePair[0]).getBytes();
+					Double score = ((Number) valueScorePair[1]).doubleValue();
+					resultSet.add(new DefaultTuple(value, score));
+				}
+				return resultSet;
+			}, commandArgs.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Long zCount(byte[] key, org.springframework.data.domain.Range<? extends Number> range) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(range, "Range must not be null");
+
+		try {
+			return connection.execute("ZCOUNT", (Long glideResult) -> glideResult, key,
+					formatRangeBound(range.getLowerBound(), true), formatRangeBound(range.getUpperBound(), false));
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Long zLexCount(byte[] key, org.springframework.data.domain.Range<byte[]> range) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(range, "Range must not be null");
+
+		try {
+			return connection.execute("ZLEXCOUNT", (Long glideResult) -> glideResult, key,
+					formatLexRangeBound(range.getLowerBound(), true),
+					formatLexRangeBound(range.getUpperBound(), false));
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Tuple zPopMin(byte[] key) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("ZPOPMIN", (Map<?, ?> glideResult) -> {
+				if (glideResult == null || glideResult.isEmpty()) {
+					return null;
+				}
+				Map.Entry<?, ?> entry = glideResult.entrySet().iterator().next();
+				byte[] value = ((GlideString) entry.getKey()).getBytes();
+				Double score = ((Number) entry.getValue()).doubleValue();
+				return new DefaultTuple(value, score);
+			}, key);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Set<Tuple> zPopMin(byte[] key, long count) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("ZPOPMIN",
+					(Object glideResult) -> glideResult != null ? convertToTupleSetForPop(glideResult, true) : null,
+					key, count);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Tuple bZPopMin(byte[] key, long timeout, TimeUnit unit) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(unit, "TimeUnit must not be null");
+
+		try {
+			long timeoutInSeconds = unit.toSeconds(timeout);
+
+			return connection.execute("BZPOPMIN", (Object[] glideResult) -> {
+				if (glideResult == null) {
+					return null;
+				}
+				byte[] value = ((GlideString) glideResult[1]).getBytes();
+				Double score = ((Number) glideResult[2]).doubleValue();
+				return new DefaultTuple(value, score);
+			}, key, timeoutInSeconds);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Tuple zPopMax(byte[] key) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("ZPOPMAX", (Map<?, ?> glideResult) -> {
+				if (glideResult == null || glideResult.isEmpty()) {
+					return null;
+				}
+				Map.Entry<?, ?> entry = glideResult.entrySet().iterator().next();
+				byte[] value = ((GlideString) entry.getKey()).getBytes();
+				Double score = ((Number) entry.getValue()).doubleValue();
+				return new DefaultTuple(value, score);
+			}, key);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Set<Tuple> zPopMax(byte[] key, long count) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("ZPOPMAX",
+					(Object glideResult) -> glideResult != null ? convertToTupleSetForPop(glideResult, false) : null,
+					key, count);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Tuple bZPopMax(byte[] key, long timeout, TimeUnit unit) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(unit, "TimeUnit must not be null");
+
+		try {
+			long timeoutInSeconds = unit.toSeconds(timeout);
+
+			return connection.execute("BZPOPMAX", (Object[] glideResult) -> {
+				if (glideResult == null) {
+					return null;
+				}
+				byte[] value = ((GlideString) glideResult[1]).getBytes();
+				Double score = ((Number) glideResult[2]).doubleValue();
+				return new DefaultTuple(value, score);
+			}, key, timeoutInSeconds);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Long zCard(byte[] key) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("ZCARD", (Long glideResult) -> glideResult, key);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Double zScore(byte[] key, byte[] value) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(value, "Value must not be null");
+
+		try {
+			return connection.execute("ZSCORE", (Double glideResult) -> glideResult, key, value);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public List<Double> zMScore(byte[] key, byte[]... values) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(values, "Values must not be null");
+		Assert.noNullElements(values, "Values must not contain null elements");
+
+		try {
+			Object[] args = new Object[values.length + 1];
+			args[0] = key;
+			System.arraycopy(values, 0, args, 1, values.length);
+
+			return connection.execute("ZMSCORE", (Object[] glideResult) -> {
+				if (glideResult == null) {
+					return null;
+				}
+				List<Double> resultList = new ArrayList<>(glideResult.length);
+				for (Object item : glideResult) {
+					resultList.add((Double) item);
+				}
+				return resultList;
+			}, args);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Long zRemRange(byte[] key, long start, long end) {
+		Assert.notNull(key, "Key must not be null");
+
+		try {
+			return connection.execute("ZREMRANGEBYRANK", (Long glideResult) -> glideResult, key, start, end);
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Long zRemRangeByLex(byte[] key, org.springframework.data.domain.Range<byte[]> range) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(range, "Range must not be null");
+
+		try {
+			return connection.execute("ZREMRANGEBYLEX", (Long glideResult) -> glideResult, key,
+					formatLexRangeBound(range.getLowerBound(), true),
+					formatLexRangeBound(range.getUpperBound(), false));
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Long zRemRangeByScore(byte[] key, org.springframework.data.domain.Range<? extends Number> range) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(range, "Range must not be null");
+
+		try {
+			return connection.execute("ZREMRANGEBYSCORE", (Long glideResult) -> glideResult, key,
+					formatRangeBound(range.getLowerBound(), true), formatRangeBound(range.getUpperBound(), false));
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Set<byte[]> zDiff(byte[]... sets) {
+		Assert.notNull(sets, "Sets must not be null");
+		Assert.noNullElements(sets, "Sets must not contain null elements");
+
+		try {
+			List<Object> commandArgs = new ArrayList<>();
+			commandArgs.add(sets.length);
+			for (byte[] set : sets) {
+				commandArgs.add(set);
+			}
+
+			return connection.execute("ZDIFF", (Object[] glideResult) -> {
+				if (glideResult == null) {
+					return null;
+				}
+				Set<byte[]> resultSet = new LinkedHashSet<>(glideResult.length);
+				for (Object item : glideResult) {
+					resultSet.add(((GlideString) item).getBytes());
+				}
+				return resultSet;
+			}, commandArgs.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Set<Tuple> zDiffWithScores(byte[]... sets) {
+		Assert.notNull(sets, "Sets must not be null");
+		Assert.noNullElements(sets, "Sets must not contain null elements");
+
+		try {
+			List<Object> commandArgs = new ArrayList<>();
+			commandArgs.add(sets.length);
+			for (byte[] set : sets) {
+				commandArgs.add(set);
+			}
+			commandArgs.add("WITHSCORES");
+
+			return connection.execute("ZDIFF", (Map<?, ?> glideResult) -> {
+				if (glideResult == null || glideResult.isEmpty()) {
+					return null;
+				}
+
+				Set<Tuple> resultSet = new LinkedHashSet<>();
+				for (Map.Entry<?, ?> entry : glideResult.entrySet()) {
+					byte[] value = ((GlideString) entry.getKey()).getBytes();
+					Double score = ((Number) entry.getValue()).doubleValue();
+					resultSet.add(new DefaultTuple(value, score));
+				}
+				return resultSet;
+			}, commandArgs.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Long zDiffStore(byte[] destKey, byte[]... sets) {
+		Assert.notNull(destKey, "Destination key must not be null");
+		Assert.notNull(sets, "Sets must not be null");
+		Assert.noNullElements(sets, "Sets must not contain null elements");
+
+		try {
+			List<Object> commandArgs = new ArrayList<>();
+			commandArgs.add(destKey);
+			commandArgs.add(sets.length);
+			for (byte[] set : sets) {
+				commandArgs.add(set);
+			}
+
+			return connection.execute("ZDIFFSTORE", (Long glideResult) -> glideResult, commandArgs.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Set<byte[]> zInter(byte[]... sets) {
+		Assert.notNull(sets, "Sets must not be null");
+		Assert.noNullElements(sets, "Sets must not contain null elements");
+
+		try {
+			List<Object> commandArgs = new ArrayList<>();
+			commandArgs.add(sets.length);
+			for (byte[] set : sets) {
+				commandArgs.add(set);
+			}
+
+			return connection.execute("ZINTER", (Object[] glideResult) -> {
+				if (glideResult == null) {
+					return null;
+				}
+				Set<byte[]> resultSet = new LinkedHashSet<>(glideResult.length);
+				for (Object item : glideResult) {
+					resultSet.add(((GlideString) item).getBytes());
+				}
+				return resultSet;
+			}, commandArgs.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Set<Tuple> zInterWithScores(byte[]... sets) {
+		Assert.notNull(sets, "Sets must not be null");
+		Assert.noNullElements(sets, "Sets must not contain null elements");
+
+		try {
+			List<Object> commandArgs = new ArrayList<>();
+			commandArgs.add(sets.length);
+			for (byte[] set : sets) {
+				commandArgs.add(set);
+			}
+			commandArgs.add("WITHSCORES");
+
+			return connection.execute("ZINTER", (Map<?, ?> glideResult) -> {
+				if (glideResult == null || glideResult.isEmpty()) {
+					return null;
+				}
+
+				Set<Tuple> resultSet = new LinkedHashSet<>();
+				for (Map.Entry<?, ?> entry : glideResult.entrySet()) {
+					byte[] value = ((GlideString) entry.getKey()).getBytes();
+					Double score = ((Number) entry.getValue()).doubleValue();
+					resultSet.add(new DefaultTuple(value, score));
+				}
+				return resultSet;
+			}, commandArgs.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Set<Tuple> zInterWithScores(Aggregate aggregate, Weights weights, byte[]... sets) {
+		Assert.notNull(aggregate, "Aggregate must not be null");
+		Assert.notNull(weights, "Weights must not be null");
+		Assert.notNull(sets, "Sets must not be null");
+		Assert.noNullElements(sets, "Sets must not contain null elements");
+
+		try {
+			List<Object> commandArgs = new ArrayList<>();
+			commandArgs.add(sets.length);
+			for (byte[] set : sets) {
+				commandArgs.add(set);
+			}
+
+			// Add WEIGHTS
+			commandArgs.add("WEIGHTS");
+			for (double weight : weights.toArray()) {
+				commandArgs.add(weight);
+			}
+
+			// Add AGGREGATE
+			commandArgs.add("AGGREGATE");
+			commandArgs.add(aggregate.name());
+
+			commandArgs.add("WITHSCORES");
+
+			return connection.execute("ZINTER", (Map<?, ?> glideResult) -> {
+				if (glideResult == null || glideResult.isEmpty()) {
+					return null;
+				}
+
+				Set<Tuple> resultSet = new LinkedHashSet<>();
+				for (Map.Entry<?, ?> entry : glideResult.entrySet()) {
+					byte[] value = ((GlideString) entry.getKey()).getBytes();
+					Double score = ((Number) entry.getValue()).doubleValue();
+					resultSet.add(new DefaultTuple(value, score));
+				}
+				return resultSet;
+			}, commandArgs.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Long zInterStore(byte[] destKey, byte[]... sets) {
+		Assert.notNull(destKey, "Destination key must not be null");
+		Assert.notNull(sets, "Sets must not be null");
+		Assert.noNullElements(sets, "Sets must not contain null elements");
+
+		try {
+			List<Object> commandArgs = new ArrayList<>();
+			commandArgs.add(destKey);
+			commandArgs.add(sets.length);
+			for (byte[] set : sets) {
+				commandArgs.add(set);
+			}
+
+			return connection.execute("ZINTERSTORE", (Long glideResult) -> glideResult, commandArgs.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Long zInterStore(byte[] destKey, Aggregate aggregate, Weights weights, byte[]... sets) {
+		Assert.notNull(destKey, "Destination key must not be null");
+		Assert.notNull(aggregate, "Aggregate must not be null");
+		Assert.notNull(weights, "Weights must not be null");
+		Assert.notNull(sets, "Sets must not be null");
+		Assert.noNullElements(sets, "Sets must not contain null elements");
+
+		try {
+			List<Object> commandArgs = new ArrayList<>();
+			commandArgs.add(destKey);
+			commandArgs.add(sets.length);
+			for (byte[] set : sets) {
+				commandArgs.add(set);
+			}
+
+			// Add WEIGHTS
+			commandArgs.add("WEIGHTS");
+			for (double weight : weights.toArray()) {
+				commandArgs.add(weight);
+			}
+
+			// Add AGGREGATE
+			commandArgs.add("AGGREGATE");
+			commandArgs.add(aggregate.name());
+
+			return connection.execute("ZINTERSTORE", (Long glideResult) -> glideResult, commandArgs.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Set<byte[]> zUnion(byte[]... sets) {
+		Assert.notNull(sets, "Sets must not be null");
+		Assert.noNullElements(sets, "Sets must not contain null elements");
+
+		try {
+			List<Object> commandArgs = new ArrayList<>();
+			commandArgs.add(sets.length);
+			for (byte[] set : sets) {
+				commandArgs.add(set);
+			}
+
+			return connection.execute("ZUNION", (Object[] glideResult) -> {
+				if (glideResult == null) {
+					return null;
+				}
+				Set<byte[]> resultSet = new LinkedHashSet<>(glideResult.length);
+				for (Object item : glideResult) {
+					resultSet.add(((GlideString) item).getBytes());
+				}
+				return resultSet;
+			}, commandArgs.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Set<Tuple> zUnionWithScores(byte[]... sets) {
+		Assert.notNull(sets, "Sets must not be null");
+		Assert.noNullElements(sets, "Sets must not contain null elements");
+
+		try {
+			List<Object> commandArgs = new ArrayList<>();
+			commandArgs.add(sets.length);
+			for (byte[] set : sets) {
+				commandArgs.add(set);
+			}
+			commandArgs.add("WITHSCORES");
+
+			return connection.execute("ZUNION", (Map<?, ?> glideResult) -> {
+				if (glideResult == null || glideResult.isEmpty()) {
+					return null;
+				}
+
+				Set<Tuple> resultSet = new LinkedHashSet<>();
+				for (Map.Entry<?, ?> entry : glideResult.entrySet()) {
+					byte[] value = ((GlideString) entry.getKey()).getBytes();
+					Double score = ((Number) entry.getValue()).doubleValue();
+					resultSet.add(new DefaultTuple(value, score));
+				}
+				return resultSet;
+			}, commandArgs.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Set<Tuple> zUnionWithScores(Aggregate aggregate, Weights weights, byte[]... sets) {
+		Assert.notNull(aggregate, "Aggregate must not be null");
+		Assert.notNull(weights, "Weights must not be null");
+		Assert.notNull(sets, "Sets must not be null");
+		Assert.noNullElements(sets, "Sets must not contain null elements");
+
+		try {
+			List<Object> commandArgs = new ArrayList<>();
+			commandArgs.add(sets.length);
+			for (byte[] set : sets) {
+				commandArgs.add(set);
+			}
+
+			// Add WEIGHTS
+			commandArgs.add("WEIGHTS");
+			for (double weight : weights.toArray()) {
+				commandArgs.add(weight);
+			}
+
+			// Add AGGREGATE
+			commandArgs.add("AGGREGATE");
+			commandArgs.add(aggregate.name());
+
+			commandArgs.add("WITHSCORES");
+
+			return connection.execute("ZUNION", (Map<?, ?> glideResult) -> {
+				if (glideResult == null || glideResult.isEmpty()) {
+					return null;
+				}
+
+				Set<Tuple> resultSet = new LinkedHashSet<>();
+				for (Map.Entry<?, ?> entry : glideResult.entrySet()) {
+					byte[] value = ((GlideString) entry.getKey()).getBytes();
+					Double score = ((Number) entry.getValue()).doubleValue();
+					resultSet.add(new DefaultTuple(value, score));
+				}
+				return resultSet;
+			}, commandArgs.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Long zUnionStore(byte[] destKey, byte[]... sets) {
+		Assert.notNull(destKey, "Destination key must not be null");
+		Assert.notNull(sets, "Sets must not be null");
+		Assert.noNullElements(sets, "Sets must not contain null elements");
+
+		try {
+			List<Object> commandArgs = new ArrayList<>();
+			commandArgs.add(destKey);
+			commandArgs.add(sets.length);
+			for (byte[] set : sets) {
+				commandArgs.add(set);
+			}
+
+			return connection.execute("ZUNIONSTORE", (Long glideResult) -> glideResult, commandArgs.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Long zUnionStore(byte[] destKey, Aggregate aggregate, Weights weights, byte[]... sets) {
+		Assert.notNull(destKey, "Destination key must not be null");
+		Assert.notNull(aggregate, "Aggregate must not be null");
+		Assert.notNull(weights, "Weights must not be null");
+		Assert.notNull(sets, "Sets must not be null");
+		Assert.noNullElements(sets, "Sets must not contain null elements");
+
+		try {
+			List<Object> commandArgs = new ArrayList<>();
+			commandArgs.add(destKey);
+			commandArgs.add(sets.length);
+			for (byte[] set : sets) {
+				commandArgs.add(set);
+			}
+
+			// Add WEIGHTS
+			commandArgs.add("WEIGHTS");
+			for (double weight : weights.toArray()) {
+				commandArgs.add(weight);
+			}
+
+			// Add AGGREGATE
+			commandArgs.add("AGGREGATE");
+			commandArgs.add(aggregate.name());
+
+			return connection.execute("ZUNIONSTORE", (Long glideResult) -> glideResult, commandArgs.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Set<byte[]> zRangeByLex(byte[] key, org.springframework.data.domain.Range<byte[]> range,
+			io.valkey.springframework.data.valkey.connection.Limit limit) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(range, "Range must not be null");
+		Assert.notNull(limit, "Limit must not be null");
+
+		try {
+			List<Object> commandArgs = new ArrayList<>();
+			commandArgs.add(key);
+			commandArgs.add(formatLexRangeBound(range.getLowerBound(), true));
+			commandArgs.add(formatLexRangeBound(range.getUpperBound(), false));
+
+			if (limit.isLimited()) {
+				commandArgs.add("LIMIT");
+				commandArgs.add(limit.getOffset());
+				commandArgs.add(limit.getCount());
+			}
+
+			return connection.execute("ZRANGEBYLEX", (Object[] glideResult) -> {
+				if (glideResult == null) {
+					return null;
+				}
+				Set<byte[]> resultSet = new LinkedHashSet<>(glideResult.length);
+				for (Object item : glideResult) {
+					resultSet.add(((GlideString) item).getBytes());
+				}
+				return resultSet;
+			}, commandArgs.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Set<byte[]> zRevRangeByLex(byte[] key, org.springframework.data.domain.Range<byte[]> range,
+			io.valkey.springframework.data.valkey.connection.Limit limit) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(range, "Range must not be null");
+		Assert.notNull(limit, "Limit must not be null");
+
+		try {
+			List<Object> commandArgs = new ArrayList<>();
+			commandArgs.add(key);
+			commandArgs.add(formatLexRangeBound(range.getUpperBound(), false));
+			commandArgs.add(formatLexRangeBound(range.getLowerBound(), true));
+
+			if (limit.isLimited()) {
+				commandArgs.add("LIMIT");
+				commandArgs.add(limit.getOffset());
+				commandArgs.add(limit.getCount());
+			}
+
+			return connection.execute("ZREVRANGEBYLEX", (Object[] glideResult) -> {
+				if (glideResult == null) {
+					return null;
+				}
+				Set<byte[]> resultSet = new LinkedHashSet<>(glideResult.length);
+				for (Object item : glideResult) {
+					resultSet.add(((GlideString) item).getBytes());
+				}
+				return resultSet;
+			}, commandArgs.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Long zRangeStoreByLex(byte[] dstKey, byte[] srcKey, org.springframework.data.domain.Range<byte[]> range,
+			io.valkey.springframework.data.valkey.connection.Limit limit) {
+		Assert.notNull(dstKey, "Destination key must not be null");
+		Assert.notNull(srcKey, "Source key must not be null");
+		Assert.notNull(range, "Range must not be null");
+		Assert.notNull(limit, "Limit must not be null");
+
+		try {
+			List<Object> commandArgs = new ArrayList<>();
+			commandArgs.add(dstKey);
+			commandArgs.add(srcKey);
+			commandArgs.add(formatLexRangeBound(range.getLowerBound(), true));
+			commandArgs.add(formatLexRangeBound(range.getUpperBound(), false));
+			commandArgs.add("BYLEX");
+
+			if (limit.isLimited()) {
+				commandArgs.add("LIMIT");
+				commandArgs.add(limit.getOffset());
+				commandArgs.add(limit.getCount());
+			}
+
+			return connection.execute("ZRANGESTORE", (Long glideResult) -> glideResult, commandArgs.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Long zRangeStoreRevByLex(byte[] dstKey, byte[] srcKey, org.springframework.data.domain.Range<byte[]> range,
+			io.valkey.springframework.data.valkey.connection.Limit limit) {
+		Assert.notNull(dstKey, "Destination key must not be null");
+		Assert.notNull(srcKey, "Source key must not be null");
+		Assert.notNull(range, "Range must not be null");
+		Assert.notNull(limit, "Limit must not be null");
+
+		try {
+			List<Object> commandArgs = new ArrayList<>();
+			commandArgs.add(dstKey);
+			commandArgs.add(srcKey);
+			commandArgs.add(formatLexRangeBound(range.getUpperBound(), false));
+			commandArgs.add(formatLexRangeBound(range.getLowerBound(), true));
+			commandArgs.add("BYLEX");
+			commandArgs.add("REV");
+
+			if (limit.isLimited()) {
+				commandArgs.add("LIMIT");
+				commandArgs.add(limit.getOffset());
+				commandArgs.add(limit.getCount());
+			}
+
+			return connection.execute("ZRANGESTORE", (Long glideResult) -> glideResult, commandArgs.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Long zRangeStoreByScore(byte[] dstKey, byte[] srcKey,
+			org.springframework.data.domain.Range<? extends Number> range,
+			io.valkey.springframework.data.valkey.connection.Limit limit) {
+		Assert.notNull(dstKey, "Destination key must not be null");
+		Assert.notNull(srcKey, "Source key must not be null");
+		Assert.notNull(range, "Range must not be null");
+		Assert.notNull(limit, "Limit must not be null");
+
+		try {
+			List<Object> commandArgs = new ArrayList<>();
+			commandArgs.add(dstKey);
+			commandArgs.add(srcKey);
+			commandArgs.add(formatRangeBound(range.getLowerBound(), true));
+			commandArgs.add(formatRangeBound(range.getUpperBound(), false));
+			commandArgs.add("BYSCORE");
+
+			if (limit.isLimited()) {
+				commandArgs.add("LIMIT");
+				commandArgs.add(limit.getOffset());
+				commandArgs.add(limit.getCount());
+			}
+
+			return connection.execute("ZRANGESTORE", (Long glideResult) -> glideResult, commandArgs.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	@Nullable public Long zRangeStoreRevByScore(byte[] dstKey, byte[] srcKey,
+			org.springframework.data.domain.Range<? extends Number> range,
+			io.valkey.springframework.data.valkey.connection.Limit limit) {
+		Assert.notNull(dstKey, "Destination key must not be null");
+		Assert.notNull(srcKey, "Source key must not be null");
+		Assert.notNull(range, "Range must not be null");
+		Assert.notNull(limit, "Limit must not be null");
+
+		try {
+			List<Object> commandArgs = new ArrayList<>();
+			commandArgs.add(dstKey);
+			commandArgs.add(srcKey);
+			commandArgs.add(formatRangeBound(range.getUpperBound(), true));
+			commandArgs.add(formatRangeBound(range.getLowerBound(), false));
+			commandArgs.add("BYSCORE");
+			commandArgs.add("REV");
+
+			if (limit.isLimited()) {
+				commandArgs.add("LIMIT");
+				commandArgs.add(limit.getOffset());
+				commandArgs.add(limit.getCount());
+			}
+
+			return connection.execute("ZRANGESTORE", (Long glideResult) -> glideResult, commandArgs.toArray());
+		}
+		catch (Exception ex) {
+			throw new ValkeyGlideExceptionConverter().convert(ex);
+		}
+	}
+
+	@Override
+	public Cursor<Tuple> zScan(byte[] key, ScanOptions options) {
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(options, "ScanOptions must not be null");
+		return new ValkeyGlideZSetScanCursor(key, options, connection);
+	}
+
+	// ==================== Helper Methods ====================
+
+	/**
+	 * Unified method to convert pop operation results to tuple sets with configurable
+	 * sort order.
+	 * @param result the result from ZPOPMIN/ZPOPMAX operation
+	 * @param ascending true for ascending order (lowest first), false for descending
+	 * order (highest first)
+	 * @return set of tuples in the specified order
+	 */
+	private Set<Tuple> convertToTupleSetForPop(Object result, boolean ascending) {
+		Object converted = ValkeyGlideConverters.defaultFromGlideResult(result);
+		List<Tuple> tuples = new ArrayList<>();
+
+		// Handle HashMap format returned by Valkey-Glide for pop operations
+		Map<?, ?> map = (Map<?, ?>) converted;
+
+		// Convert map entries to tuples
+		for (Map.Entry<?, ?> entry : map.entrySet()) {
+			byte[] value = (byte[]) entry.getKey();
+			Double score = ((Number) entry.getValue()).doubleValue();
+			tuples.add(new DefaultTuple(value, score));
+		}
+
+		// Sort tuples based on the specified order
+		tuples.sort(ascending ? (t1, t2) -> Double.compare(t1.getScore(), t2.getScore()) : // ascending:
+																							// lowest
+																							// first
+				(t1, t2) -> Double.compare(t2.getScore(), t1.getScore())); // descending:
+																			// highest
+																			// first
+
+		// Convert to LinkedHashSet to maintain order
+		Set<Tuple> resultSet = new LinkedHashSet<>();
+		resultSet.addAll(tuples);
+
+		return resultSet;
+	}
+
+	private String formatRangeBound(org.springframework.data.domain.Range.Bound<? extends Number> bound,
+			boolean isLowerBound) {
+		if (bound == null || !bound.getValue().isPresent()) {
+			return isLowerBound ? "-inf" : "+inf";
+		}
+
+		String value = bound.getValue().get().toString();
+		return bound.isInclusive() ? value : "(" + value;
+	}
+
+	private String formatLexRangeBound(org.springframework.data.domain.Range.Bound<?> bound, boolean isLowerBound) {
+		if (bound == null || !bound.getValue().isPresent()) {
+			return isLowerBound ? "-" : "+";
+		}
+
+		Object val = bound.getValue().get();
+		String value;
+		if (val instanceof byte[]) {
+			value = new String((byte[]) val, StandardCharsets.UTF_8);
+		}
+		else if (val instanceof String) {
+			value = (String) val;
+		}
+		else {
+			value = val.toString();
+		}
+
+		return bound.isInclusive() ? "[" + value : "(" + value;
+	}
+
+	/**
+	 * Simple implementation of Cursor for ZSCAN operation.
+	 */
+	private static class ValkeyGlideZSetScanCursor implements Cursor<Tuple> {
+
+		private final byte[] key;
+
+		private final ScanOptions options;
+
+		private final ValkeyGlideConnection connection;
+
+		private long cursor = 0;
+
+		private List<Tuple> tuples = new ArrayList<>();
+
+		private int currentIndex = 0;
+
+		private boolean finished = false;
+
+		public ValkeyGlideZSetScanCursor(byte[] key, ScanOptions options, ValkeyGlideConnection connection) {
+			this.key = key;
+			this.options = options;
+			this.connection = connection;
+			scanNext();
+		}
+
+		@Override
+		public boolean hasNext() {
+			if (currentIndex < tuples.size()) {
+				return true;
+			}
+			if (finished) {
+				return false;
+			}
+			scanNext();
+			return currentIndex < tuples.size();
+		}
+
+		@Override
+		public Tuple next() {
+			if (!hasNext()) {
+				throw new java.util.NoSuchElementException();
+			}
+			return tuples.get(currentIndex++);
+		}
+
+		private void scanNext() {
+			if (connection.isQueueing() || connection.isPipelined()) {
+				throw new InvalidDataAccessApiUsageException("'ZSCAN' cannot be called in pipeline / transaction mode");
+			}
+
+			try {
+				List<Object> args = new ArrayList<>();
+				args.add(key);
+				args.add(String.valueOf(cursor));
+
+				if (options.getPattern() != null) {
+					args.add("MATCH");
+					args.add(options.getPattern());
+				}
+
+				if (options.getCount() != null) {
+					args.add("COUNT");
+					args.add(options.getCount());
+				}
+
+				Object result = connection.execute("ZSCAN",
+						rawResult -> ValkeyGlideConverters.defaultFromGlideResult(rawResult), args.toArray());
+				Object converted = ValkeyGlideConverters.defaultFromGlideResult(result);
+
+				if (converted == null) {
+					finished = true;
+					return;
+				}
+
+				List<Object> scanResult = convertToList(converted);
+				if (scanResult.size() >= 2) {
+					// First element is the cursor, second is the result array
+					Object cursorObj = ValkeyGlideConverters.defaultFromGlideResult(scanResult.get(0));
+					if (cursorObj instanceof String) {
+						cursor = Long.parseLong((String) cursorObj);
+					}
+					else if (cursorObj instanceof Number) {
+						cursor = ((Number) cursorObj).longValue();
+					}
+					else if (cursorObj instanceof byte[]) {
+						cursor = Long.parseLong(new String((byte[]) cursorObj));
+					}
+					else {
+						cursor = Long.parseLong(cursorObj.toString());
+					}
+
+					if (cursor == 0) {
+						finished = true;
+					}
+
+					Object resultArray = scanResult.get(1);
+					if (resultArray != null) {
+						List<Object> tupleList = convertToList(resultArray);
+						tuples.clear();
+						currentIndex = 0;
+
+						for (int i = 0; i < tupleList.size(); i += 2) {
+							if (i + 1 < tupleList.size()) {
+								byte[] value = (byte[]) ValkeyGlideConverters.defaultFromGlideResult(tupleList.get(i));
+								Double score = parseScore(
+										ValkeyGlideConverters.defaultFromGlideResult(tupleList.get(i + 1)));
+								tuples.add(new DefaultTuple(value, score));
+							}
+						}
+					}
+				}
+			}
+			catch (Exception ex) {
+				finished = true;
+				throw new ValkeyGlideExceptionConverter().convert(ex);
+			}
+		}
+
+		@Override
+		public void close() {
+			finished = true;
+		}
+
+		@Override
+		public boolean isClosed() {
+			return finished;
+		}
+
+		@Override
+		public long getCursorId() {
+			return cursor;
+		}
+
+		@Override
+		public long getPosition() {
+			return currentIndex;
+		}
+
+		@Override
+		public Cursor.CursorId getId() {
+			return Cursor.CursorId.of(cursor);
+		}
+
+		// Helper methods for convertToList and parseScore
+		@SuppressWarnings("unchecked")
+		private List<Object> convertToList(Object obj) {
+			if (obj instanceof List) {
+				return (List<Object>) obj;
+			}
+			else if (obj instanceof Object[]) {
+				Object[] array = (Object[]) obj;
+				List<Object> list = new ArrayList<>(array.length);
+				for (Object item : array) {
+					list.add(item);
+				}
+				return list;
+			}
+			else {
+				throw new IllegalArgumentException("Cannot convert " + obj.getClass() + " to List");
+			}
+		}
+
+		private Double parseScore(Object obj) {
+			if (obj instanceof Number) {
+				return ((Number) obj).doubleValue();
+			}
+			else if (obj instanceof String) {
+				return Double.parseDouble((String) obj);
+			}
+			else if (obj instanceof byte[]) {
+				return Double.parseDouble(new String((byte[]) obj));
+			}
+			else {
+				throw new IllegalArgumentException("Cannot parse score from " + obj.getClass());
+			}
+		}
+
+	}
+
 }

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideZSetCommandsFactory.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideZSetCommandsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,8 @@ import io.valkey.springframework.data.valkey.connection.ValkeyZSetCommands;
  */
 public class ValkeyGlideZSetCommandsFactory {
 
-    public static ValkeyGlideZSetCommands create(ValkeyGlideConnection connection) {
-        return new ValkeyGlideZSetCommands(connection);
-    }
+	public static ValkeyGlideZSetCommands create(ValkeyGlideConnection connection) {
+		return new ValkeyGlideZSetCommands(connection);
+	}
+
 }

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/package-info.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/package-info.java
@@ -1,5 +1,6 @@
 /**
- * Connection package for <a href="https://github.com/valkey-io/valkey-glide">Valkey Glide</a> Valkey client.
+ * Connection package for <a href="https://github.com/valkey-io/valkey-glide">Valkey
+ * Glide</a> Valkey client.
  */
 @org.jspecify.annotations.NullMarked
 package io.valkey.springframework.data.valkey.connection.valkeyglide;

--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/AbstractValkeyGlideClusterIntegrationTests.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/AbstractValkeyGlideClusterIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,22 +38,20 @@ import io.valkey.springframework.data.valkey.test.condition.EnabledOnValkeyClust
 import io.valkey.springframework.data.valkey.test.extension.ValkeyCluster;
 
 /**
- * Abstract base class for Valkey Glide cluster integration tests that provides common setup, 
- * teardown, and utility methods to reduce code duplication across cluster test classes.
- * 
- * This class handles:
- * - Cluster connection factory creation and management via JUnit extension
- * - Server availability validation
- * - Test lifecycle management (setup/teardown)
- * - Common utility methods for key cleanup with proper error handling
- * - Cluster-specific helper methods for topology and node operations
- * - CRC16 slot calculation for hash tag support
- * 
- * Subclasses should:
- * - Override {@link #getTestKeyPatterns()} to define their specific test key patterns
- * - Implement their cluster command-specific test methods
- * - Call {@link #cleanupKey(String)} for individual key cleanup in tests
- * 
+ * Abstract base class for Valkey Glide cluster integration tests that provides common
+ * setup, teardown, and utility methods to reduce code duplication across cluster test
+ * classes.
+ *
+ * This class handles: - Cluster connection factory creation and management via JUnit
+ * extension - Server availability validation - Test lifecycle management (setup/teardown)
+ * - Common utility methods for key cleanup with proper error handling - Cluster-specific
+ * helper methods for topology and node operations - CRC16 slot calculation for hash tag
+ * support
+ *
+ * Subclasses should: - Override {@link #getTestKeyPatterns()} to define their specific
+ * test key patterns - Implement their cluster command-specific test methods - Call
+ * {@link #cleanupKey(String)} for individual key cleanup in tests
+ *
  * @author Ilia Kolominsky
  * @since 2.0
  */
@@ -62,247 +60,229 @@ import io.valkey.springframework.data.valkey.test.extension.ValkeyCluster;
 @ExtendWith(ValkeyGlideConnectionFactoryExtension.class)
 public abstract class AbstractValkeyGlideClusterIntegrationTests {
 
-    protected static final Logger logger = LoggerFactory.getLogger(AbstractValkeyGlideClusterIntegrationTests.class);
+	protected static final Logger logger = LoggerFactory.getLogger(AbstractValkeyGlideClusterIntegrationTests.class);
 
-    protected ValkeyConnectionFactory connectionFactory;
-    protected ValkeyClusterConnection clusterConnection;
+	protected ValkeyConnectionFactory connectionFactory;
 
-    @BeforeAll
-    void setUpAll(@ValkeyCluster ValkeyConnectionFactory connectionFactory) {
-        this.connectionFactory = connectionFactory;
-    }
+	protected ValkeyClusterConnection clusterConnection;
 
-    @BeforeEach
-    void setUp() {
-        clusterConnection = connectionFactory.getClusterConnection();
-        
-        // Clean up any existing test keys
-        cleanupTestKeys();
-    }
+	@BeforeAll
+	void setUpAll(@ValkeyCluster ValkeyConnectionFactory connectionFactory) {
+		this.connectionFactory = connectionFactory;
+	}
 
-    @AfterEach
-    void tearDown() {
-        if (clusterConnection != null && !clusterConnection.isClosed()) {
-            // Clean up any remaining test keys
-            cleanupTestKeys();
-            clusterConnection.close();
-        }
-    }
+	@BeforeEach
+	void setUp() {
+		clusterConnection = connectionFactory.getClusterConnection();
 
-    @AfterAll
-    void tearDownAll() {
-        // Connection factory is managed by the extension, don't destroy it here
-    }
+		// Clean up any existing test keys
+		cleanupTestKeys();
+	}
 
-    // ==================== Helper Methods ====================
+	@AfterEach
+	void tearDown() {
+		if (clusterConnection != null && !clusterConnection.isClosed()) {
+			// Clean up any remaining test keys
+			cleanupTestKeys();
+			clusterConnection.close();
+		}
+	}
 
-    /**
-     * Cleans up all test keys defined by the subclass pattern.
-     * This method is called automatically during setup and teardown.
-     * 
-     * Cleanup exceptions are logged but don't stop the cleanup process to ensure
-     * other keys can still be cleaned up. This is important for test isolation.
-     */
-    protected void cleanupTestKeys() {
-        String[] testKeys = getTestKeyPatterns();
-        
-        for (String key : testKeys) {
-            try {
-                clusterConnection.keyCommands().del(key.getBytes());
-            } catch (Exception e) {
-                logger.warn("Failed to cleanup test key '{}' during teardown: {}", key, e.getMessage());
-                // Continue with other keys - don't let one failure stop the entire cleanup
-            }
-        }
-    }
-    
-    /**
-     * Cleans up a single test key. This method should be called in finally blocks
-     * of individual test methods to ensure proper cleanup.
-     * 
-     * @param key the key to delete
-     */
-    protected void cleanupKey(String key) {
-        try {
-            clusterConnection.keyCommands().del(key.getBytes());
-        } catch (Exception e) {
-            logger.warn("Failed to cleanup test key '{}': {}", key, e.getMessage());
-        }
-    }
+	@AfterAll
+	void tearDownAll() {
+		// Connection factory is managed by the extension, don't destroy it here
+	}
 
-    /**
-     * Cleans up multiple test keys. This method should be called in finally blocks
-     * of individual test methods to ensure proper cleanup.
-     * 
-     * @param keys the keys to delete
-     */
-    protected void cleanupKeys(String... keys) {
-        for (String key : keys) {
-            cleanupKey(key);
-        }
-    }
+	// ==================== Helper Methods ====================
 
-    /**
-     * Retrieves all active master nodes in the cluster using the topology provider.
-     * 
-     * @return collection of active master nodes
-     */
-    protected Collection<ValkeyClusterNode> getActiveMasterNodes() {
-        Iterable<ValkeyClusterNode> allNodes = clusterConnection.clusterCommands().clusterGetNodes();
-        Set<ValkeyClusterNode> masters = new HashSet<>();
-        
-        for (ValkeyClusterNode node : allNodes) {
-            if (node.isMaster()) {
-                masters.add(node);
-            }
-        }
-        
-        return masters;
-    }
+	/**
+	 * Cleans up all test keys defined by the subclass pattern. This method is called
+	 * automatically during setup and teardown.
+	 *
+	 * Cleanup exceptions are logged but don't stop the cleanup process to ensure other
+	 * keys can still be cleaned up. This is important for test isolation.
+	 */
+	protected void cleanupTestKeys() {
+		String[] testKeys = getTestKeyPatterns();
 
-    /**
-     * Retrieves replicas for a given master node.
-     * 
-     * @param master the master node
-     * @return collection of replica nodes
-     */
-    protected Collection<ValkeyClusterNode> getReplicasForMaster(ValkeyClusterNode master) {
-        return clusterConnection.clusterCommands().clusterGetReplicas(master);
-    }
+		for (String key : testKeys) {
+			try {
+				clusterConnection.keyCommands().del(key.getBytes());
+			}
+			catch (Exception e) {
+				logger.warn("Failed to cleanup test key '{}' during teardown: {}", key, e.getMessage());
+				// Continue with other keys - don't let one failure stop the entire
+				// cleanup
+			}
+		}
+	}
 
-    /**
-     * Finds the node serving a given slot.
-     * 
-     * @param slot the slot number
-     * @return the node serving the slot, or null if not found
-     */
-    protected ValkeyClusterNode findNodeBySlot(int slot) {
-        return clusterConnection.clusterCommands().clusterGetNodeForSlot(slot);
-    }
+	/**
+	 * Cleans up a single test key. This method should be called in finally blocks of
+	 * individual test methods to ensure proper cleanup.
+	 * @param key the key to delete
+	 */
+	protected void cleanupKey(String key) {
+		try {
+			clusterConnection.keyCommands().del(key.getBytes());
+		}
+		catch (Exception e) {
+			logger.warn("Failed to cleanup test key '{}': {}", key, e.getMessage());
+		}
+	}
 
-    /**
-     * Calculates the CRC16 slot for a given key using Valkey cluster slot calculation.
-     * Supports hash tags (e.g., "{user}:123" → slot for "user").
-     * 
-     * @param key the key to calculate slot for
-     * @return the slot number (0-16383)
-     */
-    protected int calculateSlot(String key) {
-        return calculateSlot(key.getBytes());
-    }
+	/**
+	 * Cleans up multiple test keys. This method should be called in finally blocks of
+	 * individual test methods to ensure proper cleanup.
+	 * @param keys the keys to delete
+	 */
+	protected void cleanupKeys(String... keys) {
+		for (String key : keys) {
+			cleanupKey(key);
+		}
+	}
 
-    /**
-     * Calculates the CRC16 slot for a given key using Valkey cluster slot calculation.
-     * Supports hash tags (e.g., "{user}:123" → slot for "user").
-     * 
-     * @param key the key bytes to calculate slot for
-     * @return the slot number (0-16383)
-     */
-    protected int calculateSlot(byte[] key) {
-        // Find hash tag if present
-        int start = -1;
-        int end = -1;
-        
-        for (int i = 0; i < key.length; i++) {
-            if (key[i] == '{') {
-                start = i;
-                break;
-            }
-        }
-        
-        if (start >= 0) {
-            for (int i = start + 1; i < key.length; i++) {
-                if (key[i] == '}') {
-                    end = i;
-                    break;
-                }
-            }
-        }
-        
-        // If hash tag found and not empty, use the content between braces
-        byte[] toHash;
-        if (start >= 0 && end >= 0 && end > start + 1) {
-            toHash = Arrays.copyOfRange(key, start + 1, end);
-        } else {
-            toHash = key;
-        }
-        
-        return crc16(toHash) & 0x3FFF; // & 0x3FFF is equivalent to % 16384
-    }
+	/**
+	 * Retrieves all active master nodes in the cluster using the topology provider.
+	 * @return collection of active master nodes
+	 */
+	protected Collection<ValkeyClusterNode> getActiveMasterNodes() {
+		Iterable<ValkeyClusterNode> allNodes = clusterConnection.clusterCommands().clusterGetNodes();
+		Set<ValkeyClusterNode> masters = new HashSet<>();
 
-    /**
-     * CRC16 implementation for Valkey cluster slot calculation.
-     * 
-     * @param bytes the bytes to hash
-     * @return the CRC16 checksum
-     */
-    private int crc16(byte[] bytes) {
-        int crc = 0;
-        
-        for (byte b : bytes) {
-            crc = ((crc << 8) ^ CRC16_TAB[((crc >> 8) ^ (b & 0xFF)) & 0xFF]) & 0xFFFF;
-        }
-        
-        return crc;
-    }
+		for (ValkeyClusterNode node : allNodes) {
+			if (node.isMaster()) {
+				masters.add(node);
+			}
+		}
 
-    // CRC16 lookup table for XMODEM variant used by Valkey
-    private static final int[] CRC16_TAB = {
-        0x0000, 0x1021, 0x2042, 0x3063, 0x4084, 0x50a5, 0x60c6, 0x70e7,
-        0x8108, 0x9129, 0xa14a, 0xb16b, 0xc18c, 0xd1ad, 0xe1ce, 0xf1ef,
-        0x1231, 0x0210, 0x3273, 0x2252, 0x52b5, 0x4294, 0x72f7, 0x62d6,
-        0x9339, 0x8318, 0xb37b, 0xa35a, 0xd3bd, 0xc39c, 0xf3ff, 0xe3de,
-        0x2462, 0x3443, 0x0420, 0x1401, 0x64e6, 0x74c7, 0x44a4, 0x5485,
-        0xa56a, 0xb54b, 0x8528, 0x9509, 0xe5ee, 0xf5cf, 0xc5ac, 0xd58d,
-        0x3653, 0x2672, 0x1611, 0x0630, 0x76d7, 0x66f6, 0x5695, 0x46b4,
-        0xb75b, 0xa77a, 0x9719, 0x8738, 0xf7df, 0xe7fe, 0xd79d, 0xc7bc,
-        0x48c4, 0x58e5, 0x6886, 0x78a7, 0x0840, 0x1861, 0x2802, 0x3823,
-        0xc9cc, 0xd9ed, 0xe98e, 0xf9af, 0x8948, 0x9969, 0xa90a, 0xb92b,
-        0x5af5, 0x4ad4, 0x7ab7, 0x6a96, 0x1a71, 0x0a50, 0x3a33, 0x2a12,
-        0xdbfd, 0xcbdc, 0xfbbf, 0xeb9e, 0x9b79, 0x8b58, 0xbb3b, 0xab1a,
-        0x6ca6, 0x7c87, 0x4ce4, 0x5cc5, 0x2c22, 0x3c03, 0x0c60, 0x1c41,
-        0xedae, 0xfd8f, 0xcdec, 0xddcd, 0xad2a, 0xbd0b, 0x8d68, 0x9d49,
-        0x7e97, 0x6eb6, 0x5ed5, 0x4ef4, 0x3e13, 0x2e32, 0x1e51, 0x0e70,
-        0xff9f, 0xefbe, 0xdfdd, 0xcffc, 0xbf1b, 0xaf3a, 0x9f59, 0x8f78,
-        0x9188, 0x81a9, 0xb1ca, 0xa1eb, 0xd10c, 0xc12d, 0xf14e, 0xe16f,
-        0x1080, 0x00a1, 0x30c2, 0x20e3, 0x5004, 0x4025, 0x7046, 0x6067,
-        0x83b9, 0x9398, 0xa3fb, 0xb3da, 0xc33d, 0xd31c, 0xe37f, 0xf35e,
-        0x02b1, 0x1290, 0x22f3, 0x32d2, 0x4235, 0x5214, 0x6277, 0x7256,
-        0xb5ea, 0xa5cb, 0x95a8, 0x8589, 0xf56e, 0xe54f, 0xd52c, 0xc50d,
-        0x34e2, 0x24c3, 0x14a0, 0x0481, 0x7466, 0x6447, 0x5424, 0x4405,
-        0xa7db, 0xb7fa, 0x8799, 0x97b8, 0xe75f, 0xf77e, 0xc71d, 0xd73c,
-        0x26d3, 0x36f2, 0x0691, 0x16b0, 0x6657, 0x7676, 0x4615, 0x5634,
-        0xd94c, 0xc96d, 0xf90e, 0xe92f, 0x99c8, 0x89e9, 0xb98a, 0xa9ab,
-        0x5844, 0x4865, 0x7806, 0x6827, 0x18c0, 0x08e1, 0x3882, 0x28a3,
-        0xcb7d, 0xdb5c, 0xeb3f, 0xfb1e, 0x8bf9, 0x9bd8, 0xabbb, 0xbb9a,
-        0x4a75, 0x5a54, 0x6a37, 0x7a16, 0x0af1, 0x1ad0, 0x2ab3, 0x3a92,
-        0xfd2e, 0xed0f, 0xdd6c, 0xcd4d, 0xbdaa, 0xad8b, 0x9de8, 0x8dc9,
-        0x7c26, 0x6c07, 0x5c64, 0x4c45, 0x3ca2, 0x2c83, 0x1ce0, 0x0cc1,
-        0xef1f, 0xff3e, 0xcf5d, 0xdf7c, 0xaf9b, 0xbfba, 0x8fd9, 0x9ff8,
-        0x6e17, 0x7e36, 0x4e55, 0x5e74, 0x2e93, 0x3eb2, 0x0ed1, 0x1ef0
-    };
+		return masters;
+	}
 
-    /**
-     * Returns an array of test key patterns that should be cleaned up during
-     * setup and teardown. Subclasses must implement this method to define their
-     * specific test key patterns.
-     * 
-     * @return array of test key patterns used by the subclass
-     */
-    protected abstract String[] getTestKeyPatterns();
+	/**
+	 * Retrieves replicas for a given master node.
+	 * @param master the master node
+	 * @return collection of replica nodes
+	 */
+	protected Collection<ValkeyClusterNode> getReplicasForMaster(ValkeyClusterNode master) {
+		return clusterConnection.clusterCommands().clusterGetReplicas(master);
+	}
 
-    /**
-     * Utility method to merge multiple arrays of test key patterns.
-     * Useful for subclasses that need to combine common patterns with specific ones.
-     * 
-     * @param arrays the arrays to merge
-     * @return merged array containing all unique keys
-     */
-    protected String[] mergeKeyPatterns(String[]... arrays) {
-        Set<String> mergedKeys = new HashSet<>();
-        for (String[] array : arrays) {
-            mergedKeys.addAll(Arrays.asList(array));
-        }
-        return mergedKeys.toArray(new String[0]);
-    }
+	/**
+	 * Finds the node serving a given slot.
+	 * @param slot the slot number
+	 * @return the node serving the slot, or null if not found
+	 */
+	protected ValkeyClusterNode findNodeBySlot(int slot) {
+		return clusterConnection.clusterCommands().clusterGetNodeForSlot(slot);
+	}
+
+	/**
+	 * Calculates the CRC16 slot for a given key using Valkey cluster slot calculation.
+	 * Supports hash tags (e.g., "{user}:123" → slot for "user").
+	 * @param key the key to calculate slot for
+	 * @return the slot number (0-16383)
+	 */
+	protected int calculateSlot(String key) {
+		return calculateSlot(key.getBytes());
+	}
+
+	/**
+	 * Calculates the CRC16 slot for a given key using Valkey cluster slot calculation.
+	 * Supports hash tags (e.g., "{user}:123" → slot for "user").
+	 * @param key the key bytes to calculate slot for
+	 * @return the slot number (0-16383)
+	 */
+	protected int calculateSlot(byte[] key) {
+		// Find hash tag if present
+		int start = -1;
+		int end = -1;
+
+		for (int i = 0; i < key.length; i++) {
+			if (key[i] == '{') {
+				start = i;
+				break;
+			}
+		}
+
+		if (start >= 0) {
+			for (int i = start + 1; i < key.length; i++) {
+				if (key[i] == '}') {
+					end = i;
+					break;
+				}
+			}
+		}
+
+		// If hash tag found and not empty, use the content between braces
+		byte[] toHash;
+		if (start >= 0 && end >= 0 && end > start + 1) {
+			toHash = Arrays.copyOfRange(key, start + 1, end);
+		}
+		else {
+			toHash = key;
+		}
+
+		return crc16(toHash) & 0x3FFF; // & 0x3FFF is equivalent to % 16384
+	}
+
+	/**
+	 * CRC16 implementation for Valkey cluster slot calculation.
+	 * @param bytes the bytes to hash
+	 * @return the CRC16 checksum
+	 */
+	private int crc16(byte[] bytes) {
+		int crc = 0;
+
+		for (byte b : bytes) {
+			crc = ((crc << 8) ^ CRC16_TAB[((crc >> 8) ^ (b & 0xFF)) & 0xFF]) & 0xFFFF;
+		}
+
+		return crc;
+	}
+
+	// CRC16 lookup table for XMODEM variant used by Valkey
+	private static final int[] CRC16_TAB = { 0x0000, 0x1021, 0x2042, 0x3063, 0x4084, 0x50a5, 0x60c6, 0x70e7, 0x8108,
+			0x9129, 0xa14a, 0xb16b, 0xc18c, 0xd1ad, 0xe1ce, 0xf1ef, 0x1231, 0x0210, 0x3273, 0x2252, 0x52b5, 0x4294,
+			0x72f7, 0x62d6, 0x9339, 0x8318, 0xb37b, 0xa35a, 0xd3bd, 0xc39c, 0xf3ff, 0xe3de, 0x2462, 0x3443, 0x0420,
+			0x1401, 0x64e6, 0x74c7, 0x44a4, 0x5485, 0xa56a, 0xb54b, 0x8528, 0x9509, 0xe5ee, 0xf5cf, 0xc5ac, 0xd58d,
+			0x3653, 0x2672, 0x1611, 0x0630, 0x76d7, 0x66f6, 0x5695, 0x46b4, 0xb75b, 0xa77a, 0x9719, 0x8738, 0xf7df,
+			0xe7fe, 0xd79d, 0xc7bc, 0x48c4, 0x58e5, 0x6886, 0x78a7, 0x0840, 0x1861, 0x2802, 0x3823, 0xc9cc, 0xd9ed,
+			0xe98e, 0xf9af, 0x8948, 0x9969, 0xa90a, 0xb92b, 0x5af5, 0x4ad4, 0x7ab7, 0x6a96, 0x1a71, 0x0a50, 0x3a33,
+			0x2a12, 0xdbfd, 0xcbdc, 0xfbbf, 0xeb9e, 0x9b79, 0x8b58, 0xbb3b, 0xab1a, 0x6ca6, 0x7c87, 0x4ce4, 0x5cc5,
+			0x2c22, 0x3c03, 0x0c60, 0x1c41, 0xedae, 0xfd8f, 0xcdec, 0xddcd, 0xad2a, 0xbd0b, 0x8d68, 0x9d49, 0x7e97,
+			0x6eb6, 0x5ed5, 0x4ef4, 0x3e13, 0x2e32, 0x1e51, 0x0e70, 0xff9f, 0xefbe, 0xdfdd, 0xcffc, 0xbf1b, 0xaf3a,
+			0x9f59, 0x8f78, 0x9188, 0x81a9, 0xb1ca, 0xa1eb, 0xd10c, 0xc12d, 0xf14e, 0xe16f, 0x1080, 0x00a1, 0x30c2,
+			0x20e3, 0x5004, 0x4025, 0x7046, 0x6067, 0x83b9, 0x9398, 0xa3fb, 0xb3da, 0xc33d, 0xd31c, 0xe37f, 0xf35e,
+			0x02b1, 0x1290, 0x22f3, 0x32d2, 0x4235, 0x5214, 0x6277, 0x7256, 0xb5ea, 0xa5cb, 0x95a8, 0x8589, 0xf56e,
+			0xe54f, 0xd52c, 0xc50d, 0x34e2, 0x24c3, 0x14a0, 0x0481, 0x7466, 0x6447, 0x5424, 0x4405, 0xa7db, 0xb7fa,
+			0x8799, 0x97b8, 0xe75f, 0xf77e, 0xc71d, 0xd73c, 0x26d3, 0x36f2, 0x0691, 0x16b0, 0x6657, 0x7676, 0x4615,
+			0x5634, 0xd94c, 0xc96d, 0xf90e, 0xe92f, 0x99c8, 0x89e9, 0xb98a, 0xa9ab, 0x5844, 0x4865, 0x7806, 0x6827,
+			0x18c0, 0x08e1, 0x3882, 0x28a3, 0xcb7d, 0xdb5c, 0xeb3f, 0xfb1e, 0x8bf9, 0x9bd8, 0xabbb, 0xbb9a, 0x4a75,
+			0x5a54, 0x6a37, 0x7a16, 0x0af1, 0x1ad0, 0x2ab3, 0x3a92, 0xfd2e, 0xed0f, 0xdd6c, 0xcd4d, 0xbdaa, 0xad8b,
+			0x9de8, 0x8dc9, 0x7c26, 0x6c07, 0x5c64, 0x4c45, 0x3ca2, 0x2c83, 0x1ce0, 0x0cc1, 0xef1f, 0xff3e, 0xcf5d,
+			0xdf7c, 0xaf9b, 0xbfba, 0x8fd9, 0x9ff8, 0x6e17, 0x7e36, 0x4e55, 0x5e74, 0x2e93, 0x3eb2, 0x0ed1, 0x1ef0 };
+
+	/**
+	 * Returns an array of test key patterns that should be cleaned up during setup and
+	 * teardown. Subclasses must implement this method to define their specific test key
+	 * patterns.
+	 * @return array of test key patterns used by the subclass
+	 */
+	protected abstract String[] getTestKeyPatterns();
+
+	/**
+	 * Utility method to merge multiple arrays of test key patterns. Useful for subclasses
+	 * that need to combine common patterns with specific ones.
+	 * @param arrays the arrays to merge
+	 * @return merged array containing all unique keys
+	 */
+	protected String[] mergeKeyPatterns(String[]... arrays) {
+		Set<String> mergedKeys = new HashSet<>();
+		for (String[] array : arrays) {
+			mergedKeys.addAll(Arrays.asList(array));
+		}
+		return mergedKeys.toArray(new String[0]);
+	}
+
 }

--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/AbstractValkeyGlideIntegrationTests.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/AbstractValkeyGlideIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,21 +37,17 @@ import io.valkey.springframework.data.valkey.connection.valkeyglide.extension.Va
 import io.valkey.springframework.data.valkey.test.extension.ValkeyStandalone;
 
 /**
- * Abstract base class for Valkey Glide integration tests that provides common setup, 
+ * Abstract base class for Valkey Glide integration tests that provides common setup,
  * teardown, and utility methods to reduce code duplication across test classes.
- * 
- * This class handles:
- * - Connection factory creation and management
- * - Server availability validation
- * - Test lifecycle management (setup/teardown)
- * - Common utility methods for key cleanup with proper error handling
- * - Configuration property access
- * 
- * Subclasses should:
- * - Override {@link #getTestKeyPatterns()} to define their specific test key patterns
- * - Implement their command-specific test methods
- * - Call {@link #cleanupKey(String)} for individual key cleanup in tests
- * 
+ *
+ * This class handles: - Connection factory creation and management - Server availability
+ * validation - Test lifecycle management (setup/teardown) - Common utility methods for
+ * key cleanup with proper error handling - Configuration property access
+ *
+ * Subclasses should: - Override {@link #getTestKeyPatterns()} to define their specific
+ * test key patterns - Implement their command-specific test methods - Call
+ * {@link #cleanupKey(String)} for individual key cleanup in tests
+ *
  * @author Ilia Kolominsky
  * @since 2.0
  */
@@ -59,175 +55,167 @@ import io.valkey.springframework.data.valkey.test.extension.ValkeyStandalone;
 @ExtendWith(ValkeyGlideConnectionFactoryExtension.class)
 public abstract class AbstractValkeyGlideIntegrationTests {
 
-    protected static final Logger logger = LoggerFactory.getLogger(AbstractValkeyGlideIntegrationTests.class);
+	protected static final Logger logger = LoggerFactory.getLogger(AbstractValkeyGlideIntegrationTests.class);
 
-    protected ValkeyConnectionFactory connectionFactory;
-    protected ValkeyConnection connection;
+	protected ValkeyConnectionFactory connectionFactory;
 
-    @BeforeAll
-     void setUpAll(@ValkeyStandalone ValkeyConnectionFactory connectionFactory) {
-        // Create connection factory
-        this.connectionFactory = connectionFactory;
-        validateServerExistance(connectionFactory);
-    }
+	protected ValkeyConnection connection;
 
-    @BeforeEach
-    void setUp() {
-        connection = connectionFactory.getConnection();
-        
-        // Clean up any existing test keys
-        cleanupTestKeys();
-    }
+	@BeforeAll
+	void setUpAll(@ValkeyStandalone ValkeyConnectionFactory connectionFactory) {
+		// Create connection factory
+		this.connectionFactory = connectionFactory;
+		validateServerExistance(connectionFactory);
+	}
 
-    @AfterEach
-    void tearDown() {
-        if (connection != null && !connection.isClosed()) {
-            // Clean up any remaining test keys
-            cleanupTestKeys();
-            connection.close();
-        }
-    }
+	@BeforeEach
+	void setUp() {
+		connection = connectionFactory.getConnection();
 
-    @AfterAll
-    void tearDownAll() {
-    }
+		// Clean up any existing test keys
+		cleanupTestKeys();
+	}
 
-    // ==================== Helper Methods ====================
+	@AfterEach
+	void tearDown() {
+		if (connection != null && !connection.isClosed()) {
+			// Clean up any remaining test keys
+			cleanupTestKeys();
+			connection.close();
+		}
+	}
 
-    /**
-     * Validates that the Valkey server is available by attempting to ping it.
-     * 
-     * @param factory the connection factory to test
-     * @throws AssertionError if server is not reachable
-     */
-    protected void validateServerExistance(ValkeyConnectionFactory factory) {
-        try (ValkeyConnection connection = factory.getConnection()) {
-            assertThat(connection.ping()).isEqualTo("PONG");
-        }
-    }
+	@AfterAll
+	void tearDownAll() {
+	}
 
-    /**
-     * Gets the Valkey host from system properties, defaulting to localhost.
-     * 
-     * @return the Valkey host
-     */
-    protected String getValkeyHost() {
-        return System.getProperty("valkey.host", "localhost");
-    }
+	// ==================== Helper Methods ====================
 
-    /**
-     * Gets the Valkey port from system properties, defaulting to 6379.
-     * 
-     * @return the Valkey port
-     */
-    protected int getValkeyPort() {
-        return Integer.parseInt(System.getProperty("valkey.port", "6379"));
-    }
+	/**
+	 * Validates that the Valkey server is available by attempting to ping it.
+	 * @param factory the connection factory to test
+	 * @throws AssertionError if server is not reachable
+	 */
+	protected void validateServerExistance(ValkeyConnectionFactory factory) {
+		try (ValkeyConnection connection = factory.getConnection()) {
+			assertThat(connection.ping()).isEqualTo("PONG");
+		}
+	}
 
-    /**
-     * Cleans up all test keys defined by the subclass pattern.
-     * This method is called automatically during setup and teardown.
-     * 
-     * Cleanup exceptions are logged but don't stop the cleanup process to ensure
-     * other keys can still be cleaned up. This is important for test isolation.
-     */
-    protected void cleanupTestKeys() {
-        String[] testKeys = getTestKeyPatterns();
-        
-        for (String key : testKeys) {
-            try {
-                connection.keyCommands().del(key.getBytes());
-            } catch (Exception e) {
-                logger.warn("Failed to cleanup test key '{}' during teardown: {}", key, e.getMessage());
-                // Continue with other keys - don't let one failure stop the entire cleanup
-            }
-        }
-    }
-    
-    /**
-     * Cleans up a single test key. This method should be called in finally blocks
-     * of individual test methods to ensure proper cleanup.
-     * 
-     * @param key the key to delete
-     * @throws RuntimeException if cleanup fails and the failure should be propagated
-     */
-    protected void cleanupKey(String key) {
-        try {
-            connection.keyCommands().del(key.getBytes());
-        } catch (Exception e) {
-            logger.warn("Failed to cleanup test key '{}': {}", key, e.getMessage());
-            // For individual key cleanup in tests, we might want to know about failures
-            // but typically we don't want to fail the test just because cleanup failed
-            // Subclasses can override this behavior if needed
-        }
-    }
+	/**
+	 * Gets the Valkey host from system properties, defaulting to localhost.
+	 * @return the Valkey host
+	 */
+	protected String getValkeyHost() {
+		return System.getProperty("valkey.host", "localhost");
+	}
 
-    /**
-     * Cleans up multiple test keys. This method should be called in finally blocks
-     * of individual test methods to ensure proper cleanup.
-     * 
-     * @param keys the keys to delete
-     */
-    protected void cleanupKeys(String... keys) {
-        for (String key : keys) {
-            cleanupKey(key);
-        }
-    }
+	/**
+	 * Gets the Valkey port from system properties, defaulting to 6379.
+	 * @return the Valkey port
+	 */
+	protected int getValkeyPort() {
+		return Integer.parseInt(System.getProperty("valkey.port", "6379"));
+	}
 
-    /**
-     * Cleans up a single test key with strict error handling. This method will
-     * throw an exception if cleanup fails, which can be useful when cleanup
-     * failures indicate a serious problem that should stop the test.
-     * 
-     * @param key the key to delete
-     * @throws RuntimeException if cleanup fails
-     */
-    protected void cleanupKeyStrict(String key) {
-        try {
-            connection.keyCommands().del(key.getBytes());
-        } catch (Exception e) {
-            String message = String.format("Failed to cleanup test key '%s': %s", key, e.getMessage());
-            logger.error(message, e);
-            throw new RuntimeException(message, e);
-        }
-    }
+	/**
+	 * Cleans up all test keys defined by the subclass pattern. This method is called
+	 * automatically during setup and teardown.
+	 *
+	 * Cleanup exceptions are logged but don't stop the cleanup process to ensure other
+	 * keys can still be cleaned up. This is important for test isolation.
+	 */
+	protected void cleanupTestKeys() {
+		String[] testKeys = getTestKeyPatterns();
 
-    /**
-     * Returns an array of test key patterns that should be cleaned up during
-     * setup and teardown. Subclasses must implement this method to define their
-     * specific test key patterns.
-     * 
-     * @return array of test key patterns used by the subclass
-     */
-    protected abstract String[] getTestKeyPatterns();
+		for (String key : testKeys) {
+			try {
+				connection.keyCommands().del(key.getBytes());
+			}
+			catch (Exception e) {
+				logger.warn("Failed to cleanup test key '{}' during teardown: {}", key, e.getMessage());
+				// Continue with other keys - don't let one failure stop the entire
+				// cleanup
+			}
+		}
+	}
 
-    /**
-     * Utility method to merge multiple arrays of test key patterns.
-     * Useful for subclasses that need to combine common patterns with specific ones.
-     * 
-     * @param arrays the arrays to merge
-     * @return merged array containing all unique keys
-     */
-    protected String[] mergeKeyPatterns(String[]... arrays) {
-        Set<String> mergedKeys = new HashSet<>();
-        for (String[] array : arrays) {
-            mergedKeys.addAll(Arrays.asList(array));
-        }
-        return mergedKeys.toArray(new String[0]);
-    }
+	/**
+	 * Cleans up a single test key. This method should be called in finally blocks of
+	 * individual test methods to ensure proper cleanup.
+	 * @param key the key to delete
+	 * @throws RuntimeException if cleanup fails and the failure should be propagated
+	 */
+	protected void cleanupKey(String key) {
+		try {
+			connection.keyCommands().del(key.getBytes());
+		}
+		catch (Exception e) {
+			logger.warn("Failed to cleanup test key '{}': {}", key, e.getMessage());
+			// For individual key cleanup in tests, we might want to know about failures
+			// but typically we don't want to fail the test just because cleanup failed
+			// Subclasses can override this behavior if needed
+		}
+	}
 
-    /**
-     * Common test key patterns that are frequently used across different test classes.
-     * Subclasses can use this in combination with their specific patterns.
-     * 
-     * @return array of common test key patterns
-     */
-    protected String[] getCommonTestKeyPatterns() {
-        return new String[]{
-            "non:existent:key",
-            "test:common:key1",
-            "test:common:key2",
-            "test:common:key3"
-        };
-    }
+	/**
+	 * Cleans up multiple test keys. This method should be called in finally blocks of
+	 * individual test methods to ensure proper cleanup.
+	 * @param keys the keys to delete
+	 */
+	protected void cleanupKeys(String... keys) {
+		for (String key : keys) {
+			cleanupKey(key);
+		}
+	}
+
+	/**
+	 * Cleans up a single test key with strict error handling. This method will throw an
+	 * exception if cleanup fails, which can be useful when cleanup failures indicate a
+	 * serious problem that should stop the test.
+	 * @param key the key to delete
+	 * @throws RuntimeException if cleanup fails
+	 */
+	protected void cleanupKeyStrict(String key) {
+		try {
+			connection.keyCommands().del(key.getBytes());
+		}
+		catch (Exception e) {
+			String message = String.format("Failed to cleanup test key '%s': %s", key, e.getMessage());
+			logger.error(message, e);
+			throw new RuntimeException(message, e);
+		}
+	}
+
+	/**
+	 * Returns an array of test key patterns that should be cleaned up during setup and
+	 * teardown. Subclasses must implement this method to define their specific test key
+	 * patterns.
+	 * @return array of test key patterns used by the subclass
+	 */
+	protected abstract String[] getTestKeyPatterns();
+
+	/**
+	 * Utility method to merge multiple arrays of test key patterns. Useful for subclasses
+	 * that need to combine common patterns with specific ones.
+	 * @param arrays the arrays to merge
+	 * @return merged array containing all unique keys
+	 */
+	protected String[] mergeKeyPatterns(String[]... arrays) {
+		Set<String> mergedKeys = new HashSet<>();
+		for (String[] array : arrays) {
+			mergedKeys.addAll(Arrays.asList(array));
+		}
+		return mergedKeys.toArray(new String[0]);
+	}
+
+	/**
+	 * Common test key patterns that are frequently used across different test classes.
+	 * Subclasses can use this in combination with their specific patterns.
+	 * @return array of common test key patterns
+	 */
+	protected String[] getCommonTestKeyPatterns() {
+		return new String[] { "non:existent:key", "test:common:key1", "test:common:key2", "test:common:key3" };
+	}
+
 }

--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideClusterConnectionCommandsIntegrationTests.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideClusterConnectionCommandsIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,30 +36,31 @@ import io.valkey.springframework.data.valkey.connection.ValkeyClusterNode.SlotRa
 import io.valkey.springframework.data.valkey.test.condition.EnabledOnValkeyClusterAvailable;
 
 /**
- * Comprehensive low-level integration tests for {@link ValkeyGlideClusterConnection} 
+ * Comprehensive low-level integration tests for {@link ValkeyGlideClusterConnection}
  * cluster functionality using the ValkeyClusterCommands interface directly.
- * 
- * These tests validate the implementation of all ValkeyClusterCommands methods:
- * - Cluster topology operations (clusterGetNodes, clusterGetReplicas, clusterGetMasterReplicaMap)
- * - Slot routing operations (clusterGetSlotForKey, clusterGetNodeForSlot, clusterGetNodeForKey)
- * - Cluster information (clusterGetClusterInfo)
- * - Slot management (clusterAddSlots, clusterDeleteSlots, clusterCountKeysInSlot, clusterGetKeysInSlot)
- * - Node management (clusterMeet, clusterForget, clusterSetSlot, clusterReplicate)
- * 
- * Note: These tests cover DIRECT MODE only, as cluster mode does not support 
- * pipelining or transactions in Valkey-Glide.
- * 
- * <p><strong>Expected Cluster Topology (from Makefile):</strong>
+ *
+ * These tests validate the implementation of all ValkeyClusterCommands methods: - Cluster
+ * topology operations (clusterGetNodes, clusterGetReplicas, clusterGetMasterReplicaMap) -
+ * Slot routing operations (clusterGetSlotForKey, clusterGetNodeForSlot,
+ * clusterGetNodeForKey) - Cluster information (clusterGetClusterInfo) - Slot management
+ * (clusterAddSlots, clusterDeleteSlots, clusterCountKeysInSlot, clusterGetKeysInSlot) -
+ * Node management (clusterMeet, clusterForget, clusterSetSlot, clusterReplicate)
+ *
+ * Note: These tests cover DIRECT MODE only, as cluster mode does not support pipelining
+ * or transactions in Valkey-Glide.
+ *
+ * <p>
+ * <strong>Expected Cluster Topology (from Makefile):</strong>
  * <ul>
- *   <li>3 Master nodes: 7379, 7380, 7381</li>
- *   <li>1 Replica node: 7382 (replica of 7379)</li>
- *   <li>Slot distribution:
- *     <ul>
- *       <li>7379: slots 0-5460 (5461 slots)</li>
- *       <li>7380: slots 5461-10922 (5462 slots)</li>
- *       <li>7381: slots 10923-16383 (5461 slots)</li>
- *     </ul>
- *   </li>
+ * <li>3 Master nodes: 7379, 7380, 7381</li>
+ * <li>1 Replica node: 7382 (replica of 7379)</li>
+ * <li>Slot distribution:
+ * <ul>
+ * <li>7379: slots 0-5460 (5461 slots)</li>
+ * <li>7380: slots 5461-10922 (5462 slots)</li>
+ * <li>7381: slots 10923-16383 (5461 slots)</li>
+ * </ul>
+ * </li>
  * </ul>
  *
  * @author Ilia Kolominsky
@@ -68,759 +69,767 @@ import io.valkey.springframework.data.valkey.test.condition.EnabledOnValkeyClust
 @EnabledOnValkeyClusterAvailable
 public class ValkeyGlideClusterConnectionCommandsIntegrationTests extends AbstractValkeyGlideClusterIntegrationTests {
 
-    // Expected cluster topology constants (from Makefile cluster-init target)
-    private static final int EXPECTED_MASTER_COUNT = 3;
-    private static final int EXPECTED_REPLICA_COUNT = 1;
-    private static final int EXPECTED_TOTAL_NODES = 4;
-    
-    // Slot ranges (from Makefile cluster-slots target)
-    private static final int MASTER_1_SLOT_START = 0;
-    private static final int MASTER_1_SLOT_END = 5460;
-    private static final int MASTER_2_SLOT_START = 5461;
-    private static final int MASTER_2_SLOT_END = 10922;
-    private static final int MASTER_3_SLOT_START = 10923;
-    private static final int MASTER_3_SLOT_END = 16383;
+	// Expected cluster topology constants (from Makefile cluster-init target)
+	private static final int EXPECTED_MASTER_COUNT = 3;
 
-    @Override
-    protected String[] getTestKeyPatterns() {
-        return new String[]{
-            "{user}:test:key1", "{user}:test:key2", "{user}:test:key3",
-            "{product}:test:key1", "{product}:test:key2",
-            "test:cluster:key1", "test:cluster:key2", "test:cluster:key3",
-            "non:existent:key"
-        };
-    }
+	private static final int EXPECTED_REPLICA_COUNT = 1;
 
-    // ==================== Cluster Topology & Information Commands ====================
+	private static final int EXPECTED_TOTAL_NODES = 4;
 
-    @Test
-    void testClusterGetNodes() {
-        // Execute
-        Iterable<ValkeyClusterNode> nodes = clusterConnection.clusterCommands().clusterGetNodes();
-        
-        // Verify
-        assertThat(nodes).isNotNull();
-        
-        // Convert to list for easier assertions
-        List<ValkeyClusterNode> nodeList = (List<ValkeyClusterNode>) 
-            ((nodes instanceof List) ? nodes : 
-                java.util.stream.StreamSupport.stream(nodes.spliterator(), false)
-                    .collect(Collectors.toList()));
-        
-        // Verify expected node count
-        assertThat(nodeList).hasSize(EXPECTED_TOTAL_NODES);
-        
-        // Count masters and replicas
-        int masterCount = 0;
-        int replicaCount = 0;
-        Map<Integer, ValkeyClusterNode> nodesByPort = new HashMap<>();
-        
-        for (ValkeyClusterNode node : nodeList) {
-            // Verify basic node properties
-            assertThat(node.getId()).isNotNull();
-            assertThat(node.getHost()).isNotNull();
-            assertThat(node.getPort()).isGreaterThan(0);
-            
-            nodesByPort.put(node.getPort(), node);
-            
-            // Count masters and replicas
-            if (node.isMaster()) {
-                masterCount++;
-                // Masters should have slot ranges assigned
-                assertThat(node.getSlotRange()).isNotNull();
-                assertThat(node.getSlotRange().getSlots()).isNotEmpty();
-            } else {
-                replicaCount++;
-                // Replicas should have master ID
-                assertThat(node.getMasterId()).isNotNull();
-            }
-        }
-        
-        // Verify counts match expected topology
-        assertThat(masterCount).isEqualTo(EXPECTED_MASTER_COUNT);
-        assertThat(replicaCount).isEqualTo(EXPECTED_REPLICA_COUNT);
-        
-        // Verify expected ports are present
-        assertThat(nodesByPort).containsKeys(MASTER_NODE_1_PORT, MASTER_NODE_2_PORT, MASTER_NODE_3_PORT, REPLICAOF_NODE_1_PORT);
-        
-        // Verify master nodes
-        assertThat(nodesByPort.get(MASTER_NODE_1_PORT).isMaster()).isTrue();
-        assertThat(nodesByPort.get(MASTER_NODE_2_PORT).isMaster()).isTrue();
-        assertThat(nodesByPort.get(MASTER_NODE_3_PORT).isMaster()).isTrue();
-        
-        // Verify replica node
-        assertThat(nodesByPort.get(REPLICAOF_NODE_1_PORT).isMaster()).isFalse();
-    }
+	// Slot ranges (from Makefile cluster-slots target)
+	private static final int MASTER_1_SLOT_START = 0;
 
-    @Test
-    void testClusterGetNodesSlotDistribution() {
-        // Get all nodes
-        Iterable<ValkeyClusterNode> nodes = clusterConnection.clusterCommands().clusterGetNodes();
-        
-        Map<Integer, ValkeyClusterNode> mastersByPort = new HashMap<>();
-        for (ValkeyClusterNode node : nodes) {
-            if (node.isMaster()) {
-                mastersByPort.put(node.getPort(), node);
-            }
-        }
-        
-        // Verify Master 1 (7379) slot range: 0-5460
-        ValkeyClusterNode master1 = mastersByPort.get(MASTER_NODE_1_PORT);
-        assertThat(master1).isNotNull();
-        verifySlotRange(master1, MASTER_1_SLOT_START, MASTER_1_SLOT_END);
-        
-        // Verify Master 2 (7380) slot range: 5461-10922
-        ValkeyClusterNode master2 = mastersByPort.get(MASTER_NODE_2_PORT);
-        assertThat(master2).isNotNull();
-        verifySlotRange(master2, MASTER_2_SLOT_START, MASTER_2_SLOT_END);
-        
-        // Verify Master 3 (7381) slot range: 10923-16383
-        ValkeyClusterNode master3 = mastersByPort.get(MASTER_NODE_3_PORT);
-        assertThat(master3).isNotNull();
-        verifySlotRange(master3, MASTER_3_SLOT_START, MASTER_3_SLOT_END);
-    }
+	private static final int MASTER_1_SLOT_END = 5460;
 
-    @Test
-    void testClusterGetReplicas() {
-        // Get master node at port 7379 (which should have replica 7382)
-        ValkeyClusterNode masterWithReplica = findNodeByPort(MASTER_NODE_1_PORT);
-        assertThat(masterWithReplica).isNotNull();
-        assertThat(masterWithReplica.isMaster()).isTrue();
-        
-        // Execute
-        Collection<ValkeyClusterNode> replicas = 
-            clusterConnection.clusterCommands().clusterGetReplicas(masterWithReplica);
-        
-        // Verify - should have exactly 1 replica
-        assertThat(replicas).isNotNull();
-        assertThat(replicas).hasSize(1);
-        
-        ValkeyClusterNode replica = replicas.iterator().next();
-        assertThat(replica.getPort()).isEqualTo(REPLICAOF_NODE_1_PORT);
-        assertThat(replica.isMaster()).isFalse();
-        assertThat(replica.getMasterId()).isEqualTo(masterWithReplica.getId());
-    }
+	private static final int MASTER_2_SLOT_START = 5461;
 
-    @Test
-    void testClusterGetReplicasForMastersWithoutReplicas() {
-        // Masters 7380 and 7381 should have no replicas
-        ValkeyClusterNode master2 = findNodeByPort(MASTER_NODE_2_PORT);
-        ValkeyClusterNode master3 = findNodeByPort(MASTER_NODE_3_PORT);
-        
-        assertThat(master2).isNotNull();
-        assertThat(master3).isNotNull();
-        
-        // Execute
-        Collection<ValkeyClusterNode> replicas2 = 
-            clusterConnection.clusterCommands().clusterGetReplicas(master2);
-        Collection<ValkeyClusterNode> replicas3 = 
-            clusterConnection.clusterCommands().clusterGetReplicas(master3);
-        
-        // Verify - should have no replicas
-        assertThat(replicas2).isNotNull().isEmpty();
-        assertThat(replicas3).isNotNull().isEmpty();
-    }
+	private static final int MASTER_2_SLOT_END = 10922;
 
-    @Test
-    void testClusterGetMasterReplicaMap() {
-        // Execute
-        Map<ValkeyClusterNode, Collection<ValkeyClusterNode>> masterReplicaMap = 
-            clusterConnection.clusterCommands().clusterGetMasterReplicaMap();
-        
-        // Verify
-        assertThat(masterReplicaMap).isNotNull();
-        assertThat(masterReplicaMap).hasSize(EXPECTED_MASTER_COUNT);
-        
-        // Find master with replica (port 7379)
-        ValkeyClusterNode masterWithReplica = null;
-        Collection<ValkeyClusterNode> itsReplicas = null;
-        
-        for (Map.Entry<ValkeyClusterNode, Collection<ValkeyClusterNode>> entry : masterReplicaMap.entrySet()) {
-            if (entry.getKey().getPort() == MASTER_NODE_1_PORT) {
-                masterWithReplica = entry.getKey();
-                itsReplicas = entry.getValue();
-                break;
-            }
-        }
-        
-        // Verify master with replica
-        assertThat(masterWithReplica).isNotNull();
-        assertThat(itsReplicas).hasSize(1);
-        assertThat(itsReplicas.iterator().next().getPort()).isEqualTo(REPLICAOF_NODE_1_PORT);
-        
-        // Verify other masters have no replicas
-        for (Map.Entry<ValkeyClusterNode, Collection<ValkeyClusterNode>> entry : masterReplicaMap.entrySet()) {
-            ValkeyClusterNode master = entry.getKey();
-            if (master.getPort() == MASTER_NODE_2_PORT || master.getPort() == MASTER_NODE_3_PORT) {
-                assertThat(entry.getValue()).isEmpty();
-            }
-        }
-    }
+	private static final int MASTER_3_SLOT_START = 10923;
 
-    @Test
-    void testClusterGetClusterInfo() throws InterruptedException {
-        // Wait for cluster gossip to stabilize node count
-        Thread.sleep(1000);
-        
-        // Execute
-        ClusterInfo clusterInfo = clusterConnection.clusterCommands().clusterGetClusterInfo();
-        
-        // Verify
-        assertThat(clusterInfo).isNotNull();
-        assertThat(clusterInfo.getState()).isNotNull();
-        
-        // Verify cluster is operational
-        assertThat(clusterInfo.getState()).isIn("ok", "OK");
-        
-        // Verify all slots are assigned
-        assertThat(clusterInfo.getSlotsAssigned()).isEqualTo(16384);
-        assertThat(clusterInfo.getSlotsOk()).isEqualTo(16384);
-        assertThat(clusterInfo.getSlotsFail()).isEqualTo(0);
-        
-        // Verify node count
-        assertThat(clusterInfo.getKnownNodes()).isEqualTo(EXPECTED_TOTAL_NODES);
-    }
+	private static final int MASTER_3_SLOT_END = 16383;
 
-    // ==================== Slot & Key Routing Commands ====================
+	@Override
+	protected String[] getTestKeyPatterns() {
+		return new String[] { "{user}:test:key1", "{user}:test:key2", "{user}:test:key3", "{product}:test:key1",
+				"{product}:test:key2", "test:cluster:key1", "test:cluster:key2", "test:cluster:key3",
+				"non:existent:key" };
+	}
 
-    @Test
-    void testClusterGetSlotForKey() {
-        byte[] key = "{user}:test:key1".getBytes();
-        
-        // Execute
-        Integer slot = clusterConnection.clusterCommands().clusterGetSlotForKey(key);
-        
-        // Verify
-        assertThat(slot).isNotNull();
-        assertThat(slot).isBetween(0, 16383); // Valid slot range
-        
-        // Verify matches expected slot calculation
-        int expectedSlot = calculateSlot("{user}:test:key1");
-        assertThat(slot).isEqualTo(expectedSlot);
-    }
+	// ==================== Cluster Topology & Information Commands ====================
 
-    @Test
-    void testClusterGetSlotForKeyWithHashTags() {
-        // Test that keys with same hash tag go to same slot
-        byte[] key1 = "{user}:123".getBytes();
-        byte[] key2 = "{user}:456".getBytes();
-        byte[] key3 = "{user}:abc".getBytes();
-        
-        Integer slot1 = clusterConnection.clusterCommands().clusterGetSlotForKey(key1);
-        Integer slot2 = clusterConnection.clusterCommands().clusterGetSlotForKey(key2);
-        Integer slot3 = clusterConnection.clusterCommands().clusterGetSlotForKey(key3);
-        
-        // All should map to same slot (hash tag is "user")
-        assertThat(slot1).isEqualTo(slot2);
-        assertThat(slot2).isEqualTo(slot3);
-        
-        // Verify with manual calculation
-        int expectedSlot = calculateSlot("{user}:123");
-        assertThat(slot1).isEqualTo(expectedSlot);
-    }
+	@Test
+	void testClusterGetNodes() {
+		// Execute
+		Iterable<ValkeyClusterNode> nodes = clusterConnection.clusterCommands().clusterGetNodes();
 
-    @Test
-    void testClusterGetNodeForKey() {
-        // Create a key that should map to each master
-        // We need to find keys that map to different masters' slot ranges
-        
-        String key1 = findKeyForSlotRange(MASTER_1_SLOT_START, MASTER_1_SLOT_END);
-        String key2 = findKeyForSlotRange(MASTER_2_SLOT_START, MASTER_2_SLOT_END);
-        String key3 = findKeyForSlotRange(MASTER_3_SLOT_START, MASTER_3_SLOT_END);
-        
-        // Verify each key maps to correct master
-        ValkeyClusterNode node1 = clusterConnection.clusterCommands().clusterGetNodeForKey(key1.getBytes());
-        ValkeyClusterNode node2 = clusterConnection.clusterCommands().clusterGetNodeForKey(key2.getBytes());
-        ValkeyClusterNode node3 = clusterConnection.clusterCommands().clusterGetNodeForKey(key3.getBytes());
-        
-        assertThat(node1).isNotNull();
-        assertThat(node2).isNotNull();
-        assertThat(node3).isNotNull();
-        
-        // Verify they are different nodes (different masters)
-        assertThat(node1.getId()).isNotEqualTo(node2.getId());
-        assertThat(node2.getId()).isNotEqualTo(node3.getId());
-        assertThat(node1.getId()).isNotEqualTo(node3.getId());
-    }
+		// Verify
+		assertThat(nodes).isNotNull();
 
-    @Test
-    void testClusterCountKeysInSlot() {
-        // Set up test data in a specific slot (ensure it's in master 1's range)
-        String key1 = "{user}:test:key1";
-        String key2 = "{user}:test:key2";
-        String key3 = "{user}:test:key3";
-        
-        try {
-            // Add keys to ensure they're in same slot
-            clusterConnection.stringCommands().set(key1.getBytes(), "value1".getBytes());
-            clusterConnection.stringCommands().set(key2.getBytes(), "value2".getBytes());
-            clusterConnection.stringCommands().set(key3.getBytes(), "value3".getBytes());
-            
-            // Get the slot for these keys
-            Integer slot = clusterConnection.clusterCommands().clusterGetSlotForKey(key1.getBytes());
-            
-            // Execute
-            Long count = clusterConnection.clusterCommands().clusterCountKeysInSlot(slot);
-            
-            // Verify - should have at least our 3 test keys
-            assertThat(count).isNotNull();
-            assertThat(count).isGreaterThanOrEqualTo(3);
-        } finally {
-            cleanupKeys(key1, key2, key3);
-        }
-    }
+		// Convert to list for easier assertions
+		List<ValkeyClusterNode> nodeList = (List<ValkeyClusterNode>) ((nodes instanceof List) ? nodes
+				: java.util.stream.StreamSupport.stream(nodes.spliterator(), false).collect(Collectors.toList()));
 
-    
-    @Test
-    void testClusterGetKeysInSlot() {
-        // Set up test data
-        String key1 = "{product}:test:key1";
-        String key2 = "{product}:test:key2";
-        
-        try {
-            // Add keys
-            clusterConnection.stringCommands().set(key1.getBytes(), "value1".getBytes());
-            clusterConnection.stringCommands().set(key2.getBytes(), "value2".getBytes());
-            
-            // Get the slot
-            Integer slot = clusterConnection.clusterCommands().clusterGetSlotForKey(key1.getBytes());
-            
-            // Execute - request up to 10 keys
-            List<byte[]> keys = clusterConnection.clusterCommands().clusterGetKeysInSlot(slot, 10);
-            
-            // Verify
-            assertThat(keys).isNotNull();
-            assertThat(keys).hasSize(2);
-            
-            // Verify our test keys are in the result
-            Set<String> keyStrings = keys.stream()
-                .map(String::new)
-                .collect(Collectors.toSet());
-            
-            assertThat(keyStrings).contains(key1, key2);
-            
-        } finally {
-            cleanupKeys(key1, key2);
-        }
-    }
+		// Verify expected node count
+		assertThat(nodeList).hasSize(EXPECTED_TOTAL_NODES);
 
-    // ==================== Cluster Modification Commands (with State Restoration) ====================
+		// Count masters and replicas
+		int masterCount = 0;
+		int replicaCount = 0;
+		Map<Integer, ValkeyClusterNode> nodesByPort = new HashMap<>();
 
-    @Test
-    void testClusterAddSlotsAndDeleteSlots() {
-        // This test modifies cluster state but restores it at the end
-        
-        // Find a master and temporarily remove some slots, then add them back
-        ValkeyClusterNode master2 = findNodeByPort(MASTER_NODE_2_PORT);
-        assertThat(master2).isNotNull();
-        
-        // Choose slots from middle of master2's range to temporarily remove
-        int slot1 = MASTER_2_SLOT_START + 1000;
-        int slot2 = MASTER_2_SLOT_START + 1001;
-        int slot3 = MASTER_2_SLOT_START + 1002;
-        
-        try {
-            // Step 1: Delete slots
-            clusterConnection.clusterCommands().clusterDeleteSlots(master2, slot1, slot2, slot3);
-            
-            // Verify deletion: try to delete again - should FAIL
-            assertThatThrownBy(() -> 
-                clusterConnection.clusterCommands().clusterDeleteSlots(master2, slot1, slot2, slot3))
-                .isInstanceOf(DataAccessException.class);
-            
-            // Step 2: Add slots back
-            clusterConnection.clusterCommands().clusterAddSlots(master2, slot1, slot2, slot3);
-            logger.info("Added slots back");
-            
-            // Verify addition: try to add again - should FAIL
-            assertThatThrownBy(() ->
-                clusterConnection.clusterCommands().clusterAddSlots(master2, slot1, slot2, slot3))
-                .isInstanceOf(DataAccessException.class);
-            
-            // Final verification
-            ValkeyClusterNode nodeForSlot1 = clusterConnection.clusterCommands().clusterGetNodeForSlot(slot1);
-            assertThat(nodeForSlot1.getPort()).isEqualTo(MASTER_NODE_2_PORT);
+		for (ValkeyClusterNode node : nodeList) {
+			// Verify basic node properties
+			assertThat(node.getId()).isNotNull();
+			assertThat(node.getHost()).isNotNull();
+			assertThat(node.getPort()).isGreaterThan(0);
 
-        } catch (Exception e) {
-            try { clusterConnection.clusterCommands().clusterAddSlots(master2, slot1, slot2, slot3); } catch (Exception ignore) {}
-            throw e;
-        }
-    }
+			nodesByPort.put(node.getPort(), node);
 
-    @Test
-    void testClusterAddSlotsWithSlotRange() {
-        // This test modifies cluster state but restores it at the end
-        
-        ValkeyClusterNode master3 = findNodeByPort(MASTER_NODE_3_PORT);
-        assertThat(master3).isNotNull();
-        
-        // Choose a small range from master3 to temporarily remove and re-add
-        int rangeStart = MASTER_3_SLOT_START + 2000;
-        int rangeEnd = MASTER_3_SLOT_START + 2004; // 5 slots
-        SlotRange testRange = new SlotRange(rangeStart, rangeEnd);
-        
-        try {
-            // Step 1: Delete slot range
-            clusterConnection.clusterCommands().clusterDeleteSlotsInRange(master3, testRange);
-            
-            // Verify deletion: try to delete again - should FAIL
-            assertThatThrownBy(() ->
-                clusterConnection.clusterCommands().clusterDeleteSlotsInRange(master3, testRange))
-                .isInstanceOf(DataAccessException.class);
-            
-            // Step 2: Add slot range back
-            clusterConnection.clusterCommands().clusterAddSlots(master3, testRange);
-            
-            // Verify addition: try to add again - should FAIL
-            assertThatThrownBy(() ->
-                clusterConnection.clusterCommands().clusterAddSlots(master3, testRange))
-                .isInstanceOf(DataAccessException.class);
-            
-            // Final verification
-            ValkeyClusterNode nodeForSlot = clusterConnection.clusterCommands().clusterGetNodeForSlot(rangeStart);
-            assertThat(nodeForSlot.getPort()).isEqualTo(MASTER_NODE_3_PORT);
-            
-        } catch (Exception e) {
-            try { clusterConnection.clusterCommands().clusterAddSlots(master3, testRange); } catch (Exception ignore) {}
-            throw e;
-        }
-    }
+			// Count masters and replicas
+			if (node.isMaster()) {
+				masterCount++;
+				// Masters should have slot ranges assigned
+				assertThat(node.getSlotRange()).isNotNull();
+				assertThat(node.getSlotRange().getSlots()).isNotEmpty();
+			}
+			else {
+				replicaCount++;
+				// Replicas should have master ID
+				assertThat(node.getMasterId()).isNotNull();
+			}
+		}
 
-    // I suspect there is a bug in the interface that prevents specifying the node ID for IMPORTING/MIGRATING modes.
-    // Valkey-Glide uses Jedis approach of taking the id of the node parameter, which is the destination node and is incorrect by the protocol.
-    // Hence, the comprehensive migration test below is disabled until this is resolved.
-    @Test
-    void testClusterSetSlot() {
-        // Test CLUSTER SETSLOT command with different modes
-        
-        ValkeyClusterNode master1 = findNodeByPort(MASTER_NODE_1_PORT);
-        ValkeyClusterNode master2 = findNodeByPort(MASTER_NODE_2_PORT);
-        assertThat(master1).isNotNull();
-        assertThat(master2).isNotNull();
-        
-        // Choose a slot from master1's range to test migration
-        int slotToMigrate = MASTER_1_SLOT_START + 500;
-        
-        try {
-            // Step 1: Mark slot as MIGRATING on source node (master1)
-            clusterConnection.clusterCommands().clusterSetSlot(master1, slotToMigrate, AddSlots.MIGRATING);
-            
-            // Step 2: Mark slot as IMPORTING on destination node (master2)
-            clusterConnection.clusterCommands().clusterSetSlot(master2, slotToMigrate, AddSlots.IMPORTING);
+		// Verify counts match expected topology
+		assertThat(masterCount).isEqualTo(EXPECTED_MASTER_COUNT);
+		assertThat(replicaCount).isEqualTo(EXPECTED_REPLICA_COUNT);
 
-            // Step 3: Set slot to STABLE state to restore
-            clusterConnection.clusterCommands().clusterSetSlot(master1, slotToMigrate, AddSlots.STABLE);
-            clusterConnection.clusterCommands().clusterSetSlot(master2, slotToMigrate, AddSlots.STABLE); 
-            
-            // Restore both nodes to STABLE
-            ValkeyClusterNode nodeForSlot = clusterConnection.clusterCommands().clusterGetNodeForSlot(slotToMigrate);
-            assertThat(nodeForSlot.getPort()).isEqualTo(MASTER_NODE_1_PORT);
-            
-        } finally {
-            clusterConnection.clusterCommands().clusterSetSlot(master1, slotToMigrate, AddSlots.STABLE);
-            clusterConnection.clusterCommands().clusterSetSlot(master2, slotToMigrate, AddSlots.STABLE);
-        }
-    }
+		// Verify expected ports are present
+		assertThat(nodesByPort).containsKeys(MASTER_NODE_1_PORT, MASTER_NODE_2_PORT, MASTER_NODE_3_PORT,
+				REPLICAOF_NODE_1_PORT);
 
-    @Test
-    @org.junit.jupiter.api.Disabled("""
-        WARNING: This test is currently disabled, probably due state propagation delays in the cluster.
-        
-        Despite implementing cache invalidation in ValkeyGlideClusterConnection, the test still fails 
-        because the cluster's internal state may take time to propagate, or there may be additional 
-        caching layers we haven't identified.
-        
-        Test will remain disabled until the root cause is fully identified and resolved.
-        """)
-    void testClusterSetSlotWithActualMigration() {
-        // Comprehensive test that performs actual slot migration with key transfer
-        // This test validates the complete CLUSTER SETSLOT workflow including key migration
-        
-        ValkeyClusterNode sourceNode = findNodeByPort(MASTER_NODE_1_PORT);
-        ValkeyClusterNode destNode = findNodeByPort(MASTER_NODE_2_PORT);
-        assertThat(sourceNode).isNotNull();
-        assertThat(destNode).isNotNull();
-        
-        // Choose a slot from master1's range that we'll migrate to master2
-        int slotToMigrate = MASTER_1_SLOT_START + 1000;
-        
-        // Find a key that maps to this specific slot using ClusterSlotHashUtil
-        String testKey = "test-key-{" + slotToMigrate + "}"; // TODO: implement getKeyForSlot
-        byte[] keyBytes = testKey.getBytes();
-        byte[] valueBytes = "migration-test-value".getBytes();
-        
-        try {
-            // Setup: Create test key in the slot on source node
-            clusterConnection.stringCommands().set(keyBytes, valueBytes);
-            
-            // Verify key exists and is on source node
-            byte[] originalValue = clusterConnection.stringCommands().get(keyBytes);
-            assertThat(originalValue).isEqualTo(valueBytes);
-            
-            // Step 1: Mark slot as IMPORTING on destination node (with source node ID)
-            // According to docs: CLUSTER SETSLOT <slot> IMPORTING <source-node-id>
-            clusterConnection.clusterCommands().clusterSetSlot(destNode, slotToMigrate, AddSlots.IMPORTING);
-            
-            // Step 2: Mark slot as MIGRATING on source node (with destination node ID)
-            // According to docs: CLUSTER SETSLOT <slot> MIGRATING <destination-node-id>
-            clusterConnection.clusterCommands().clusterSetSlot(sourceNode, slotToMigrate, AddSlots.MIGRATING);
-            
-            // Step 3: Migrate the key from source to destination
-            // MIGRATE <host> <port> <key> <db> <timeout> [COPY] [REPLACE]
-            clusterConnection.serverCommands().migrate(
-                keyBytes,
-                destNode,
-                0, // database 0
-                null, // no option (will do atomic move)
-                5000 // 5 second timeout
-            );
-            
-            // Step 4: Complete the migration by assigning slot to destination
-            // This should be done on the destination node first, then propagated
-            clusterConnection.clusterCommands().clusterSetSlot(destNode, slotToMigrate, AddSlots.NODE);
-            
-            // Propagate to source node
-            clusterConnection.clusterCommands().clusterSetSlot(sourceNode, slotToMigrate, AddSlots.NODE);
-            
-            // Step 5: Verify migration was successful
-            // The slot should now be owned by destination node
-            ValkeyClusterNode newOwner = clusterConnection.clusterCommands().clusterGetNodeForSlot(slotToMigrate);
-            assertThat(newOwner.getPort()).isEqualTo(MASTER_NODE_2_PORT);
-            
-            // Verify the key is accessible and has correct value
-            byte[] migratedValue = clusterConnection.stringCommands().get(keyBytes);
-            assertThat(migratedValue).isEqualTo(valueBytes);
-            
-        } finally {
-            clusterConnection.serverCommands().flushAll();
-            
-            // Assign slot back to source
-            clusterConnection.clusterCommands().clusterSetSlot(sourceNode, slotToMigrate, AddSlots.NODE);
-            clusterConnection.clusterCommands().clusterSetSlot(destNode, slotToMigrate, AddSlots.NODE);
-        }
-    }
+		// Verify master nodes
+		assertThat(nodesByPort.get(MASTER_NODE_1_PORT).isMaster()).isTrue();
+		assertThat(nodesByPort.get(MASTER_NODE_2_PORT).isMaster()).isTrue();
+		assertThat(nodesByPort.get(MASTER_NODE_3_PORT).isMaster()).isTrue();
 
-    @Test
-    void testClusterMeet() {
-        // CLUSTER MEET adds a node to the cluster
-        // Since we're testing with an existing cluster, we'll verify the command works
-        // but won't actually add a new node (as that would require a new Valkey instance)
-        
-        // Get existing nodes
-        Iterable<ValkeyClusterNode> nodes = clusterConnection.clusterCommands().clusterGetNodes();
-        ValkeyClusterNode existingNode = nodes.iterator().next();
-        
-        // Create a node reference (this won't add a new node, just test the command execution)
-        ValkeyClusterNode nodeToMeet = ValkeyClusterNode.newValkeyClusterNode()
-            .listeningAt(existingNode.getHost(), existingNode.getPort())
-            .build();
-        
-        // Execute CLUSTER MEET (should be idempotent for existing nodes)
-        clusterConnection.clusterCommands().clusterMeet(nodeToMeet);
-        
-        // Verify cluster still has expected number of nodes
-        Iterable<ValkeyClusterNode> nodesAfter = clusterConnection.clusterCommands().clusterGetNodes();
-        List<ValkeyClusterNode> nodeList = java.util.stream.StreamSupport
-            .stream(nodesAfter.spliterator(), false)
-            .collect(Collectors.toList());
-        
-        assertThat(nodeList).hasSize(EXPECTED_TOTAL_NODES);
-    }
+		// Verify replica node
+		assertThat(nodesByPort.get(REPLICAOF_NODE_1_PORT).isMaster()).isFalse();
+	}
 
-    @Test
-    void testClusterReplicate() {
-        // CLUSTER REPLICATE makes a node a replica of a master
-        // We'll test by verifying the existing replica relationship
-        
-        ValkeyClusterNode master1 = findNodeByPort(MASTER_NODE_1_PORT);
-        ValkeyClusterNode replica = findNodeByPort(REPLICAOF_NODE_1_PORT);
-        
-        assertThat(master1).isNotNull();
-        assertThat(replica).isNotNull();
-        
-        // Verify current state: replica should already be replicating master1
-        assertThat(replica.isMaster()).isFalse();
-        assertThat(replica.getMasterId()).isEqualTo(master1.getId());
-        
-        // Re-execute CLUSTER REPLICATE (should be idempotent)
-        clusterConnection.clusterCommands().clusterReplicate(master1, replica);
-        
-        // Verify replica relationship is still intact
-        Collection<ValkeyClusterNode> replicas = 
-            clusterConnection.clusterCommands().clusterGetReplicas(master1);
-        assertThat(replicas).hasSize(1);
-        assertThat(replicas.iterator().next().getPort()).isEqualTo(REPLICAOF_NODE_1_PORT);
-    }
+	@Test
+	void testClusterGetNodesSlotDistribution() {
+		// Get all nodes
+		Iterable<ValkeyClusterNode> nodes = clusterConnection.clusterCommands().clusterGetNodes();
 
-    @Test
-    void testClusterForget() {
-        // CLUSTER FORGET removes a node from the cluster
-        // This is a very destructive operation, so we'll only test it in a controlled way
-        // We cannot actually forget a master node as it would break the cluster
-        
-        // Instead, verify that attempting to forget a non-existent node doesn't break things
-        ValkeyClusterNode nonExistentNode = ValkeyClusterNode.newValkeyClusterNode()
-            .listeningAt("127.0.0.1", 9999)
-            .withId("0000000000000000000000000000000000000000")
-            .build();
-        
-        assertThatThrownBy(() -> 
-            clusterConnection.clusterCommands().clusterForget(nonExistentNode))
-            .isInstanceOf(DataAccessException.class);
-        
-        // Verify cluster still has all expected nodes
-        Iterable<ValkeyClusterNode> nodes = clusterConnection.clusterCommands().clusterGetNodes();
-        List<ValkeyClusterNode> nodeList = java.util.stream.StreamSupport
-            .stream(nodes.spliterator(), false)
-            .collect(Collectors.toList());
-        
-        assertThat(nodeList).hasSize(EXPECTED_TOTAL_NODES);
-    }
+		Map<Integer, ValkeyClusterNode> mastersByPort = new HashMap<>();
+		for (ValkeyClusterNode node : nodes) {
+			if (node.isMaster()) {
+				mastersByPort.put(node.getPort(), node);
+			}
+		}
 
-    // ==================== Edge Cases & Error Handling ====================
+		// Verify Master 1 (7379) slot range: 0-5460
+		ValkeyClusterNode master1 = mastersByPort.get(MASTER_NODE_1_PORT);
+		assertThat(master1).isNotNull();
+		verifySlotRange(master1, MASTER_1_SLOT_START, MASTER_1_SLOT_END);
 
-    @Test
-    void testClusterGetSlotForNonExistentKey() {
-        byte[] key = "non:existent:key:12345".getBytes();
-        
-        // Execute - should still return slot even if key doesn't exist
-        Integer slot = clusterConnection.clusterCommands().clusterGetSlotForKey(key);
-        
-        // Verify
-        assertThat(slot).isNotNull();
-        assertThat(slot).isBetween(0, 16383);
-        
-        // Verify matches calculation
-        int expectedSlot = calculateSlot(key);
-        assertThat(slot).isEqualTo(expectedSlot);
-    }
+		// Verify Master 2 (7380) slot range: 5461-10922
+		ValkeyClusterNode master2 = mastersByPort.get(MASTER_NODE_2_PORT);
+		assertThat(master2).isNotNull();
+		verifySlotRange(master2, MASTER_2_SLOT_START, MASTER_2_SLOT_END);
 
-    @Test
-    void testClusterTopologyConsistency() {
-        // Get nodes from different methods and verify consistency
-        Iterable<ValkeyClusterNode> allNodes = clusterConnection.clusterCommands().clusterGetNodes();
-        Map<ValkeyClusterNode, Collection<ValkeyClusterNode>> masterReplicaMap = 
-            clusterConnection.clusterCommands().clusterGetMasterReplicaMap();
-        
-        // Count masters from both sources
-        int masterCountFromNodes = 0;
-        for (ValkeyClusterNode node : allNodes) {
-            if (node.isMaster()) {
-                masterCountFromNodes++;
-            }
-        }
-        
-        int masterCountFromMap = masterReplicaMap.size();
-        
-        // Should match expected counts
-        assertThat(masterCountFromNodes).isEqualTo(EXPECTED_MASTER_COUNT);
-        assertThat(masterCountFromMap).isEqualTo(EXPECTED_MASTER_COUNT);
-    }
+		// Verify Master 3 (7381) slot range: 10923-16383
+		ValkeyClusterNode master3 = mastersByPort.get(MASTER_NODE_3_PORT);
+		assertThat(master3).isNotNull();
+		verifySlotRange(master3, MASTER_3_SLOT_START, MASTER_3_SLOT_END);
+	}
 
-    @Test
-    void testSlotRangeCoverage() {
-        // Verify all slots 0-16383 are covered by master nodes
-        Collection<ValkeyClusterNode> masters = getActiveMasterNodes();
-        
-        assertThat(masters).hasSize(EXPECTED_MASTER_COUNT);
-        
-        boolean[] slotsCovered = new boolean[16384];
-        
-        for (ValkeyClusterNode master : masters) {
-            SlotRange slotRange = master.getSlotRange();
-            assertThat(slotRange).isNotNull();
-            
-            for (Integer slot : slotRange.getSlots()) {
-                slotsCovered[slot] = true;
-            }
-        }
-        
-        // Count covered slots
-        int coveredCount = 0;
-        for (boolean covered : slotsCovered) {
-            if (covered) coveredCount++;
-        }
-        
-        // All 16384 slots should be covered
-        assertThat(coveredCount).isEqualTo(16384);
-    }
+	@Test
+	void testClusterGetReplicas() {
+		// Get master node at port 7379 (which should have replica 7382)
+		ValkeyClusterNode masterWithReplica = findNodeByPort(MASTER_NODE_1_PORT);
+		assertThat(masterWithReplica).isNotNull();
+		assertThat(masterWithReplica.isMaster()).isTrue();
 
-    @Test
-    void testHashTagSlotCalculationConsistency() {
-        // Test various hash tag patterns
-        String[][] keyPairs = {
-            {"{user}:profile", "{user}:settings"},
-            {"{order}:123", "{order}:456"},
-            {"{product:id}:abc", "{product:id}:xyz"},
-            {"prefix:{tag}:suffix1", "prefix:{tag}:suffix2"}
-        };
-        
-        for (String[] pair : keyPairs) {
-            Integer slot1 = clusterConnection.clusterCommands().clusterGetSlotForKey(pair[0].getBytes());
-            Integer slot2 = clusterConnection.clusterCommands().clusterGetSlotForKey(pair[1].getBytes());
-            
-            // Both keys should map to same slot
-            assertThat(slot1).isEqualTo(slot2);
-            
-            // Verify against manual calculation
-            int expectedSlot = calculateSlot(pair[0]);
-            assertThat(slot1).isEqualTo(expectedSlot);
-        }
-    }
+		// Execute
+		Collection<ValkeyClusterNode> replicas = clusterConnection.clusterCommands()
+			.clusterGetReplicas(masterWithReplica);
 
-    // ==================== Helper Methods ====================
+		// Verify - should have exactly 1 replica
+		assertThat(replicas).isNotNull();
+		assertThat(replicas).hasSize(1);
 
-    /**
-     * Verifies that a node's slot range matches the expected start and end slots.
-     */
-    private void verifySlotRange(ValkeyClusterNode node, int expectedStart, int expectedEnd) {
-        SlotRange slotRange = node.getSlotRange();
-        assertThat(slotRange).isNotNull();
-        
-        Set<Integer> slots = slotRange.getSlots();
-        assertThat(slots).isNotEmpty();
-        
-        int actualStart = slots.stream().min(Integer::compare).orElse(-1);
-        int actualEnd = slots.stream().max(Integer::compare).orElse(-1);
-        
-        assertThat(actualStart).isEqualTo(expectedStart);
-        assertThat(actualEnd).isEqualTo(expectedEnd);
-        
-        int expectedSlotCount = expectedEnd - expectedStart + 1;
-        assertThat(slots).hasSize(expectedSlotCount);
-        
-        logger.info("Node at port {} has slots {}-{} ({} slots)", 
-            node.getPort(), actualStart, actualEnd, slots.size());
-    }
+		ValkeyClusterNode replica = replicas.iterator().next();
+		assertThat(replica.getPort()).isEqualTo(REPLICAOF_NODE_1_PORT);
+		assertThat(replica.isMaster()).isFalse();
+		assertThat(replica.getMasterId()).isEqualTo(masterWithReplica.getId());
+	}
 
-    /**
-     * Finds a node by its port number.
-     */
-    private ValkeyClusterNode findNodeByPort(int port) {
-        Iterable<ValkeyClusterNode> nodes = clusterConnection.clusterCommands().clusterGetNodes();
-        for (ValkeyClusterNode node : nodes) {
-            if (node.getPort() == port) {
-                return node;
-            }
-        }
-        return null;
-    }
+	@Test
+	void testClusterGetReplicasForMastersWithoutReplicas() {
+		// Masters 7380 and 7381 should have no replicas
+		ValkeyClusterNode master2 = findNodeByPort(MASTER_NODE_2_PORT);
+		ValkeyClusterNode master3 = findNodeByPort(MASTER_NODE_3_PORT);
 
-    /**
-     * Finds a key whose slot falls within the specified range.
-     * Uses a simple iteration approach to find a suitable key.
-     */
-    private String findKeyForSlotRange(int startSlot, int endSlot) {
-        // Try different keys until we find one in the range
-        for (int i = 0; i < 10000; i++) {
-            String key = "test:key:" + i;
-            int slot = calculateSlot(key);
-            if (slot >= startSlot && slot <= endSlot) {
-                return key;
-            }
-        }
-        
-        // Fallback: use hash tag with slot number
-        return "{slot" + startSlot + "}:key";
-    }
+		assertThat(master2).isNotNull();
+		assertThat(master3).isNotNull();
+
+		// Execute
+		Collection<ValkeyClusterNode> replicas2 = clusterConnection.clusterCommands().clusterGetReplicas(master2);
+		Collection<ValkeyClusterNode> replicas3 = clusterConnection.clusterCommands().clusterGetReplicas(master3);
+
+		// Verify - should have no replicas
+		assertThat(replicas2).isNotNull().isEmpty();
+		assertThat(replicas3).isNotNull().isEmpty();
+	}
+
+	@Test
+	void testClusterGetMasterReplicaMap() {
+		// Execute
+		Map<ValkeyClusterNode, Collection<ValkeyClusterNode>> masterReplicaMap = clusterConnection.clusterCommands()
+			.clusterGetMasterReplicaMap();
+
+		// Verify
+		assertThat(masterReplicaMap).isNotNull();
+		assertThat(masterReplicaMap).hasSize(EXPECTED_MASTER_COUNT);
+
+		// Find master with replica (port 7379)
+		ValkeyClusterNode masterWithReplica = null;
+		Collection<ValkeyClusterNode> itsReplicas = null;
+
+		for (Map.Entry<ValkeyClusterNode, Collection<ValkeyClusterNode>> entry : masterReplicaMap.entrySet()) {
+			if (entry.getKey().getPort() == MASTER_NODE_1_PORT) {
+				masterWithReplica = entry.getKey();
+				itsReplicas = entry.getValue();
+				break;
+			}
+		}
+
+		// Verify master with replica
+		assertThat(masterWithReplica).isNotNull();
+		assertThat(itsReplicas).hasSize(1);
+		assertThat(itsReplicas.iterator().next().getPort()).isEqualTo(REPLICAOF_NODE_1_PORT);
+
+		// Verify other masters have no replicas
+		for (Map.Entry<ValkeyClusterNode, Collection<ValkeyClusterNode>> entry : masterReplicaMap.entrySet()) {
+			ValkeyClusterNode master = entry.getKey();
+			if (master.getPort() == MASTER_NODE_2_PORT || master.getPort() == MASTER_NODE_3_PORT) {
+				assertThat(entry.getValue()).isEmpty();
+			}
+		}
+	}
+
+	@Test
+	void testClusterGetClusterInfo() throws InterruptedException {
+		// Wait for cluster gossip to stabilize node count
+		Thread.sleep(1000);
+
+		// Execute
+		ClusterInfo clusterInfo = clusterConnection.clusterCommands().clusterGetClusterInfo();
+
+		// Verify
+		assertThat(clusterInfo).isNotNull();
+		assertThat(clusterInfo.getState()).isNotNull();
+
+		// Verify cluster is operational
+		assertThat(clusterInfo.getState()).isIn("ok", "OK");
+
+		// Verify all slots are assigned
+		assertThat(clusterInfo.getSlotsAssigned()).isEqualTo(16384);
+		assertThat(clusterInfo.getSlotsOk()).isEqualTo(16384);
+		assertThat(clusterInfo.getSlotsFail()).isEqualTo(0);
+
+		// Verify node count
+		assertThat(clusterInfo.getKnownNodes()).isEqualTo(EXPECTED_TOTAL_NODES);
+	}
+
+	// ==================== Slot & Key Routing Commands ====================
+
+	@Test
+	void testClusterGetSlotForKey() {
+		byte[] key = "{user}:test:key1".getBytes();
+
+		// Execute
+		Integer slot = clusterConnection.clusterCommands().clusterGetSlotForKey(key);
+
+		// Verify
+		assertThat(slot).isNotNull();
+		assertThat(slot).isBetween(0, 16383); // Valid slot range
+
+		// Verify matches expected slot calculation
+		int expectedSlot = calculateSlot("{user}:test:key1");
+		assertThat(slot).isEqualTo(expectedSlot);
+	}
+
+	@Test
+	void testClusterGetSlotForKeyWithHashTags() {
+		// Test that keys with same hash tag go to same slot
+		byte[] key1 = "{user}:123".getBytes();
+		byte[] key2 = "{user}:456".getBytes();
+		byte[] key3 = "{user}:abc".getBytes();
+
+		Integer slot1 = clusterConnection.clusterCommands().clusterGetSlotForKey(key1);
+		Integer slot2 = clusterConnection.clusterCommands().clusterGetSlotForKey(key2);
+		Integer slot3 = clusterConnection.clusterCommands().clusterGetSlotForKey(key3);
+
+		// All should map to same slot (hash tag is "user")
+		assertThat(slot1).isEqualTo(slot2);
+		assertThat(slot2).isEqualTo(slot3);
+
+		// Verify with manual calculation
+		int expectedSlot = calculateSlot("{user}:123");
+		assertThat(slot1).isEqualTo(expectedSlot);
+	}
+
+	@Test
+	void testClusterGetNodeForKey() {
+		// Create a key that should map to each master
+		// We need to find keys that map to different masters' slot ranges
+
+		String key1 = findKeyForSlotRange(MASTER_1_SLOT_START, MASTER_1_SLOT_END);
+		String key2 = findKeyForSlotRange(MASTER_2_SLOT_START, MASTER_2_SLOT_END);
+		String key3 = findKeyForSlotRange(MASTER_3_SLOT_START, MASTER_3_SLOT_END);
+
+		// Verify each key maps to correct master
+		ValkeyClusterNode node1 = clusterConnection.clusterCommands().clusterGetNodeForKey(key1.getBytes());
+		ValkeyClusterNode node2 = clusterConnection.clusterCommands().clusterGetNodeForKey(key2.getBytes());
+		ValkeyClusterNode node3 = clusterConnection.clusterCommands().clusterGetNodeForKey(key3.getBytes());
+
+		assertThat(node1).isNotNull();
+		assertThat(node2).isNotNull();
+		assertThat(node3).isNotNull();
+
+		// Verify they are different nodes (different masters)
+		assertThat(node1.getId()).isNotEqualTo(node2.getId());
+		assertThat(node2.getId()).isNotEqualTo(node3.getId());
+		assertThat(node1.getId()).isNotEqualTo(node3.getId());
+	}
+
+	@Test
+	void testClusterCountKeysInSlot() {
+		// Set up test data in a specific slot (ensure it's in master 1's range)
+		String key1 = "{user}:test:key1";
+		String key2 = "{user}:test:key2";
+		String key3 = "{user}:test:key3";
+
+		try {
+			// Add keys to ensure they're in same slot
+			clusterConnection.stringCommands().set(key1.getBytes(), "value1".getBytes());
+			clusterConnection.stringCommands().set(key2.getBytes(), "value2".getBytes());
+			clusterConnection.stringCommands().set(key3.getBytes(), "value3".getBytes());
+
+			// Get the slot for these keys
+			Integer slot = clusterConnection.clusterCommands().clusterGetSlotForKey(key1.getBytes());
+
+			// Execute
+			Long count = clusterConnection.clusterCommands().clusterCountKeysInSlot(slot);
+
+			// Verify - should have at least our 3 test keys
+			assertThat(count).isNotNull();
+			assertThat(count).isGreaterThanOrEqualTo(3);
+		}
+		finally {
+			cleanupKeys(key1, key2, key3);
+		}
+	}
+
+	@Test
+	void testClusterGetKeysInSlot() {
+		// Set up test data
+		String key1 = "{product}:test:key1";
+		String key2 = "{product}:test:key2";
+
+		try {
+			// Add keys
+			clusterConnection.stringCommands().set(key1.getBytes(), "value1".getBytes());
+			clusterConnection.stringCommands().set(key2.getBytes(), "value2".getBytes());
+
+			// Get the slot
+			Integer slot = clusterConnection.clusterCommands().clusterGetSlotForKey(key1.getBytes());
+
+			// Execute - request up to 10 keys
+			List<byte[]> keys = clusterConnection.clusterCommands().clusterGetKeysInSlot(slot, 10);
+
+			// Verify
+			assertThat(keys).isNotNull();
+			assertThat(keys).hasSize(2);
+
+			// Verify our test keys are in the result
+			Set<String> keyStrings = keys.stream().map(String::new).collect(Collectors.toSet());
+
+			assertThat(keyStrings).contains(key1, key2);
+
+		}
+		finally {
+			cleanupKeys(key1, key2);
+		}
+	}
+
+	// ==================== Cluster Modification Commands (with State Restoration)
+	// ====================
+
+	@Test
+	void testClusterAddSlotsAndDeleteSlots() {
+		// This test modifies cluster state but restores it at the end
+
+		// Find a master and temporarily remove some slots, then add them back
+		ValkeyClusterNode master2 = findNodeByPort(MASTER_NODE_2_PORT);
+		assertThat(master2).isNotNull();
+
+		// Choose slots from middle of master2's range to temporarily remove
+		int slot1 = MASTER_2_SLOT_START + 1000;
+		int slot2 = MASTER_2_SLOT_START + 1001;
+		int slot3 = MASTER_2_SLOT_START + 1002;
+
+		try {
+			// Step 1: Delete slots
+			clusterConnection.clusterCommands().clusterDeleteSlots(master2, slot1, slot2, slot3);
+
+			// Verify deletion: try to delete again - should FAIL
+			assertThatThrownBy(
+					() -> clusterConnection.clusterCommands().clusterDeleteSlots(master2, slot1, slot2, slot3))
+				.isInstanceOf(DataAccessException.class);
+
+			// Step 2: Add slots back
+			clusterConnection.clusterCommands().clusterAddSlots(master2, slot1, slot2, slot3);
+			logger.info("Added slots back");
+
+			// Verify addition: try to add again - should FAIL
+			assertThatThrownBy(() -> clusterConnection.clusterCommands().clusterAddSlots(master2, slot1, slot2, slot3))
+				.isInstanceOf(DataAccessException.class);
+
+			// Final verification
+			ValkeyClusterNode nodeForSlot1 = clusterConnection.clusterCommands().clusterGetNodeForSlot(slot1);
+			assertThat(nodeForSlot1.getPort()).isEqualTo(MASTER_NODE_2_PORT);
+
+		}
+		catch (Exception e) {
+			try {
+				clusterConnection.clusterCommands().clusterAddSlots(master2, slot1, slot2, slot3);
+			}
+			catch (Exception ignore) {
+			}
+			throw e;
+		}
+	}
+
+	@Test
+	void testClusterAddSlotsWithSlotRange() {
+		// This test modifies cluster state but restores it at the end
+
+		ValkeyClusterNode master3 = findNodeByPort(MASTER_NODE_3_PORT);
+		assertThat(master3).isNotNull();
+
+		// Choose a small range from master3 to temporarily remove and re-add
+		int rangeStart = MASTER_3_SLOT_START + 2000;
+		int rangeEnd = MASTER_3_SLOT_START + 2004; // 5 slots
+		SlotRange testRange = new SlotRange(rangeStart, rangeEnd);
+
+		try {
+			// Step 1: Delete slot range
+			clusterConnection.clusterCommands().clusterDeleteSlotsInRange(master3, testRange);
+
+			// Verify deletion: try to delete again - should FAIL
+			assertThatThrownBy(() -> clusterConnection.clusterCommands().clusterDeleteSlotsInRange(master3, testRange))
+				.isInstanceOf(DataAccessException.class);
+
+			// Step 2: Add slot range back
+			clusterConnection.clusterCommands().clusterAddSlots(master3, testRange);
+
+			// Verify addition: try to add again - should FAIL
+			assertThatThrownBy(() -> clusterConnection.clusterCommands().clusterAddSlots(master3, testRange))
+				.isInstanceOf(DataAccessException.class);
+
+			// Final verification
+			ValkeyClusterNode nodeForSlot = clusterConnection.clusterCommands().clusterGetNodeForSlot(rangeStart);
+			assertThat(nodeForSlot.getPort()).isEqualTo(MASTER_NODE_3_PORT);
+
+		}
+		catch (Exception e) {
+			try {
+				clusterConnection.clusterCommands().clusterAddSlots(master3, testRange);
+			}
+			catch (Exception ignore) {
+			}
+			throw e;
+		}
+	}
+
+	// I suspect there is a bug in the interface that prevents specifying the node ID for
+	// IMPORTING/MIGRATING modes.
+	// Valkey-Glide uses Jedis approach of taking the id of the node parameter, which is
+	// the destination node and is incorrect by the protocol.
+	// Hence, the comprehensive migration test below is disabled until this is resolved.
+	@Test
+	void testClusterSetSlot() {
+		// Test CLUSTER SETSLOT command with different modes
+
+		ValkeyClusterNode master1 = findNodeByPort(MASTER_NODE_1_PORT);
+		ValkeyClusterNode master2 = findNodeByPort(MASTER_NODE_2_PORT);
+		assertThat(master1).isNotNull();
+		assertThat(master2).isNotNull();
+
+		// Choose a slot from master1's range to test migration
+		int slotToMigrate = MASTER_1_SLOT_START + 500;
+
+		try {
+			// Step 1: Mark slot as MIGRATING on source node (master1)
+			clusterConnection.clusterCommands().clusterSetSlot(master1, slotToMigrate, AddSlots.MIGRATING);
+
+			// Step 2: Mark slot as IMPORTING on destination node (master2)
+			clusterConnection.clusterCommands().clusterSetSlot(master2, slotToMigrate, AddSlots.IMPORTING);
+
+			// Step 3: Set slot to STABLE state to restore
+			clusterConnection.clusterCommands().clusterSetSlot(master1, slotToMigrate, AddSlots.STABLE);
+			clusterConnection.clusterCommands().clusterSetSlot(master2, slotToMigrate, AddSlots.STABLE);
+
+			// Restore both nodes to STABLE
+			ValkeyClusterNode nodeForSlot = clusterConnection.clusterCommands().clusterGetNodeForSlot(slotToMigrate);
+			assertThat(nodeForSlot.getPort()).isEqualTo(MASTER_NODE_1_PORT);
+
+		}
+		finally {
+			clusterConnection.clusterCommands().clusterSetSlot(master1, slotToMigrate, AddSlots.STABLE);
+			clusterConnection.clusterCommands().clusterSetSlot(master2, slotToMigrate, AddSlots.STABLE);
+		}
+	}
+
+	@Test
+	@org.junit.jupiter.api.Disabled("""
+			WARNING: This test is currently disabled, probably due state propagation delays in the cluster.
+
+			Despite implementing cache invalidation in ValkeyGlideClusterConnection, the test still fails
+			because the cluster's internal state may take time to propagate, or there may be additional
+			caching layers we haven't identified.
+
+			Test will remain disabled until the root cause is fully identified and resolved.
+			""")
+	void testClusterSetSlotWithActualMigration() {
+		// Comprehensive test that performs actual slot migration with key transfer
+		// This test validates the complete CLUSTER SETSLOT workflow including key
+		// migration
+
+		ValkeyClusterNode sourceNode = findNodeByPort(MASTER_NODE_1_PORT);
+		ValkeyClusterNode destNode = findNodeByPort(MASTER_NODE_2_PORT);
+		assertThat(sourceNode).isNotNull();
+		assertThat(destNode).isNotNull();
+
+		// Choose a slot from master1's range that we'll migrate to master2
+		int slotToMigrate = MASTER_1_SLOT_START + 1000;
+
+		// Find a key that maps to this specific slot using ClusterSlotHashUtil
+		String testKey = "test-key-{" + slotToMigrate + "}"; // TODO: implement
+																// getKeyForSlot
+		byte[] keyBytes = testKey.getBytes();
+		byte[] valueBytes = "migration-test-value".getBytes();
+
+		try {
+			// Setup: Create test key in the slot on source node
+			clusterConnection.stringCommands().set(keyBytes, valueBytes);
+
+			// Verify key exists and is on source node
+			byte[] originalValue = clusterConnection.stringCommands().get(keyBytes);
+			assertThat(originalValue).isEqualTo(valueBytes);
+
+			// Step 1: Mark slot as IMPORTING on destination node (with source node ID)
+			// According to docs: CLUSTER SETSLOT <slot> IMPORTING <source-node-id>
+			clusterConnection.clusterCommands().clusterSetSlot(destNode, slotToMigrate, AddSlots.IMPORTING);
+
+			// Step 2: Mark slot as MIGRATING on source node (with destination node ID)
+			// According to docs: CLUSTER SETSLOT <slot> MIGRATING <destination-node-id>
+			clusterConnection.clusterCommands().clusterSetSlot(sourceNode, slotToMigrate, AddSlots.MIGRATING);
+
+			// Step 3: Migrate the key from source to destination
+			// MIGRATE <host> <port> <key> <db> <timeout> [COPY] [REPLACE]
+			clusterConnection.serverCommands()
+				.migrate(keyBytes, destNode, 0, // database 0
+						null, // no option (will do atomic move)
+						5000 // 5 second timeout
+				);
+
+			// Step 4: Complete the migration by assigning slot to destination
+			// This should be done on the destination node first, then propagated
+			clusterConnection.clusterCommands().clusterSetSlot(destNode, slotToMigrate, AddSlots.NODE);
+
+			// Propagate to source node
+			clusterConnection.clusterCommands().clusterSetSlot(sourceNode, slotToMigrate, AddSlots.NODE);
+
+			// Step 5: Verify migration was successful
+			// The slot should now be owned by destination node
+			ValkeyClusterNode newOwner = clusterConnection.clusterCommands().clusterGetNodeForSlot(slotToMigrate);
+			assertThat(newOwner.getPort()).isEqualTo(MASTER_NODE_2_PORT);
+
+			// Verify the key is accessible and has correct value
+			byte[] migratedValue = clusterConnection.stringCommands().get(keyBytes);
+			assertThat(migratedValue).isEqualTo(valueBytes);
+
+		}
+		finally {
+			clusterConnection.serverCommands().flushAll();
+
+			// Assign slot back to source
+			clusterConnection.clusterCommands().clusterSetSlot(sourceNode, slotToMigrate, AddSlots.NODE);
+			clusterConnection.clusterCommands().clusterSetSlot(destNode, slotToMigrate, AddSlots.NODE);
+		}
+	}
+
+	@Test
+	void testClusterMeet() {
+		// CLUSTER MEET adds a node to the cluster
+		// Since we're testing with an existing cluster, we'll verify the command works
+		// but won't actually add a new node (as that would require a new Valkey instance)
+
+		// Get existing nodes
+		Iterable<ValkeyClusterNode> nodes = clusterConnection.clusterCommands().clusterGetNodes();
+		ValkeyClusterNode existingNode = nodes.iterator().next();
+
+		// Create a node reference (this won't add a new node, just test the command
+		// execution)
+		ValkeyClusterNode nodeToMeet = ValkeyClusterNode.newValkeyClusterNode()
+			.listeningAt(existingNode.getHost(), existingNode.getPort())
+			.build();
+
+		// Execute CLUSTER MEET (should be idempotent for existing nodes)
+		clusterConnection.clusterCommands().clusterMeet(nodeToMeet);
+
+		// Verify cluster still has expected number of nodes
+		Iterable<ValkeyClusterNode> nodesAfter = clusterConnection.clusterCommands().clusterGetNodes();
+		List<ValkeyClusterNode> nodeList = java.util.stream.StreamSupport.stream(nodesAfter.spliterator(), false)
+			.collect(Collectors.toList());
+
+		assertThat(nodeList).hasSize(EXPECTED_TOTAL_NODES);
+	}
+
+	@Test
+	void testClusterReplicate() {
+		// CLUSTER REPLICATE makes a node a replica of a master
+		// We'll test by verifying the existing replica relationship
+
+		ValkeyClusterNode master1 = findNodeByPort(MASTER_NODE_1_PORT);
+		ValkeyClusterNode replica = findNodeByPort(REPLICAOF_NODE_1_PORT);
+
+		assertThat(master1).isNotNull();
+		assertThat(replica).isNotNull();
+
+		// Verify current state: replica should already be replicating master1
+		assertThat(replica.isMaster()).isFalse();
+		assertThat(replica.getMasterId()).isEqualTo(master1.getId());
+
+		// Re-execute CLUSTER REPLICATE (should be idempotent)
+		clusterConnection.clusterCommands().clusterReplicate(master1, replica);
+
+		// Verify replica relationship is still intact
+		Collection<ValkeyClusterNode> replicas = clusterConnection.clusterCommands().clusterGetReplicas(master1);
+		assertThat(replicas).hasSize(1);
+		assertThat(replicas.iterator().next().getPort()).isEqualTo(REPLICAOF_NODE_1_PORT);
+	}
+
+	@Test
+	void testClusterForget() {
+		// CLUSTER FORGET removes a node from the cluster
+		// This is a very destructive operation, so we'll only test it in a controlled way
+		// We cannot actually forget a master node as it would break the cluster
+
+		// Instead, verify that attempting to forget a non-existent node doesn't break
+		// things
+		ValkeyClusterNode nonExistentNode = ValkeyClusterNode.newValkeyClusterNode()
+			.listeningAt("127.0.0.1", 9999)
+			.withId("0000000000000000000000000000000000000000")
+			.build();
+
+		assertThatThrownBy(() -> clusterConnection.clusterCommands().clusterForget(nonExistentNode))
+			.isInstanceOf(DataAccessException.class);
+
+		// Verify cluster still has all expected nodes
+		Iterable<ValkeyClusterNode> nodes = clusterConnection.clusterCommands().clusterGetNodes();
+		List<ValkeyClusterNode> nodeList = java.util.stream.StreamSupport.stream(nodes.spliterator(), false)
+			.collect(Collectors.toList());
+
+		assertThat(nodeList).hasSize(EXPECTED_TOTAL_NODES);
+	}
+
+	// ==================== Edge Cases & Error Handling ====================
+
+	@Test
+	void testClusterGetSlotForNonExistentKey() {
+		byte[] key = "non:existent:key:12345".getBytes();
+
+		// Execute - should still return slot even if key doesn't exist
+		Integer slot = clusterConnection.clusterCommands().clusterGetSlotForKey(key);
+
+		// Verify
+		assertThat(slot).isNotNull();
+		assertThat(slot).isBetween(0, 16383);
+
+		// Verify matches calculation
+		int expectedSlot = calculateSlot(key);
+		assertThat(slot).isEqualTo(expectedSlot);
+	}
+
+	@Test
+	void testClusterTopologyConsistency() {
+		// Get nodes from different methods and verify consistency
+		Iterable<ValkeyClusterNode> allNodes = clusterConnection.clusterCommands().clusterGetNodes();
+		Map<ValkeyClusterNode, Collection<ValkeyClusterNode>> masterReplicaMap = clusterConnection.clusterCommands()
+			.clusterGetMasterReplicaMap();
+
+		// Count masters from both sources
+		int masterCountFromNodes = 0;
+		for (ValkeyClusterNode node : allNodes) {
+			if (node.isMaster()) {
+				masterCountFromNodes++;
+			}
+		}
+
+		int masterCountFromMap = masterReplicaMap.size();
+
+		// Should match expected counts
+		assertThat(masterCountFromNodes).isEqualTo(EXPECTED_MASTER_COUNT);
+		assertThat(masterCountFromMap).isEqualTo(EXPECTED_MASTER_COUNT);
+	}
+
+	@Test
+	void testSlotRangeCoverage() {
+		// Verify all slots 0-16383 are covered by master nodes
+		Collection<ValkeyClusterNode> masters = getActiveMasterNodes();
+
+		assertThat(masters).hasSize(EXPECTED_MASTER_COUNT);
+
+		boolean[] slotsCovered = new boolean[16384];
+
+		for (ValkeyClusterNode master : masters) {
+			SlotRange slotRange = master.getSlotRange();
+			assertThat(slotRange).isNotNull();
+
+			for (Integer slot : slotRange.getSlots()) {
+				slotsCovered[slot] = true;
+			}
+		}
+
+		// Count covered slots
+		int coveredCount = 0;
+		for (boolean covered : slotsCovered) {
+			if (covered)
+				coveredCount++;
+		}
+
+		// All 16384 slots should be covered
+		assertThat(coveredCount).isEqualTo(16384);
+	}
+
+	@Test
+	void testHashTagSlotCalculationConsistency() {
+		// Test various hash tag patterns
+		String[][] keyPairs = { { "{user}:profile", "{user}:settings" }, { "{order}:123", "{order}:456" },
+				{ "{product:id}:abc", "{product:id}:xyz" }, { "prefix:{tag}:suffix1", "prefix:{tag}:suffix2" } };
+
+		for (String[] pair : keyPairs) {
+			Integer slot1 = clusterConnection.clusterCommands().clusterGetSlotForKey(pair[0].getBytes());
+			Integer slot2 = clusterConnection.clusterCommands().clusterGetSlotForKey(pair[1].getBytes());
+
+			// Both keys should map to same slot
+			assertThat(slot1).isEqualTo(slot2);
+
+			// Verify against manual calculation
+			int expectedSlot = calculateSlot(pair[0]);
+			assertThat(slot1).isEqualTo(expectedSlot);
+		}
+	}
+
+	// ==================== Helper Methods ====================
+
+	/**
+	 * Verifies that a node's slot range matches the expected start and end slots.
+	 */
+	private void verifySlotRange(ValkeyClusterNode node, int expectedStart, int expectedEnd) {
+		SlotRange slotRange = node.getSlotRange();
+		assertThat(slotRange).isNotNull();
+
+		Set<Integer> slots = slotRange.getSlots();
+		assertThat(slots).isNotEmpty();
+
+		int actualStart = slots.stream().min(Integer::compare).orElse(-1);
+		int actualEnd = slots.stream().max(Integer::compare).orElse(-1);
+
+		assertThat(actualStart).isEqualTo(expectedStart);
+		assertThat(actualEnd).isEqualTo(expectedEnd);
+
+		int expectedSlotCount = expectedEnd - expectedStart + 1;
+		assertThat(slots).hasSize(expectedSlotCount);
+
+		logger.info("Node at port {} has slots {}-{} ({} slots)", node.getPort(), actualStart, actualEnd, slots.size());
+	}
+
+	/**
+	 * Finds a node by its port number.
+	 */
+	private ValkeyClusterNode findNodeByPort(int port) {
+		Iterable<ValkeyClusterNode> nodes = clusterConnection.clusterCommands().clusterGetNodes();
+		for (ValkeyClusterNode node : nodes) {
+			if (node.getPort() == port) {
+				return node;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Finds a key whose slot falls within the specified range. Uses a simple iteration
+	 * approach to find a suitable key.
+	 */
+	private String findKeyForSlotRange(int startSlot, int endSlot) {
+		// Try different keys until we find one in the range
+		for (int i = 0; i < 10000; i++) {
+			String key = "test:key:" + i;
+			int slot = calculateSlot(key);
+			if (slot >= startSlot && slot <= endSlot) {
+				return key;
+			}
+		}
+
+		// Fallback: use hash tag with slot number
+		return "{slot" + startSlot + "}:key";
+	}
+
 }

--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideClusterConnectionFactoryIntegrationTests.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideClusterConnectionFactoryIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,18 +48,21 @@ import io.valkey.springframework.data.valkey.test.condition.EnabledOnValkeyClust
 
 /**
  * Integration tests for {@link ValkeyGlideConnectionFactory} in cluster mode.
- * 
- * <p>These tests verify that the connection factory works correctly with a Valkey cluster,
+ *
+ * <p>
+ * These tests verify that the connection factory works correctly with a Valkey cluster,
  * ensuring that the cluster adapter properly handles routing and result aggregation.
- * 
- * <p><strong>Important Notes:</strong>
+ *
+ * <p>
+ * <strong>Important Notes:</strong>
  * <ul>
- *   <li>All test keys use hash tags (e.g., {@code {test}:key}) to ensure multi-key operations
- *       work correctly in cluster mode by routing to the same slot.</li>
- *   <li>Transactions ({@code MULTI/EXEC}) are not supported in cluster mode and are omitted.</li>
- *   <li>Pipeline operations are supported in cluster mode via {@code ClusterBatch}.</li>
+ * <li>All test keys use hash tags (e.g., {@code {test}:key}) to ensure multi-key
+ * operations work correctly in cluster mode by routing to the same slot.</li>
+ * <li>Transactions ({@code MULTI/EXEC}) are not supported in cluster mode and are
+ * omitted.</li>
+ * <li>Pipeline operations are supported in cluster mode via {@code ClusterBatch}.</li>
  * </ul>
- * 
+ *
  * @author Ilia Kolominsky
  * @since 2.0
  */
@@ -67,1499 +70,1498 @@ import io.valkey.springframework.data.valkey.test.condition.EnabledOnValkeyClust
 @TestInstance(Lifecycle.PER_CLASS)
 public class ValkeyGlideClusterConnectionFactoryIntegrationTests {
 
-    private ValkeyGlideConnectionFactory connectionFactory;
-    private ValkeyTemplate<String, String> template;
-
-    @BeforeAll
-    void setup() {
-        // Create a cluster connection factory for tests
-        connectionFactory = createClusterConnectionFactory();
-        
-        // Verify we're in cluster mode
-        assertThat(connectionFactory.isClusterAware()).isTrue();
-
-        // Create a template for easier testing
-        template = new ValkeyTemplate<>();
-        template.setConnectionFactory(connectionFactory);
-        template.setKeySerializer(StringValkeySerializer.UTF_8);
-        template.setValueSerializer(StringValkeySerializer.UTF_8);
-        template.setHashKeySerializer(StringValkeySerializer.UTF_8);
-        template.setHashValueSerializer(StringValkeySerializer.UTF_8);
-        template.afterPropertiesSet();
-    }
-
-    @AfterAll
-    void teardown() {
-        if (connectionFactory != null) {
-            connectionFactory.destroy();
-        }
-    }
-
-    /**
-     * Creates a cluster connection factory for testing.
-     */
-    private ValkeyGlideConnectionFactory createClusterConnectionFactory() {
-        ValkeyClusterConfiguration clusterConfig = new ValkeyClusterConfiguration();
-        
-        // Use ClusterTestVariables for consistency with other tests
-        clusterConfig.clusterNode(ClusterTestVariables.CLUSTER_NODE_1);
-        clusterConfig.clusterNode(ClusterTestVariables.CLUSTER_NODE_2);
-        clusterConfig.clusterNode(ClusterTestVariables.CLUSTER_NODE_3);
-        clusterConfig.clusterNode(ClusterTestVariables.REPLICA_OF_NODE_1);
-        return new ValkeyGlideConnectionFactory(clusterConfig, new DefaultValkeyGlideClientConfiguration());
-    }
-
-    @Test
-    void testGetClusterConnection() {
-        ValkeyClusterConnection clusterConnection = connectionFactory.getClusterConnection();
-        assertThat(clusterConnection).isNotNull();
-        assertThat(clusterConnection).isInstanceOf(ValkeyGlideClusterConnection.class);
-        clusterConnection.close();
-    }
-
-    @Test
-    void testHashOperations() {
-        // Use hash tags to ensure all keys land on the same slot
-        String key1 = "{hash}:basic";
-        String key2 = "{hash}:putall";
-        String key3 = "{hash}:putifabsent";
-        String key4 = "{hash}:increment";
-        String key5 = "{hash}:length";
-        String key6 = "{hash}:delete";
-        String key7 = "{hash}:random";
-        String key8 = "{hash}:scan";
-        String key9 = "{hash}:expiration";
-        
-        try {
-            template.opsForHash().put(key1, "field1", "value1");
-            template.opsForHash().put(key1, "field2", "value2");
-
-            assertThat(template.opsForHash().get(key1, "field1")).isEqualTo("value1");
-            assertThat(template.opsForHash().get(key1, "field2")).isEqualTo("value2");
-
-            // PUTALL operation
-            Map<String, String> hashMap = Map.of(
-                "field1", "value1",
-                "field2", "value2",
-                "field3", "value3"
-            );
-            template.opsForHash().putAll(key2, hashMap);
-            
-            assertThat(template.opsForHash().get(key2, "field1")).isEqualTo("value1");
-            assertThat(template.opsForHash().get(key2, "field2")).isEqualTo("value2");
-            assertThat(template.opsForHash().get(key2, "field3")).isEqualTo("value3");
-
-            // PUTIFABSENT operation
-            Boolean putResult1 = template.opsForHash().putIfAbsent(key3, "field1", "value1");
-            assertThat(putResult1).isTrue();
-            Boolean putResult2 = template.opsForHash().putIfAbsent(key3, "field1", "different_value");
-            assertThat(putResult2).isFalse();
-            assertThat(template.opsForHash().get(key3, "field1")).isEqualTo("value1");
-
-            // HASKEY operation
-            assertThat(template.opsForHash().hasKey(key1, "field1")).isTrue();
-            assertThat(template.opsForHash().hasKey(key1, "nonexistent")).isFalse();
-
-            // MULTIGET operation
-            List<Object> hashKeys = List.of("field1", "field2", "nonexistent");
-            List<Object> multiGetResult = template.opsForHash().multiGet(key1, hashKeys);
-            assertThat(multiGetResult).containsExactly("value1", "value2", null);
-
-            // SIZE operation
-            assertThat(template.opsForHash().size(key1)).isEqualTo(2);
-            assertThat(template.opsForHash().size(key2)).isEqualTo(3);
-
-            // KEYS operation
-            Set<Object> keys = template.opsForHash().keys(key2);
-            assertThat(keys).containsExactlyInAnyOrder("field1", "field2", "field3");
-
-            // VALUES operation
-            List<Object> values = template.opsForHash().values(key2);
-            assertThat(values).containsExactlyInAnyOrder("value1", "value2", "value3");
-
-            // ENTRIES operation (HGETALL)
-            Map<Object, Object> entries = template.opsForHash().entries(key2);
-            assertThat(entries).hasSize(3);
-            assertThat(entries.get("field1")).isEqualTo("value1");
-            assertThat(entries.get("field2")).isEqualTo("value2");
-            assertThat(entries.get("field3")).isEqualTo("value3");
-
-            // INCREMENT operations
-            template.opsForHash().put(key4, "counter", "10");
-            
-            // Long increment
-            Long incrResult1 = template.opsForHash().increment(key4, "counter", 5L);
-            assertThat(incrResult1).isEqualTo(15L);
-            
-            Long incrResult2 = template.opsForHash().increment(key4, "counter", -3L);
-            assertThat(incrResult2).isEqualTo(12L);
-            
-            // Double increment (using different field to avoid conflicts)
-            template.opsForHash().put(key4, "floatcounter", "10.5");
-            Double floatIncrResult = template.opsForHash().increment(key4, "floatcounter", 2.5);
-            assertThat(floatIncrResult).isEqualTo(13.0);
-
-            // LENGTHOFVALUE operation
-            template.opsForHash().put(key5, "field1", "Hello World!");
-            Long lengthResult = template.opsForHash().lengthOfValue(key5, "field1");
-            assertThat(lengthResult).isEqualTo(12L);
-            
-            // Length of non-existent field
-            Long lengthNonExistent = template.opsForHash().lengthOfValue(key5, "nonexistent");
-            assertThat(lengthNonExistent).isEqualTo(0L);
-
-            // DELETE hash fields operation
-            template.opsForHash().put(key6, "field1", "value1");
-            template.opsForHash().put(key6, "field2", "value2");
-            template.opsForHash().put(key6, "field3", "value3");
-            
-            Long deleteResult = template.opsForHash().delete(key6, "field1", "field2");
-            assertThat(deleteResult).isEqualTo(2L);
-            assertThat(template.opsForHash().hasKey(key6, "field1")).isFalse();
-            assertThat(template.opsForHash().hasKey(key6, "field2")).isFalse();
-            assertThat(template.opsForHash().hasKey(key6, "field3")).isTrue();
-
-            // RANDOM operations
-            template.opsForHash().putAll(key7, Map.of(
-                "field1", "value1",
-                "field2", "value2",
-                "field3", "value3",
-                "field4", "value4"
-            ));
-
-            // Random key
-            Object randomKey = template.opsForHash().randomKey(key7);
-            assertThat(randomKey).isIn("field1", "field2", "field3", "field4");
-            
-            // Random entry
-            Map.Entry<Object, Object> randomEntry = template.opsForHash().randomEntry(key7);
-            assertThat(randomEntry.getKey()).isIn("field1", "field2", "field3", "field4");
-            assertThat(randomEntry.getValue().toString()).startsWith("value");
-            
-            // Random keys with count
-            List<Object> randomKeys = template.opsForHash().randomKeys(key7, 2);
-            assertThat(randomKeys).hasSize(2);
-            assertThat(randomKeys).allMatch(key -> List.of("field1", "field2", "field3", "field4").contains(key));
-
-            // Random entries with count
-            Map<Object, Object> randomEntries = template.opsForHash().randomEntries(key7, 2);
-            assertThat(randomEntries).hasSize(2);
-            randomEntries.forEach((k, v) -> {
-                assertThat(k).isIn("field1", "field2", "field3", "field4");
-                assertThat(v.toString()).startsWith("value");
-            });
-
-            // SCAN operation (using ValkeyCallback for direct access to connection)
-            template.opsForHash().putAll(key8, Map.of(
-                "scanfield1", "scanvalue1",
-                "scanfield2", "scanvalue2",
-                "scanfield3", "scanvalue3"
-            ));
-            
-            // Test hScan using connection directly
-            template.execute((ValkeyCallback<Void>) connection -> {
-                try (var cursor = connection.hashCommands().hScan(key8.getBytes(), 
-                        io.valkey.springframework.data.valkey.core.ScanOptions.scanOptions().count(10).build())) {
-                    int count = 0;
-                    while (cursor.hasNext()) {
-                        Map.Entry<byte[], byte[]> entry = cursor.next();
-                        String field = new String(entry.getKey());
-                        String value = new String(entry.getValue());
-                        assertThat(field).startsWith("scanfield");
-                        assertThat(value).startsWith("scanvalue");
-                        count++;
-                    }
-                    assertThat(count).isEqualTo(3);
-                }
-                return null;
-            });
-
-            // Test hash field expiration operations (requires Valkey 7.4+)
-            if (isServerVersionAtLeast(7, 4)) {
-                template.opsForHash().putAll(key9, Map.of(
-                    "expirefield1", "expirevalue1",
-                    "expirefield2", "expirevalue2",
-                    "persistfield", "persistvalue"
-                ));
-
-                // Test hExpire - Set TTL in seconds
-                template.execute((ValkeyCallback<List<Long>>) connection -> {
-                    List<Long> result = connection.hashCommands().hExpire(key9.getBytes(), 60L, 
-                        "expirefield1".getBytes(), "expirefield2".getBytes());
-                    assertThat(result).containsExactly(1L, 1L);
-                    return result;
-                });
-
-                // Test hpExpire - Set TTL in milliseconds  
-                template.execute((ValkeyCallback<List<Long>>) connection -> {
-                    List<Long> result = connection.hashCommands().hpExpire(key9.getBytes(), 60000L,
-                        "expirefield1".getBytes());
-                    assertThat(result).containsExactly(1L);
-                    return result;
-                });
-
-                // Test hExpireAt - Set expiration at specific timestamp
-                long futureTimestamp = System.currentTimeMillis() / 1000 + 120;
-                template.execute((ValkeyCallback<List<Long>>) connection -> {
-                    List<Long> result = connection.hashCommands().hExpireAt(key9.getBytes(), futureTimestamp,
-                        "expirefield1".getBytes());
-                    assertThat(result).containsExactly(1L);
-                    return result;
-                });
-
-                // Test hpExpireAt - Set expiration at specific timestamp in milliseconds
-                long futureTimestampMillis = System.currentTimeMillis() + 120000;
-                template.execute((ValkeyCallback<List<Long>>) connection -> {
-                    List<Long> result = connection.hashCommands().hpExpireAt(key9.getBytes(), futureTimestampMillis,
-                        "expirefield2".getBytes());
-                    assertThat(result).containsExactly(1L);
-                    return result;
-                });
-
-                // Test hTtl - Get TTL in seconds
-                template.execute((ValkeyCallback<List<Long>>) connection -> {
-                    List<Long> result = connection.hashCommands().hTtl(key9.getBytes(), 
-                        "expirefield1".getBytes(), "persistfield".getBytes());
-                    assertThat(result).hasSize(2);
-                    assertThat(result.get(0)).isGreaterThan(0L);
-                    assertThat(result.get(1)).isEqualTo(-1L);
-                    return result;
-                });
-
-                template.execute((ValkeyCallback<List<Long>>) connection -> {
-                    List<Long> result = connection.hashCommands().hpTtl(key9.getBytes(),
-                        "expirefield1".getBytes(), "persistfield".getBytes());
-                    assertThat(result).hasSize(2);
-                    assertThat(result.get(0)).isGreaterThan(0L);
-                    assertThat(result.get(1)).isEqualTo(-1L);
-                    return result;
-                });
-
-                // Test hPersist - Remove expiration from fields
-                template.execute((ValkeyCallback<List<Long>>) connection -> {
-                    List<Long> result = connection.hashCommands().hPersist(key9.getBytes(),
-                        "expirefield1".getBytes(), "expirefield2".getBytes());
-                    assertThat(result).containsExactly(1L, 1L);
-                    return result;
-                });
-
-                // Verify fields no longer have expiration after hPersist
-                template.execute((ValkeyCallback<List<Long>>) connection -> {
-                    List<Long> result = connection.hashCommands().hTtl(key9.getBytes(),
-                        "expirefield1".getBytes(), "expirefield2".getBytes());
-                    assertThat(result).containsExactly(-1L, -1L);
-                    return result;
-                });
-            }
-        } finally {
-            // Clean up all test keys
-            template.delete(key1);
-            template.delete(key2);
-            template.delete(key3);
-            template.delete(key4);
-            template.delete(key5);
-            template.delete(key6);
-            template.delete(key7);
-            template.delete(key8);
-            template.delete(key9);
-        }
-    }
-
-    @Test
-    void testListOperations() {
-        // Use hash tags to ensure all keys land on the same slot
-        String key1 = "{list}:basic";
-        String key2 = "{list}:push";
-        String key3 = "{list}:range";
-        String key4 = "{list}:insert";
-        String key5 = "{list}:move";
-        String key6 = "{list}:set";
-        String key7 = "{list}:remove";
-        String key8 = "{list}:blocking";
-        String srcKey = "{list}:src";
-        String dstKey = "{list}:dst";
-
-        try {
-            // Basic LPUSH/RPUSH operations
-            template.opsForList().leftPush(key1, "value1");
-            template.opsForList().leftPush(key1, "value2");
-            template.opsForList().rightPush(key1, "value3");
-
-            assertThat(template.opsForList().size(key1)).isEqualTo(3);
-            
-            // Test LRANGE to verify order
-            List<String> range = template.opsForList().range(key1, 0, -1);
-            assertThat(range).containsExactly("value2", "value1", "value3");
-
-            // Test LINDEX - get element at index
-            assertThat(template.opsForList().index(key1, 0)).isEqualTo("value2");
-            assertThat(template.opsForList().index(key1, 1)).isEqualTo("value1");
-            assertThat(template.opsForList().index(key1, 2)).isEqualTo("value3");
-            
-            // Test convenience methods getFirst and getLast
-            String firstLastKey = "{list}:firstlast";
-            template.opsForList().rightPushAll(firstLastKey, "first", "middle", "last");
-            
-            String firstElement = template.opsForList().getFirst(firstLastKey);
-            assertThat(firstElement).isEqualTo("first");
-            
-            String lastElement = template.opsForList().getLast(firstLastKey);
-            assertThat(lastElement).isEqualTo("last");
-            
-            // Test with empty list
-            String emptyKey = "{list}:empty";
-            String firstEmpty = template.opsForList().getFirst(emptyKey);
-            assertThat(firstEmpty).isNull();
-            
-            String lastEmpty = template.opsForList().getLast(emptyKey);
-            assertThat(lastEmpty).isNull();
-            
-            template.delete(firstLastKey);
-
-            // Test LPOP/RPOP
-            assertThat(template.opsForList().leftPop(key1)).isEqualTo("value2");
-            assertThat(template.opsForList().rightPop(key1)).isEqualTo("value3");
-            assertThat(template.opsForList().size(key1)).isEqualTo(1);
-
-            // Test LPUSHX/RPUSHX (push only if key exists)
-            template.opsForList().leftPushIfPresent(key2, "shouldnotwork");
-            assertThat(template.opsForList().size(key2)).isEqualTo(0);
-            
-            template.opsForList().leftPush(key2, "initial");
-            template.opsForList().leftPushIfPresent(key2, "shouldwork");
-            template.opsForList().rightPushIfPresent(key2, "alsowork");
-            
-            List<String> key2Range = template.opsForList().range(key2, 0, -1);
-            assertThat(key2Range).containsExactly("shouldwork", "initial", "alsowork");
-
-            // Test LEFTPUSHALL operations
-            String leftPushAllKey = "{list}:leftpushall";
-            
-            template.opsForList().leftPushAll(leftPushAllKey, "first", "second", "third");
-            List<String> leftPushAllResult1 = template.opsForList().range(leftPushAllKey, 0, -1);
-            assertThat(leftPushAllResult1).containsExactly("third", "second", "first");
-            
-            template.delete(leftPushAllKey);
-            template.opsForList().leftPushAll(leftPushAllKey, List.of("a", "b", "c"));
-            List<String> leftPushAllResult2 = template.opsForList().range(leftPushAllKey, 0, -1);
-            assertThat(leftPushAllResult2).containsExactly("c", "b", "a");
-            
-            template.delete(leftPushAllKey);
-
-            // Test LRANGE and LTRIM
-            template.opsForList().rightPushAll(key3, "a", "b", "c", "d", "e");
-            List<String> beforeTrim = template.opsForList().range(key3, 0, -1);
-            assertThat(beforeTrim).containsExactly("a", "b", "c", "d", "e");
-            
-            template.opsForList().trim(key3, 1, 3);
-            List<String> afterTrim = template.opsForList().range(key3, 0, -1);
-            assertThat(afterTrim).containsExactly("b", "c", "d");
-
-            // Test LINSERT - insert before/after pivot
-            template.opsForList().rightPushAll(key4, "first", "pivot", "last");
-            
-            template.execute((ValkeyCallback<Long>) connection -> 
-                connection.listCommands().lInsert(key4.getBytes(), 
-                    ValkeyListCommands.Position.BEFORE, "pivot".getBytes(), "before_pivot".getBytes()));
-            
-            template.execute((ValkeyCallback<Long>) connection -> 
-                connection.listCommands().lInsert(key4.getBytes(), 
-                    ValkeyListCommands.Position.AFTER, "pivot".getBytes(), "after_pivot".getBytes()));
-            
-            List<String> insertResult = template.opsForList().range(key4, 0, -1);
-            assertThat(insertResult).containsExactly("first", "before_pivot", "pivot", "after_pivot", "last");
-
-            // Test LMOVE (move element between lists)
-            template.opsForList().rightPushAll(key5, "move1", "move2", "move3");
-            String dstKey5 = key5 + "_dst";
-            
-            template.execute((ValkeyCallback<byte[]>) connection -> 
-                connection.listCommands().lMove(key5.getBytes(), dstKey5.getBytes(), 
-                    ValkeyListCommands.Direction.LEFT, ValkeyListCommands.Direction.RIGHT));
-            
-            assertThat(template.opsForList().range(key5, 0, -1)).containsExactly("move2", "move3");
-            assertThat(template.opsForList().range(dstKey5, 0, -1)).containsExactly("move1");
-            
-            // Test high-level move operations
-            String moveHighKey1 = "{list}:movehigh1";
-            String moveHighKey2 = "{list}:movehigh2";
-            template.opsForList().rightPushAll(moveHighKey1, "high1", "high2", "high3");
-            
-            String movedValue1 = template.opsForList().move(
-                io.valkey.springframework.data.valkey.core.ListOperations.MoveFrom.fromTail(moveHighKey1),
-                io.valkey.springframework.data.valkey.core.ListOperations.MoveTo.toHead(moveHighKey2)
-            );
-            assertThat(movedValue1).isEqualTo("high3");
-            assertThat(template.opsForList().range(moveHighKey1, 0, -1)).containsExactly("high1", "high2");
-            assertThat(template.opsForList().range(moveHighKey2, 0, -1)).containsExactly("high3");
-            
-            String movedValue2 = template.opsForList().move(
-                io.valkey.springframework.data.valkey.core.ListOperations.MoveFrom.fromHead(moveHighKey1),
-                io.valkey.springframework.data.valkey.core.ListOperations.MoveTo.toTail(moveHighKey2)
-            );
-            assertThat(movedValue2).isEqualTo("high1");
-            assertThat(template.opsForList().range(moveHighKey1, 0, -1)).containsExactly("high2");
-            assertThat(template.opsForList().range(moveHighKey2, 0, -1)).containsExactly("high3", "high1");
-            
-            template.delete(moveHighKey1);
-            template.delete(moveHighKey2);
-
-            // Test LSET - set element at index
-            template.opsForList().rightPushAll(key6, "original1", "original2", "original3");
-            template.opsForList().set(key6, 1, "modified");
-            
-            List<String> setResult = template.opsForList().range(key6, 0, -1);
-            assertThat(setResult).containsExactly("original1", "modified", "original3");
-
-            // Test LREM - remove occurrences of value
-            template.opsForList().rightPushAll(key7, "remove", "keep", "remove", "keep", "remove");
-            Long removedCount = template.opsForList().remove(key7, 2, "remove");
-            assertThat(removedCount).isEqualTo(2L);
-            
-            List<String> removeResult = template.opsForList().range(key7, 0, -1);
-            assertThat(removeResult).containsExactly("keep", "keep", "remove");
-
-            // Test LPOP/RPOP with count (Valkey 6.2+)
-            template.opsForList().rightPushAll(key8, "pop1", "pop2", "pop3", "pop4", "pop5");
-            
-            List<String> leftPopped = template.opsForList().leftPop(key8, 2);
-            if (leftPopped != null) {
-                assertThat(leftPopped).containsExactly("pop1", "pop2");
-                
-                List<String> rightPopped = template.opsForList().rightPop(key8, 2);
-                assertThat(rightPopped).containsExactly("pop5", "pop4");
-                
-                assertThat(template.opsForList().range(key8, 0, -1)).containsExactly("pop3");
-            }
-
-            // Test RPOPLPUSH - atomically move from end to beginning
-            template.opsForList().rightPushAll(srcKey, "src1", "src2", "src3");
-            template.opsForList().rightPushAll(dstKey, "dst1");
-            
-            String moved = template.opsForList().rightPopAndLeftPush(srcKey, dstKey);
-            assertThat(moved).isEqualTo("src3");
-            assertThat(template.opsForList().range(srcKey, 0, -1)).containsExactly("src1", "src2");
-            assertThat(template.opsForList().range(dstKey, 0, -1)).containsExactly("src3", "dst1");
-
-            // Test LPOS - find position of element (Valkey 6.0.6+)
-            if (isServerVersionAtLeast(6, 1)) {
-                String posKey = "{list}:position";
-                template.opsForList().rightPushAll(posKey, "a", "b", "c", "b", "d");
-                
-                Long firstPos = template.opsForList().indexOf(posKey, "b");
-                assertThat(firstPos).isEqualTo(1L);
-                
-                Long lastPos = template.opsForList().lastIndexOf(posKey, "b");
-                assertThat(lastPos).isEqualTo(3L);
-                
-                Long notFoundPos = template.opsForList().indexOf(posKey, "z");
-                assertThat(notFoundPos).isNull();
-                
-                Long notFoundLastPos = template.opsForList().lastIndexOf(posKey, "z");
-                assertThat(notFoundLastPos).isNull();
-                
-                List<Long> positions = template.execute((ValkeyCallback<List<Long>>) connection -> 
-                    connection.listCommands().lPos(posKey.getBytes(), "b".getBytes(), null, 2));
-                assertThat(positions).containsExactly(1L, 3L);
-                
-                template.delete(posKey);
-            }
-
-        } finally {
-            // Clean up all test keys
-            template.delete(key1);
-            template.delete(key2);
-            template.delete(key3);
-            template.delete(key4);
-            template.delete(key5);
-            template.delete(key5 + "_dst");
-            template.delete(key6);
-            template.delete(key7);
-            template.delete(key8);
-            template.delete(srcKey);
-            template.delete(dstKey);
-        }
-    }
-
-    @Test
-    void testSetOperations() {
-        // Use hash tags to ensure all keys land on the same slot
-        String key1 = "{set}:basic";
-        String key2 = "{set}:operations";
-        String key3 = "{set}:union";
-        String key4 = "{set}:intersection";
-        String key5 = "{set}:difference";
-        String key6 = "{set}:random";
-        String key7 = "{set}:pop";
-        String key8 = "{set}:move";
-        String key9 = "{set}:scan";
-        String key10 = "{set}:scanhigh";
-        String destKey = "{set}:dest";
-
-        try {
-            // Basic SADD operations
-            Long addResult1 = template.opsForSet().add(key1, "value1", "value2", "value3");
-            assertThat(addResult1).isEqualTo(3L);
-
-            // Add duplicate - should return 0
-            Long addResult2 = template.opsForSet().add(key1, "value2");
-            assertThat(addResult2).isEqualTo(0L);
-
-            // SCARD - Set cardinality (size)
-            assertThat(template.opsForSet().size(key1)).isEqualTo(3);
-
-            // SISMEMBER - Check membership
-            assertThat(template.opsForSet().isMember(key1, "value2")).isTrue();
-            assertThat(template.opsForSet().isMember(key1, "nonexistent")).isFalse();
-
-            // SMISMEMBER - Check multiple membership (Valkey 6.2+)
-            if (isServerVersionAtLeast(6, 2)) {
-                template.execute((ValkeyCallback<List<Boolean>>) connection -> {
-                    Map<Object, Boolean> membershipMap = template.opsForSet().isMember(key1, "value1", "nonexistent", "value3");
-                    assertThat(membershipMap.get("value1")).isTrue();
-                    assertThat(membershipMap.get("nonexistent")).isFalse();
-                    assertThat(membershipMap.get("value3")).isTrue();
-                    return null;
-                });
-            }
-
-            // SMEMBERS - Get all members
-            Set<String> members = template.opsForSet().members(key1);
-            assertThat(members).containsExactlyInAnyOrder("value1", "value2", "value3");
-
-            // SREM - Remove members
-            Long remResult1 = template.opsForSet().remove(key1, "value2");
-            assertThat(remResult1).isEqualTo(1L);
-            assertThat(template.opsForSet().size(key1)).isEqualTo(2);
-
-            Long remResult2 = template.opsForSet().remove(key1, "value1", "nonexistent");
-            assertThat(remResult2).isEqualTo(1L);
-            assertThat(template.opsForSet().size(key1)).isEqualTo(1);
-
-            // Set up sets for set operations
-            template.opsForSet().add(key2, "a", "b", "c");
-            template.opsForSet().add(key3, "b", "c", "d");
-            template.opsForSet().add(key4, "c", "d", "e");
-
-            // SUNION - Union of sets
-            Set<String> unionResult = template.opsForSet().union(key2, key3);
-            assertThat(unionResult).containsExactlyInAnyOrder("a", "b", "c", "d");
-
-            // SUNION with multiple keys
-            Set<String> unionMultiResult = template.opsForSet().union(key2, List.of(key3, key4));
-            assertThat(unionMultiResult).containsExactlyInAnyOrder("a", "b", "c", "d", "e");
-
-            // SUNIONSTORE - Store union result
-            Long unionStoreResult = template.opsForSet().unionAndStore(key2, key3, destKey);
-            assertThat(unionStoreResult).isEqualTo(4L);
-            assertThat(template.opsForSet().members(destKey)).containsExactlyInAnyOrder("a", "b", "c", "d");
-            template.delete(destKey);
-
-            // SUNIONSTORE with multiple keys
-            Long unionStoreMultiResult = template.opsForSet().unionAndStore(key2, List.of(key3, key4), destKey);
-            assertThat(unionStoreMultiResult).isEqualTo(5L);
-            assertThat(template.opsForSet().members(destKey)).containsExactlyInAnyOrder("a", "b", "c", "d", "e");
-            template.delete(destKey);
-
-            // SINTER - Intersection of sets
-            Set<String> intersectResult = template.opsForSet().intersect(key2, key3);
-            assertThat(intersectResult).containsExactlyInAnyOrder("b", "c");
-
-            // SINTER with multiple keys
-            Set<String> intersectMultiResult = template.opsForSet().intersect(key2, List.of(key3, key4));
-            assertThat(intersectMultiResult).containsExactlyInAnyOrder("c");
-
-            // SINTERSTORE - Store intersection result
-            Long intersectStoreResult = template.opsForSet().intersectAndStore(key2, key3, destKey);
-            assertThat(intersectStoreResult).isEqualTo(2L);
-            assertThat(template.opsForSet().members(destKey)).containsExactlyInAnyOrder("b", "c");
-            template.delete(destKey);
-
-            // SINTERSTORE with multiple keys
-            Long intersectStoreMultiResult = template.opsForSet().intersectAndStore(key2, List.of(key3, key4), destKey);
-            assertThat(intersectStoreMultiResult).isEqualTo(1L);
-            assertThat(template.opsForSet().members(destKey)).containsExactlyInAnyOrder("c");
-            template.delete(destKey);
-
-            // SDIFF - Difference of sets
-            Set<String> diffResult = template.opsForSet().difference(key2, key3);
-            assertThat(diffResult).containsExactlyInAnyOrder("a");
-
-            // SDIFF with multiple keys
-            Set<String> diffMultiResult = template.opsForSet().difference(key2, List.of(key3, key4));
-            assertThat(diffMultiResult).containsExactlyInAnyOrder("a");
-
-            // SDIFFSTORE - Store difference result
-            Long diffStoreResult = template.opsForSet().differenceAndStore(key2, key3, destKey);
-            assertThat(diffStoreResult).isEqualTo(1L);
-            assertThat(template.opsForSet().members(destKey)).containsExactlyInAnyOrder("a");
-            template.delete(destKey);
-
-            // SDIFFSTORE with multiple keys
-            Long diffStoreMultiResult = template.opsForSet().differenceAndStore(key2, List.of(key3, key4), destKey);
-            assertThat(diffStoreMultiResult).isEqualTo(1L);
-            assertThat(template.opsForSet().members(destKey)).containsExactlyInAnyOrder("a");
-            template.delete(destKey);
-
-            // SRANDMEMBER operations
-            template.opsForSet().add(key6, "rand1", "rand2", "rand3", "rand4", "rand5");
-            
-            // SRANDMEMBER - Single random member
-            String randomMember = template.opsForSet().randomMember(key6);
-            assertThat(randomMember).isIn("rand1", "rand2", "rand3", "rand4", "rand5");
-
-            // SRANDMEMBER with count
-            List<String> randomMembers = template.opsForSet().randomMembers(key6, 3);
-            assertThat(randomMembers).hasSize(3);
-            assertThat(randomMembers).allMatch(member -> 
-                List.of("rand1", "rand2", "rand3", "rand4", "rand5").contains(member));
-            
-            // SRANDMEMBER with negative count
-            Set<String> randomDistinct = template.opsForSet().distinctRandomMembers(key6, 3);
-            assertThat(randomDistinct).hasSizeLessThanOrEqualTo(3);
-            assertThat(randomDistinct).allMatch(member -> 
-                List.of("rand1", "rand2", "rand3", "rand4", "rand5").contains(member));
-
-            // SPOP operations
-            template.opsForSet().add(key7, "pop1", "pop2", "pop3", "pop4");
-            
-            // SPOP - Single pop
-            String poppedMember = template.opsForSet().pop(key7);
-            assertThat(poppedMember).isIn("pop1", "pop2", "pop3", "pop4");
-            assertThat(template.opsForSet().size(key7)).isEqualTo(3);
-
-            // SPOP with count
-            List<String> poppedMembers = template.opsForSet().pop(key7, 2);
-            if (poppedMembers != null) {
-                assertThat(poppedMembers).hasSize(2);
-                assertThat(template.opsForSet().size(key7)).isEqualTo(1);
-            }
-
-            // SMOVE - Move member between sets
-            template.opsForSet().add(key8, "move1", "move2", "move3");
-            String moveDestKey = key8 + "_dest";
-            
-            Boolean moveResult = template.opsForSet().move(key8, "move2", moveDestKey);
-            assertThat(moveResult).isTrue();
-            assertThat(template.opsForSet().isMember(key8, "move2")).isFalse();
-            assertThat(template.opsForSet().isMember(moveDestKey, "move2")).isTrue();
-
-            // Try to move non-existent member
-            Boolean moveResult2 = template.opsForSet().move(key8, "nonexistent", moveDestKey);
-            assertThat(moveResult2).isFalse();
-            
-            template.delete(moveDestKey);
-
-            // SSCAN operation
-            template.opsForSet().add(key9, "scan1", "scan2", "scan3", "scan4", "scan5");
-            
-            template.execute((ValkeyCallback<Void>) connection -> {
-                try (var cursor = connection.setCommands().sScan(key9.getBytes(), 
-                        io.valkey.springframework.data.valkey.core.ScanOptions.scanOptions().count(10).build())) {
-                    Set<String> scannedMembers = new java.util.HashSet<>();
-                    while (cursor.hasNext()) {
-                        byte[] member = cursor.next();
-                        scannedMembers.add(new String(member));
-                    }
-                    assertThat(scannedMembers).containsExactlyInAnyOrder("scan1", "scan2", "scan3", "scan4", "scan5");
-                }
-                return null;
-            });
-
-            // Test high-level SetOperations.scan() method
-            template.opsForSet().add(key10, "high1", "high2", "high3", "high4", "high5");
-            
-            try (io.valkey.springframework.data.valkey.core.Cursor<String> cursor = 
-                    template.opsForSet().scan(key10, 
-                        io.valkey.springframework.data.valkey.core.ScanOptions.scanOptions().count(10).build())) {
-                Set<String> scannedHighMembers = new java.util.HashSet<>();
-                while (cursor.hasNext()) {
-                    String member = cursor.next();
-                    scannedHighMembers.add(member);
-                }
-                assertThat(scannedHighMembers).containsExactlyInAnyOrder("high1", "high2", "high3", "high4", "high5");
-            }
-
-        } finally {
-            // Clean up all test keys
-            template.delete(key1);
-            template.delete(key2);
-            template.delete(key3);
-            template.delete(key4);
-            template.delete(key5);
-            template.delete(key6);
-            template.delete(key7);
-            template.delete(key8);
-            template.delete(key9);
-            template.delete(key10);
-            template.delete(destKey);
-            template.delete(key8 + "_dest");
-        }
-    }
-
-    @Test
-    void testStringOperations() {
-        // Use hash tags to ensure all keys land on the same slot for multi-key operations
-        String key1 = "{string}:basic";
-        String key2 = "{string}:expire";
-        String key3 = "{string}:setnx";
-        String key4 = "{string}:getset";
-        String multi1Key = "{string}:multi1";
-        String multi2Key = "{string}:multi2";
-        String multi3Key = "{string}:multi3";
-        String msetnx1Key = "{string}:msetnx1";
-        String msetnx2Key = "{string}:msetnx2";
-        String counterKey = "{string}:counter";
-        String floatCounterKey = "{string}:floatcounter";
-        String appendKey = "{string}:append";
-        String setRangeKey = "{string}:setrange";
-        String bitKey = "{string}:bits";
-        String bitKey1 = "{string}:bit1";
-        String bitKey2 = "{string}:bit2";
-        String bitDestKey = "{string}:bitop";
-        
-        try {
-            String value1 = "Hello, valkey-glide!";
-            
-            template.opsForValue().set(key1, value1);
-            String retrieved1 = template.opsForValue().get(key1);
-            assertThat(retrieved1).isEqualTo(value1);
-
-            // SET with expiration
-            String value2 = "Expiring value";
-            template.opsForValue().set(key2, value2, Duration.ofSeconds(60));
-            String retrieved2 = template.opsForValue().get(key2);
-            assertThat(retrieved2).isEqualTo(value2);
-
-            // SETNX (Set if Not eXists)
-            String value3 = "New value";
-            Boolean setResult1 = template.opsForValue().setIfAbsent(key3, value3);
-            assertThat(setResult1).isTrue();
-            Boolean setResult2 = template.opsForValue().setIfAbsent(key3, "Different value");
-            assertThat(setResult2).isFalse();
-            assertThat(template.opsForValue().get(key3)).isEqualTo(value3);
-
-            // GETSET operation
-            template.opsForValue().set(key4, "old value");
-            String oldValue = template.opsForValue().getAndSet(key4, "new value");
-            assertThat(oldValue).isEqualTo("old value");
-            assertThat(template.opsForValue().get(key4)).isEqualTo("new value");
-
-            // MGET/MSET operations
-            Map<String, String> multiValues = Map.of(
-                multi1Key, "value1",
-                multi2Key, "value2",
-                multi3Key, "value3"
-            );
-            template.opsForValue().multiSet(multiValues);
-            
-            List<String> multiRetrieved = template.opsForValue().multiGet(List.of(
-                multi1Key, multi2Key, multi3Key));
-            assertThat(multiRetrieved).containsExactly("value1", "value2", "value3");
-         
-            // MSETNX operation
-            Map<String, String> msetnxValues = Map.of(
-                msetnx1Key, "msetnx_value1",
-                msetnx2Key, "msetnx_value2"
-            );
-            Boolean msetnxResult = template.opsForValue().multiSetIfAbsent(msetnxValues);
-            assertThat(msetnxResult).isTrue();
-            assertThat(template.opsForValue().get(msetnx1Key)).isEqualTo("msetnx_value1");
-
-            // INCR/DECR operations
-            template.opsForValue().set(counterKey, "10");
-            
-            Long incResult1 = template.opsForValue().increment(counterKey);
-            assertThat(incResult1).isEqualTo(11L);
-            
-            Long incResult2 = template.opsForValue().increment(counterKey, 5L);
-            assertThat(incResult2).isEqualTo(16L);
-            
-            Long decrResult1 = template.opsForValue().decrement(counterKey);
-            assertThat(decrResult1).isEqualTo(15L);
-            
-            Long decrResult2 = template.opsForValue().decrement(counterKey, 3L);
-            assertThat(decrResult2).isEqualTo(12L);
-            
-            // Floating point increment
-            template.opsForValue().set(floatCounterKey, "10");
-            Double incFloatResult = template.opsForValue().increment(floatCounterKey, 2.5);
-            assertThat(incFloatResult).isEqualTo(12.5);
-
-            // APPEND operation
-            template.opsForValue().set(appendKey, "Hello");
-            Integer appendResult = template.opsForValue().append(appendKey, " World!");
-            assertThat(appendResult).isEqualTo(12);
-            assertThat(template.opsForValue().get(appendKey)).isEqualTo("Hello World!");
-
-            // STRING LENGTH operation
-            Long strlenResult = template.opsForValue().size(appendKey);
-            assertThat(strlenResult).isEqualTo(12L);
-
-            // GETRANGE operation
-            String rangeResult = template.opsForValue().get(appendKey, 0, 4);
-            assertThat(rangeResult).isEqualTo("Hello");
-            
-            // SETRANGE operation
-            template.opsForValue().set(appendKey, "Hello World!", 6);
-            template.opsForValue().set(setRangeKey, "Hello");
-            template.opsForValue().set(setRangeKey, " Valkey", 5);
-            assertThat(template.opsForValue().get(setRangeKey)).startsWith("Hello");
-            
-            // BIT operations
-            template.opsForValue().set(bitKey, "a");
-            
-            Boolean getBitResult = template.execute((ValkeyCallback<Boolean>) connection -> 
-                connection.stringCommands().getBit(bitKey.getBytes(), 1));
-            assertThat(getBitResult).isTrue();
-            
-            Boolean setBitResult = template.execute((ValkeyCallback<Boolean>) connection -> 
-                connection.stringCommands().setBit(bitKey.getBytes(), 0, true));
-            assertThat(setBitResult).isFalse();
-            
-            Long bitCountResult = template.execute((ValkeyCallback<Long>) connection -> 
-                connection.stringCommands().bitCount(bitKey.getBytes()));
-            assertThat(bitCountResult).isGreaterThan(0L);
-
-            // BITOP operation
-            template.opsForValue().set(bitKey1, "a");
-            template.opsForValue().set(bitKey2, "b");
-            
-            Long bitOpResult = template.execute((ValkeyCallback<Long>) connection -> 
-                connection.stringCommands().bitOp(ValkeyStringCommands.BitOperation.AND, 
-                    bitDestKey.getBytes(), bitKey1.getBytes(), bitKey2.getBytes()));
-            assertThat(bitOpResult).isEqualTo(1L);
-        } finally {
-            // Clean up all test keys
-            template.delete(key1);
-            template.delete(key2);
-            template.delete(key3);
-            template.delete(key4);
-            template.delete(multi1Key);
-            template.delete(multi2Key);
-            template.delete(multi3Key);
-            template.delete(msetnx1Key);
-            template.delete(msetnx2Key);
-            template.delete(counterKey);
-            template.delete(floatCounterKey);
-            template.delete(appendKey);
-            template.delete(setRangeKey);
-            template.delete(bitKey);
-            template.delete(bitKey1);
-            template.delete(bitKey2);
-            template.delete(bitDestKey);
-        }
-    }
-
-    /**
-     * Note: Transactions (MULTI/EXEC) are NOT supported in cluster mode.
-     * This test is intentionally omitted as cluster mode does not support transactions
-     * that span multiple keys, and even single-key transactions have limited support.
-     */
-
-    // ==================== Pipeline Tests ====================
-
-    @Test
-    void testBasicPipelineFlow() {
-        String key1 = "{pipe}:basic:key1";
-        String key2 = "{pipe}:basic:key2";
-
-        try {
-            template.execute((ValkeyCallback<Object>) connection -> {
-                assertThat(connection.isPipelined()).isFalse();
-
-                connection.openPipeline();
-                assertThat(connection.isPipelined()).isTrue();
-
-                connection.stringCommands().set(key1.getBytes(), "value1".getBytes());
-                connection.stringCommands().set(key2.getBytes(), "value2".getBytes());
-                connection.stringCommands().get(key1.getBytes());
-                connection.stringCommands().get(key2.getBytes());
-
-                List<Object> results = connection.closePipeline();
-
-                assertThat(connection.isPipelined()).isFalse();
-                assertThat(results).hasSize(4);
-                assertThat(results.get(0)).isEqualTo(true);
-                assertThat(results.get(1)).isEqualTo(true);
-                assertThat(results.get(2)).isEqualTo("value1".getBytes());
-                assertThat(results.get(3)).isEqualTo("value2".getBytes());
-                return null;
-            });
-        } finally {
-            template.delete(key1);
-            template.delete(key2);
-        }
-    }
-
-    @Test
-    void testEmptyPipeline() {
-        template.execute((ValkeyCallback<Object>) connection -> {
-            connection.openPipeline();
-            assertThat(connection.isPipelined()).isTrue();
-
-            List<Object> results = connection.closePipeline();
-
-            assertThat(connection.isPipelined()).isFalse();
-            assertThat(results).isNotNull();
-            assertThat(results).isEmpty();
-            return null;
-        });
-    }
-
-    @Test
-    void testMultipleConsecutivePipelines() {
-        String key1 = "{pipe}:consecutive:key1";
-        String key2 = "{pipe}:consecutive:key2";
-
-        try {
-            template.execute((ValkeyCallback<Object>) connection -> {
-                connection.openPipeline();
-                connection.stringCommands().set(key1.getBytes(), "pipe1_value".getBytes());
-                List<Object> results1 = connection.closePipeline();
-
-                assertThat(results1).hasSize(1);
-                assertThat(results1.get(0)).isEqualTo(true);
-
-                connection.openPipeline();
-                connection.stringCommands().set(key2.getBytes(), "pipe2_value".getBytes());
-                connection.stringCommands().get(key1.getBytes());
-                List<Object> results2 = connection.closePipeline();
-
-                assertThat(results2).hasSize(2);
-                assertThat(results2.get(0)).isEqualTo(true);
-                assertThat(results2.get(1)).isEqualTo("pipe1_value".getBytes());
-                return null;
-            });
-        } finally {
-            template.delete(key1);
-            template.delete(key2);
-        }
-    }
-
-    @Test
-    void testPipelineWithCrossSlotKeys() {
-        String key1 = "pipe:cross:key1";
-        String key2 = "pipe:cross:key2";
-
-        try {
-            template.execute((ValkeyCallback<Object>) connection -> {
-                connection.openPipeline();
-                connection.stringCommands().set(key1.getBytes(), "cross1".getBytes());
-                connection.stringCommands().set(key2.getBytes(), "cross2".getBytes());
-                connection.stringCommands().get(key1.getBytes());
-                connection.stringCommands().get(key2.getBytes());
-
-                List<Object> results = connection.closePipeline();
-
-                assertThat(results).hasSize(4);
-                assertThat(results.get(0)).isEqualTo(true);
-                assertThat(results.get(1)).isEqualTo(true);
-                assertThat(results.get(2)).isEqualTo("cross1".getBytes());
-                assertThat(results.get(3)).isEqualTo("cross2".getBytes());
-                return null;
-            });
-        } finally {
-            template.delete(key1);
-            template.delete(key2);
-        }
-    }
-
-    // ==================== Pipeline: Mixed Command Type Tests ====================
-
-    @Test
-    void testPipelineWithMixedCommandTypes() {
-        String stringKey = "{pipe}:mixed:string";
-        String hashKey = "{pipe}:mixed:hash";
-        String listKey = "{pipe}:mixed:list";
-        String setKey = "{pipe}:mixed:set";
-        String zsetKey = "{pipe}:mixed:zset";
-
-        try {
-            template.execute((ValkeyCallback<Object>) connection -> {
-                connection.openPipeline();
-
-                connection.stringCommands().set(stringKey.getBytes(), "string_value".getBytes());
-                connection.stringCommands().get(stringKey.getBytes());
-
-                connection.hashCommands().hSet(hashKey.getBytes(), "field1".getBytes(), "hash_value".getBytes());
-                connection.hashCommands().hGet(hashKey.getBytes(), "field1".getBytes());
-
-                connection.listCommands().lPush(listKey.getBytes(), "list_item".getBytes());
-                connection.listCommands().lLen(listKey.getBytes());
-
-                connection.setCommands().sAdd(setKey.getBytes(), "set_member".getBytes());
-                connection.setCommands().sCard(setKey.getBytes());
-
-                connection.zSetCommands().zAdd(zsetKey.getBytes(), 1.0, "zset_member".getBytes());
-                connection.zSetCommands().zCard(zsetKey.getBytes());
-
-                List<Object> results = connection.closePipeline();
-
-                assertThat(results).hasSize(10);
-
-                assertThat(results.get(0)).isEqualTo(true);
-                assertThat(results.get(2)).isEqualTo(true);
-                assertThat(results.get(4)).isEqualTo(1L);
-                assertThat(results.get(6)).isEqualTo(1L);
-                assertThat(results.get(8)).isEqualTo(true);
-
-                assertThat(results.get(1)).isEqualTo("string_value".getBytes());
-                assertThat(results.get(3)).isEqualTo("hash_value".getBytes());
-                assertThat(results.get(5)).isEqualTo(1L);
-                assertThat(results.get(7)).isEqualTo(1L);
-                assertThat(results.get(9)).isEqualTo(1L);
-                return null;
-            });
-        } finally {
-            template.delete(stringKey);
-            template.delete(hashKey);
-            template.delete(listKey);
-            template.delete(setKey);
-            template.delete(zsetKey);
-        }
-    }
-
-    @Test
-    void testPipelineWithMixedCommandTypesCrossSlot() {
-        String stringKey = "pipe:mixed:cs:string";
-        String hashKey = "pipe:mixed:cs:hash";
-        String listKey = "pipe:mixed:cs:list";
-        String setKey = "pipe:mixed:cs:set";
-
-        try {
-            template.execute((ValkeyCallback<Object>) connection -> {
-                connection.openPipeline();
-
-                connection.stringCommands().set(stringKey.getBytes(), "str_val".getBytes());
-                connection.hashCommands().hSet(hashKey.getBytes(), "f1".getBytes(), "h_val".getBytes());
-                connection.listCommands().lPush(listKey.getBytes(), "l_item".getBytes());
-                connection.setCommands().sAdd(setKey.getBytes(), "s_member".getBytes());
-
-                connection.stringCommands().get(stringKey.getBytes());
-                connection.hashCommands().hGet(hashKey.getBytes(), "f1".getBytes());
-                connection.listCommands().lLen(listKey.getBytes());
-                connection.setCommands().sCard(setKey.getBytes());
-
-                List<Object> results = connection.closePipeline();
-
-                assertThat(results).hasSize(8);
-                assertThat(results.get(0)).isEqualTo(true);
-                assertThat(results.get(1)).isEqualTo(true);
-                assertThat(results.get(2)).isEqualTo(1L);
-                assertThat(results.get(3)).isEqualTo(1L);
-                assertThat(results.get(4)).isEqualTo("str_val".getBytes());
-                assertThat(results.get(5)).isEqualTo("h_val".getBytes());
-                assertThat(results.get(6)).isEqualTo(1L);
-                assertThat(results.get(7)).isEqualTo(1L);
-                return null;
-            });
-        } finally {
-            template.delete(stringKey);
-            template.delete(hashKey);
-            template.delete(listKey);
-            template.delete(setKey);
-        }
-    }
-
-    // ==================== Pipeline: State Management Tests ====================
-
-    @Test
-    void testIsPipelinedState() {
-        template.execute((ValkeyCallback<Object>) connection -> {
-            assertThat(connection.isPipelined()).isFalse();
-
-            connection.openPipeline();
-            assertThat(connection.isPipelined()).isTrue();
-
-            connection.closePipeline();
-            assertThat(connection.isPipelined()).isFalse();
-            return null;
-        });
-    }
-
-    @Test
-    void testPipelineTransactionIsolation() {
-        template.execute((ValkeyCallback<Object>) connection -> {
-            connection.openPipeline();
-
-            // In cluster mode, multi() is blocked entirely (not just during pipeline)
-            assertThatThrownBy(() -> connection.multi())
-                .isInstanceOf(InvalidDataAccessApiUsageException.class);
-
-            connection.closePipeline();
-            return null;
-        });
-    }
-
-    // ==================== Pipeline: Edge Cases and Error Handling ====================
-
-    @Test
-    void testClosePipelineWithoutOpen() {
-        template.execute((ValkeyCallback<Object>) connection -> {
-            assertThat(connection.isPipelined()).isFalse();
-
-            List<Object> results = connection.closePipeline();
-
-            assertThat(results).isNotNull();
-            assertThat(results).isEmpty();
-            assertThat(connection.isPipelined()).isFalse();
-            return null;
-        });
-    }
-
-    @Test
-    void testNestedOpenPipelineCalls() {
-        String key = "{pipe}:nested:key";
-
-        try {
-            template.execute((ValkeyCallback<Object>) connection -> {
-                connection.openPipeline();
-                assertThat(connection.isPipelined()).isTrue();
-
-                connection.openPipeline();
-                assertThat(connection.isPipelined()).isTrue();
-
-                connection.stringCommands().set(key.getBytes(), "nested_value".getBytes());
-
-                List<Object> results = connection.closePipeline();
-
-                assertThat(connection.isPipelined()).isFalse();
-                assertThat(results).hasSize(1);
-                assertThat(results.get(0)).isEqualTo(true);
-                return null;
-            });
-        } finally {
-            template.delete(key);
-        }
-    }
-
-    @Test
-    void testPipelineWithNonExistentKeys() {
-        String nonExistentKey1 = "{pipe}:nonexist:key1";
-        String nonExistentKey2 = "{pipe}:nonexist:key2";
-
-        template.execute((ValkeyCallback<Object>) connection -> {
-            connection.openPipeline();
-
-            connection.stringCommands().get(nonExistentKey1.getBytes());
-            connection.stringCommands().get(nonExistentKey2.getBytes());
-            connection.listCommands().lLen("{pipe}:nonexist:list".getBytes());
-            connection.setCommands().sCard("{pipe}:nonexist:set".getBytes());
-
-            List<Object> results = connection.closePipeline();
-
-            assertThat(results).hasSize(4);
-            assertThat(results.get(0)).isNull();
-            assertThat(results.get(1)).isNull();
-            assertThat(results.get(2)).isEqualTo(0L);
-            assertThat(results.get(3)).isEqualTo(0L);
-            return null;
-        });
-    }
-
-    @Test
-    void testPipelineWithEmptyValues() {
-        String key = "{pipe}:empty:key";
-
-        try {
-            template.execute((ValkeyCallback<Object>) connection -> {
-                connection.openPipeline();
-
-                connection.stringCommands().set(key.getBytes(), new byte[0]);
-                connection.stringCommands().get(key.getBytes());
-                connection.stringCommands().strLen(key.getBytes());
-
-                List<Object> results = connection.closePipeline();
-
-                assertThat(results).hasSize(3);
-                assertThat(results.get(0)).isEqualTo(true);
-                assertThat(results.get(1)).isEqualTo(new byte[0]);
-                assertThat(results.get(2)).isEqualTo(0L);
-                return null;
-            });
-        } finally {
-            template.delete(key);
-        }
-    }
-
-    // ==================== Pipeline: Large Pipeline Tests ====================
-
-    @Test
-    void testLargePipeline() {
-        String keyPrefix = "{pipe}:large:key";
-        int commandCount = 100;
-
-        try {
-            template.execute((ValkeyCallback<Object>) connection -> {
-                connection.openPipeline();
-
-                for (int i = 0; i < commandCount; i++) {
-                    String key = keyPrefix + ":" + i;
-                    connection.stringCommands().set(key.getBytes(), ("value" + i).getBytes());
-                }
-
-                List<Object> results = connection.closePipeline();
-
-                assertThat(results).hasSize(commandCount);
-                for (int i = 0; i < commandCount; i++) {
-                    assertThat(results.get(i)).isEqualTo(true);
-                }
-                return null;
-            });
-
-            // Verify values were set
-            template.execute((ValkeyCallback<Object>) connection -> {
-                assertThat(connection.stringCommands().get((keyPrefix + ":0").getBytes()))
-                    .isEqualTo("value0".getBytes());
-                assertThat(connection.stringCommands().get((keyPrefix + ":50").getBytes()))
-                    .isEqualTo("value50".getBytes());
-                assertThat(connection.stringCommands().get((keyPrefix + ":99").getBytes()))
-                    .isEqualTo("value99".getBytes());
-                return null;
-            });
-        } finally {
-            for (int i = 0; i < commandCount; i++) {
-                template.delete(keyPrefix + ":" + i);
-            }
-        }
-    }
-
-    @Test
-    void testLargePipelineCrossSlot() {
-        String keyPrefix = "pipe:largecs:key";
-        int commandCount = 100;
-
-        try {
-            template.execute((ValkeyCallback<Object>) connection -> {
-                connection.openPipeline();
-
-                for (int i = 0; i < commandCount; i++) {
-                    String key = keyPrefix + ":" + i;
-                    connection.stringCommands().set(key.getBytes(), ("value" + i).getBytes());
-                }
-
-                List<Object> results = connection.closePipeline();
-
-                assertThat(results).hasSize(commandCount);
-                for (int i = 0; i < commandCount; i++) {
-                    assertThat(results.get(i)).isEqualTo(true);
-                }
-                return null;
-            });
-
-            // Verify a few values
-            template.execute((ValkeyCallback<Object>) connection -> {
-                assertThat(connection.stringCommands().get((keyPrefix + ":0").getBytes()))
-                    .isEqualTo("value0".getBytes());
-                assertThat(connection.stringCommands().get((keyPrefix + ":99").getBytes()))
-                    .isEqualTo("value99".getBytes());
-                return null;
-            });
-        } finally {
-            for (int i = 0; i < commandCount; i++) {
-                template.delete(keyPrefix + ":" + i);
-            }
-        }
-    }
-
-    @Test
-    void testPipelinePerformance() {
-        String keyPrefix = "{pipe}:perf:key";
-        int commandCount = 200;
-
-        try {
-            template.execute((ValkeyCallback<Object>) connection -> {
-                long startTime = System.currentTimeMillis();
-
-                connection.openPipeline();
-
-                for (int i = 0; i < commandCount; i++) {
-                    String key = keyPrefix + ":" + i;
-                    connection.stringCommands().set(key.getBytes(), ("value" + i).getBytes());
-                    connection.stringCommands().get(key.getBytes());
-                }
-
-                List<Object> results = connection.closePipeline();
-
-                long duration = System.currentTimeMillis() - startTime;
-
-                assertThat(results).hasSize(commandCount * 2);
-                assertThat(duration).isLessThan(10000);
-
-                for (int i = 0; i < commandCount; i += 10) {
-                    assertThat(results.get(i * 2)).isEqualTo(true);
-                    assertThat(results.get(i * 2 + 1)).isEqualTo(("value" + i).getBytes());
-                }
-                return null;
-            });
-        } finally {
-            for (int i = 0; i < commandCount; i++) {
-                template.delete(keyPrefix + ":" + i);
-            }
-        }
-    }
-
-    // ==================== Pipeline: Concurrent Tests ====================
-
-    @Test
-    void testConcurrentPipelines() throws Exception {
-        String sharedKey = "{pipe}:concurrent:shared";
-        String keyPrefix = "{pipe}:concurrent:key";
-        ExecutorService executor = Executors.newFixedThreadPool(5);
-
-        try {
-            template.opsForValue().set(sharedKey, "shared_value");
-
-            CompletableFuture<?>[] futures = new CompletableFuture[5];
-
-            for (int i = 0; i < 5; i++) {
-                final int threadId = i;
-                futures[i] = CompletableFuture.runAsync(() -> {
-                    try (ValkeyConnection conn = connectionFactory.getClusterConnection()) {
-                        conn.openPipeline();
-                        conn.stringCommands().set((keyPrefix + ":" + threadId).getBytes(),
-                            ("thread" + threadId).getBytes());
-                        conn.stringCommands().get(sharedKey.getBytes());
-                        List<Object> results = conn.closePipeline();
-
-                        assertThat(results).hasSize(2);
-                        assertThat(results.get(0)).isEqualTo(true);
-                        assertThat(results.get(1)).isEqualTo("shared_value".getBytes());
-                    }
-                }, executor);
-            }
-
-            CompletableFuture.allOf(futures).get(10, TimeUnit.SECONDS);
-
-            // Verify all threads succeeded
-            for (int i = 0; i < 5; i++) {
-                assertThat(template.opsForValue().get(keyPrefix + ":" + i))
-                    .isEqualTo("thread" + i);
-            }
-        } finally {
-            executor.shutdown();
-            template.delete(sharedKey);
-            for (int i = 0; i < 5; i++) {
-                template.delete(keyPrefix + ":" + i);
-            }
-        }
-    }
-
-    // ==================== Pipeline: Result Conversion Tests ====================
-
-    @Test
-    void testPipelineResultConversion() {
-        String key = "{pipe}:convert:key";
-        String counterKey = "{pipe}:convert:counter";
-
-        try {
-            template.execute((ValkeyCallback<Object>) connection -> {
-                connection.openPipeline();
-
-                connection.stringCommands().set(key.getBytes(), "42".getBytes());
-                connection.stringCommands().get(key.getBytes());
-                connection.stringCommands().set(counterKey.getBytes(), "10".getBytes());
-                connection.stringCommands().incr(counterKey.getBytes());
-                connection.stringCommands().strLen(counterKey.getBytes());
-
-                List<Object> results = connection.closePipeline();
-
-                assertThat(results).hasSize(5);
-                assertThat(results.get(0)).isEqualTo(true);
-                assertThat(results.get(1)).isEqualTo("42".getBytes());
-                assertThat(results.get(2)).isEqualTo(true);
-                assertThat(results.get(3)).isEqualTo(11L);
-                assertThat(results.get(4)).isEqualTo(2L);
-                return null;
-            });
-        } finally {
-            template.delete(key);
-            template.delete(counterKey);
-        }
-    }
-
-    // ==================== Pipeline: Error Recovery Tests ====================
-
-    @Test
-    void testPipelineErrorRecovery() {
-        String validKey = "{pipe}:error:valid";
-        String nonExistentKey = "{pipe}:error:nonexist";
-
-        try {
-            template.execute((ValkeyCallback<Object>) connection -> {
-                connection.openPipeline();
-
-                connection.stringCommands().set(validKey.getBytes(), "valid_value".getBytes());
-                connection.stringCommands().get(nonExistentKey.getBytes());
-                connection.stringCommands().get(validKey.getBytes());
-
-                List<Object> results = connection.closePipeline();
-
-                assertThat(results).hasSize(3);
-                assertThat(results.get(0)).isEqualTo(true);
-                assertThat(results.get(1)).isNull();
-                assertThat(results.get(2)).isEqualTo("valid_value".getBytes());
-                return null;
-            });
-        } finally {
-            template.delete(validKey);
-        }
-    }
-
-    // ==================== Pipeline: State Consistency Tests ====================
-
-    @Test
-    void testPipelineStateConsistency() {
-        template.execute((ValkeyCallback<Object>) connection -> {
-            assertThat(connection.isPipelined()).isFalse();
-
-            for (int i = 0; i < 3; i++) {
-                connection.openPipeline();
-                assertThat(connection.isPipelined()).isTrue();
-
-                List<Object> results = connection.closePipeline();
-                assertThat(connection.isPipelined()).isFalse();
-                assertThat(results).isEmpty();
-            }
-
-            assertThat(connection.isPipelined()).isFalse();
-            return null;
-        });
-    }
-
-    /**
-     * Checks if the server version is at least the specified major.minor version.
-     */
-    private boolean isServerVersionAtLeast(int majorVersion, int minorVersion) {
-        return template.execute((ValkeyCallback<Boolean>) connection -> {
-            Properties serverInfo = connection.serverCommands().info("server");
-            String versionString = serverInfo.getProperty("valkey_version",
-                    serverInfo.getProperty("redis_version"));
-            
-            if (versionString == null) {
-                versionString = serverInfo.getProperty("server_version");
-            }
-            
-            if (versionString == null) {
-                return false;
-            }
-            
-            String[] versionParts = versionString.split("\\.");
-            if (versionParts.length < 2) {
-                return false;
-            }
-            
-            int serverMajor = Integer.parseInt(versionParts[0]);
-            int serverMinor = Integer.parseInt(versionParts[1]);
-            
-            if (serverMajor > majorVersion) {
-                return true;
-            } else if (serverMajor == majorVersion) {
-                return serverMinor >= minorVersion;
-            } else {
-                return false;
-            }
-        });
-    }
+	private ValkeyGlideConnectionFactory connectionFactory;
+
+	private ValkeyTemplate<String, String> template;
+
+	@BeforeAll
+	void setup() {
+		// Create a cluster connection factory for tests
+		connectionFactory = createClusterConnectionFactory();
+
+		// Verify we're in cluster mode
+		assertThat(connectionFactory.isClusterAware()).isTrue();
+
+		// Create a template for easier testing
+		template = new ValkeyTemplate<>();
+		template.setConnectionFactory(connectionFactory);
+		template.setKeySerializer(StringValkeySerializer.UTF_8);
+		template.setValueSerializer(StringValkeySerializer.UTF_8);
+		template.setHashKeySerializer(StringValkeySerializer.UTF_8);
+		template.setHashValueSerializer(StringValkeySerializer.UTF_8);
+		template.afterPropertiesSet();
+	}
+
+	@AfterAll
+	void teardown() {
+		if (connectionFactory != null) {
+			connectionFactory.destroy();
+		}
+	}
+
+	/**
+	 * Creates a cluster connection factory for testing.
+	 */
+	private ValkeyGlideConnectionFactory createClusterConnectionFactory() {
+		ValkeyClusterConfiguration clusterConfig = new ValkeyClusterConfiguration();
+
+		// Use ClusterTestVariables for consistency with other tests
+		clusterConfig.clusterNode(ClusterTestVariables.CLUSTER_NODE_1);
+		clusterConfig.clusterNode(ClusterTestVariables.CLUSTER_NODE_2);
+		clusterConfig.clusterNode(ClusterTestVariables.CLUSTER_NODE_3);
+		clusterConfig.clusterNode(ClusterTestVariables.REPLICA_OF_NODE_1);
+		return new ValkeyGlideConnectionFactory(clusterConfig, new DefaultValkeyGlideClientConfiguration());
+	}
+
+	@Test
+	void testGetClusterConnection() {
+		ValkeyClusterConnection clusterConnection = connectionFactory.getClusterConnection();
+		assertThat(clusterConnection).isNotNull();
+		assertThat(clusterConnection).isInstanceOf(ValkeyGlideClusterConnection.class);
+		clusterConnection.close();
+	}
+
+	@Test
+	void testHashOperations() {
+		// Use hash tags to ensure all keys land on the same slot
+		String key1 = "{hash}:basic";
+		String key2 = "{hash}:putall";
+		String key3 = "{hash}:putifabsent";
+		String key4 = "{hash}:increment";
+		String key5 = "{hash}:length";
+		String key6 = "{hash}:delete";
+		String key7 = "{hash}:random";
+		String key8 = "{hash}:scan";
+		String key9 = "{hash}:expiration";
+
+		try {
+			template.opsForHash().put(key1, "field1", "value1");
+			template.opsForHash().put(key1, "field2", "value2");
+
+			assertThat(template.opsForHash().get(key1, "field1")).isEqualTo("value1");
+			assertThat(template.opsForHash().get(key1, "field2")).isEqualTo("value2");
+
+			// PUTALL operation
+			Map<String, String> hashMap = Map.of("field1", "value1", "field2", "value2", "field3", "value3");
+			template.opsForHash().putAll(key2, hashMap);
+
+			assertThat(template.opsForHash().get(key2, "field1")).isEqualTo("value1");
+			assertThat(template.opsForHash().get(key2, "field2")).isEqualTo("value2");
+			assertThat(template.opsForHash().get(key2, "field3")).isEqualTo("value3");
+
+			// PUTIFABSENT operation
+			Boolean putResult1 = template.opsForHash().putIfAbsent(key3, "field1", "value1");
+			assertThat(putResult1).isTrue();
+			Boolean putResult2 = template.opsForHash().putIfAbsent(key3, "field1", "different_value");
+			assertThat(putResult2).isFalse();
+			assertThat(template.opsForHash().get(key3, "field1")).isEqualTo("value1");
+
+			// HASKEY operation
+			assertThat(template.opsForHash().hasKey(key1, "field1")).isTrue();
+			assertThat(template.opsForHash().hasKey(key1, "nonexistent")).isFalse();
+
+			// MULTIGET operation
+			List<Object> hashKeys = List.of("field1", "field2", "nonexistent");
+			List<Object> multiGetResult = template.opsForHash().multiGet(key1, hashKeys);
+			assertThat(multiGetResult).containsExactly("value1", "value2", null);
+
+			// SIZE operation
+			assertThat(template.opsForHash().size(key1)).isEqualTo(2);
+			assertThat(template.opsForHash().size(key2)).isEqualTo(3);
+
+			// KEYS operation
+			Set<Object> keys = template.opsForHash().keys(key2);
+			assertThat(keys).containsExactlyInAnyOrder("field1", "field2", "field3");
+
+			// VALUES operation
+			List<Object> values = template.opsForHash().values(key2);
+			assertThat(values).containsExactlyInAnyOrder("value1", "value2", "value3");
+
+			// ENTRIES operation (HGETALL)
+			Map<Object, Object> entries = template.opsForHash().entries(key2);
+			assertThat(entries).hasSize(3);
+			assertThat(entries.get("field1")).isEqualTo("value1");
+			assertThat(entries.get("field2")).isEqualTo("value2");
+			assertThat(entries.get("field3")).isEqualTo("value3");
+
+			// INCREMENT operations
+			template.opsForHash().put(key4, "counter", "10");
+
+			// Long increment
+			Long incrResult1 = template.opsForHash().increment(key4, "counter", 5L);
+			assertThat(incrResult1).isEqualTo(15L);
+
+			Long incrResult2 = template.opsForHash().increment(key4, "counter", -3L);
+			assertThat(incrResult2).isEqualTo(12L);
+
+			// Double increment (using different field to avoid conflicts)
+			template.opsForHash().put(key4, "floatcounter", "10.5");
+			Double floatIncrResult = template.opsForHash().increment(key4, "floatcounter", 2.5);
+			assertThat(floatIncrResult).isEqualTo(13.0);
+
+			// LENGTHOFVALUE operation
+			template.opsForHash().put(key5, "field1", "Hello World!");
+			Long lengthResult = template.opsForHash().lengthOfValue(key5, "field1");
+			assertThat(lengthResult).isEqualTo(12L);
+
+			// Length of non-existent field
+			Long lengthNonExistent = template.opsForHash().lengthOfValue(key5, "nonexistent");
+			assertThat(lengthNonExistent).isEqualTo(0L);
+
+			// DELETE hash fields operation
+			template.opsForHash().put(key6, "field1", "value1");
+			template.opsForHash().put(key6, "field2", "value2");
+			template.opsForHash().put(key6, "field3", "value3");
+
+			Long deleteResult = template.opsForHash().delete(key6, "field1", "field2");
+			assertThat(deleteResult).isEqualTo(2L);
+			assertThat(template.opsForHash().hasKey(key6, "field1")).isFalse();
+			assertThat(template.opsForHash().hasKey(key6, "field2")).isFalse();
+			assertThat(template.opsForHash().hasKey(key6, "field3")).isTrue();
+
+			// RANDOM operations
+			template.opsForHash()
+				.putAll(key7, Map.of("field1", "value1", "field2", "value2", "field3", "value3", "field4", "value4"));
+
+			// Random key
+			Object randomKey = template.opsForHash().randomKey(key7);
+			assertThat(randomKey).isIn("field1", "field2", "field3", "field4");
+
+			// Random entry
+			Map.Entry<Object, Object> randomEntry = template.opsForHash().randomEntry(key7);
+			assertThat(randomEntry.getKey()).isIn("field1", "field2", "field3", "field4");
+			assertThat(randomEntry.getValue().toString()).startsWith("value");
+
+			// Random keys with count
+			List<Object> randomKeys = template.opsForHash().randomKeys(key7, 2);
+			assertThat(randomKeys).hasSize(2);
+			assertThat(randomKeys).allMatch(key -> List.of("field1", "field2", "field3", "field4").contains(key));
+
+			// Random entries with count
+			Map<Object, Object> randomEntries = template.opsForHash().randomEntries(key7, 2);
+			assertThat(randomEntries).hasSize(2);
+			randomEntries.forEach((k, v) -> {
+				assertThat(k).isIn("field1", "field2", "field3", "field4");
+				assertThat(v.toString()).startsWith("value");
+			});
+
+			// SCAN operation (using ValkeyCallback for direct access to connection)
+			template.opsForHash()
+				.putAll(key8,
+						Map.of("scanfield1", "scanvalue1", "scanfield2", "scanvalue2", "scanfield3", "scanvalue3"));
+
+			// Test hScan using connection directly
+			template.execute((ValkeyCallback<Void>) connection -> {
+				try (var cursor = connection.hashCommands()
+					.hScan(key8.getBytes(),
+							io.valkey.springframework.data.valkey.core.ScanOptions.scanOptions().count(10).build())) {
+					int count = 0;
+					while (cursor.hasNext()) {
+						Map.Entry<byte[], byte[]> entry = cursor.next();
+						String field = new String(entry.getKey());
+						String value = new String(entry.getValue());
+						assertThat(field).startsWith("scanfield");
+						assertThat(value).startsWith("scanvalue");
+						count++;
+					}
+					assertThat(count).isEqualTo(3);
+				}
+				return null;
+			});
+
+			// Test hash field expiration operations (requires Valkey 7.4+)
+			if (isServerVersionAtLeast(7, 4)) {
+				template.opsForHash()
+					.putAll(key9, Map.of("expirefield1", "expirevalue1", "expirefield2", "expirevalue2", "persistfield",
+							"persistvalue"));
+
+				// Test hExpire - Set TTL in seconds
+				template.execute((ValkeyCallback<List<Long>>) connection -> {
+					List<Long> result = connection.hashCommands()
+						.hExpire(key9.getBytes(), 60L, "expirefield1".getBytes(), "expirefield2".getBytes());
+					assertThat(result).containsExactly(1L, 1L);
+					return result;
+				});
+
+				// Test hpExpire - Set TTL in milliseconds
+				template.execute((ValkeyCallback<List<Long>>) connection -> {
+					List<Long> result = connection.hashCommands()
+						.hpExpire(key9.getBytes(), 60000L, "expirefield1".getBytes());
+					assertThat(result).containsExactly(1L);
+					return result;
+				});
+
+				// Test hExpireAt - Set expiration at specific timestamp
+				long futureTimestamp = System.currentTimeMillis() / 1000 + 120;
+				template.execute((ValkeyCallback<List<Long>>) connection -> {
+					List<Long> result = connection.hashCommands()
+						.hExpireAt(key9.getBytes(), futureTimestamp, "expirefield1".getBytes());
+					assertThat(result).containsExactly(1L);
+					return result;
+				});
+
+				// Test hpExpireAt - Set expiration at specific timestamp in milliseconds
+				long futureTimestampMillis = System.currentTimeMillis() + 120000;
+				template.execute((ValkeyCallback<List<Long>>) connection -> {
+					List<Long> result = connection.hashCommands()
+						.hpExpireAt(key9.getBytes(), futureTimestampMillis, "expirefield2".getBytes());
+					assertThat(result).containsExactly(1L);
+					return result;
+				});
+
+				// Test hTtl - Get TTL in seconds
+				template.execute((ValkeyCallback<List<Long>>) connection -> {
+					List<Long> result = connection.hashCommands()
+						.hTtl(key9.getBytes(), "expirefield1".getBytes(), "persistfield".getBytes());
+					assertThat(result).hasSize(2);
+					assertThat(result.get(0)).isGreaterThan(0L);
+					assertThat(result.get(1)).isEqualTo(-1L);
+					return result;
+				});
+
+				template.execute((ValkeyCallback<List<Long>>) connection -> {
+					List<Long> result = connection.hashCommands()
+						.hpTtl(key9.getBytes(), "expirefield1".getBytes(), "persistfield".getBytes());
+					assertThat(result).hasSize(2);
+					assertThat(result.get(0)).isGreaterThan(0L);
+					assertThat(result.get(1)).isEqualTo(-1L);
+					return result;
+				});
+
+				// Test hPersist - Remove expiration from fields
+				template.execute((ValkeyCallback<List<Long>>) connection -> {
+					List<Long> result = connection.hashCommands()
+						.hPersist(key9.getBytes(), "expirefield1".getBytes(), "expirefield2".getBytes());
+					assertThat(result).containsExactly(1L, 1L);
+					return result;
+				});
+
+				// Verify fields no longer have expiration after hPersist
+				template.execute((ValkeyCallback<List<Long>>) connection -> {
+					List<Long> result = connection.hashCommands()
+						.hTtl(key9.getBytes(), "expirefield1".getBytes(), "expirefield2".getBytes());
+					assertThat(result).containsExactly(-1L, -1L);
+					return result;
+				});
+			}
+		}
+		finally {
+			// Clean up all test keys
+			template.delete(key1);
+			template.delete(key2);
+			template.delete(key3);
+			template.delete(key4);
+			template.delete(key5);
+			template.delete(key6);
+			template.delete(key7);
+			template.delete(key8);
+			template.delete(key9);
+		}
+	}
+
+	@Test
+	void testListOperations() {
+		// Use hash tags to ensure all keys land on the same slot
+		String key1 = "{list}:basic";
+		String key2 = "{list}:push";
+		String key3 = "{list}:range";
+		String key4 = "{list}:insert";
+		String key5 = "{list}:move";
+		String key6 = "{list}:set";
+		String key7 = "{list}:remove";
+		String key8 = "{list}:blocking";
+		String srcKey = "{list}:src";
+		String dstKey = "{list}:dst";
+
+		try {
+			// Basic LPUSH/RPUSH operations
+			template.opsForList().leftPush(key1, "value1");
+			template.opsForList().leftPush(key1, "value2");
+			template.opsForList().rightPush(key1, "value3");
+
+			assertThat(template.opsForList().size(key1)).isEqualTo(3);
+
+			// Test LRANGE to verify order
+			List<String> range = template.opsForList().range(key1, 0, -1);
+			assertThat(range).containsExactly("value2", "value1", "value3");
+
+			// Test LINDEX - get element at index
+			assertThat(template.opsForList().index(key1, 0)).isEqualTo("value2");
+			assertThat(template.opsForList().index(key1, 1)).isEqualTo("value1");
+			assertThat(template.opsForList().index(key1, 2)).isEqualTo("value3");
+
+			// Test convenience methods getFirst and getLast
+			String firstLastKey = "{list}:firstlast";
+			template.opsForList().rightPushAll(firstLastKey, "first", "middle", "last");
+
+			String firstElement = template.opsForList().getFirst(firstLastKey);
+			assertThat(firstElement).isEqualTo("first");
+
+			String lastElement = template.opsForList().getLast(firstLastKey);
+			assertThat(lastElement).isEqualTo("last");
+
+			// Test with empty list
+			String emptyKey = "{list}:empty";
+			String firstEmpty = template.opsForList().getFirst(emptyKey);
+			assertThat(firstEmpty).isNull();
+
+			String lastEmpty = template.opsForList().getLast(emptyKey);
+			assertThat(lastEmpty).isNull();
+
+			template.delete(firstLastKey);
+
+			// Test LPOP/RPOP
+			assertThat(template.opsForList().leftPop(key1)).isEqualTo("value2");
+			assertThat(template.opsForList().rightPop(key1)).isEqualTo("value3");
+			assertThat(template.opsForList().size(key1)).isEqualTo(1);
+
+			// Test LPUSHX/RPUSHX (push only if key exists)
+			template.opsForList().leftPushIfPresent(key2, "shouldnotwork");
+			assertThat(template.opsForList().size(key2)).isEqualTo(0);
+
+			template.opsForList().leftPush(key2, "initial");
+			template.opsForList().leftPushIfPresent(key2, "shouldwork");
+			template.opsForList().rightPushIfPresent(key2, "alsowork");
+
+			List<String> key2Range = template.opsForList().range(key2, 0, -1);
+			assertThat(key2Range).containsExactly("shouldwork", "initial", "alsowork");
+
+			// Test LEFTPUSHALL operations
+			String leftPushAllKey = "{list}:leftpushall";
+
+			template.opsForList().leftPushAll(leftPushAllKey, "first", "second", "third");
+			List<String> leftPushAllResult1 = template.opsForList().range(leftPushAllKey, 0, -1);
+			assertThat(leftPushAllResult1).containsExactly("third", "second", "first");
+
+			template.delete(leftPushAllKey);
+			template.opsForList().leftPushAll(leftPushAllKey, List.of("a", "b", "c"));
+			List<String> leftPushAllResult2 = template.opsForList().range(leftPushAllKey, 0, -1);
+			assertThat(leftPushAllResult2).containsExactly("c", "b", "a");
+
+			template.delete(leftPushAllKey);
+
+			// Test LRANGE and LTRIM
+			template.opsForList().rightPushAll(key3, "a", "b", "c", "d", "e");
+			List<String> beforeTrim = template.opsForList().range(key3, 0, -1);
+			assertThat(beforeTrim).containsExactly("a", "b", "c", "d", "e");
+
+			template.opsForList().trim(key3, 1, 3);
+			List<String> afterTrim = template.opsForList().range(key3, 0, -1);
+			assertThat(afterTrim).containsExactly("b", "c", "d");
+
+			// Test LINSERT - insert before/after pivot
+			template.opsForList().rightPushAll(key4, "first", "pivot", "last");
+
+			template.execute((ValkeyCallback<Long>) connection -> connection.listCommands()
+				.lInsert(key4.getBytes(), ValkeyListCommands.Position.BEFORE, "pivot".getBytes(),
+						"before_pivot".getBytes()));
+
+			template.execute((ValkeyCallback<Long>) connection -> connection.listCommands()
+				.lInsert(key4.getBytes(), ValkeyListCommands.Position.AFTER, "pivot".getBytes(),
+						"after_pivot".getBytes()));
+
+			List<String> insertResult = template.opsForList().range(key4, 0, -1);
+			assertThat(insertResult).containsExactly("first", "before_pivot", "pivot", "after_pivot", "last");
+
+			// Test LMOVE (move element between lists)
+			template.opsForList().rightPushAll(key5, "move1", "move2", "move3");
+			String dstKey5 = key5 + "_dst";
+
+			template.execute((ValkeyCallback<byte[]>) connection -> connection.listCommands()
+				.lMove(key5.getBytes(), dstKey5.getBytes(), ValkeyListCommands.Direction.LEFT,
+						ValkeyListCommands.Direction.RIGHT));
+
+			assertThat(template.opsForList().range(key5, 0, -1)).containsExactly("move2", "move3");
+			assertThat(template.opsForList().range(dstKey5, 0, -1)).containsExactly("move1");
+
+			// Test high-level move operations
+			String moveHighKey1 = "{list}:movehigh1";
+			String moveHighKey2 = "{list}:movehigh2";
+			template.opsForList().rightPushAll(moveHighKey1, "high1", "high2", "high3");
+
+			String movedValue1 = template.opsForList()
+				.move(io.valkey.springframework.data.valkey.core.ListOperations.MoveFrom.fromTail(moveHighKey1),
+						io.valkey.springframework.data.valkey.core.ListOperations.MoveTo.toHead(moveHighKey2));
+			assertThat(movedValue1).isEqualTo("high3");
+			assertThat(template.opsForList().range(moveHighKey1, 0, -1)).containsExactly("high1", "high2");
+			assertThat(template.opsForList().range(moveHighKey2, 0, -1)).containsExactly("high3");
+
+			String movedValue2 = template.opsForList()
+				.move(io.valkey.springframework.data.valkey.core.ListOperations.MoveFrom.fromHead(moveHighKey1),
+						io.valkey.springframework.data.valkey.core.ListOperations.MoveTo.toTail(moveHighKey2));
+			assertThat(movedValue2).isEqualTo("high1");
+			assertThat(template.opsForList().range(moveHighKey1, 0, -1)).containsExactly("high2");
+			assertThat(template.opsForList().range(moveHighKey2, 0, -1)).containsExactly("high3", "high1");
+
+			template.delete(moveHighKey1);
+			template.delete(moveHighKey2);
+
+			// Test LSET - set element at index
+			template.opsForList().rightPushAll(key6, "original1", "original2", "original3");
+			template.opsForList().set(key6, 1, "modified");
+
+			List<String> setResult = template.opsForList().range(key6, 0, -1);
+			assertThat(setResult).containsExactly("original1", "modified", "original3");
+
+			// Test LREM - remove occurrences of value
+			template.opsForList().rightPushAll(key7, "remove", "keep", "remove", "keep", "remove");
+			Long removedCount = template.opsForList().remove(key7, 2, "remove");
+			assertThat(removedCount).isEqualTo(2L);
+
+			List<String> removeResult = template.opsForList().range(key7, 0, -1);
+			assertThat(removeResult).containsExactly("keep", "keep", "remove");
+
+			// Test LPOP/RPOP with count (Valkey 6.2+)
+			template.opsForList().rightPushAll(key8, "pop1", "pop2", "pop3", "pop4", "pop5");
+
+			List<String> leftPopped = template.opsForList().leftPop(key8, 2);
+			if (leftPopped != null) {
+				assertThat(leftPopped).containsExactly("pop1", "pop2");
+
+				List<String> rightPopped = template.opsForList().rightPop(key8, 2);
+				assertThat(rightPopped).containsExactly("pop5", "pop4");
+
+				assertThat(template.opsForList().range(key8, 0, -1)).containsExactly("pop3");
+			}
+
+			// Test RPOPLPUSH - atomically move from end to beginning
+			template.opsForList().rightPushAll(srcKey, "src1", "src2", "src3");
+			template.opsForList().rightPushAll(dstKey, "dst1");
+
+			String moved = template.opsForList().rightPopAndLeftPush(srcKey, dstKey);
+			assertThat(moved).isEqualTo("src3");
+			assertThat(template.opsForList().range(srcKey, 0, -1)).containsExactly("src1", "src2");
+			assertThat(template.opsForList().range(dstKey, 0, -1)).containsExactly("src3", "dst1");
+
+			// Test LPOS - find position of element (Valkey 6.0.6+)
+			if (isServerVersionAtLeast(6, 1)) {
+				String posKey = "{list}:position";
+				template.opsForList().rightPushAll(posKey, "a", "b", "c", "b", "d");
+
+				Long firstPos = template.opsForList().indexOf(posKey, "b");
+				assertThat(firstPos).isEqualTo(1L);
+
+				Long lastPos = template.opsForList().lastIndexOf(posKey, "b");
+				assertThat(lastPos).isEqualTo(3L);
+
+				Long notFoundPos = template.opsForList().indexOf(posKey, "z");
+				assertThat(notFoundPos).isNull();
+
+				Long notFoundLastPos = template.opsForList().lastIndexOf(posKey, "z");
+				assertThat(notFoundLastPos).isNull();
+
+				List<Long> positions = template
+					.execute((ValkeyCallback<List<Long>>) connection -> connection.listCommands()
+						.lPos(posKey.getBytes(), "b".getBytes(), null, 2));
+				assertThat(positions).containsExactly(1L, 3L);
+
+				template.delete(posKey);
+			}
+
+		}
+		finally {
+			// Clean up all test keys
+			template.delete(key1);
+			template.delete(key2);
+			template.delete(key3);
+			template.delete(key4);
+			template.delete(key5);
+			template.delete(key5 + "_dst");
+			template.delete(key6);
+			template.delete(key7);
+			template.delete(key8);
+			template.delete(srcKey);
+			template.delete(dstKey);
+		}
+	}
+
+	@Test
+	void testSetOperations() {
+		// Use hash tags to ensure all keys land on the same slot
+		String key1 = "{set}:basic";
+		String key2 = "{set}:operations";
+		String key3 = "{set}:union";
+		String key4 = "{set}:intersection";
+		String key5 = "{set}:difference";
+		String key6 = "{set}:random";
+		String key7 = "{set}:pop";
+		String key8 = "{set}:move";
+		String key9 = "{set}:scan";
+		String key10 = "{set}:scanhigh";
+		String destKey = "{set}:dest";
+
+		try {
+			// Basic SADD operations
+			Long addResult1 = template.opsForSet().add(key1, "value1", "value2", "value3");
+			assertThat(addResult1).isEqualTo(3L);
+
+			// Add duplicate - should return 0
+			Long addResult2 = template.opsForSet().add(key1, "value2");
+			assertThat(addResult2).isEqualTo(0L);
+
+			// SCARD - Set cardinality (size)
+			assertThat(template.opsForSet().size(key1)).isEqualTo(3);
+
+			// SISMEMBER - Check membership
+			assertThat(template.opsForSet().isMember(key1, "value2")).isTrue();
+			assertThat(template.opsForSet().isMember(key1, "nonexistent")).isFalse();
+
+			// SMISMEMBER - Check multiple membership (Valkey 6.2+)
+			if (isServerVersionAtLeast(6, 2)) {
+				template.execute((ValkeyCallback<List<Boolean>>) connection -> {
+					Map<Object, Boolean> membershipMap = template.opsForSet()
+						.isMember(key1, "value1", "nonexistent", "value3");
+					assertThat(membershipMap.get("value1")).isTrue();
+					assertThat(membershipMap.get("nonexistent")).isFalse();
+					assertThat(membershipMap.get("value3")).isTrue();
+					return null;
+				});
+			}
+
+			// SMEMBERS - Get all members
+			Set<String> members = template.opsForSet().members(key1);
+			assertThat(members).containsExactlyInAnyOrder("value1", "value2", "value3");
+
+			// SREM - Remove members
+			Long remResult1 = template.opsForSet().remove(key1, "value2");
+			assertThat(remResult1).isEqualTo(1L);
+			assertThat(template.opsForSet().size(key1)).isEqualTo(2);
+
+			Long remResult2 = template.opsForSet().remove(key1, "value1", "nonexistent");
+			assertThat(remResult2).isEqualTo(1L);
+			assertThat(template.opsForSet().size(key1)).isEqualTo(1);
+
+			// Set up sets for set operations
+			template.opsForSet().add(key2, "a", "b", "c");
+			template.opsForSet().add(key3, "b", "c", "d");
+			template.opsForSet().add(key4, "c", "d", "e");
+
+			// SUNION - Union of sets
+			Set<String> unionResult = template.opsForSet().union(key2, key3);
+			assertThat(unionResult).containsExactlyInAnyOrder("a", "b", "c", "d");
+
+			// SUNION with multiple keys
+			Set<String> unionMultiResult = template.opsForSet().union(key2, List.of(key3, key4));
+			assertThat(unionMultiResult).containsExactlyInAnyOrder("a", "b", "c", "d", "e");
+
+			// SUNIONSTORE - Store union result
+			Long unionStoreResult = template.opsForSet().unionAndStore(key2, key3, destKey);
+			assertThat(unionStoreResult).isEqualTo(4L);
+			assertThat(template.opsForSet().members(destKey)).containsExactlyInAnyOrder("a", "b", "c", "d");
+			template.delete(destKey);
+
+			// SUNIONSTORE with multiple keys
+			Long unionStoreMultiResult = template.opsForSet().unionAndStore(key2, List.of(key3, key4), destKey);
+			assertThat(unionStoreMultiResult).isEqualTo(5L);
+			assertThat(template.opsForSet().members(destKey)).containsExactlyInAnyOrder("a", "b", "c", "d", "e");
+			template.delete(destKey);
+
+			// SINTER - Intersection of sets
+			Set<String> intersectResult = template.opsForSet().intersect(key2, key3);
+			assertThat(intersectResult).containsExactlyInAnyOrder("b", "c");
+
+			// SINTER with multiple keys
+			Set<String> intersectMultiResult = template.opsForSet().intersect(key2, List.of(key3, key4));
+			assertThat(intersectMultiResult).containsExactlyInAnyOrder("c");
+
+			// SINTERSTORE - Store intersection result
+			Long intersectStoreResult = template.opsForSet().intersectAndStore(key2, key3, destKey);
+			assertThat(intersectStoreResult).isEqualTo(2L);
+			assertThat(template.opsForSet().members(destKey)).containsExactlyInAnyOrder("b", "c");
+			template.delete(destKey);
+
+			// SINTERSTORE with multiple keys
+			Long intersectStoreMultiResult = template.opsForSet().intersectAndStore(key2, List.of(key3, key4), destKey);
+			assertThat(intersectStoreMultiResult).isEqualTo(1L);
+			assertThat(template.opsForSet().members(destKey)).containsExactlyInAnyOrder("c");
+			template.delete(destKey);
+
+			// SDIFF - Difference of sets
+			Set<String> diffResult = template.opsForSet().difference(key2, key3);
+			assertThat(diffResult).containsExactlyInAnyOrder("a");
+
+			// SDIFF with multiple keys
+			Set<String> diffMultiResult = template.opsForSet().difference(key2, List.of(key3, key4));
+			assertThat(diffMultiResult).containsExactlyInAnyOrder("a");
+
+			// SDIFFSTORE - Store difference result
+			Long diffStoreResult = template.opsForSet().differenceAndStore(key2, key3, destKey);
+			assertThat(diffStoreResult).isEqualTo(1L);
+			assertThat(template.opsForSet().members(destKey)).containsExactlyInAnyOrder("a");
+			template.delete(destKey);
+
+			// SDIFFSTORE with multiple keys
+			Long diffStoreMultiResult = template.opsForSet().differenceAndStore(key2, List.of(key3, key4), destKey);
+			assertThat(diffStoreMultiResult).isEqualTo(1L);
+			assertThat(template.opsForSet().members(destKey)).containsExactlyInAnyOrder("a");
+			template.delete(destKey);
+
+			// SRANDMEMBER operations
+			template.opsForSet().add(key6, "rand1", "rand2", "rand3", "rand4", "rand5");
+
+			// SRANDMEMBER - Single random member
+			String randomMember = template.opsForSet().randomMember(key6);
+			assertThat(randomMember).isIn("rand1", "rand2", "rand3", "rand4", "rand5");
+
+			// SRANDMEMBER with count
+			List<String> randomMembers = template.opsForSet().randomMembers(key6, 3);
+			assertThat(randomMembers).hasSize(3);
+			assertThat(randomMembers)
+				.allMatch(member -> List.of("rand1", "rand2", "rand3", "rand4", "rand5").contains(member));
+
+			// SRANDMEMBER with negative count
+			Set<String> randomDistinct = template.opsForSet().distinctRandomMembers(key6, 3);
+			assertThat(randomDistinct).hasSizeLessThanOrEqualTo(3);
+			assertThat(randomDistinct)
+				.allMatch(member -> List.of("rand1", "rand2", "rand3", "rand4", "rand5").contains(member));
+
+			// SPOP operations
+			template.opsForSet().add(key7, "pop1", "pop2", "pop3", "pop4");
+
+			// SPOP - Single pop
+			String poppedMember = template.opsForSet().pop(key7);
+			assertThat(poppedMember).isIn("pop1", "pop2", "pop3", "pop4");
+			assertThat(template.opsForSet().size(key7)).isEqualTo(3);
+
+			// SPOP with count
+			List<String> poppedMembers = template.opsForSet().pop(key7, 2);
+			if (poppedMembers != null) {
+				assertThat(poppedMembers).hasSize(2);
+				assertThat(template.opsForSet().size(key7)).isEqualTo(1);
+			}
+
+			// SMOVE - Move member between sets
+			template.opsForSet().add(key8, "move1", "move2", "move3");
+			String moveDestKey = key8 + "_dest";
+
+			Boolean moveResult = template.opsForSet().move(key8, "move2", moveDestKey);
+			assertThat(moveResult).isTrue();
+			assertThat(template.opsForSet().isMember(key8, "move2")).isFalse();
+			assertThat(template.opsForSet().isMember(moveDestKey, "move2")).isTrue();
+
+			// Try to move non-existent member
+			Boolean moveResult2 = template.opsForSet().move(key8, "nonexistent", moveDestKey);
+			assertThat(moveResult2).isFalse();
+
+			template.delete(moveDestKey);
+
+			// SSCAN operation
+			template.opsForSet().add(key9, "scan1", "scan2", "scan3", "scan4", "scan5");
+
+			template.execute((ValkeyCallback<Void>) connection -> {
+				try (var cursor = connection.setCommands()
+					.sScan(key9.getBytes(),
+							io.valkey.springframework.data.valkey.core.ScanOptions.scanOptions().count(10).build())) {
+					Set<String> scannedMembers = new java.util.HashSet<>();
+					while (cursor.hasNext()) {
+						byte[] member = cursor.next();
+						scannedMembers.add(new String(member));
+					}
+					assertThat(scannedMembers).containsExactlyInAnyOrder("scan1", "scan2", "scan3", "scan4", "scan5");
+				}
+				return null;
+			});
+
+			// Test high-level SetOperations.scan() method
+			template.opsForSet().add(key10, "high1", "high2", "high3", "high4", "high5");
+
+			try (io.valkey.springframework.data.valkey.core.Cursor<String> cursor = template.opsForSet()
+				.scan(key10, io.valkey.springframework.data.valkey.core.ScanOptions.scanOptions().count(10).build())) {
+				Set<String> scannedHighMembers = new java.util.HashSet<>();
+				while (cursor.hasNext()) {
+					String member = cursor.next();
+					scannedHighMembers.add(member);
+				}
+				assertThat(scannedHighMembers).containsExactlyInAnyOrder("high1", "high2", "high3", "high4", "high5");
+			}
+
+		}
+		finally {
+			// Clean up all test keys
+			template.delete(key1);
+			template.delete(key2);
+			template.delete(key3);
+			template.delete(key4);
+			template.delete(key5);
+			template.delete(key6);
+			template.delete(key7);
+			template.delete(key8);
+			template.delete(key9);
+			template.delete(key10);
+			template.delete(destKey);
+			template.delete(key8 + "_dest");
+		}
+	}
+
+	@Test
+	void testStringOperations() {
+		// Use hash tags to ensure all keys land on the same slot for multi-key operations
+		String key1 = "{string}:basic";
+		String key2 = "{string}:expire";
+		String key3 = "{string}:setnx";
+		String key4 = "{string}:getset";
+		String multi1Key = "{string}:multi1";
+		String multi2Key = "{string}:multi2";
+		String multi3Key = "{string}:multi3";
+		String msetnx1Key = "{string}:msetnx1";
+		String msetnx2Key = "{string}:msetnx2";
+		String counterKey = "{string}:counter";
+		String floatCounterKey = "{string}:floatcounter";
+		String appendKey = "{string}:append";
+		String setRangeKey = "{string}:setrange";
+		String bitKey = "{string}:bits";
+		String bitKey1 = "{string}:bit1";
+		String bitKey2 = "{string}:bit2";
+		String bitDestKey = "{string}:bitop";
+
+		try {
+			String value1 = "Hello, valkey-glide!";
+
+			template.opsForValue().set(key1, value1);
+			String retrieved1 = template.opsForValue().get(key1);
+			assertThat(retrieved1).isEqualTo(value1);
+
+			// SET with expiration
+			String value2 = "Expiring value";
+			template.opsForValue().set(key2, value2, Duration.ofSeconds(60));
+			String retrieved2 = template.opsForValue().get(key2);
+			assertThat(retrieved2).isEqualTo(value2);
+
+			// SETNX (Set if Not eXists)
+			String value3 = "New value";
+			Boolean setResult1 = template.opsForValue().setIfAbsent(key3, value3);
+			assertThat(setResult1).isTrue();
+			Boolean setResult2 = template.opsForValue().setIfAbsent(key3, "Different value");
+			assertThat(setResult2).isFalse();
+			assertThat(template.opsForValue().get(key3)).isEqualTo(value3);
+
+			// GETSET operation
+			template.opsForValue().set(key4, "old value");
+			String oldValue = template.opsForValue().getAndSet(key4, "new value");
+			assertThat(oldValue).isEqualTo("old value");
+			assertThat(template.opsForValue().get(key4)).isEqualTo("new value");
+
+			// MGET/MSET operations
+			Map<String, String> multiValues = Map.of(multi1Key, "value1", multi2Key, "value2", multi3Key, "value3");
+			template.opsForValue().multiSet(multiValues);
+
+			List<String> multiRetrieved = template.opsForValue().multiGet(List.of(multi1Key, multi2Key, multi3Key));
+			assertThat(multiRetrieved).containsExactly("value1", "value2", "value3");
+
+			// MSETNX operation
+			Map<String, String> msetnxValues = Map.of(msetnx1Key, "msetnx_value1", msetnx2Key, "msetnx_value2");
+			Boolean msetnxResult = template.opsForValue().multiSetIfAbsent(msetnxValues);
+			assertThat(msetnxResult).isTrue();
+			assertThat(template.opsForValue().get(msetnx1Key)).isEqualTo("msetnx_value1");
+
+			// INCR/DECR operations
+			template.opsForValue().set(counterKey, "10");
+
+			Long incResult1 = template.opsForValue().increment(counterKey);
+			assertThat(incResult1).isEqualTo(11L);
+
+			Long incResult2 = template.opsForValue().increment(counterKey, 5L);
+			assertThat(incResult2).isEqualTo(16L);
+
+			Long decrResult1 = template.opsForValue().decrement(counterKey);
+			assertThat(decrResult1).isEqualTo(15L);
+
+			Long decrResult2 = template.opsForValue().decrement(counterKey, 3L);
+			assertThat(decrResult2).isEqualTo(12L);
+
+			// Floating point increment
+			template.opsForValue().set(floatCounterKey, "10");
+			Double incFloatResult = template.opsForValue().increment(floatCounterKey, 2.5);
+			assertThat(incFloatResult).isEqualTo(12.5);
+
+			// APPEND operation
+			template.opsForValue().set(appendKey, "Hello");
+			Integer appendResult = template.opsForValue().append(appendKey, " World!");
+			assertThat(appendResult).isEqualTo(12);
+			assertThat(template.opsForValue().get(appendKey)).isEqualTo("Hello World!");
+
+			// STRING LENGTH operation
+			Long strlenResult = template.opsForValue().size(appendKey);
+			assertThat(strlenResult).isEqualTo(12L);
+
+			// GETRANGE operation
+			String rangeResult = template.opsForValue().get(appendKey, 0, 4);
+			assertThat(rangeResult).isEqualTo("Hello");
+
+			// SETRANGE operation
+			template.opsForValue().set(appendKey, "Hello World!", 6);
+			template.opsForValue().set(setRangeKey, "Hello");
+			template.opsForValue().set(setRangeKey, " Valkey", 5);
+			assertThat(template.opsForValue().get(setRangeKey)).startsWith("Hello");
+
+			// BIT operations
+			template.opsForValue().set(bitKey, "a");
+
+			Boolean getBitResult = template.execute(
+					(ValkeyCallback<Boolean>) connection -> connection.stringCommands().getBit(bitKey.getBytes(), 1));
+			assertThat(getBitResult).isTrue();
+
+			Boolean setBitResult = template.execute((ValkeyCallback<Boolean>) connection -> connection.stringCommands()
+				.setBit(bitKey.getBytes(), 0, true));
+			assertThat(setBitResult).isFalse();
+
+			Long bitCountResult = template
+				.execute((ValkeyCallback<Long>) connection -> connection.stringCommands().bitCount(bitKey.getBytes()));
+			assertThat(bitCountResult).isGreaterThan(0L);
+
+			// BITOP operation
+			template.opsForValue().set(bitKey1, "a");
+			template.opsForValue().set(bitKey2, "b");
+
+			Long bitOpResult = template.execute((ValkeyCallback<Long>) connection -> connection.stringCommands()
+				.bitOp(ValkeyStringCommands.BitOperation.AND, bitDestKey.getBytes(), bitKey1.getBytes(),
+						bitKey2.getBytes()));
+			assertThat(bitOpResult).isEqualTo(1L);
+		}
+		finally {
+			// Clean up all test keys
+			template.delete(key1);
+			template.delete(key2);
+			template.delete(key3);
+			template.delete(key4);
+			template.delete(multi1Key);
+			template.delete(multi2Key);
+			template.delete(multi3Key);
+			template.delete(msetnx1Key);
+			template.delete(msetnx2Key);
+			template.delete(counterKey);
+			template.delete(floatCounterKey);
+			template.delete(appendKey);
+			template.delete(setRangeKey);
+			template.delete(bitKey);
+			template.delete(bitKey1);
+			template.delete(bitKey2);
+			template.delete(bitDestKey);
+		}
+	}
+
+	/**
+	 * Note: Transactions (MULTI/EXEC) are NOT supported in cluster mode. This test is
+	 * intentionally omitted as cluster mode does not support transactions that span
+	 * multiple keys, and even single-key transactions have limited support.
+	 */
+
+	// ==================== Pipeline Tests ====================
+
+	@Test
+	void testBasicPipelineFlow() {
+		String key1 = "{pipe}:basic:key1";
+		String key2 = "{pipe}:basic:key2";
+
+		try {
+			template.execute((ValkeyCallback<Object>) connection -> {
+				assertThat(connection.isPipelined()).isFalse();
+
+				connection.openPipeline();
+				assertThat(connection.isPipelined()).isTrue();
+
+				connection.stringCommands().set(key1.getBytes(), "value1".getBytes());
+				connection.stringCommands().set(key2.getBytes(), "value2".getBytes());
+				connection.stringCommands().get(key1.getBytes());
+				connection.stringCommands().get(key2.getBytes());
+
+				List<Object> results = connection.closePipeline();
+
+				assertThat(connection.isPipelined()).isFalse();
+				assertThat(results).hasSize(4);
+				assertThat(results.get(0)).isEqualTo(true);
+				assertThat(results.get(1)).isEqualTo(true);
+				assertThat(results.get(2)).isEqualTo("value1".getBytes());
+				assertThat(results.get(3)).isEqualTo("value2".getBytes());
+				return null;
+			});
+		}
+		finally {
+			template.delete(key1);
+			template.delete(key2);
+		}
+	}
+
+	@Test
+	void testEmptyPipeline() {
+		template.execute((ValkeyCallback<Object>) connection -> {
+			connection.openPipeline();
+			assertThat(connection.isPipelined()).isTrue();
+
+			List<Object> results = connection.closePipeline();
+
+			assertThat(connection.isPipelined()).isFalse();
+			assertThat(results).isNotNull();
+			assertThat(results).isEmpty();
+			return null;
+		});
+	}
+
+	@Test
+	void testMultipleConsecutivePipelines() {
+		String key1 = "{pipe}:consecutive:key1";
+		String key2 = "{pipe}:consecutive:key2";
+
+		try {
+			template.execute((ValkeyCallback<Object>) connection -> {
+				connection.openPipeline();
+				connection.stringCommands().set(key1.getBytes(), "pipe1_value".getBytes());
+				List<Object> results1 = connection.closePipeline();
+
+				assertThat(results1).hasSize(1);
+				assertThat(results1.get(0)).isEqualTo(true);
+
+				connection.openPipeline();
+				connection.stringCommands().set(key2.getBytes(), "pipe2_value".getBytes());
+				connection.stringCommands().get(key1.getBytes());
+				List<Object> results2 = connection.closePipeline();
+
+				assertThat(results2).hasSize(2);
+				assertThat(results2.get(0)).isEqualTo(true);
+				assertThat(results2.get(1)).isEqualTo("pipe1_value".getBytes());
+				return null;
+			});
+		}
+		finally {
+			template.delete(key1);
+			template.delete(key2);
+		}
+	}
+
+	@Test
+	void testPipelineWithCrossSlotKeys() {
+		String key1 = "pipe:cross:key1";
+		String key2 = "pipe:cross:key2";
+
+		try {
+			template.execute((ValkeyCallback<Object>) connection -> {
+				connection.openPipeline();
+				connection.stringCommands().set(key1.getBytes(), "cross1".getBytes());
+				connection.stringCommands().set(key2.getBytes(), "cross2".getBytes());
+				connection.stringCommands().get(key1.getBytes());
+				connection.stringCommands().get(key2.getBytes());
+
+				List<Object> results = connection.closePipeline();
+
+				assertThat(results).hasSize(4);
+				assertThat(results.get(0)).isEqualTo(true);
+				assertThat(results.get(1)).isEqualTo(true);
+				assertThat(results.get(2)).isEqualTo("cross1".getBytes());
+				assertThat(results.get(3)).isEqualTo("cross2".getBytes());
+				return null;
+			});
+		}
+		finally {
+			template.delete(key1);
+			template.delete(key2);
+		}
+	}
+
+	// ==================== Pipeline: Mixed Command Type Tests ====================
+
+	@Test
+	void testPipelineWithMixedCommandTypes() {
+		String stringKey = "{pipe}:mixed:string";
+		String hashKey = "{pipe}:mixed:hash";
+		String listKey = "{pipe}:mixed:list";
+		String setKey = "{pipe}:mixed:set";
+		String zsetKey = "{pipe}:mixed:zset";
+
+		try {
+			template.execute((ValkeyCallback<Object>) connection -> {
+				connection.openPipeline();
+
+				connection.stringCommands().set(stringKey.getBytes(), "string_value".getBytes());
+				connection.stringCommands().get(stringKey.getBytes());
+
+				connection.hashCommands().hSet(hashKey.getBytes(), "field1".getBytes(), "hash_value".getBytes());
+				connection.hashCommands().hGet(hashKey.getBytes(), "field1".getBytes());
+
+				connection.listCommands().lPush(listKey.getBytes(), "list_item".getBytes());
+				connection.listCommands().lLen(listKey.getBytes());
+
+				connection.setCommands().sAdd(setKey.getBytes(), "set_member".getBytes());
+				connection.setCommands().sCard(setKey.getBytes());
+
+				connection.zSetCommands().zAdd(zsetKey.getBytes(), 1.0, "zset_member".getBytes());
+				connection.zSetCommands().zCard(zsetKey.getBytes());
+
+				List<Object> results = connection.closePipeline();
+
+				assertThat(results).hasSize(10);
+
+				assertThat(results.get(0)).isEqualTo(true);
+				assertThat(results.get(2)).isEqualTo(true);
+				assertThat(results.get(4)).isEqualTo(1L);
+				assertThat(results.get(6)).isEqualTo(1L);
+				assertThat(results.get(8)).isEqualTo(true);
+
+				assertThat(results.get(1)).isEqualTo("string_value".getBytes());
+				assertThat(results.get(3)).isEqualTo("hash_value".getBytes());
+				assertThat(results.get(5)).isEqualTo(1L);
+				assertThat(results.get(7)).isEqualTo(1L);
+				assertThat(results.get(9)).isEqualTo(1L);
+				return null;
+			});
+		}
+		finally {
+			template.delete(stringKey);
+			template.delete(hashKey);
+			template.delete(listKey);
+			template.delete(setKey);
+			template.delete(zsetKey);
+		}
+	}
+
+	@Test
+	void testPipelineWithMixedCommandTypesCrossSlot() {
+		String stringKey = "pipe:mixed:cs:string";
+		String hashKey = "pipe:mixed:cs:hash";
+		String listKey = "pipe:mixed:cs:list";
+		String setKey = "pipe:mixed:cs:set";
+
+		try {
+			template.execute((ValkeyCallback<Object>) connection -> {
+				connection.openPipeline();
+
+				connection.stringCommands().set(stringKey.getBytes(), "str_val".getBytes());
+				connection.hashCommands().hSet(hashKey.getBytes(), "f1".getBytes(), "h_val".getBytes());
+				connection.listCommands().lPush(listKey.getBytes(), "l_item".getBytes());
+				connection.setCommands().sAdd(setKey.getBytes(), "s_member".getBytes());
+
+				connection.stringCommands().get(stringKey.getBytes());
+				connection.hashCommands().hGet(hashKey.getBytes(), "f1".getBytes());
+				connection.listCommands().lLen(listKey.getBytes());
+				connection.setCommands().sCard(setKey.getBytes());
+
+				List<Object> results = connection.closePipeline();
+
+				assertThat(results).hasSize(8);
+				assertThat(results.get(0)).isEqualTo(true);
+				assertThat(results.get(1)).isEqualTo(true);
+				assertThat(results.get(2)).isEqualTo(1L);
+				assertThat(results.get(3)).isEqualTo(1L);
+				assertThat(results.get(4)).isEqualTo("str_val".getBytes());
+				assertThat(results.get(5)).isEqualTo("h_val".getBytes());
+				assertThat(results.get(6)).isEqualTo(1L);
+				assertThat(results.get(7)).isEqualTo(1L);
+				return null;
+			});
+		}
+		finally {
+			template.delete(stringKey);
+			template.delete(hashKey);
+			template.delete(listKey);
+			template.delete(setKey);
+		}
+	}
+
+	// ==================== Pipeline: State Management Tests ====================
+
+	@Test
+	void testIsPipelinedState() {
+		template.execute((ValkeyCallback<Object>) connection -> {
+			assertThat(connection.isPipelined()).isFalse();
+
+			connection.openPipeline();
+			assertThat(connection.isPipelined()).isTrue();
+
+			connection.closePipeline();
+			assertThat(connection.isPipelined()).isFalse();
+			return null;
+		});
+	}
+
+	@Test
+	void testPipelineTransactionIsolation() {
+		template.execute((ValkeyCallback<Object>) connection -> {
+			connection.openPipeline();
+
+			// In cluster mode, multi() is blocked entirely (not just during pipeline)
+			assertThatThrownBy(() -> connection.multi()).isInstanceOf(InvalidDataAccessApiUsageException.class);
+
+			connection.closePipeline();
+			return null;
+		});
+	}
+
+	// ==================== Pipeline: Edge Cases and Error Handling ====================
+
+	@Test
+	void testClosePipelineWithoutOpen() {
+		template.execute((ValkeyCallback<Object>) connection -> {
+			assertThat(connection.isPipelined()).isFalse();
+
+			List<Object> results = connection.closePipeline();
+
+			assertThat(results).isNotNull();
+			assertThat(results).isEmpty();
+			assertThat(connection.isPipelined()).isFalse();
+			return null;
+		});
+	}
+
+	@Test
+	void testNestedOpenPipelineCalls() {
+		String key = "{pipe}:nested:key";
+
+		try {
+			template.execute((ValkeyCallback<Object>) connection -> {
+				connection.openPipeline();
+				assertThat(connection.isPipelined()).isTrue();
+
+				connection.openPipeline();
+				assertThat(connection.isPipelined()).isTrue();
+
+				connection.stringCommands().set(key.getBytes(), "nested_value".getBytes());
+
+				List<Object> results = connection.closePipeline();
+
+				assertThat(connection.isPipelined()).isFalse();
+				assertThat(results).hasSize(1);
+				assertThat(results.get(0)).isEqualTo(true);
+				return null;
+			});
+		}
+		finally {
+			template.delete(key);
+		}
+	}
+
+	@Test
+	void testPipelineWithNonExistentKeys() {
+		String nonExistentKey1 = "{pipe}:nonexist:key1";
+		String nonExistentKey2 = "{pipe}:nonexist:key2";
+
+		template.execute((ValkeyCallback<Object>) connection -> {
+			connection.openPipeline();
+
+			connection.stringCommands().get(nonExistentKey1.getBytes());
+			connection.stringCommands().get(nonExistentKey2.getBytes());
+			connection.listCommands().lLen("{pipe}:nonexist:list".getBytes());
+			connection.setCommands().sCard("{pipe}:nonexist:set".getBytes());
+
+			List<Object> results = connection.closePipeline();
+
+			assertThat(results).hasSize(4);
+			assertThat(results.get(0)).isNull();
+			assertThat(results.get(1)).isNull();
+			assertThat(results.get(2)).isEqualTo(0L);
+			assertThat(results.get(3)).isEqualTo(0L);
+			return null;
+		});
+	}
+
+	@Test
+	void testPipelineWithEmptyValues() {
+		String key = "{pipe}:empty:key";
+
+		try {
+			template.execute((ValkeyCallback<Object>) connection -> {
+				connection.openPipeline();
+
+				connection.stringCommands().set(key.getBytes(), new byte[0]);
+				connection.stringCommands().get(key.getBytes());
+				connection.stringCommands().strLen(key.getBytes());
+
+				List<Object> results = connection.closePipeline();
+
+				assertThat(results).hasSize(3);
+				assertThat(results.get(0)).isEqualTo(true);
+				assertThat(results.get(1)).isEqualTo(new byte[0]);
+				assertThat(results.get(2)).isEqualTo(0L);
+				return null;
+			});
+		}
+		finally {
+			template.delete(key);
+		}
+	}
+
+	// ==================== Pipeline: Large Pipeline Tests ====================
+
+	@Test
+	void testLargePipeline() {
+		String keyPrefix = "{pipe}:large:key";
+		int commandCount = 100;
+
+		try {
+			template.execute((ValkeyCallback<Object>) connection -> {
+				connection.openPipeline();
+
+				for (int i = 0; i < commandCount; i++) {
+					String key = keyPrefix + ":" + i;
+					connection.stringCommands().set(key.getBytes(), ("value" + i).getBytes());
+				}
+
+				List<Object> results = connection.closePipeline();
+
+				assertThat(results).hasSize(commandCount);
+				for (int i = 0; i < commandCount; i++) {
+					assertThat(results.get(i)).isEqualTo(true);
+				}
+				return null;
+			});
+
+			// Verify values were set
+			template.execute((ValkeyCallback<Object>) connection -> {
+				assertThat(connection.stringCommands().get((keyPrefix + ":0").getBytes()))
+					.isEqualTo("value0".getBytes());
+				assertThat(connection.stringCommands().get((keyPrefix + ":50").getBytes()))
+					.isEqualTo("value50".getBytes());
+				assertThat(connection.stringCommands().get((keyPrefix + ":99").getBytes()))
+					.isEqualTo("value99".getBytes());
+				return null;
+			});
+		}
+		finally {
+			for (int i = 0; i < commandCount; i++) {
+				template.delete(keyPrefix + ":" + i);
+			}
+		}
+	}
+
+	@Test
+	void testLargePipelineCrossSlot() {
+		String keyPrefix = "pipe:largecs:key";
+		int commandCount = 100;
+
+		try {
+			template.execute((ValkeyCallback<Object>) connection -> {
+				connection.openPipeline();
+
+				for (int i = 0; i < commandCount; i++) {
+					String key = keyPrefix + ":" + i;
+					connection.stringCommands().set(key.getBytes(), ("value" + i).getBytes());
+				}
+
+				List<Object> results = connection.closePipeline();
+
+				assertThat(results).hasSize(commandCount);
+				for (int i = 0; i < commandCount; i++) {
+					assertThat(results.get(i)).isEqualTo(true);
+				}
+				return null;
+			});
+
+			// Verify a few values
+			template.execute((ValkeyCallback<Object>) connection -> {
+				assertThat(connection.stringCommands().get((keyPrefix + ":0").getBytes()))
+					.isEqualTo("value0".getBytes());
+				assertThat(connection.stringCommands().get((keyPrefix + ":99").getBytes()))
+					.isEqualTo("value99".getBytes());
+				return null;
+			});
+		}
+		finally {
+			for (int i = 0; i < commandCount; i++) {
+				template.delete(keyPrefix + ":" + i);
+			}
+		}
+	}
+
+	@Test
+	void testPipelinePerformance() {
+		String keyPrefix = "{pipe}:perf:key";
+		int commandCount = 200;
+
+		try {
+			template.execute((ValkeyCallback<Object>) connection -> {
+				long startTime = System.currentTimeMillis();
+
+				connection.openPipeline();
+
+				for (int i = 0; i < commandCount; i++) {
+					String key = keyPrefix + ":" + i;
+					connection.stringCommands().set(key.getBytes(), ("value" + i).getBytes());
+					connection.stringCommands().get(key.getBytes());
+				}
+
+				List<Object> results = connection.closePipeline();
+
+				long duration = System.currentTimeMillis() - startTime;
+
+				assertThat(results).hasSize(commandCount * 2);
+				assertThat(duration).isLessThan(10000);
+
+				for (int i = 0; i < commandCount; i += 10) {
+					assertThat(results.get(i * 2)).isEqualTo(true);
+					assertThat(results.get(i * 2 + 1)).isEqualTo(("value" + i).getBytes());
+				}
+				return null;
+			});
+		}
+		finally {
+			for (int i = 0; i < commandCount; i++) {
+				template.delete(keyPrefix + ":" + i);
+			}
+		}
+	}
+
+	// ==================== Pipeline: Concurrent Tests ====================
+
+	@Test
+	void testConcurrentPipelines() throws Exception {
+		String sharedKey = "{pipe}:concurrent:shared";
+		String keyPrefix = "{pipe}:concurrent:key";
+		ExecutorService executor = Executors.newFixedThreadPool(5);
+
+		try {
+			template.opsForValue().set(sharedKey, "shared_value");
+
+			CompletableFuture<?>[] futures = new CompletableFuture[5];
+
+			for (int i = 0; i < 5; i++) {
+				final int threadId = i;
+				futures[i] = CompletableFuture.runAsync(() -> {
+					try (ValkeyConnection conn = connectionFactory.getClusterConnection()) {
+						conn.openPipeline();
+						conn.stringCommands()
+							.set((keyPrefix + ":" + threadId).getBytes(), ("thread" + threadId).getBytes());
+						conn.stringCommands().get(sharedKey.getBytes());
+						List<Object> results = conn.closePipeline();
+
+						assertThat(results).hasSize(2);
+						assertThat(results.get(0)).isEqualTo(true);
+						assertThat(results.get(1)).isEqualTo("shared_value".getBytes());
+					}
+				}, executor);
+			}
+
+			CompletableFuture.allOf(futures).get(10, TimeUnit.SECONDS);
+
+			// Verify all threads succeeded
+			for (int i = 0; i < 5; i++) {
+				assertThat(template.opsForValue().get(keyPrefix + ":" + i)).isEqualTo("thread" + i);
+			}
+		}
+		finally {
+			executor.shutdown();
+			template.delete(sharedKey);
+			for (int i = 0; i < 5; i++) {
+				template.delete(keyPrefix + ":" + i);
+			}
+		}
+	}
+
+	// ==================== Pipeline: Result Conversion Tests ====================
+
+	@Test
+	void testPipelineResultConversion() {
+		String key = "{pipe}:convert:key";
+		String counterKey = "{pipe}:convert:counter";
+
+		try {
+			template.execute((ValkeyCallback<Object>) connection -> {
+				connection.openPipeline();
+
+				connection.stringCommands().set(key.getBytes(), "42".getBytes());
+				connection.stringCommands().get(key.getBytes());
+				connection.stringCommands().set(counterKey.getBytes(), "10".getBytes());
+				connection.stringCommands().incr(counterKey.getBytes());
+				connection.stringCommands().strLen(counterKey.getBytes());
+
+				List<Object> results = connection.closePipeline();
+
+				assertThat(results).hasSize(5);
+				assertThat(results.get(0)).isEqualTo(true);
+				assertThat(results.get(1)).isEqualTo("42".getBytes());
+				assertThat(results.get(2)).isEqualTo(true);
+				assertThat(results.get(3)).isEqualTo(11L);
+				assertThat(results.get(4)).isEqualTo(2L);
+				return null;
+			});
+		}
+		finally {
+			template.delete(key);
+			template.delete(counterKey);
+		}
+	}
+
+	// ==================== Pipeline: Error Recovery Tests ====================
+
+	@Test
+	void testPipelineErrorRecovery() {
+		String validKey = "{pipe}:error:valid";
+		String nonExistentKey = "{pipe}:error:nonexist";
+
+		try {
+			template.execute((ValkeyCallback<Object>) connection -> {
+				connection.openPipeline();
+
+				connection.stringCommands().set(validKey.getBytes(), "valid_value".getBytes());
+				connection.stringCommands().get(nonExistentKey.getBytes());
+				connection.stringCommands().get(validKey.getBytes());
+
+				List<Object> results = connection.closePipeline();
+
+				assertThat(results).hasSize(3);
+				assertThat(results.get(0)).isEqualTo(true);
+				assertThat(results.get(1)).isNull();
+				assertThat(results.get(2)).isEqualTo("valid_value".getBytes());
+				return null;
+			});
+		}
+		finally {
+			template.delete(validKey);
+		}
+	}
+
+	// ==================== Pipeline: State Consistency Tests ====================
+
+	@Test
+	void testPipelineStateConsistency() {
+		template.execute((ValkeyCallback<Object>) connection -> {
+			assertThat(connection.isPipelined()).isFalse();
+
+			for (int i = 0; i < 3; i++) {
+				connection.openPipeline();
+				assertThat(connection.isPipelined()).isTrue();
+
+				List<Object> results = connection.closePipeline();
+				assertThat(connection.isPipelined()).isFalse();
+				assertThat(results).isEmpty();
+			}
+
+			assertThat(connection.isPipelined()).isFalse();
+			return null;
+		});
+	}
+
+	/**
+	 * Checks if the server version is at least the specified major.minor version.
+	 */
+	private boolean isServerVersionAtLeast(int majorVersion, int minorVersion) {
+		return template.execute((ValkeyCallback<Boolean>) connection -> {
+			Properties serverInfo = connection.serverCommands().info("server");
+			String versionString = serverInfo.getProperty("valkey_version", serverInfo.getProperty("redis_version"));
+
+			if (versionString == null) {
+				versionString = serverInfo.getProperty("server_version");
+			}
+
+			if (versionString == null) {
+				return false;
+			}
+
+			String[] versionParts = versionString.split("\\.");
+			if (versionParts.length < 2) {
+				return false;
+			}
+
+			int serverMajor = Integer.parseInt(versionParts[0]);
+			int serverMinor = Integer.parseInt(versionParts[1]);
+
+			if (serverMajor > majorVersion) {
+				return true;
+			}
+			else if (serverMajor == majorVersion) {
+				return serverMinor >= minorVersion;
+			}
+			else {
+				return false;
+			}
+		});
+	}
+
 }

--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideClusterConnectionTests.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideClusterConnectionTests.java
@@ -95,49 +95,60 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			new HostAndPort(CLUSTER_HOST, MASTER_NODE_2_PORT), new HostAndPort(CLUSTER_HOST, MASTER_NODE_3_PORT));
 
 	private static final byte[] KEY_1_BYTES = ValkeyGlideConverters.toBytes(KEY_1);
+
 	private static final byte[] KEY_2_BYTES = ValkeyGlideConverters.toBytes(KEY_2);
+
 	private static final byte[] KEY_3_BYTES = ValkeyGlideConverters.toBytes(KEY_3);
 
 	private static final byte[] SAME_SLOT_KEY_1_BYTES = ValkeyGlideConverters.toBytes(SAME_SLOT_KEY_1);
+
 	private static final byte[] SAME_SLOT_KEY_2_BYTES = ValkeyGlideConverters.toBytes(SAME_SLOT_KEY_2);
+
 	private static final byte[] SAME_SLOT_KEY_3_BYTES = ValkeyGlideConverters.toBytes(SAME_SLOT_KEY_3);
 
 	private static final byte[] VALUE_1_BYTES = ValkeyGlideConverters.toBytes(VALUE_1);
+
 	private static final byte[] VALUE_2_BYTES = ValkeyGlideConverters.toBytes(VALUE_2);
+
 	private static final byte[] VALUE_3_BYTES = ValkeyGlideConverters.toBytes(VALUE_3);
 
 	private static final String STRING_ARIGENTO = "arigento";
+
 	private static final String STRING_CATANIA = "catania";
+
 	private static final String STRING_PALERMO = "palermo";
 
-	private static final GeoLocation<byte[]> ARIGENTO = new GeoLocation<>(STRING_ARIGENTO.getBytes(Charset.forName("UTF-8")),
-			POINT_ARIGENTO);
-	private static final GeoLocation<byte[]> CATANIA = new GeoLocation<>(STRING_CATANIA.getBytes(Charset.forName("UTF-8")),
-			POINT_CATANIA);
-	private static final GeoLocation<byte[]> PALERMO = new GeoLocation<>(STRING_PALERMO.getBytes(Charset.forName("UTF-8")),
-			POINT_PALERMO);
+	private static final GeoLocation<byte[]> ARIGENTO = new GeoLocation<>(
+			STRING_ARIGENTO.getBytes(Charset.forName("UTF-8")), POINT_ARIGENTO);
 
-	private static final Map<String, GeospatialData> GLIDE_GEO_DATA = Map.of(
-		STRING_ARIGENTO, new GeospatialData(POINT_ARIGENTO.getX(), POINT_ARIGENTO.getY()),
-		STRING_CATANIA, new GeospatialData(POINT_CATANIA.getX(), POINT_CATANIA.getY()),
-		STRING_PALERMO, new GeospatialData(POINT_PALERMO.getX(), POINT_PALERMO.getY())
-    );
+	private static final GeoLocation<byte[]> CATANIA = new GeoLocation<>(
+			STRING_CATANIA.getBytes(Charset.forName("UTF-8")), POINT_CATANIA);
+
+	private static final GeoLocation<byte[]> PALERMO = new GeoLocation<>(
+			STRING_PALERMO.getBytes(Charset.forName("UTF-8")), POINT_PALERMO);
+
+	private static final Map<String, GeospatialData> GLIDE_GEO_DATA = Map.of(STRING_ARIGENTO,
+			new GeospatialData(POINT_ARIGENTO.getX(), POINT_ARIGENTO.getY()), STRING_CATANIA,
+			new GeospatialData(POINT_CATANIA.getX(), POINT_CATANIA.getY()), STRING_PALERMO,
+			new GeospatialData(POINT_PALERMO.getX(), POINT_PALERMO.getY()));
 
 	private final GlideClusterClient nativeConnection;
+
 	private final ValkeyGlideClusterConnection clusterConnection;
 
 	/**
-	 * Constructor that extracts the native GlideClusterClient from the connection factory.
-	 * This enables the dual-layer testing approach where we use the native client for setup/verification.
+	 * Constructor that extracts the native GlideClusterClient from the connection
+	 * factory. This enables the dual-layer testing approach where we use the native
+	 * client for setup/verification.
 	 */
 	public ValkeyGlideClusterConnectionTests(@ValkeyCluster ValkeyConnectionFactory factory) {
 		// Get cluster connection from factory
 		ValkeyClusterConnection connection = factory.getClusterConnection();
-		
+
 		if (!(connection instanceof ValkeyGlideClusterConnection)) {
 			throw new IllegalStateException("Expected ValkeyGlideClusterConnection but got " + connection.getClass());
 		}
-		
+
 		clusterConnection = (ValkeyGlideClusterConnection) connection;
 		nativeConnection = (GlideClusterClient) clusterConnection.getNativeConnection();
 	}
@@ -154,7 +165,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			clusterConnection.append(KEY_1_BYTES, VALUE_2_BYTES);
 
 			assertThat(nativeConnection.get(KEY_1).get()).isEqualTo(VALUE_1.concat(VALUE_2));
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -163,11 +175,12 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	public void bRPopLPushShouldWork() {
 
 		try {
-			nativeConnection.lpush(KEY_1, new String[]{VALUE_1, VALUE_2}).get();
+			nativeConnection.lpush(KEY_1, new String[] { VALUE_1, VALUE_2 }).get();
 			assertThat(clusterConnection.bRPopLPush(0, KEY_1_BYTES, KEY_2_BYTES)).isEqualTo(VALUE_1_BYTES);
-			assertThat(nativeConnection.exists(new String[]{KEY_1}).get()).isEqualTo(1);
-			assertThat(nativeConnection.exists(new String[]{KEY_2}).get()).isEqualTo(1);
-		} catch (Exception e) {
+			assertThat(nativeConnection.exists(new String[] { KEY_1 }).get()).isEqualTo(1);
+			assertThat(nativeConnection.exists(new String[] { KEY_2 }).get()).isEqualTo(1);
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -175,12 +188,14 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void bRPopLPushShouldWorkOnSameSlotKeys() {
 		try {
-			nativeConnection.lpush(SAME_SLOT_KEY_1, new String[]{VALUE_1, VALUE_2}).get();
-			
-			assertThat(clusterConnection.bRPopLPush(0, SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES)).isEqualTo(VALUE_1_BYTES);
-			assertThat(nativeConnection.exists(new String[]{SAME_SLOT_KEY_1}).get()).isEqualTo(1);
-			assertThat(nativeConnection.exists(new String[]{SAME_SLOT_KEY_2}).get()).isEqualTo(1);
-		} catch (Exception e) {
+			nativeConnection.lpush(SAME_SLOT_KEY_1, new String[] { VALUE_1, VALUE_2 }).get();
+
+			assertThat(clusterConnection.bRPopLPush(0, SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES))
+				.isEqualTo(VALUE_1_BYTES);
+			assertThat(nativeConnection.exists(new String[] { SAME_SLOT_KEY_1 }).get()).isEqualTo(1);
+			assertThat(nativeConnection.exists(new String[] { SAME_SLOT_KEY_2 }).get()).isEqualTo(1);
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -192,7 +207,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.setbit(KEY_1, 1, 0).get();
 
 			assertThat(clusterConnection.bitCount(KEY_1_BYTES)).isEqualTo(1L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -207,7 +223,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.setbit(KEY_1, 4, 1).get();
 
 			assertThat(clusterConnection.bitCount(KEY_1_BYTES, 0, 3)).isEqualTo(3L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -215,7 +232,7 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void bitOpShouldThrowExceptionWhenKeysDoNotMapToSameSlot() {
 		assertThatExceptionOfType(DataAccessException.class)
-				.isThrownBy(() -> clusterConnection.bitOp(BitOperation.AND, KEY_1_BYTES, KEY_2_BYTES, KEY_3_BYTES));
+			.isThrownBy(() -> clusterConnection.bitOp(BitOperation.AND, KEY_1_BYTES, KEY_2_BYTES, KEY_3_BYTES));
 	}
 
 	@Test // DATAREDIS-315
@@ -224,10 +241,12 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.set(SAME_SLOT_KEY_1, "foo").get();
 			nativeConnection.set(SAME_SLOT_KEY_2, "bar").get();
 
-			clusterConnection.bitOp(BitOperation.AND, SAME_SLOT_KEY_3_BYTES, SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES);
+			clusterConnection.bitOp(BitOperation.AND, SAME_SLOT_KEY_3_BYTES, SAME_SLOT_KEY_1_BYTES,
+					SAME_SLOT_KEY_2_BYTES);
 
 			assertThat(nativeConnection.get(SAME_SLOT_KEY_3).get()).isEqualTo("bab");
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -235,11 +254,12 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void blPopShouldPopElementCorrectly() {
 		try {
-			nativeConnection.lpush(KEY_1, new String[]{VALUE_1, VALUE_2}).get();
-			nativeConnection.lpush(KEY_2, new String[]{VALUE_3}).get();
+			nativeConnection.lpush(KEY_1, new String[] { VALUE_1, VALUE_2 }).get();
+			nativeConnection.lpush(KEY_2, new String[] { VALUE_3 }).get();
 
 			assertThat(clusterConnection.bLPop(100, KEY_1_BYTES, KEY_2_BYTES).size()).isEqualTo(2);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -247,8 +267,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void blPopShouldPopElementCorrectlyWhenKeyOnSameSlot() {
 		try {
-			nativeConnection.lpush(SAME_SLOT_KEY_1, new String[]{VALUE_1, VALUE_2}).get();
-			nativeConnection.lpush(SAME_SLOT_KEY_2, new String[]{VALUE_3}).get();
+			nativeConnection.lpush(SAME_SLOT_KEY_1, new String[] { VALUE_1, VALUE_2 }).get();
+			nativeConnection.lpush(SAME_SLOT_KEY_2, new String[] { VALUE_3 }).get();
 
 			assertThat(clusterConnection.bLPop(100, SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES).size()).isEqualTo(2);
 		}
@@ -259,12 +279,13 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 	@Test // DATAREDIS-315
 	public void brPopShouldPopElementCorrectly() {
-		try {		
-			nativeConnection.lpush(KEY_1, new String[]{VALUE_1, VALUE_2}).get();
-			nativeConnection.lpush(KEY_2, new String[]{VALUE_3}).get();
+		try {
+			nativeConnection.lpush(KEY_1, new String[] { VALUE_1, VALUE_2 }).get();
+			nativeConnection.lpush(KEY_2, new String[] { VALUE_3 }).get();
 
 			assertThat(clusterConnection.bRPop(100, KEY_1_BYTES, KEY_2_BYTES).size()).isEqualTo(2);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -272,11 +293,12 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void brPopShouldPopElementCorrectlyWhenKeyOnSameSlot() {
 		try {
-			nativeConnection.lpush(SAME_SLOT_KEY_1, new String[]{VALUE_1, VALUE_2}).get();
-			nativeConnection.lpush(SAME_SLOT_KEY_2, new String[]{VALUE_3}).get();
+			nativeConnection.lpush(SAME_SLOT_KEY_1, new String[] { VALUE_1, VALUE_2 }).get();
+			nativeConnection.lpush(SAME_SLOT_KEY_2, new String[] { VALUE_3 }).get();
 
 			assertThat(clusterConnection.bRPop(100, SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES).size()).isEqualTo(2);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -290,12 +312,12 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	public void clusterGetMasterReplicaMapShouldListMastersAndReplicasCorrectly() {
 
 		Map<ValkeyClusterNode, Collection<ValkeyClusterNode>> masterReplicaMap = clusterConnection
-				.clusterGetMasterReplicaMap();
+			.clusterGetMasterReplicaMap();
 
 		assertThat(masterReplicaMap).isNotNull();
 		assertThat(masterReplicaMap.size()).isEqualTo(3);
 		assertThat(masterReplicaMap.get(new ValkeyClusterNode(CLUSTER_HOST, MASTER_NODE_1_PORT)))
-				.contains(new ValkeyClusterNode(CLUSTER_HOST, REPLICAOF_NODE_1_PORT));
+			.contains(new ValkeyClusterNode(CLUSTER_HOST, REPLICAOF_NODE_1_PORT));
 		assertThat(masterReplicaMap.get(new ValkeyClusterNode(CLUSTER_HOST, MASTER_NODE_2_PORT)).isEmpty()).isTrue();
 		assertThat(masterReplicaMap.get(new ValkeyClusterNode(CLUSTER_HOST, MASTER_NODE_3_PORT)).isEmpty()).isTrue();
 	}
@@ -303,7 +325,7 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void clusterGetReplicasShouldReturnReplicaCorrectly() {
 		Set<ValkeyClusterNode> replicas = clusterConnection
-				.clusterGetReplicas(new ValkeyClusterNode(CLUSTER_HOST, MASTER_NODE_1_PORT));
+			.clusterGetReplicas(new ValkeyClusterNode(CLUSTER_HOST, MASTER_NODE_1_PORT));
 
 		assertThat(replicas.size()).isEqualTo(1);
 		assertThat(replicas).contains(new ValkeyClusterNode(CLUSTER_HOST, REPLICAOF_NODE_1_PORT));
@@ -316,8 +338,9 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.set(SAME_SLOT_KEY_2, VALUE_2).get();
 
 			assertThat(clusterConnection.clusterCountKeysInSlot(ClusterSlotHashUtil.calculateSlot(SAME_SLOT_KEY_1)))
-					.isEqualTo(2L);
-		} catch (Exception e) {
+				.isEqualTo(2L);
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -328,10 +351,14 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.set(KEY_1, VALUE_1).get();
 			nativeConnection.set(KEY_2, VALUE_2).get();
 
-			assertThat(clusterConnection.dbSize(new ValkeyClusterNode("127.0.0.1", 7379, SlotRange.empty()))).isEqualTo(1L);
-			assertThat(clusterConnection.dbSize(new ValkeyClusterNode("127.0.0.1", 7380, SlotRange.empty()))).isEqualTo(1L);
-			assertThat(clusterConnection.dbSize(new ValkeyClusterNode("127.0.0.1", 7381, SlotRange.empty()))).isEqualTo(0L);
-		} catch (Exception e) {
+			assertThat(clusterConnection.dbSize(new ValkeyClusterNode("127.0.0.1", 7379, SlotRange.empty())))
+				.isEqualTo(1L);
+			assertThat(clusterConnection.dbSize(new ValkeyClusterNode("127.0.0.1", 7380, SlotRange.empty())))
+				.isEqualTo(1L);
+			assertThat(clusterConnection.dbSize(new ValkeyClusterNode("127.0.0.1", 7381, SlotRange.empty())))
+				.isEqualTo(0L);
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -343,7 +370,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.set(KEY_2, VALUE_2).get();
 
 			assertThat(clusterConnection.dbSize()).isEqualTo(2L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -354,7 +382,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.set(KEY_1, "5").get();
 
 			assertThat(clusterConnection.decrBy(KEY_1_BYTES, 4)).isEqualTo(1L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -365,7 +394,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.set(KEY_1, "5").get();
 
 			assertThat(clusterConnection.decr(KEY_1_BYTES)).isEqualTo(4L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -380,7 +410,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(nativeConnection.get(KEY_1).get()).isNull();
 			assertThat(nativeConnection.get(KEY_2).get()).isNull();
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -395,7 +426,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(nativeConnection.get(SAME_SLOT_KEY_1).get()).isNull();
 			assertThat(nativeConnection.get(SAME_SLOT_KEY_2).get()).isNull();
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -408,7 +440,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			clusterConnection.del(KEY_1_BYTES);
 
 			assertThat(nativeConnection.get(KEY_1).get()).isNull();
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -427,7 +460,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			clusterConnection.restore(KEY_2_BYTES, 0, dumpedValue);
 
 			assertThat(nativeConnection.get(KEY_2).get()).isEqualTo(VALUE_1);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -444,7 +478,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			clusterConnection.keyCommands().restore(KEY_1_BYTES, 0, dumpedValue, true);
 
 			assertThat(nativeConnection.get(KEY_1).get()).isEqualTo(VALUE_1);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -452,7 +487,7 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void echoShouldReturnInputCorrectly() {
 		assertThatExceptionOfType(InvalidDataAccessApiUsageException.class)
-				.isThrownBy(() -> clusterConnection.echo(VALUE_1_BYTES));
+			.isThrownBy(() -> clusterConnection.echo(VALUE_1_BYTES));
 	}
 
 	@Test // DATAREDIS-315
@@ -467,7 +502,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			assertThat(clusterConnection.execute("SET", KEY_1_BYTES, VALUE_1_BYTES)).isEqualTo(true);
 
 			assertThat(nativeConnection.get(KEY_1).get()).isEqualTo(VALUE_1);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -480,15 +516,16 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			assertThat(result).isEqualTo(true);
 
 			assertThat(nativeConnection.get(KEY_1).get()).isEqualTo(VALUE_1);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
 
 	@Test // DATAREDIS-689
 	void executeWithNoKeyAndArgsThrowsException() {
-		assertThatIllegalArgumentException()
-				.isThrownBy(() -> clusterConnection.execute("KEYS", (byte[]) null, Collections.singletonList("*".getBytes())));
+		assertThatIllegalArgumentException().isThrownBy(
+				() -> clusterConnection.execute("KEYS", (byte[]) null, Collections.singletonList("*".getBytes())));
 	}
 
 	@Test // DATAREDIS-529
@@ -497,14 +534,16 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.set(KEY_1, "true").get();
 
 			assertThat(clusterConnection.keyCommands().exists(KEY_1_BYTES, KEY_1_BYTES)).isEqualTo(2L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
 
 	@Test // DATAREDIS-529
 	public void existsWithMultipleKeysShouldConsiderAbsentKeys() {
-		assertThat(clusterConnection.keyCommands().exists("no-exist-1".getBytes(), "no-exist-2".getBytes())).isEqualTo(0L);
+		assertThat(clusterConnection.keyCommands().exists("no-exist-1".getBytes(), "no-exist-2".getBytes()))
+			.isEqualTo(0L);
 	}
 
 	@Test // DATAREDIS-529
@@ -514,9 +553,10 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.set(KEY_2, "true").get();
 			nativeConnection.set(KEY_3, "true").get();
 
-			assertThat(clusterConnection.keyCommands().exists(KEY_1_BYTES, KEY_2_BYTES, KEY_3_BYTES, "nonexistent".getBytes()))
-					.isEqualTo(3L);
-		} catch (Exception e) {
+			assertThat(clusterConnection.keyCommands()
+				.exists(KEY_1_BYTES, KEY_2_BYTES, KEY_3_BYTES, "nonexistent".getBytes())).isEqualTo(3L);
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -529,7 +569,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			clusterConnection.expireAt(KEY_1_BYTES, System.currentTimeMillis() / 1000 + 5000);
 
 			assertThat(nativeConnection.ttl(KEY_1).get()).isGreaterThan(1);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -541,14 +582,18 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.set(KEY_1, VALUE_1).get();
 
 			assertThat(clusterConnection.expireAt(KEY_1_BYTES, System.currentTimeMillis() / 1000 + 5000,
-					ExpirationOptions.Condition.XX)).isFalse();
+					ExpirationOptions.Condition.XX))
+				.isFalse();
 			assertThat(clusterConnection.expireAt(KEY_1_BYTES, System.currentTimeMillis() / 1000 + 5000,
-					ExpirationOptions.Condition.NX)).isTrue();
+					ExpirationOptions.Condition.NX))
+				.isTrue();
 			assertThat(clusterConnection.expireAt(KEY_1_BYTES, System.currentTimeMillis() / 1000 + 15000,
-					ExpirationOptions.Condition.LT)).isFalse();
+					ExpirationOptions.Condition.LT))
+				.isFalse();
 
 			assertThat(nativeConnection.ttl(KEY_1).get()).isGreaterThan(1);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -561,7 +606,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			clusterConnection.expire(KEY_1_BYTES, 5);
 
 			assertThat(nativeConnection.ttl(KEY_1).get()).isGreaterThan(1);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -577,7 +623,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			assertThat(clusterConnection.expire(KEY_1_BYTES, 15, ExpirationOptions.Condition.LT)).isFalse();
 
 			assertThat(nativeConnection.ttl(KEY_1).get()).isGreaterThan(1);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -592,7 +639,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(nativeConnection.get(KEY_1).get()).isNotNull();
 			assertThat(nativeConnection.get(KEY_2).get()).isNull();
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -607,7 +655,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(nativeConnection.get(KEY_1).get()).isNotNull();
 			assertThat(nativeConnection.get(KEY_2).get()).isNull();
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -622,7 +671,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(nativeConnection.get(KEY_1).get()).isNotNull();
 			assertThat(nativeConnection.get(KEY_2).get()).isNull();
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -637,7 +687,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(nativeConnection.get(KEY_1).get()).isNull();
 			assertThat(nativeConnection.get(KEY_2).get()).isNull();
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -652,7 +703,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(nativeConnection.get(KEY_1).get()).isNull();
 			assertThat(nativeConnection.get(KEY_2).get()).isNull();
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -667,7 +719,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(nativeConnection.get(KEY_1).get()).isNull();
 			assertThat(nativeConnection.get(KEY_2).get()).isNull();
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -682,7 +735,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(nativeConnection.get(KEY_1).get()).isNotNull();
 			assertThat(nativeConnection.get(KEY_2).get()).isNull();
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -697,7 +751,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(nativeConnection.get(KEY_1).get()).isNotNull();
 			assertThat(nativeConnection.get(KEY_2).get()).isNull();
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -712,7 +767,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(nativeConnection.get(KEY_1).get()).isNotNull();
 			assertThat(nativeConnection.get(KEY_2).get()).isNull();
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -727,7 +783,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(nativeConnection.get(KEY_1).get()).isNull();
 			assertThat(nativeConnection.get(KEY_2).get()).isNull();
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -742,7 +799,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(nativeConnection.get(KEY_1).get()).isNull();
 			assertThat(nativeConnection.get(KEY_2).get()).isNull();
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -757,14 +815,16 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(nativeConnection.get(KEY_1).get()).isNull();
 			assertThat(nativeConnection.get(KEY_2).get()).isNull();
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
 
 	@Test // DATAREDIS-438
 	public void geoAddMultipleGeoLocations() {
-		assertThat(clusterConnection.geoAdd(KEY_1_BYTES, Arrays.asList(PALERMO, ARIGENTO, CATANIA, PALERMO))).isEqualTo(3L);
+		assertThat(clusterConnection.geoAdd(KEY_1_BYTES, Arrays.asList(PALERMO, ARIGENTO, CATANIA, PALERMO)))
+			.isEqualTo(3L);
 	}
 
 	@Test // DATAREDIS-438
@@ -780,7 +840,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			Distance distance = clusterConnection.geoDist(KEY_1_BYTES, PALERMO.getName(), CATANIA.getName());
 			assertThat(distance.getValue()).isCloseTo(166274.15156960033D, offset(0.005));
 			assertThat(distance.getUnit()).isEqualTo("m");
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -790,10 +851,12 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 		try {
 			nativeConnection.geoadd(KEY_1, GLIDE_GEO_DATA).get();
 
-			Distance distance = clusterConnection.geoDist(KEY_1_BYTES, PALERMO.getName(), CATANIA.getName(), KILOMETERS);
+			Distance distance = clusterConnection.geoDist(KEY_1_BYTES, PALERMO.getName(), CATANIA.getName(),
+					KILOMETERS);
 			assertThat(distance.getValue()).isCloseTo(166.27415156960033D, offset(0.005));
 			assertThat(distance.getUnit()).isEqualTo("km");
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -801,15 +864,15 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-438
 	public void geoHash() {
 		try {
-			nativeConnection.geoadd(KEY_1, 
-				Map.of(STRING_PALERMO, new GeospatialData(POINT_PALERMO.getX(), POINT_PALERMO.getY()),
-					STRING_CATANIA, new GeospatialData(POINT_CATANIA.getX(), POINT_CATANIA.getY())
-				)
-			).get();
+			nativeConnection
+				.geoadd(KEY_1, Map.of(STRING_PALERMO, new GeospatialData(POINT_PALERMO.getX(), POINT_PALERMO.getY()),
+						STRING_CATANIA, new GeospatialData(POINT_CATANIA.getX(), POINT_CATANIA.getY())))
+				.get();
 
 			List<String> result = clusterConnection.geoHash(KEY_1_BYTES, PALERMO.getName(), CATANIA.getName());
 			assertThat(result).containsExactly("sqc8b49rny0", "sqdtr74hyu0");
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -817,16 +880,16 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-438
 	public void geoHashNonExisting() {
 		try {
-			nativeConnection.geoadd(KEY_1, 
-				Map.of(STRING_PALERMO, new GeospatialData(POINT_PALERMO.getX(), POINT_PALERMO.getY()),
-					STRING_CATANIA, new GeospatialData(POINT_CATANIA.getX(), POINT_CATANIA.getY())
-				)
-			).get();
+			nativeConnection
+				.geoadd(KEY_1, Map.of(STRING_PALERMO, new GeospatialData(POINT_PALERMO.getX(), POINT_PALERMO.getY()),
+						STRING_CATANIA, new GeospatialData(POINT_CATANIA.getX(), POINT_CATANIA.getY())))
+				.get();
 
 			List<String> result = clusterConnection.geoHash(KEY_1_BYTES, PALERMO.getName(), ARIGENTO.getName(),
 					CATANIA.getName());
 			assertThat(result).containsExactly("sqc8b49rny0", (String) null, "sqdtr74hyu0");
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -834,11 +897,10 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-438
 	public void geoPosition() {
 		try {
-			nativeConnection.geoadd(KEY_1, 
-				Map.of(STRING_PALERMO, new GeospatialData(POINT_PALERMO.getX(), POINT_PALERMO.getY()),
-					STRING_CATANIA, new GeospatialData(POINT_CATANIA.getX(), POINT_CATANIA.getY())
-				)
-			).get();
+			nativeConnection
+				.geoadd(KEY_1, Map.of(STRING_PALERMO, new GeospatialData(POINT_PALERMO.getX(), POINT_PALERMO.getY()),
+						STRING_CATANIA, new GeospatialData(POINT_CATANIA.getX(), POINT_CATANIA.getY())))
+				.get();
 
 			List<Point> positions = clusterConnection.geoPos(KEY_1_BYTES, PALERMO.getName(), CATANIA.getName());
 
@@ -847,7 +909,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(positions.get(1).getX()).isCloseTo(POINT_CATANIA.getX(), offset(0.005));
 			assertThat(positions.get(1).getY()).isCloseTo(POINT_CATANIA.getY(), offset(0.005));
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -855,11 +918,10 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-438
 	public void geoPositionNonExisting() {
 		try {
-			nativeConnection.geoadd(KEY_1, 
-				Map.of(STRING_PALERMO, new GeospatialData(POINT_PALERMO.getX(), POINT_PALERMO.getY()),
-					STRING_CATANIA, new GeospatialData(POINT_CATANIA.getX(), POINT_CATANIA.getY())
-				)
-			).get();
+			nativeConnection
+				.geoadd(KEY_1, Map.of(STRING_PALERMO, new GeospatialData(POINT_PALERMO.getX(), POINT_PALERMO.getY()),
+						STRING_CATANIA, new GeospatialData(POINT_CATANIA.getX(), POINT_CATANIA.getY())))
+				.get();
 
 			List<Point> positions = clusterConnection.geoPos(KEY_1_BYTES, PALERMO.getName(), ARIGENTO.getName(),
 					CATANIA.getName());
@@ -871,7 +933,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(positions.get(2).getX()).isCloseTo(POINT_CATANIA.getX(), offset(0.005));
 			assertThat(positions.get(2).getY()).isCloseTo(POINT_CATANIA.getY(), offset(0.005));
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -879,18 +942,18 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-438
 	public void geoRadiusByMemberShouldApplyLimit() {
 		try {
-			nativeConnection.geoadd(KEY_1, 
-				Map.of(STRING_PALERMO, new GeospatialData(POINT_PALERMO.getX(), POINT_PALERMO.getY()),
-					STRING_ARIGENTO, new GeospatialData(POINT_ARIGENTO.getX(), POINT_ARIGENTO.getY()),
-					STRING_CATANIA, new GeospatialData(POINT_CATANIA.getX(), POINT_CATANIA.getY())
-				)
-			).get();
+			nativeConnection.geoadd(KEY_1,
+					Map.of(STRING_PALERMO, new GeospatialData(POINT_PALERMO.getX(), POINT_PALERMO.getY()),
+							STRING_ARIGENTO, new GeospatialData(POINT_ARIGENTO.getX(), POINT_ARIGENTO.getY()),
+							STRING_CATANIA, new GeospatialData(POINT_CATANIA.getX(), POINT_CATANIA.getY())))
+				.get();
 
 			GeoResults<GeoLocation<byte[]>> result = clusterConnection.geoRadiusByMember(KEY_1_BYTES, PALERMO.getName(),
 					new Distance(200, KILOMETERS), newGeoRadiusArgs().limit(2));
 
 			assertThat(result.getContent()).hasSize(2);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -898,12 +961,11 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-438
 	public void geoRadiusByMemberShouldReturnDistanceCorrectly() {
 		try {
-			nativeConnection.geoadd(KEY_1, 
-				Map.of(STRING_PALERMO, new GeospatialData(POINT_PALERMO.getX(), POINT_PALERMO.getY()),
-					STRING_ARIGENTO, new GeospatialData(POINT_ARIGENTO.getX(), POINT_ARIGENTO.getY()),
-					STRING_CATANIA, new GeospatialData(POINT_CATANIA.getX(), POINT_CATANIA.getY())
-				)
-			).get();
+			nativeConnection.geoadd(KEY_1,
+					Map.of(STRING_PALERMO, new GeospatialData(POINT_PALERMO.getX(), POINT_PALERMO.getY()),
+							STRING_ARIGENTO, new GeospatialData(POINT_ARIGENTO.getX(), POINT_ARIGENTO.getY()),
+							STRING_CATANIA, new GeospatialData(POINT_CATANIA.getX(), POINT_CATANIA.getY())))
+				.get();
 
 			GeoResults<GeoLocation<byte[]>> result = clusterConnection.geoRadiusByMember(KEY_1_BYTES, PALERMO.getName(),
 					new Distance(100, KILOMETERS), newGeoRadiusArgs().includeDistance());
@@ -911,7 +973,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			assertThat(result.getContent()).hasSize(2);
 			assertThat(result.getContent().get(0).getDistance().getValue()).isCloseTo(90.978D, offset(0.005));
 			assertThat(result.getContent().get(0).getDistance().getUnit()).isEqualTo("km");
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -919,38 +982,38 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-438
 	public void geoRadiusByMemberShouldReturnMembersCorrectly() {
 		try {
-			nativeConnection.geoadd(KEY_1, 
-				Map.of(STRING_PALERMO, new GeospatialData(POINT_PALERMO.getX(), POINT_PALERMO.getY()),
-					STRING_ARIGENTO, new GeospatialData(POINT_ARIGENTO.getX(), POINT_ARIGENTO.getY()),
-					STRING_CATANIA, new GeospatialData(POINT_CATANIA.getX(), POINT_CATANIA.getY())
-				)
-			).get();
+			nativeConnection.geoadd(KEY_1,
+					Map.of(STRING_PALERMO, new GeospatialData(POINT_PALERMO.getX(), POINT_PALERMO.getY()),
+							STRING_ARIGENTO, new GeospatialData(POINT_ARIGENTO.getX(), POINT_ARIGENTO.getY()),
+							STRING_CATANIA, new GeospatialData(POINT_CATANIA.getX(), POINT_CATANIA.getY())))
+				.get();
 
 			GeoResults<GeoLocation<byte[]>> result = clusterConnection.geoRadiusByMember(KEY_1_BYTES, PALERMO.getName(),
 					new Distance(100, KILOMETERS), newGeoRadiusArgs().sortAscending());
 
 			assertThat(result.getContent().get(0).getContent().getName()).isEqualTo(PALERMO.getName());
 			assertThat(result.getContent().get(1).getContent().getName()).isEqualTo(ARIGENTO.getName());
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
-		}	
+		}
 	}
 
 	@Test // DATAREDIS-438
 	public void geoRadiusShouldApplyLimit() {
 		try {
-			nativeConnection.geoadd(KEY_1, 
-				Map.of(STRING_PALERMO, new GeospatialData(POINT_PALERMO.getX(), POINT_PALERMO.getY()),
-					STRING_ARIGENTO, new GeospatialData(POINT_ARIGENTO.getX(), POINT_ARIGENTO.getY()),
-					STRING_CATANIA, new GeospatialData(POINT_CATANIA.getX(), POINT_CATANIA.getY())
-				)
-			).get();
+			nativeConnection.geoadd(KEY_1,
+					Map.of(STRING_PALERMO, new GeospatialData(POINT_PALERMO.getX(), POINT_PALERMO.getY()),
+							STRING_ARIGENTO, new GeospatialData(POINT_ARIGENTO.getX(), POINT_ARIGENTO.getY()),
+							STRING_CATANIA, new GeospatialData(POINT_CATANIA.getX(), POINT_CATANIA.getY())))
+				.get();
 
 			GeoResults<GeoLocation<byte[]>> result = clusterConnection.geoRadius(KEY_1_BYTES,
 					new Circle(new Point(15D, 37D), new Distance(200D, KILOMETERS)), newGeoRadiusArgs().limit(2));
 
 			assertThat(result.getContent()).hasSize(2);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -958,19 +1021,20 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-438
 	public void geoRadiusShouldReturnDistanceCorrectly() {
 		try {
-			nativeConnection.geoadd(KEY_1, 
-				Map.of(STRING_PALERMO, new GeospatialData(POINT_PALERMO.getX(), POINT_PALERMO.getY()),
-					STRING_ARIGENTO, new GeospatialData(POINT_ARIGENTO.getX(), POINT_ARIGENTO.getY()),
-					STRING_CATANIA, new GeospatialData(POINT_CATANIA.getX(), POINT_CATANIA.getY())
-				)
-			).get();
+			nativeConnection.geoadd(KEY_1,
+					Map.of(STRING_PALERMO, new GeospatialData(POINT_PALERMO.getX(), POINT_PALERMO.getY()),
+							STRING_ARIGENTO, new GeospatialData(POINT_ARIGENTO.getX(), POINT_ARIGENTO.getY()),
+							STRING_CATANIA, new GeospatialData(POINT_CATANIA.getX(), POINT_CATANIA.getY())))
+				.get();
 			GeoResults<GeoLocation<byte[]>> result = clusterConnection.geoRadius(KEY_1_BYTES,
-					new Circle(new Point(15D, 37D), new Distance(200D, KILOMETERS)), newGeoRadiusArgs().includeDistance());
+					new Circle(new Point(15D, 37D), new Distance(200D, KILOMETERS)),
+					newGeoRadiusArgs().includeDistance());
 
 			assertThat(result.getContent()).hasSize(3);
 			assertThat(result.getContent().get(0).getDistance().getValue()).isCloseTo(130.423D, offset(0.005));
 			assertThat(result.getContent().get(0).getDistance().getUnit()).isEqualTo("km");
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -978,17 +1042,17 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-438
 	public void geoRadiusShouldReturnMembersCorrectly() {
 		try {
-			nativeConnection.geoadd(KEY_1, 
-				Map.of(STRING_PALERMO, new GeospatialData(POINT_PALERMO.getX(), POINT_PALERMO.getY()),
-					STRING_ARIGENTO, new GeospatialData(POINT_ARIGENTO.getX(), POINT_ARIGENTO.getY()),
-					STRING_CATANIA, new GeospatialData(POINT_CATANIA.getX(), POINT_CATANIA.getY())
-				)
-			).get();
+			nativeConnection.geoadd(KEY_1,
+					Map.of(STRING_PALERMO, new GeospatialData(POINT_PALERMO.getX(), POINT_PALERMO.getY()),
+							STRING_ARIGENTO, new GeospatialData(POINT_ARIGENTO.getX(), POINT_ARIGENTO.getY()),
+							STRING_CATANIA, new GeospatialData(POINT_CATANIA.getX(), POINT_CATANIA.getY())))
+				.get();
 
 			GeoResults<GeoLocation<byte[]>> result = clusterConnection.geoRadius(KEY_1_BYTES,
 					new Circle(new Point(15D, 37D), new Distance(150D, KILOMETERS)));
 			assertThat(result.getContent()).hasSize(2);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -996,14 +1060,14 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-438
 	public void geoRemoveDeletesMembers() {
 		try {
-			nativeConnection.geoadd(KEY_1, 
-				Map.of(STRING_PALERMO, new GeospatialData(POINT_PALERMO.getX(), POINT_PALERMO.getY()),
-					STRING_ARIGENTO, new GeospatialData(POINT_ARIGENTO.getX(), POINT_ARIGENTO.getY()),
-					STRING_CATANIA, new GeospatialData(POINT_CATANIA.getX(), POINT_CATANIA.getY())
-				)
-			).get();
+			nativeConnection.geoadd(KEY_1,
+					Map.of(STRING_PALERMO, new GeospatialData(POINT_PALERMO.getX(), POINT_PALERMO.getY()),
+							STRING_ARIGENTO, new GeospatialData(POINT_ARIGENTO.getX(), POINT_ARIGENTO.getY()),
+							STRING_CATANIA, new GeospatialData(POINT_CATANIA.getX(), POINT_CATANIA.getY())))
+				.get();
 			assertThat(clusterConnection.geoRemove(KEY_1_BYTES, ARIGENTO.getName())).isEqualTo(1L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1016,7 +1080,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(clusterConnection.getBit(KEY_1_BYTES, 0)).isTrue();
 			assertThat(clusterConnection.getBit(KEY_1_BYTES, 1)).isFalse();
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1024,13 +1089,14 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void getClusterNodeForKeyShouldReturnNodeCorrectly() {
 		assertThat((ValkeyNode) clusterConnection.clusterGetNodeForKey(KEY_1_BYTES))
-				.isEqualTo(new ValkeyNode("127.0.0.1", 7380));
+			.isEqualTo(new ValkeyNode("127.0.0.1", 7380));
 	}
 
 	@Test // DATAREDIS-315, DATAREDIS-661
 	public void getConfigShouldLoadConfigurationOfSpecificNode() {
 
-		Properties result = clusterConnection.getConfig(new ValkeyClusterNode(CLUSTER_HOST, REPLICAOF_NODE_1_PORT), "*");
+		Properties result = clusterConnection.getConfig(new ValkeyClusterNode(CLUSTER_HOST, REPLICAOF_NODE_1_PORT),
+				"*");
 
 		assertThat(result.getProperty("slaveof")).endsWith("7379");
 	}
@@ -1040,7 +1106,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 		Properties result = clusterConnection.getConfig("*max-*-entries*");
 
-		// config get *max-*-entries on valkey 3.0.7 returns 8 entries per node while on 3.2.0-rc3 returns 6.
+		// config get *max-*-entries on valkey 3.0.7 returns 8 entries per node while on
+		// 3.2.0-rc3 returns 6.
 		// @link https://github.com/spring-projects/spring-data-valkey/pull/187
 		assertThat(result.size() % 3).isEqualTo(0);
 
@@ -1055,9 +1122,10 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	public void getRangeShouldReturnValueCorrectly() {
 		try {
 			nativeConnection.set(KEY_1, VALUE_1).get();
-			
+
 			assertThat(clusterConnection.getRange(KEY_1_BYTES, 0, 2)).isEqualTo(ValkeyGlideConverters.toBytes("val"));
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1070,7 +1138,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(clusterConnection.getEx(KEY_1_BYTES, Expiration.seconds(10))).isEqualTo(VALUE_1_BYTES);
 			assertThat(clusterConnection.ttl(KEY_1_BYTES)).isGreaterThan(1);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1083,7 +1152,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(clusterConnection.getDel(KEY_1_BYTES)).isEqualTo(VALUE_1_BYTES);
 			assertThat(clusterConnection.exists(KEY_1_BYTES)).isFalse();
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1097,7 +1167,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(valueBeforeSet).isEqualTo(VALUE_1_BYTES);
 			assertThat(nativeConnection.get(KEY_1).get()).isEqualTo(VALUE_2);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1108,7 +1179,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.set(KEY_1, VALUE_1).get();
 
 			assertThat(clusterConnection.get(KEY_1_BYTES)).isEqualTo(VALUE_1_BYTES);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1123,7 +1195,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(nativeConnection.hexists(KEY_1, KEY_2).get()).isFalse();
 			assertThat(nativeConnection.hexists(KEY_1, KEY_3).get()).isTrue();
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1136,7 +1209,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			assertThat(clusterConnection.hExists(KEY_1_BYTES, KEY_2_BYTES)).isTrue();
 			assertThat(clusterConnection.hExists(KEY_1_BYTES, KEY_3_BYTES)).isFalse();
 			assertThat(clusterConnection.hExists(ValkeyGlideConverters.toBytes("foo"), KEY_2_BYTES)).isFalse();
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1150,14 +1224,16 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			nativeConnection.hset(KEY_1, hashes).get();
 
-			Map<String, String> hGetAllString = clusterConnection.hGetAll(KEY_1_BYTES).entrySet().stream()
-        		.collect(Collectors.toMap(
-					e -> new String(e.getKey(), StandardCharsets.UTF_8),
-					e -> new String(e.getValue(), StandardCharsets.UTF_8)));
+			Map<String, String> hGetAllString = clusterConnection.hGetAll(KEY_1_BYTES)
+				.entrySet()
+				.stream()
+				.collect(Collectors.toMap(e -> new String(e.getKey(), StandardCharsets.UTF_8),
+						e -> new String(e.getValue(), StandardCharsets.UTF_8)));
 
 			assertThat(hGetAllString.containsKey(KEY_2)).isTrue();
 			assertThat(hGetAllString.containsKey(KEY_3)).isTrue();
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1171,7 +1247,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.hset(KEY_1, hashes).get();
 
 			assertThat(clusterConnection.hGet(KEY_1_BYTES, KEY_2_BYTES)).isEqualTo(VALUE_1_BYTES);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1188,7 +1265,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			clusterConnection.hIncrBy(KEY_1_BYTES, KEY_3_BYTES, 3.5D);
 
 			assertThat(nativeConnection.hget(KEY_1, KEY_3).get()).isEqualTo("5.5");
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1205,7 +1283,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			clusterConnection.hIncrBy(KEY_1_BYTES, KEY_3_BYTES, 3);
 
 			assertThat(nativeConnection.hget(KEY_1, KEY_3).get()).isEqualTo("5");
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1220,7 +1299,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.hset(KEY_1, hashes).get();
 
 			assertThat(clusterConnection.hKeys(KEY_1_BYTES)).contains(KEY_2_BYTES, KEY_3_BYTES);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1235,7 +1315,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.hset(KEY_1, hashes).get();
 
 			assertThat(clusterConnection.hLen(KEY_1_BYTES)).isEqualTo(2L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1249,8 +1330,10 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			nativeConnection.hset(KEY_1, hashes).get();
 
-			assertThat(clusterConnection.hMGet(KEY_1_BYTES, KEY_2_BYTES, KEY_3_BYTES)).contains(VALUE_1_BYTES, VALUE_2_BYTES);
-		} catch (Exception e) {
+			assertThat(clusterConnection.hMGet(KEY_1_BYTES, KEY_2_BYTES, KEY_3_BYTES)).contains(VALUE_1_BYTES,
+					VALUE_2_BYTES);
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1264,8 +1347,9 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			clusterConnection.hMSet(KEY_1_BYTES, hashes);
 
-			assertThat(nativeConnection.hmget(KEY_1, new String[]{KEY_2, KEY_3}).get()).contains(VALUE_1, VALUE_2);
-		} catch (Exception e) {
+			assertThat(nativeConnection.hmget(KEY_1, new String[] { KEY_2, KEY_3 }).get()).contains(VALUE_1, VALUE_2);
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1291,7 +1375,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			}
 
 			assertThat(i).isEqualTo(nrOfValues);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1307,7 +1392,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			clusterConnection.hSetNX(KEY_1_BYTES, KEY_2_BYTES, VALUE_2_BYTES);
 
 			assertThat(nativeConnection.hget(KEY_1, KEY_2).get()).isEqualTo(VALUE_1);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1318,7 +1404,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			clusterConnection.hSetNX(KEY_1_BYTES, KEY_2_BYTES, VALUE_1_BYTES);
 
 			assertThat(nativeConnection.hget(KEY_1, KEY_2).get()).isEqualTo(VALUE_1);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1329,7 +1416,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			clusterConnection.hSet(KEY_1_BYTES, KEY_2_BYTES, VALUE_1_BYTES);
 
 			assertThat(nativeConnection.hget(KEY_1, KEY_2).get()).isEqualTo(VALUE_1);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1340,8 +1428,9 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.hset(KEY_1, Map.of(KEY_2, VALUE_3)).get();
 
 			assertThat(clusterConnection.hashCommands().hStrLen(KEY_1_BYTES, KEY_2_BYTES))
-					.isEqualTo(Long.valueOf(VALUE_3.length()));
-		} catch (Exception e) {
+				.isEqualTo(Long.valueOf(VALUE_3.length()));
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1352,7 +1441,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.hset(KEY_1, Map.of(KEY_2, VALUE_3)).get();
 
 			assertThat(clusterConnection.hashCommands().hStrLen(KEY_1_BYTES, KEY_3_BYTES)).isEqualTo(0L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1370,8 +1460,9 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(clusterConnection.hashCommands().hExpire(KEY_1_BYTES, 5L, KEY_2_BYTES)).contains(1L);
 			assertThat(clusterConnection.hashCommands().hTtl(KEY_1_BYTES, KEY_2_BYTES))
-					.allSatisfy(val -> assertThat(val).isBetween(0L, 5L));
-		} catch (Exception e) {
+				.allSatisfy(val -> assertThat(val).isBetween(0L, 5L));
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1385,7 +1476,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			assertThat(clusterConnection.hashCommands().hExpire(KEY_1_BYTES, 5L, KEY_1_BYTES)).contains(-2L);
 			// missing key
 			assertThat(clusterConnection.hashCommands().hExpire(KEY_2_BYTES, 5L, KEY_2_BYTES)).contains(-2L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1397,7 +1489,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.hset(KEY_1, Map.of(KEY_2, VALUE_3)).get();
 
 			assertThat(clusterConnection.hashCommands().hExpire(KEY_1_BYTES, 0L, KEY_2_BYTES)).contains(2L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1410,8 +1503,9 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(clusterConnection.hashCommands().hpExpire(KEY_1_BYTES, 5000L, KEY_2_BYTES)).contains(1L);
 			assertThat(clusterConnection.hashCommands().hTtl(KEY_1_BYTES, TimeUnit.MILLISECONDS, KEY_2_BYTES))
-					.allSatisfy(val -> assertThat(val).isBetween(0L, 5000L));
-		} catch (Exception e) {
+				.allSatisfy(val -> assertThat(val).isBetween(0L, 5000L));
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1425,7 +1519,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			assertThat(clusterConnection.hashCommands().hpExpire(KEY_1_BYTES, 5L, KEY_1_BYTES)).contains(-2L);
 			// missing key
 			assertThat(clusterConnection.hashCommands().hpExpire(KEY_2_BYTES, 5L, KEY_2_BYTES)).contains(-2L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1437,7 +1532,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.hset(KEY_1, Map.of(KEY_2, VALUE_3)).get();
 
 			assertThat(clusterConnection.hashCommands().hpExpire(KEY_1_BYTES, 0L, KEY_2_BYTES)).contains(2L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1449,10 +1545,12 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.hset(KEY_1, Map.of(KEY_2, VALUE_3)).get();
 			long inFiveSeconds = Instant.now().plusSeconds(5L).getEpochSecond();
 
-			assertThat(clusterConnection.hashCommands().hExpireAt(KEY_1_BYTES, inFiveSeconds, KEY_2_BYTES)).contains(1L);
+			assertThat(clusterConnection.hashCommands().hExpireAt(KEY_1_BYTES, inFiveSeconds, KEY_2_BYTES))
+				.contains(1L);
 			assertThat(clusterConnection.hashCommands().hTtl(KEY_1_BYTES, KEY_2_BYTES))
-					.allSatisfy(val -> assertThat(val).isBetween(0L, 5L));
-		} catch (Exception e) {
+				.allSatisfy(val -> assertThat(val).isBetween(0L, 5L));
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1465,10 +1563,13 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			long inFiveSeconds = Instant.now().plusSeconds(5L).getEpochSecond();
 
 			// missing field
-			assertThat(clusterConnection.hashCommands().hExpireAt(KEY_1_BYTES, inFiveSeconds, KEY_1_BYTES)).contains(-2L);
+			assertThat(clusterConnection.hashCommands().hExpireAt(KEY_1_BYTES, inFiveSeconds, KEY_1_BYTES))
+				.contains(-2L);
 			// missing key
-			assertThat(clusterConnection.hashCommands().hExpireAt(KEY_2_BYTES, inFiveSeconds, KEY_2_BYTES)).contains(-2L);
-		} catch (Exception e) {
+			assertThat(clusterConnection.hashCommands().hExpireAt(KEY_2_BYTES, inFiveSeconds, KEY_2_BYTES))
+				.contains(-2L);
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1480,7 +1581,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.hset(KEY_1, Map.of(KEY_2, VALUE_3)).get();
 
 			assertThat(clusterConnection.hashCommands().hExpireAt(KEY_1_BYTES, 0L, KEY_2_BYTES)).contains(2L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1492,10 +1594,12 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.hset(KEY_1, Map.of(KEY_2, VALUE_3)).get();
 			long inFiveSeconds = Instant.now().plusSeconds(5L).toEpochMilli();
 
-			assertThat(clusterConnection.hashCommands().hpExpireAt(KEY_1_BYTES, inFiveSeconds, KEY_2_BYTES)).contains(1L);
+			assertThat(clusterConnection.hashCommands().hpExpireAt(KEY_1_BYTES, inFiveSeconds, KEY_2_BYTES))
+				.contains(1L);
 			assertThat(clusterConnection.hashCommands().hTtl(KEY_1_BYTES, TimeUnit.MILLISECONDS, KEY_2_BYTES))
-					.allSatisfy(val -> assertThat(val).isBetween(0L, 5000L));
-		} catch (Exception e) {
+				.allSatisfy(val -> assertThat(val).isBetween(0L, 5000L));
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1508,10 +1612,13 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			long inFiveSeconds = Instant.now().plusSeconds(5L).toEpochMilli();
 
 			// missing field
-			assertThat(clusterConnection.hashCommands().hpExpireAt(KEY_1_BYTES, inFiveSeconds, KEY_1_BYTES)).contains(-2L);
+			assertThat(clusterConnection.hashCommands().hpExpireAt(KEY_1_BYTES, inFiveSeconds, KEY_1_BYTES))
+				.contains(-2L);
 			// missing key
-			assertThat(clusterConnection.hashCommands().hpExpireAt(KEY_2_BYTES, inFiveSeconds, KEY_2_BYTES)).contains(-2L);
-		} catch (Exception e) {
+			assertThat(clusterConnection.hashCommands().hpExpireAt(KEY_2_BYTES, inFiveSeconds, KEY_2_BYTES))
+				.contains(-2L);
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1523,7 +1630,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.hset(KEY_1, Map.of(KEY_2, VALUE_3)).get();
 
 			assertThat(clusterConnection.hashCommands().hpExpireAt(KEY_1_BYTES, 0L, KEY_2_BYTES)).contains(2L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1537,7 +1645,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			assertThat(clusterConnection.hashCommands().hExpire(KEY_1_BYTES, 5L, KEY_2_BYTES)).contains(1L);
 			assertThat(clusterConnection.hashCommands().hPersist(KEY_1_BYTES, KEY_2_BYTES)).contains(1L);
 			assertThat(clusterConnection.hashCommands().hTtl(KEY_1_BYTES, KEY_2_BYTES)).contains(-1L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1548,7 +1657,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 		try {
 			nativeConnection.hset(KEY_1, Map.of(KEY_2, VALUE_3)).get();
 			assertThat(clusterConnection.hashCommands().hPersist(KEY_1_BYTES, KEY_2_BYTES)).contains(-1L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1561,7 +1671,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(clusterConnection.hashCommands().hPersist(KEY_1_BYTES, KEY_1_BYTES)).contains(-2L);
 			assertThat(clusterConnection.hashCommands().hPersist(KEY_3_BYTES, KEY_2_BYTES)).contains(-2L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1573,7 +1684,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.hset(KEY_1, Map.of(KEY_2, VALUE_3)).get();
 
 			assertThat(clusterConnection.hashCommands().hTtl(KEY_1_BYTES, KEY_2_BYTES)).contains(-1L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1591,7 +1703,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.hset(KEY_1, Map.of(KEY_2, VALUE_1, KEY_3, VALUE_2)).get();
 
 			assertThat(clusterConnection.hVals(KEY_1_BYTES)).contains(VALUE_1_BYTES, VALUE_2_BYTES);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1602,7 +1715,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.set(KEY_1, "1").get();
 
 			assertThat(clusterConnection.incrBy(KEY_1_BYTES, 5.5D)).isEqualTo(6.5D);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1613,7 +1727,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.set(KEY_1, "1").get();
 
 			assertThat(clusterConnection.incrBy(KEY_1_BYTES, 5)).isEqualTo(6L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1624,7 +1739,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.set(KEY_1, "1").get();
 
 			assertThat(clusterConnection.incr(KEY_1_BYTES)).isEqualTo(2L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1639,7 +1755,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void infoShouldCollectInfoForSpecificNodeAndSection() {
 
-		Properties properties = clusterConnection.info(new ValkeyClusterNode(CLUSTER_HOST, MASTER_NODE_2_PORT), "server");
+		Properties properties = clusterConnection.info(new ValkeyClusterNode(CLUSTER_HOST, MASTER_NODE_2_PORT),
+				"server");
 
 		assertThat(properties.getProperty("tcp_port")).isEqualTo(Integer.toString(MASTER_NODE_2_PORT));
 		assertThat(properties.getProperty("used_memory")).isNull();
@@ -1649,8 +1766,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	public void infoShouldCollectionInfoFromAllClusterNodes() {
 
 		Properties singleNodeInfo = clusterConnection.serverCommands().info(new ValkeyClusterNode("127.0.0.1", 7380));
-		assertThat(Double.valueOf(clusterConnection.serverCommands().info().size())).isCloseTo(singleNodeInfo.size() * 3,
-				offset(12d));
+		assertThat(Double.valueOf(clusterConnection.serverCommands().info().size()))
+			.isCloseTo(singleNodeInfo.size() * 3, offset(12d));
 	}
 
 	@Test // DATAREDIS-315
@@ -1660,7 +1777,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.set(KEY_2, VALUE_2).get();
 
 			assertThat(clusterConnection.keys(ValkeyGlideConverters.toBytes("*"))).contains(KEY_1_BYTES, KEY_2_BYTES);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1672,10 +1790,11 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.set(KEY_2, VALUE_2).get();
 
 			Set<byte[]> keysOnNode = clusterConnection.keys(new ValkeyClusterNode("127.0.0.1", 7379, SlotRange.empty()),
-				ValkeyGlideConverters.toBytes("*"));
+					ValkeyGlideConverters.toBytes("*"));
 
 			assertThat(keysOnNode).contains(KEY_2_BYTES).doesNotContain(KEY_1_BYTES);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1692,7 +1811,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(keys).contains(KEY_1_BYTES, KEY_2_BYTES);
 
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1703,13 +1823,15 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.set(KEY_1, VALUE_1).get();
 			nativeConnection.set(KEY_2, VALUE_2).get();
 
-			Cursor<byte[]> cursor = clusterConnection.scan(new ValkeyClusterNode("127.0.0.1", 7379, SlotRange.empty()), NONE);
+			Cursor<byte[]> cursor = clusterConnection.scan(new ValkeyClusterNode("127.0.0.1", 7379, SlotRange.empty()),
+					NONE);
 
 			List<byte[]> keysOnNode = new ArrayList<>();
 			cursor.forEachRemaining(keysOnNode::add);
 
 			assertThat(keysOnNode).contains(KEY_2_BYTES).doesNotContain(KEY_1_BYTES);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1717,10 +1839,11 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void lIndexShouldGetElementAtIndexCorrectly() {
 		try {
-			nativeConnection.rpush(KEY_1, new String[]{VALUE_1, VALUE_2, "foo", "bar"}).get();
+			nativeConnection.rpush(KEY_1, new String[] { VALUE_1, VALUE_2, "foo", "bar" }).get();
 
 			assertThat(clusterConnection.lIndex(KEY_1_BYTES, 1)).isEqualTo(VALUE_2_BYTES);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1728,12 +1851,14 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void lInsertShouldAddElementAtPositionCorrectly() {
 		try {
-			nativeConnection.rpush(KEY_1, new String[]{VALUE_1, VALUE_2, "foo", "bar"}).get();
+			nativeConnection.rpush(KEY_1, new String[] { VALUE_1, VALUE_2, "foo", "bar" }).get();
 
-			clusterConnection.lInsert(KEY_1_BYTES, Position.AFTER, VALUE_2_BYTES, ValkeyGlideConverters.toBytes("booh"));
+			clusterConnection.lInsert(KEY_1_BYTES, Position.AFTER, VALUE_2_BYTES,
+					ValkeyGlideConverters.toBytes("booh"));
 
 			assertThat(nativeConnection.lrange(KEY_1, 0, -1).get()[2]).isEqualTo("booh");
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1742,16 +1867,19 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@EnabledOnCommand("LMOVE")
 	public void lMoveShouldMoveElementsCorrectly() {
 		try {
-			nativeConnection.rpush(SAME_SLOT_KEY_1, new String[]{VALUE_1, VALUE_2, VALUE_3}).get();
+			nativeConnection.rpush(SAME_SLOT_KEY_1, new String[] { VALUE_1, VALUE_2, VALUE_3 }).get();
 
-			assertThat(clusterConnection.lMove(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES, Direction.RIGHT, Direction.LEFT))
-					.isEqualTo(VALUE_3_BYTES);
-			assertThat(clusterConnection.lMove(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES, Direction.RIGHT, Direction.LEFT))
-					.isEqualTo(VALUE_2_BYTES);
+			assertThat(clusterConnection.lMove(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES, Direction.RIGHT,
+					Direction.LEFT))
+				.isEqualTo(VALUE_3_BYTES);
+			assertThat(clusterConnection.lMove(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES, Direction.RIGHT,
+					Direction.LEFT))
+				.isEqualTo(VALUE_2_BYTES);
 
 			assertThat(nativeConnection.lrange(SAME_SLOT_KEY_1, 0, -1).get()).containsExactly(VALUE_1);
 			assertThat(nativeConnection.lrange(SAME_SLOT_KEY_2, 0, -1).get()).containsExactly(VALUE_2, VALUE_3);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1760,19 +1888,22 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@EnabledOnCommand("BLMOVE")
 	public void blMoveShouldMoveElementsCorrectly() {
 		try {
-			nativeConnection.rpush(SAME_SLOT_KEY_1, new String[]{VALUE_2, VALUE_3}).get();
+			nativeConnection.rpush(SAME_SLOT_KEY_1, new String[] { VALUE_2, VALUE_3 }).get();
 
-			assertThat(clusterConnection.lMove(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES, Direction.RIGHT, Direction.LEFT))
-					.isEqualTo(VALUE_3_BYTES);
-			assertThat(clusterConnection.lMove(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES, Direction.RIGHT, Direction.LEFT))
-					.isEqualTo(VALUE_2_BYTES);
-			assertThat(
-					clusterConnection.bLMove(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES, Direction.RIGHT, Direction.LEFT, 0.01))
-					.isNull();
+			assertThat(clusterConnection.lMove(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES, Direction.RIGHT,
+					Direction.LEFT))
+				.isEqualTo(VALUE_3_BYTES);
+			assertThat(clusterConnection.lMove(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES, Direction.RIGHT,
+					Direction.LEFT))
+				.isEqualTo(VALUE_2_BYTES);
+			assertThat(clusterConnection.bLMove(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES, Direction.RIGHT,
+					Direction.LEFT, 0.01))
+				.isNull();
 
 			assertThat(nativeConnection.lrange(SAME_SLOT_KEY_1, 0, -1).get()).isEmpty();
 			assertThat(nativeConnection.lrange(SAME_SLOT_KEY_2, 0, -1).get()).containsExactly(VALUE_2, VALUE_3);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1780,10 +1911,11 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void lLenShouldCountValuesCorrectly() {
 		try {
-			nativeConnection.lpush(KEY_1, new String[]{VALUE_1, VALUE_2}).get();
+			nativeConnection.lpush(KEY_1, new String[] { VALUE_1, VALUE_2 }).get();
 
 			assertThat(clusterConnection.lLen(KEY_1_BYTES)).isEqualTo(2L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1791,10 +1923,11 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void lPopShouldReturnElementCorrectly() {
 		try {
-			nativeConnection.rpush(KEY_1, new String[]{VALUE_1, VALUE_2}).get();
+			nativeConnection.rpush(KEY_1, new String[] { VALUE_1, VALUE_2 }).get();
 
 			assertThat(clusterConnection.lPop(KEY_1_BYTES)).isEqualTo(VALUE_1_BYTES);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1804,8 +1937,9 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 		try {
 			clusterConnection.lPushX(KEY_1_BYTES, VALUE_1_BYTES);
 
-			assertThat(nativeConnection.exists(new String[]{KEY_1}).get()).isEqualTo(0);
-		} catch (Exception e) {
+			assertThat(nativeConnection.exists(new String[] { KEY_1 }).get()).isEqualTo(0);
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1816,7 +1950,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			clusterConnection.lPush(KEY_1_BYTES, VALUE_1_BYTES, VALUE_2_BYTES);
 
 			assertThat(nativeConnection.lrange(KEY_1, 0, -1).get()).contains(VALUE_1, VALUE_2);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1824,10 +1959,11 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void lRangeShouldGetValuesCorrectly() {
 		try {
-			nativeConnection.rpush(KEY_1, new String[]{VALUE_1, VALUE_2}).get();
+			nativeConnection.rpush(KEY_1, new String[] { VALUE_1, VALUE_2 }).get();
 
 			assertThat(clusterConnection.lRange(KEY_1_BYTES, 0L, -1L)).contains(VALUE_1_BYTES, VALUE_2_BYTES);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1835,12 +1971,13 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void lRemShouldRemoveElementAtPositionCorrectly() {
 		try {
-			nativeConnection.rpush(KEY_1, new String[]{VALUE_1, VALUE_2, "foo", "bar"}).get();
+			nativeConnection.rpush(KEY_1, new String[] { VALUE_1, VALUE_2, "foo", "bar" }).get();
 
 			clusterConnection.lRem(KEY_1_BYTES, 1L, VALUE_1_BYTES);
 
 			assertThat(nativeConnection.llen(KEY_1).get()).isEqualTo(3L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1848,12 +1985,13 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void lSetShouldSetElementAtPositionCorrectly() {
 		try {
-			nativeConnection.rpush(KEY_1, new String[]{VALUE_1, VALUE_2, "foo", "bar"}).get();
+			nativeConnection.rpush(KEY_1, new String[] { VALUE_1, VALUE_2, "foo", "bar" }).get();
 
 			clusterConnection.lSet(KEY_1_BYTES, 1L, VALUE_1_BYTES);
 
 			assertThat(nativeConnection.lrange(KEY_1, 0, -1).get()[1]).isEqualTo(VALUE_1);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1861,12 +1999,13 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void lTrimShouldTrimListCorrectly() {
 		try {
-			nativeConnection.lpush(KEY_1, new String[]{VALUE_1, VALUE_2, "foo", "bar"}).get();
+			nativeConnection.lpush(KEY_1, new String[] { VALUE_1, VALUE_2, "foo", "bar" }).get();
 
 			clusterConnection.lTrim(KEY_1_BYTES, 2, 3);
 
 			assertThat(nativeConnection.lrange(KEY_1, 0, -1).get()).contains(VALUE_1, VALUE_2);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1878,7 +2017,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.set(KEY_2, VALUE_2).get();
 
 			assertThat(clusterConnection.mGet(KEY_1_BYTES, KEY_2_BYTES)).containsExactly(VALUE_1_BYTES, VALUE_2_BYTES);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1892,7 +2032,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			List<byte[]> result = clusterConnection.mGet(KEY_1_BYTES, KEY_2_BYTES, KEY_3_BYTES, KEY_1_BYTES);
 			assertThat(result).containsExactly(VALUE_1_BYTES, VALUE_2_BYTES, VALUE_3_BYTES, VALUE_1_BYTES);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1903,9 +2044,10 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.set(SAME_SLOT_KEY_1, VALUE_1).get();
 			nativeConnection.set(SAME_SLOT_KEY_2, VALUE_2).get();
 
-			assertThat(clusterConnection.mGet(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES)).containsExactly(VALUE_1_BYTES,
-					VALUE_2_BYTES);
-		} catch (Exception e) {
+			assertThat(clusterConnection.mGet(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES))
+				.containsExactly(VALUE_1_BYTES, VALUE_2_BYTES);
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1916,9 +2058,11 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.set(SAME_SLOT_KEY_1, VALUE_1).get();
 			nativeConnection.set(SAME_SLOT_KEY_2, VALUE_2).get();
 
-			List<byte[]> result = clusterConnection.mGet(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES, SAME_SLOT_KEY_1_BYTES);
+			List<byte[]> result = clusterConnection.mGet(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES,
+					SAME_SLOT_KEY_1_BYTES);
 			assertThat(result).containsExactly(VALUE_1_BYTES, VALUE_2_BYTES, VALUE_1_BYTES);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1935,7 +2079,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(nativeConnection.get(KEY_1).get()).isEqualTo(VALUE_1);
 			assertThat(nativeConnection.get(KEY_2).get()).isEqualTo(VALUE_3);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1951,7 +2096,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(nativeConnection.get(KEY_1).get()).isEqualTo(VALUE_1);
 			assertThat(nativeConnection.get(KEY_2).get()).isEqualTo(VALUE_2);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1967,7 +2113,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(nativeConnection.get(SAME_SLOT_KEY_1).get()).isEqualTo(VALUE_1);
 			assertThat(nativeConnection.get(SAME_SLOT_KEY_2).get()).isEqualTo(VALUE_2);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1983,7 +2130,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(nativeConnection.get(KEY_1).get()).isEqualTo(VALUE_1);
 			assertThat(nativeConnection.get(KEY_2).get()).isEqualTo(VALUE_2);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -1999,7 +2147,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(nativeConnection.get(SAME_SLOT_KEY_1).get()).isEqualTo(VALUE_1);
 			assertThat(nativeConnection.get(SAME_SLOT_KEY_2).get()).isEqualTo(VALUE_2);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2007,7 +2156,7 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void moveShouldNotBeSupported() {
 		assertThatExceptionOfType(InvalidDataAccessApiUsageException.class)
-				.isThrownBy(() -> clusterConnection.move(KEY_1_BYTES, 3));
+			.isThrownBy(() -> clusterConnection.move(KEY_1_BYTES, 3));
 	}
 
 	@Test // DATAREDIS-315
@@ -2023,7 +2172,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			clusterConnection.pExpireAt(KEY_1_BYTES, System.currentTimeMillis() + 5000);
 
 			assertThat(nativeConnection.ttl(KEY_1).get()).isGreaterThan(1);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2034,18 +2184,19 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 		try {
 			nativeConnection.set(KEY_1, VALUE_1).get();
 
-			assertThat(
-					clusterConnection.pExpireAt(KEY_1_BYTES, System.currentTimeMillis() + 5000, ExpirationOptions.Condition.XX))
-					.isFalse();
-			assertThat(
-					clusterConnection.pExpireAt(KEY_1_BYTES, System.currentTimeMillis() + 5000, ExpirationOptions.Condition.NX))
-					.isTrue();
-			assertThat(
-					clusterConnection.pExpireAt(KEY_1_BYTES, System.currentTimeMillis() + 15000, ExpirationOptions.Condition.LT))
-					.isFalse();
+			assertThat(clusterConnection.pExpireAt(KEY_1_BYTES, System.currentTimeMillis() + 5000,
+					ExpirationOptions.Condition.XX))
+				.isFalse();
+			assertThat(clusterConnection.pExpireAt(KEY_1_BYTES, System.currentTimeMillis() + 5000,
+					ExpirationOptions.Condition.NX))
+				.isTrue();
+			assertThat(clusterConnection.pExpireAt(KEY_1_BYTES, System.currentTimeMillis() + 15000,
+					ExpirationOptions.Condition.LT))
+				.isFalse();
 
 			assertThat(nativeConnection.ttl(KEY_1).get()).isGreaterThan(1);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2058,7 +2209,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			clusterConnection.pExpire(KEY_1_BYTES, 5000);
 
 			assertThat(nativeConnection.ttl(KEY_1).get()).isGreaterThan(1);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2074,7 +2226,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			assertThat(clusterConnection.pExpire(KEY_1_BYTES, 15000, ExpirationOptions.Condition.LT)).isFalse();
 
 			assertThat(nativeConnection.ttl(KEY_1).get()).isGreaterThan(1);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2099,7 +2252,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.expire(KEY_1, 5).get();
 
 			assertThat(clusterConnection.pTtl(KEY_1_BYTES)).isGreaterThan(1);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2110,7 +2264,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.set(KEY_1, VALUE_1).get();
 
 			assertThat(clusterConnection.pTtl(KEY_1_BYTES)).isEqualTo(-1L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2128,11 +2283,12 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void persistShouldRemoveTTL() {
 		try {
-			nativeConnection.set(KEY_1, VALUE_1, SetOptions.builder().expiry(Expiry.Seconds(10L)).build()).get(); 
+			nativeConnection.set(KEY_1, VALUE_1, SetOptions.builder().expiry(Expiry.Seconds(10L)).build()).get();
 
 			assertThat(clusterConnection.persist(KEY_1_BYTES)).isTrue();
 			assertThat(nativeConnection.ttl(KEY_1).get()).isEqualTo(-1L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2142,8 +2298,9 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 		try {
 			clusterConnection.pfAdd(KEY_1_BYTES, VALUE_1_BYTES, VALUE_2_BYTES, VALUE_3_BYTES);
 
-			assertThat(nativeConnection.pfcount(new String[]{KEY_1}).get()).isEqualTo(3L);
-		} catch (Exception e) {
+			assertThat(nativeConnection.pfcount(new String[] { KEY_1 }).get()).isEqualTo(3L);
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2151,11 +2308,12 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void pfCountShouldAllowCountingOnSameSlotKeys() {
 		try {
-			nativeConnection.pfadd(SAME_SLOT_KEY_1, new String[]{VALUE_1, VALUE_2}).get();
-			nativeConnection.pfadd(SAME_SLOT_KEY_2, new String[]{VALUE_2, VALUE_3}).get();
+			nativeConnection.pfadd(SAME_SLOT_KEY_1, new String[] { VALUE_1, VALUE_2 }).get();
+			nativeConnection.pfadd(SAME_SLOT_KEY_2, new String[] { VALUE_2, VALUE_3 }).get();
 
 			assertThat(clusterConnection.pfCount(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES)).isEqualTo(3L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2163,9 +2321,10 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void pfCountShouldAllowCountingOnSingleKey() {
 		try {
-			nativeConnection.pfadd(KEY_1, new String[]{VALUE_1, VALUE_2, VALUE_3}).get();
+			nativeConnection.pfadd(KEY_1, new String[] { VALUE_1, VALUE_2, VALUE_3 }).get();
 			assertThat(clusterConnection.pfCount(KEY_1_BYTES)).isEqualTo(3L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2173,12 +2332,13 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void pfCountShouldThrowErrorCountingOnDifferentSlotKeys() {
 		try {
-			nativeConnection.pfadd(KEY_1, new String[]{VALUE_1, VALUE_2}).get();
-			nativeConnection.pfadd(KEY_2, new String[]{VALUE_2, VALUE_3}).get();
+			nativeConnection.pfadd(KEY_1, new String[] { VALUE_1, VALUE_2 }).get();
+			nativeConnection.pfadd(KEY_2, new String[] { VALUE_2, VALUE_3 }).get();
 
 			assertThatExceptionOfType(DataAccessException.class)
-					.isThrownBy(() -> clusterConnection.pfCount(KEY_1_BYTES, KEY_2_BYTES));
-		} catch (Exception e) {
+				.isThrownBy(() -> clusterConnection.pfCount(KEY_1_BYTES, KEY_2_BYTES));
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2186,19 +2346,20 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void pfMergeShouldThrowErrorOnDifferentSlotKeys() {
 		assertThatExceptionOfType(DataAccessException.class)
-				.isThrownBy(() -> clusterConnection.pfMerge(KEY_3_BYTES, KEY_1_BYTES, KEY_2_BYTES));
+			.isThrownBy(() -> clusterConnection.pfMerge(KEY_3_BYTES, KEY_1_BYTES, KEY_2_BYTES));
 	}
 
 	@Test // DATAREDIS-315
 	public void pfMergeShouldWorkWhenAllKeysMapToSameSlot() {
 		try {
-			nativeConnection.pfadd(SAME_SLOT_KEY_1, new String[]{VALUE_1, VALUE_2}).get();
-			nativeConnection.pfadd(SAME_SLOT_KEY_2, new String[]{VALUE_2, VALUE_3}).get();
+			nativeConnection.pfadd(SAME_SLOT_KEY_1, new String[] { VALUE_1, VALUE_2 }).get();
+			nativeConnection.pfadd(SAME_SLOT_KEY_2, new String[] { VALUE_2, VALUE_3 }).get();
 
 			clusterConnection.pfMerge(SAME_SLOT_KEY_3_BYTES, SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES);
 
-			assertThat(nativeConnection.pfcount(new String[]{SAME_SLOT_KEY_3}).get()).isEqualTo(3L);
-		} catch (Exception e) {
+			assertThat(nativeConnection.pfcount(new String[] { SAME_SLOT_KEY_3 }).get()).isEqualTo(3L);
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2210,23 +2371,25 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 	@Test // DATAREDIS-315
 	public void pingShouldRetrunPongForExistingNode() {
-		assertThat(clusterConnection.ping(new ValkeyClusterNode("127.0.0.1", 7379, SlotRange.empty()))).isEqualTo("PONG");
+		assertThat(clusterConnection.ping(new ValkeyClusterNode("127.0.0.1", 7379, SlotRange.empty())))
+			.isEqualTo("PONG");
 	}
 
 	@Test // DATAREDIS-315
 	public void pingShouldThrowExceptionWhenNodeNotKnownToCluster() {
 		assertThatIllegalArgumentException()
-				.isThrownBy(() -> clusterConnection.ping(new ValkeyClusterNode("127.0.0.1", 1234, null)));
+			.isThrownBy(() -> clusterConnection.ping(new ValkeyClusterNode("127.0.0.1", 1234, null)));
 	}
 
 	@Test // DATAREDIS-315
 	public void rPopLPushShouldWorkWhenDoNotMapToSameSlot() {
 		try {
-			nativeConnection.lpush(KEY_1, new String[]{VALUE_1, VALUE_2}).get();
+			nativeConnection.lpush(KEY_1, new String[] { VALUE_1, VALUE_2 }).get();
 
 			assertThat(clusterConnection.rPopLPush(KEY_1_BYTES, KEY_2_BYTES)).isEqualTo(VALUE_1_BYTES);
-			assertThat(nativeConnection.exists(new String[]{KEY_2}).get()).isEqualTo(1L);
-		} catch (Exception e) {
+			assertThat(nativeConnection.exists(new String[] { KEY_2 }).get()).isEqualTo(1L);
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2234,11 +2397,13 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void rPopLPushShouldWorkWhenKeysOnSameSlot() {
 		try {
-			nativeConnection.lpush(SAME_SLOT_KEY_1, new String[]{VALUE_1, VALUE_2}).get();
+			nativeConnection.lpush(SAME_SLOT_KEY_1, new String[] { VALUE_1, VALUE_2 }).get();
 
-			assertThat(clusterConnection.rPopLPush(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES)).isEqualTo(VALUE_1_BYTES);
-			assertThat(nativeConnection.exists(new String[]{SAME_SLOT_KEY_2}).get()).isEqualTo(1L);
-		} catch (Exception e) {
+			assertThat(clusterConnection.rPopLPush(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES))
+				.isEqualTo(VALUE_1_BYTES);
+			assertThat(nativeConnection.exists(new String[] { SAME_SLOT_KEY_2 }).get()).isEqualTo(1L);
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2246,10 +2411,11 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void rPopShouldReturnElementCorrectly() {
 		try {
-			nativeConnection.rpush(KEY_1, new String[]{VALUE_1, VALUE_2}).get();
+			nativeConnection.rpush(KEY_1, new String[] { VALUE_1, VALUE_2 }).get();
 
 			assertThat(clusterConnection.rPop(KEY_1_BYTES)).isEqualTo(VALUE_2_BYTES);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2259,8 +2425,9 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 		try {
 			clusterConnection.rPushX(KEY_1_BYTES, VALUE_1_BYTES);
 
-			assertThat(nativeConnection.exists(new String[]{KEY_1}).get()).isEqualTo(0L);
-		} catch (Exception e) {
+			assertThat(nativeConnection.exists(new String[] { KEY_1 }).get()).isEqualTo(0L);
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2271,7 +2438,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			clusterConnection.rPush(KEY_1_BYTES, VALUE_1_BYTES, VALUE_2_BYTES);
 
 			assertThat(nativeConnection.lrange(KEY_1, 0, -1).get()).contains(VALUE_1, VALUE_2);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2283,7 +2451,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.set(KEY_2, VALUE_2).get();
 
 			assertThat(clusterConnection.randomKey()).isNotNull();
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2300,9 +2469,10 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			clusterConnection.rename(KEY_1_BYTES, KEY_2_BYTES);
 
-			assertThat(nativeConnection.exists(new String[]{KEY_1}).get()).isEqualTo(0L);
+			assertThat(nativeConnection.exists(new String[] { KEY_1 }).get()).isEqualTo(0L);
 			assertThat(nativeConnection.get(KEY_2).get()).isEqualTo(VALUE_1);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2315,9 +2485,10 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			clusterConnection.rename(KEY_1_BYTES, KEY_2_BYTES);
 
-			assertThat(nativeConnection.exists(new String[]{KEY_1}).get()).isEqualTo(0L);
+			assertThat(nativeConnection.exists(new String[] { KEY_1 }).get()).isEqualTo(0L);
 			assertThat(nativeConnection.get(KEY_2).get()).isEqualTo(VALUE_1);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2329,9 +2500,10 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(clusterConnection.renameNX(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES)).isTrue();
 
-			assertThat(nativeConnection.exists(new String[]{SAME_SLOT_KEY_1}).get()).isEqualTo(0L);
+			assertThat(nativeConnection.exists(new String[] { SAME_SLOT_KEY_1 }).get()).isEqualTo(0L);
 			assertThat(nativeConnection.get(SAME_SLOT_KEY_2).get()).isEqualTo(VALUE_1);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2346,7 +2518,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(nativeConnection.get(KEY_1).get()).isEqualTo(VALUE_1);
 			assertThat(nativeConnection.get(KEY_2).get()).isEqualTo(VALUE_2);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2358,9 +2531,10 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(clusterConnection.renameNX(KEY_1_BYTES, KEY_2_BYTES)).isTrue();
 
-			assertThat(nativeConnection.exists(new String[]{KEY_1}).get()).isEqualTo(0L);
+			assertThat(nativeConnection.exists(new String[] { KEY_1 }).get()).isEqualTo(0L);
 			assertThat(nativeConnection.get(KEY_2).get()).isEqualTo(VALUE_1);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2372,9 +2546,10 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			clusterConnection.rename(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES);
 
-			assertThat(nativeConnection.exists(new String[]{SAME_SLOT_KEY_1}).get()).isEqualTo(0L);
+			assertThat(nativeConnection.exists(new String[] { SAME_SLOT_KEY_1 }).get()).isEqualTo(0L);
 			assertThat(nativeConnection.get(SAME_SLOT_KEY_2).get()).isEqualTo(VALUE_1);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2385,7 +2560,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			clusterConnection.sAdd(KEY_1_BYTES, VALUE_1_BYTES, VALUE_2_BYTES);
 
 			assertThat(nativeConnection.smembers(KEY_1).get()).contains(VALUE_1, VALUE_2);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2393,10 +2569,11 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void sCardShouldCountValuesInSetCorrectly() {
 		try {
-			nativeConnection.sadd(KEY_1, new String[]{VALUE_1, VALUE_2}).get();
+			nativeConnection.sadd(KEY_1, new String[] { VALUE_1, VALUE_2 }).get();
 
 			assertThat(clusterConnection.sCard(KEY_1_BYTES)).isEqualTo(2L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2404,11 +2581,12 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void sDiffShouldWorkWhenKeysMapToSameSlot() {
 		try {
-			nativeConnection.sadd(SAME_SLOT_KEY_1, new String[]{VALUE_1, VALUE_2}).get();
-			nativeConnection.sadd(SAME_SLOT_KEY_2, new String[]{VALUE_2, VALUE_3}).get();
+			nativeConnection.sadd(SAME_SLOT_KEY_1, new String[] { VALUE_1, VALUE_2 }).get();
+			nativeConnection.sadd(SAME_SLOT_KEY_2, new String[] { VALUE_2, VALUE_3 }).get();
 
 			assertThat(clusterConnection.sDiff(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES)).contains(VALUE_1_BYTES);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2416,13 +2594,14 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315, DATAREDIS-647
 	public void sDiffShouldWorkWhenKeysNotMapToSameSlot() {
 		try {
-			nativeConnection.sadd(KEY_1, new String[]{VALUE_1, VALUE_2}).get();
-			nativeConnection.sadd(KEY_2, new String[]{VALUE_2, VALUE_3}).get();
-			nativeConnection.sadd(KEY_3, new String[]{VALUE_1, VALUE_3}).get();
+			nativeConnection.sadd(KEY_1, new String[] { VALUE_1, VALUE_2 }).get();
+			nativeConnection.sadd(KEY_2, new String[] { VALUE_2, VALUE_3 }).get();
+			nativeConnection.sadd(KEY_3, new String[] { VALUE_1, VALUE_3 }).get();
 
 			assertThat(clusterConnection.sDiff(KEY_1_BYTES, KEY_2_BYTES)).contains(VALUE_1_BYTES);
 			assertThat(clusterConnection.sDiff(KEY_1_BYTES, KEY_2_BYTES, KEY_3_BYTES)).isEmpty();
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2430,13 +2609,14 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void sDiffStoreShouldWorkWhenKeysMapToSameSlot() {
 		try {
-			nativeConnection.sadd(SAME_SLOT_KEY_1, new String[]{VALUE_1, VALUE_2}).get();
-			nativeConnection.sadd(SAME_SLOT_KEY_2, new String[]{VALUE_2, VALUE_3}).get();
+			nativeConnection.sadd(SAME_SLOT_KEY_1, new String[] { VALUE_1, VALUE_2 }).get();
+			nativeConnection.sadd(SAME_SLOT_KEY_2, new String[] { VALUE_2, VALUE_3 }).get();
 
 			clusterConnection.sDiffStore(SAME_SLOT_KEY_3_BYTES, SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES);
 
 			assertThat(nativeConnection.smembers(SAME_SLOT_KEY_3).get()).contains(VALUE_1);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2444,13 +2624,14 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void sDiffStoreShouldWorkWhenKeysNotMapToSameSlot() {
 		try {
-			nativeConnection.sadd(KEY_1, new String[]{VALUE_1, VALUE_2}).get();
-			nativeConnection.sadd(KEY_2, new String[]{VALUE_2, VALUE_3}).get();
+			nativeConnection.sadd(KEY_1, new String[] { VALUE_1, VALUE_2 }).get();
+			nativeConnection.sadd(KEY_2, new String[] { VALUE_2, VALUE_3 }).get();
 
 			clusterConnection.sDiffStore(KEY_3_BYTES, KEY_1_BYTES, KEY_2_BYTES);
 
 			assertThat(nativeConnection.smembers(KEY_3).get()).contains(VALUE_1);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2458,11 +2639,12 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void sInterShouldWorkForKeysMappingToSameSlot() {
 		try {
-			nativeConnection.sadd(SAME_SLOT_KEY_1, new String[]{VALUE_1, VALUE_2}).get();
-			nativeConnection.sadd(SAME_SLOT_KEY_2, new String[]{VALUE_2, VALUE_3}).get();
+			nativeConnection.sadd(SAME_SLOT_KEY_1, new String[] { VALUE_1, VALUE_2 }).get();
+			nativeConnection.sadd(SAME_SLOT_KEY_2, new String[] { VALUE_2, VALUE_3 }).get();
 
 			assertThat(clusterConnection.sInter(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES)).contains(VALUE_2_BYTES);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2470,11 +2652,12 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void sInterShouldWorkForKeysNotMappingToSameSlot() {
 		try {
-			nativeConnection.sadd(KEY_1, new String[]{VALUE_1, VALUE_2}).get();
-			nativeConnection.sadd(KEY_2, new String[]{VALUE_2, VALUE_3}).get();
+			nativeConnection.sadd(KEY_1, new String[] { VALUE_1, VALUE_2 }).get();
+			nativeConnection.sadd(KEY_2, new String[] { VALUE_2, VALUE_3 }).get();
 
 			assertThat(clusterConnection.sInter(KEY_1_BYTES, KEY_2_BYTES)).contains(VALUE_2_BYTES);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2482,13 +2665,14 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void sInterStoreShouldWorkForKeysMappingToSameSlot() {
 		try {
-			nativeConnection.sadd(SAME_SLOT_KEY_1, new String[]{VALUE_1, VALUE_2}).get();
-			nativeConnection.sadd(SAME_SLOT_KEY_2, new String[]{VALUE_2, VALUE_3}).get();
+			nativeConnection.sadd(SAME_SLOT_KEY_1, new String[] { VALUE_1, VALUE_2 }).get();
+			nativeConnection.sadd(SAME_SLOT_KEY_2, new String[] { VALUE_2, VALUE_3 }).get();
 
 			clusterConnection.sInterStore(SAME_SLOT_KEY_3_BYTES, SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES);
 
 			assertThat(nativeConnection.smembers(SAME_SLOT_KEY_3).get()).contains(VALUE_2);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2496,13 +2680,14 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void sInterStoreShouldWorkForKeysNotMappingToSameSlot() {
 		try {
-			nativeConnection.sadd(KEY_1, new String[]{VALUE_1, VALUE_2}).get();
-			nativeConnection.sadd(KEY_2, new String[]{VALUE_2, VALUE_3}).get();
+			nativeConnection.sadd(KEY_1, new String[] { VALUE_1, VALUE_2 }).get();
+			nativeConnection.sadd(KEY_2, new String[] { VALUE_2, VALUE_3 }).get();
 
 			clusterConnection.sInterStore(KEY_3_BYTES, KEY_1_BYTES, KEY_2_BYTES);
 
 			assertThat(nativeConnection.smembers(KEY_3).get()).contains(VALUE_2);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2510,10 +2695,11 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void sIsMemberShouldReturnFalseIfValueIsMemberOfSet() {
 		try {
-			nativeConnection.sadd(KEY_1, new String[]{VALUE_1, VALUE_2}).get();
+			nativeConnection.sadd(KEY_1, new String[] { VALUE_1, VALUE_2 }).get();
 
 			assertThat(clusterConnection.sIsMember(KEY_1_BYTES, ValkeyGlideConverters.toBytes("foo"))).isFalse();
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2521,10 +2707,11 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void sIsMemberShouldReturnTrueIfValueIsMemberOfSet() {
 		try {
-			nativeConnection.sadd(KEY_1, new String[]{VALUE_1, VALUE_2}).get();
+			nativeConnection.sadd(KEY_1, new String[] { VALUE_1, VALUE_2 }).get();
 
 			assertThat(clusterConnection.sIsMember(KEY_1_BYTES, VALUE_1_BYTES)).isTrue();
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2533,11 +2720,12 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@EnabledOnCommand("SMISMEMBER")
 	public void sMIsMemberShouldReturnCorrectValues() {
 		try {
-			nativeConnection.sadd(KEY_1, new String[]{VALUE_1, VALUE_2}).get();
+			nativeConnection.sadd(KEY_1, new String[] { VALUE_1, VALUE_2 }).get();
 
 			assertThat(clusterConnection.sMIsMember(KEY_1_BYTES, VALUE_1_BYTES, VALUE_2_BYTES, VALUE_3_BYTES))
-					.containsExactly(true, true, false);
-		} catch (Exception e) {
+				.containsExactly(true, true, false);
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2545,10 +2733,11 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void sMembersShouldReturnValuesContainedInSetCorrectly() {
 		try {
-			nativeConnection.sadd(KEY_1, new String[]{VALUE_1, VALUE_2}).get();
+			nativeConnection.sadd(KEY_1, new String[] { VALUE_1, VALUE_2 }).get();
 
 			assertThat(clusterConnection.sMembers(KEY_1_BYTES)).contains(VALUE_1_BYTES, VALUE_2_BYTES);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2556,14 +2745,15 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void sMoveShouldWorkWhenKeysDoNotMapToSameSlot() {
 		try {
-			nativeConnection.sadd(KEY_1, new String[]{VALUE_1, VALUE_2}).get();
-			nativeConnection.sadd(KEY_2, new String[]{VALUE_3}).get();
+			nativeConnection.sadd(KEY_1, new String[] { VALUE_1, VALUE_2 }).get();
+			nativeConnection.sadd(KEY_2, new String[] { VALUE_3 }).get();
 
 			clusterConnection.sMove(KEY_1_BYTES, KEY_2_BYTES, VALUE_2_BYTES);
 
 			assertThat(nativeConnection.sismember(KEY_1, VALUE_2).get()).isFalse();
 			assertThat(nativeConnection.sismember(KEY_2, VALUE_2).get()).isTrue();
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2571,14 +2761,15 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void sMoveShouldWorkWhenKeysMapToSameSlot() {
 		try {
-			nativeConnection.sadd(SAME_SLOT_KEY_1, new String[]{VALUE_1, VALUE_2}).get();
-			nativeConnection.sadd(SAME_SLOT_KEY_2, new String[]{VALUE_3}).get();
+			nativeConnection.sadd(SAME_SLOT_KEY_1, new String[] { VALUE_1, VALUE_2 }).get();
+			nativeConnection.sadd(SAME_SLOT_KEY_2, new String[] { VALUE_3 }).get();
 
 			clusterConnection.sMove(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES, VALUE_2_BYTES);
 
 			assertThat(nativeConnection.sismember(SAME_SLOT_KEY_1, VALUE_2).get()).isFalse();
 			assertThat(nativeConnection.sismember(SAME_SLOT_KEY_2, VALUE_2).get()).isTrue();
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2586,10 +2777,11 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void sPopShouldPopValueFromSetCorrectly() {
 		try {
-			nativeConnection.sadd(KEY_1, new String[]{VALUE_1, VALUE_2}).get();
+			nativeConnection.sadd(KEY_1, new String[] { VALUE_1, VALUE_2 }).get();
 
 			assertThat(clusterConnection.sPop(KEY_1_BYTES)).isNotNull();
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2597,11 +2789,12 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-668
 	void sPopWithCountShouldPopValueFromSetCorrectly() {
 		try {
-			nativeConnection.sadd(KEY_1, new String[]{VALUE_1, VALUE_2, VALUE_3}).get();
+			nativeConnection.sadd(KEY_1, new String[] { VALUE_1, VALUE_2, VALUE_3 }).get();
 
 			assertThat(clusterConnection.setCommands().sPop(KEY_1_BYTES, 2)).hasSize(2);
 			assertThat(nativeConnection.scard(KEY_1).get()).isEqualTo(1L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2609,10 +2802,11 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void sRandMamberShouldReturnValueCorrectly() {
 		try {
-			nativeConnection.sadd(KEY_1, new String[]{VALUE_1, VALUE_2}).get();
+			nativeConnection.sadd(KEY_1, new String[] { VALUE_1, VALUE_2 }).get();
 
 			assertThat(clusterConnection.sRandMember(KEY_1_BYTES)).isNotNull();
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2620,10 +2814,11 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void sRandMamberWithCountShouldReturnValueCorrectly() {
 		try {
-			nativeConnection.sadd(KEY_1, new String[]{VALUE_1, VALUE_2}).get();
+			nativeConnection.sadd(KEY_1, new String[] { VALUE_1, VALUE_2 }).get();
 
 			assertThat(clusterConnection.sRandMember(KEY_1_BYTES, 3)).isNotNull();
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2631,12 +2826,13 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void sRemShouldRemoveValueFromSetCorrectly() {
 		try {
-			nativeConnection.sadd(KEY_1, new String[]{VALUE_1, VALUE_2}).get();
+			nativeConnection.sadd(KEY_1, new String[] { VALUE_1, VALUE_2 }).get();
 
 			clusterConnection.sRem(KEY_1_BYTES, VALUE_2_BYTES);
 
 			assertThat(nativeConnection.smembers(KEY_1).get()).contains(VALUE_1);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2644,12 +2840,13 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void sUnionShouldWorkForKeysMappingToSameSlot() {
 		try {
-			nativeConnection.sadd(SAME_SLOT_KEY_1, new String[]{VALUE_1, VALUE_2}).get();
-			nativeConnection.sadd(SAME_SLOT_KEY_2, new String[]{VALUE_2, VALUE_3}).get();
+			nativeConnection.sadd(SAME_SLOT_KEY_1, new String[] { VALUE_1, VALUE_2 }).get();
+			nativeConnection.sadd(SAME_SLOT_KEY_2, new String[] { VALUE_2, VALUE_3 }).get();
 
 			assertThat(clusterConnection.sUnion(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES)).contains(VALUE_1_BYTES,
 					VALUE_2_BYTES, VALUE_3_BYTES);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2657,12 +2854,13 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void sUnionShouldWorkForKeysNotMappingToSameSlot() {
 		try {
-			nativeConnection.sadd(KEY_1, new String[]{VALUE_1, VALUE_2}).get();
-			nativeConnection.sadd(KEY_2, new String[]{VALUE_2, VALUE_3}).get();
+			nativeConnection.sadd(KEY_1, new String[] { VALUE_1, VALUE_2 }).get();
+			nativeConnection.sadd(KEY_2, new String[] { VALUE_2, VALUE_3 }).get();
 
 			assertThat(clusterConnection.sUnion(KEY_1_BYTES, KEY_2_BYTES)).contains(VALUE_1_BYTES, VALUE_2_BYTES,
 					VALUE_3_BYTES);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2670,13 +2868,14 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void sUnionStoreShouldWorkForKeysMappingToSameSlot() {
 		try {
-			nativeConnection.sadd(SAME_SLOT_KEY_1, new String[]{VALUE_1, VALUE_2}).get();
-			nativeConnection.sadd(SAME_SLOT_KEY_2, new String[]{VALUE_2, VALUE_3}).get();
+			nativeConnection.sadd(SAME_SLOT_KEY_1, new String[] { VALUE_1, VALUE_2 }).get();
+			nativeConnection.sadd(SAME_SLOT_KEY_2, new String[] { VALUE_2, VALUE_3 }).get();
 
 			clusterConnection.sUnionStore(SAME_SLOT_KEY_3_BYTES, SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES);
 
 			assertThat(nativeConnection.smembers(SAME_SLOT_KEY_3).get()).contains(VALUE_1, VALUE_2, VALUE_3);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2684,13 +2883,14 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void sUnionStoreShouldWorkForKeysNotMappingToSameSlot() {
 		try {
-			nativeConnection.sadd(KEY_1, new String[]{VALUE_1, VALUE_2}).get();
-			nativeConnection.sadd(KEY_2, new String[]{VALUE_2, VALUE_3}).get();
+			nativeConnection.sadd(KEY_1, new String[] { VALUE_1, VALUE_2 }).get();
+			nativeConnection.sadd(KEY_2, new String[] { VALUE_2, VALUE_3 }).get();
 
 			clusterConnection.sUnionStore(KEY_3_BYTES, KEY_1_BYTES, KEY_2_BYTES);
 
 			assertThat(nativeConnection.smembers(KEY_3).get()).contains(VALUE_1, VALUE_2, VALUE_3);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2713,7 +2913,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(nativeConnection.getbit(KEY_1, 0).get()).isEqualTo(1);
 			assertThat(nativeConnection.getbit(KEY_1, 1).get()).isEqualTo(0);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2725,7 +2926,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(nativeConnection.get(KEY_1).get()).isEqualTo(VALUE_1);
 			assertThat(nativeConnection.ttl(KEY_1).get()).isGreaterThan(1);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2738,7 +2940,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			clusterConnection.setNX(KEY_1_BYTES, VALUE_2_BYTES);
 
 			assertThat(nativeConnection.get(KEY_1).get()).isEqualTo(VALUE_1);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2749,7 +2952,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			clusterConnection.setNX(KEY_1_BYTES, VALUE_1_BYTES);
 
 			assertThat(nativeConnection.get(KEY_1).get()).isEqualTo(VALUE_1);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2762,7 +2966,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			clusterConnection.setRange(KEY_1_BYTES, ValkeyGlideConverters.toBytes("UE"), 3);
 
 			assertThat(nativeConnection.get(KEY_1).get()).isEqualTo("valUE1");
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2773,7 +2978,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			clusterConnection.set(KEY_1_BYTES, VALUE_1_BYTES);
 
 			assertThat(nativeConnection.get(KEY_1).get()).isEqualTo(VALUE_1);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2785,10 +2991,11 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			clusterConnection.set(KEY_1_BYTES, VALUE_2_BYTES, Expiration.seconds(1), SetOption.ifAbsent());
 
-			assertThat(nativeConnection.exists(new String[]{KEY_1}).get()).isEqualTo(1L);
+			assertThat(nativeConnection.exists(new String[] { KEY_1 }).get()).isEqualTo(1L);
 			assertThat(nativeConnection.ttl(KEY_1).get()).isEqualTo(-1L);
 			assertThat(nativeConnection.get(KEY_1).get()).isEqualTo(VALUE_1);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2798,9 +3005,10 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 		try {
 			clusterConnection.set(KEY_1_BYTES, VALUE_1_BYTES, Expiration.seconds(1), SetOption.ifAbsent());
 
-			assertThat(nativeConnection.exists(new String[]{KEY_1}).get()).isEqualTo(1L);
+			assertThat(nativeConnection.exists(new String[] { KEY_1 }).get()).isEqualTo(1L);
 			assertThat(nativeConnection.ttl(KEY_1).get()).isEqualTo(1L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2810,8 +3018,9 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 		try {
 			clusterConnection.set(KEY_1_BYTES, VALUE_1_BYTES, Expiration.seconds(1), SetOption.ifPresent());
 
-			assertThat(nativeConnection.exists(new String[]{KEY_1}).get()).isEqualTo(0);
-		} catch (Exception e) {
+			assertThat(nativeConnection.exists(new String[] { KEY_1 }).get()).isEqualTo(0);
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2823,10 +3032,11 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			clusterConnection.set(KEY_1_BYTES, VALUE_2_BYTES, Expiration.seconds(1), SetOption.ifPresent());
 
-			assertThat(nativeConnection.exists(new String[]{KEY_1}).get()).isEqualTo(1L);
+			assertThat(nativeConnection.exists(new String[] { KEY_1 }).get()).isEqualTo(1L);
 			assertThat(nativeConnection.ttl(KEY_1).get()).isEqualTo(1L);
 			assertThat(nativeConnection.get(KEY_1).get()).isEqualTo(VALUE_2);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2836,9 +3046,10 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 		try {
 			clusterConnection.set(KEY_1_BYTES, VALUE_1_BYTES, Expiration.milliseconds(500), SetOption.upsert());
 
-			assertThat(nativeConnection.exists(new String[]{KEY_1}).get()).isEqualTo(1L);
+			assertThat(nativeConnection.exists(new String[] { KEY_1 }).get()).isEqualTo(1L);
 			assertThat(nativeConnection.pttl(KEY_1).get()).isCloseTo(500L, offset(499L));
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2848,9 +3059,10 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 		try {
 			clusterConnection.set(KEY_1_BYTES, VALUE_1_BYTES, Expiration.seconds(1), SetOption.upsert());
 
-			assertThat(nativeConnection.exists(new String[]{KEY_1}).get()).isEqualTo(1L);
+			assertThat(nativeConnection.exists(new String[] { KEY_1 }).get()).isEqualTo(1L);
 			assertThat(nativeConnection.ttl(KEY_1).get()).isEqualTo(1L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2860,9 +3072,10 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 		try {
 			clusterConnection.set(KEY_1_BYTES, VALUE_1_BYTES, Expiration.persistent(), SetOption.ifAbsent());
 
-			assertThat(nativeConnection.exists(new String[]{KEY_1}).get()).isEqualTo(1L);
+			assertThat(nativeConnection.exists(new String[] { KEY_1 }).get()).isEqualTo(1L);
 			assertThat(nativeConnection.ttl(KEY_1).get()).isEqualTo(-1L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2873,10 +3086,11 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.set(KEY_1, VALUE_1).get();
 			clusterConnection.set(KEY_1_BYTES, VALUE_2_BYTES, Expiration.persistent(), SetOption.ifPresent());
 
-			assertThat(nativeConnection.exists(new String[]{KEY_1}).get()).isEqualTo(1L);
+			assertThat(nativeConnection.exists(new String[] { KEY_1 }).get()).isEqualTo(1L);
 			assertThat(clusterConnection.get(KEY_1_BYTES)).isEqualTo(VALUE_2_BYTES);
 			assertThat(nativeConnection.ttl(KEY_1).get()).isEqualTo(-1L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2891,11 +3105,13 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void sortAndStoreShouldAddSortedValuesValuesCorrectly() {
 		try {
-			nativeConnection.lpush(KEY_1, new String[]{VALUE_2, VALUE_1}).get();
+			nativeConnection.lpush(KEY_1, new String[] { VALUE_2, VALUE_1 }).get();
 
-			assertThat(clusterConnection.sort(KEY_1_BYTES, new DefaultSortParameters().alpha(), KEY_2_BYTES)).isEqualTo(2L);
-			assertThat(nativeConnection.exists(new String[]{KEY_2}).get()).isEqualTo(1L);
-		} catch (Exception e) {
+			assertThat(clusterConnection.sort(KEY_1_BYTES, new DefaultSortParameters().alpha(), KEY_2_BYTES))
+				.isEqualTo(2L);
+			assertThat(nativeConnection.exists(new String[] { KEY_2 }).get()).isEqualTo(1L);
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2903,12 +3119,14 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315, GH-2341
 	public void sortAndStoreShouldReplaceDestinationList() {
 		try {
-			nativeConnection.lpush(KEY_1, new String[]{VALUE_2, VALUE_1}).get();
-			nativeConnection.lpush(KEY_2, new String[]{VALUE_3}).get();
+			nativeConnection.lpush(KEY_1, new String[] { VALUE_2, VALUE_1 }).get();
+			nativeConnection.lpush(KEY_2, new String[] { VALUE_3 }).get();
 
-			assertThat(clusterConnection.sort(KEY_1_BYTES, new DefaultSortParameters().alpha(), KEY_2_BYTES)).isEqualTo(2L);
+			assertThat(clusterConnection.sort(KEY_1_BYTES, new DefaultSortParameters().alpha(), KEY_2_BYTES))
+				.isEqualTo(2L);
 			assertThat(nativeConnection.llen(KEY_2).get()).isEqualTo(2L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2916,11 +3134,12 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void sortShouldReturnValuesCorrectly() {
 		try {
-			nativeConnection.lpush(KEY_1, new String[]{VALUE_2, VALUE_1}).get();
+			nativeConnection.lpush(KEY_1, new String[] { VALUE_2, VALUE_1 }).get();
 
 			assertThat(clusterConnection.sort(KEY_1_BYTES, new DefaultSortParameters().alpha())).contains(VALUE_1_BYTES,
 					VALUE_2_BYTES);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2929,7 +3148,7 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	public void sscanShouldRetrieveAllValuesInSetCorrectly() {
 		try {
 			for (int i = 0; i < 30; i++) {
-				nativeConnection.sadd(KEY_1, new String[]{String.valueOf(i)}).get();
+				nativeConnection.sadd(KEY_1, new String[] { String.valueOf(i) }).get();
 			}
 
 			int count = 0;
@@ -2940,7 +3159,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			}
 
 			assertThat(count).isEqualTo(30);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2951,7 +3171,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.set(KEY_1, VALUE_1).get();
 
 			assertThat(clusterConnection.strLen(KEY_1_BYTES)).isEqualTo(6L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2980,7 +3201,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.expire(KEY_1, 5).get();
 
 			assertThat(clusterConnection.ttl(KEY_1_BYTES)).isGreaterThan(1);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -2993,14 +3215,15 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void typeShouldReadKeyTypeCorrectly() {
 		try {
-			nativeConnection.sadd(KEY_1, new String[]{VALUE_1}).get();
+			nativeConnection.sadd(KEY_1, new String[] { VALUE_1 }).get();
 			nativeConnection.set(KEY_2, VALUE_2).get();
 			nativeConnection.hset(KEY_3, Collections.singletonMap(KEY_1, VALUE_1)).get();
 
 			assertThat(clusterConnection.type(KEY_1_BYTES)).isEqualTo(DataType.SET);
 			assertThat(clusterConnection.type(KEY_2_BYTES)).isEqualTo(DataType.STRING);
 			assertThat(clusterConnection.type(KEY_3_BYTES)).isEqualTo(DataType.HASH);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3025,7 +3248,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			clusterConnection.zAdd(KEY_1_BYTES, tuples);
 
 			assertThat(nativeConnection.zcard(KEY_1).get()).isEqualTo(2L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3037,7 +3261,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			clusterConnection.zAdd(KEY_1_BYTES, 20D, VALUE_2_BYTES);
 
 			assertThat(nativeConnection.zcard(KEY_1).get()).isEqualTo(2L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3050,7 +3275,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.zadd(KEY_1, Map.of(VALUE_3, 5D)).get();
 
 			assertThat(clusterConnection.zCard(KEY_1_BYTES)).isEqualTo(3L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3063,7 +3289,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.zadd(KEY_1, Map.of(VALUE_3, 5D)).get();
 
 			assertThat(clusterConnection.zCount(KEY_1_BYTES, 10, 20)).isEqualTo(2L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3077,7 +3304,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			clusterConnection.zIncrBy(KEY_1_BYTES, 100D, VALUE_1_BYTES);
 
 			assertThat(nativeConnection.zrank(KEY_1, VALUE_1).get()).isEqualTo(1L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3086,11 +3314,11 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	public void zDiffShouldThrowExceptionWhenKeysDoNotMapToSameSlots() {
 
 		assertThatExceptionOfType(DataAccessException.class)
-				.isThrownBy(() -> clusterConnection.zDiff(KEY_3_BYTES, KEY_1_BYTES, KEY_2_BYTES));
+			.isThrownBy(() -> clusterConnection.zDiff(KEY_3_BYTES, KEY_1_BYTES, KEY_2_BYTES));
 		assertThatExceptionOfType(DataAccessException.class)
-				.isThrownBy(() -> clusterConnection.zDiffStore(KEY_3_BYTES, KEY_1_BYTES, KEY_2_BYTES));
+			.isThrownBy(() -> clusterConnection.zDiffStore(KEY_3_BYTES, KEY_1_BYTES, KEY_2_BYTES));
 		assertThatExceptionOfType(DataAccessException.class)
-				.isThrownBy(() -> clusterConnection.zDiffWithScores(KEY_3_BYTES, KEY_1_BYTES, KEY_2_BYTES));
+			.isThrownBy(() -> clusterConnection.zDiffWithScores(KEY_3_BYTES, KEY_1_BYTES, KEY_2_BYTES));
 	}
 
 	@Test // GH-2041
@@ -3104,8 +3332,9 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(clusterConnection.zDiff(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES)).contains(VALUE_1_BYTES);
 			assertThat(clusterConnection.zDiffWithScores(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES))
-					.contains(new DefaultTuple(VALUE_1_BYTES, 10D));
-		} catch (Exception e) {
+				.contains(new DefaultTuple(VALUE_1_BYTES, 10D));
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3122,7 +3351,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			clusterConnection.zDiffStore(SAME_SLOT_KEY_3_BYTES, SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES);
 
 			assertThat(nativeConnection.zrange(SAME_SLOT_KEY_3, new RangeByIndex(0, -1)).get()).contains(VALUE_1);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3131,9 +3361,9 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	public void zInterShouldThrowExceptionWhenKeysDoNotMapToSameSlots() {
 
 		assertThatExceptionOfType(DataAccessException.class)
-				.isThrownBy(() -> clusterConnection.zInter(KEY_3_BYTES, KEY_1_BYTES, KEY_2_BYTES));
+			.isThrownBy(() -> clusterConnection.zInter(KEY_3_BYTES, KEY_1_BYTES, KEY_2_BYTES));
 		assertThatExceptionOfType(DataAccessException.class)
-				.isThrownBy(() -> clusterConnection.zInterWithScores(KEY_3_BYTES, KEY_1_BYTES, KEY_2_BYTES));
+			.isThrownBy(() -> clusterConnection.zInterWithScores(KEY_3_BYTES, KEY_1_BYTES, KEY_2_BYTES));
 	}
 
 	@Test // GH-2042
@@ -3147,8 +3377,9 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(clusterConnection.zInter(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES)).contains(VALUE_2_BYTES);
 			assertThat(clusterConnection.zInterWithScores(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES))
-					.contains(new DefaultTuple(VALUE_2_BYTES, 40D));
-		} catch (Exception e) {
+				.contains(new DefaultTuple(VALUE_2_BYTES, 40D));
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3157,7 +3388,7 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	public void zInterStoreShouldThrowExceptionWhenKeysDoNotMapToSameSlots() {
 
 		assertThatExceptionOfType(DataAccessException.class)
-				.isThrownBy(() -> clusterConnection.zInterStore(KEY_3_BYTES, KEY_1_BYTES, KEY_2_BYTES));
+			.isThrownBy(() -> clusterConnection.zInterStore(KEY_3_BYTES, KEY_1_BYTES, KEY_2_BYTES));
 	}
 
 	@Test // DATAREDIS-315
@@ -3172,7 +3403,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			clusterConnection.zInterStore(SAME_SLOT_KEY_3_BYTES, SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES);
 
 			assertThat(nativeConnection.zrange(SAME_SLOT_KEY_3, new RangeByIndex(0, -1)).get()).contains(VALUE_2);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3188,7 +3420,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			assertThat(clusterConnection.zPopMin(KEY_1_BYTES)).isEqualTo(new DefaultTuple(VALUE_1_BYTES, 10D));
 			assertThat(clusterConnection.zPopMin(KEY_1_BYTES, 2)).containsExactly(new DefaultTuple(VALUE_2_BYTES, 20D),
 					new DefaultTuple(VALUE_3_BYTES, 30D));
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3204,8 +3437,9 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.zadd(KEY_1, Map.of(VALUE_3, 30D)).get();
 
 			assertThat(clusterConnection.bZPopMin(KEY_1_BYTES, 1, TimeUnit.SECONDS))
-					.isEqualTo(new DefaultTuple(VALUE_1_BYTES, 10D));
-		} catch (Exception e) {
+				.isEqualTo(new DefaultTuple(VALUE_1_BYTES, 10D));
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3221,7 +3455,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			assertThat(clusterConnection.zPopMax(KEY_1_BYTES)).isEqualTo(new DefaultTuple(VALUE_3_BYTES, 30D));
 			assertThat(clusterConnection.zPopMax(KEY_1_BYTES, 2)).containsExactly(new DefaultTuple(VALUE_2_BYTES, 20D),
 					new DefaultTuple(VALUE_1_BYTES, 10D));
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3237,8 +3472,9 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.zadd(KEY_1, Map.of(VALUE_3, 30D)).get();
 
 			assertThat(clusterConnection.bZPopMax(KEY_1_BYTES, 1, TimeUnit.SECONDS))
-					.isEqualTo(new DefaultTuple(VALUE_3_BYTES, 30D));
-		} catch (Exception e) {
+				.isEqualTo(new DefaultTuple(VALUE_3_BYTES, 30D));
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3252,7 +3488,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(clusterConnection.zRandMember(KEY_1_BYTES)).isIn(VALUE_1_BYTES, VALUE_2_BYTES);
 			assertThat(clusterConnection.zRandMember(KEY_1_BYTES, 2)).hasSize(2).contains(VALUE_1_BYTES, VALUE_2_BYTES);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3266,7 +3503,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(clusterConnection.zRandMemberWithScore(KEY_1_BYTES)).isNotNull();
 			assertThat(clusterConnection.zRandMemberWithScore(KEY_1_BYTES, 2)).hasSize(2);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3295,7 +3533,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			values = clusterConnection.zRangeByLex(KEY_1_BYTES, Range.range().gte("aaa").lt("g").toRange());
 			assertThat(values).contains(ValkeyGlideConverters.toBytes("b"), ValkeyGlideConverters.toBytes("c"),
-					ValkeyGlideConverters.toBytes("d"), ValkeyGlideConverters.toBytes("e"), ValkeyGlideConverters.toBytes("f"));
+					ValkeyGlideConverters.toBytes("d"), ValkeyGlideConverters.toBytes("e"),
+					ValkeyGlideConverters.toBytes("f"));
 			assertThat(values).doesNotContain(ValkeyGlideConverters.toBytes("a"), ValkeyGlideConverters.toBytes("g"));
 
 			values = clusterConnection.zRangeByLex(KEY_1_BYTES, Range.range().gte("e").toRange());
@@ -3303,7 +3542,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 					ValkeyGlideConverters.toBytes("g"));
 			assertThat(values).doesNotContain(ValkeyGlideConverters.toBytes("a"), ValkeyGlideConverters.toBytes("b"),
 					ValkeyGlideConverters.toBytes("c"), ValkeyGlideConverters.toBytes("d"));
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3332,16 +3572,22 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			values = clusterConnection.zRevRangeByLex(KEY_1_BYTES, Range.range().gte("aaa").lt("g").toRange());
 			assertThat(values).containsExactly(ValkeyGlideConverters.toBytes("f"), ValkeyGlideConverters.toBytes("e"),
-					ValkeyGlideConverters.toBytes("d"), ValkeyGlideConverters.toBytes("c"), ValkeyGlideConverters.toBytes("b"));
+					ValkeyGlideConverters.toBytes("d"), ValkeyGlideConverters.toBytes("c"),
+					ValkeyGlideConverters.toBytes("b"));
 			assertThat(values).doesNotContain(ValkeyGlideConverters.toBytes("a"), ValkeyGlideConverters.toBytes("g"));
 
 			values = clusterConnection.zRevRangeByLex(KEY_1_BYTES, Range.range().lte("d").toRange(),
-					io.valkey.springframework.data.valkey.connection.ValkeyZSetCommands.Limit.limit().count(2).offset(1));
+					io.valkey.springframework.data.valkey.connection.ValkeyZSetCommands.Limit.limit()
+						.count(2)
+						.offset(1));
 
-			assertThat(values).hasSize(2).containsExactly(ValkeyGlideConverters.toBytes("c"), ValkeyGlideConverters.toBytes("b"));
+			assertThat(values).hasSize(2)
+				.containsExactly(ValkeyGlideConverters.toBytes("c"), ValkeyGlideConverters.toBytes("b"));
 			assertThat(values).doesNotContain(ValkeyGlideConverters.toBytes("a"), ValkeyGlideConverters.toBytes("d"),
-					ValkeyGlideConverters.toBytes("e"), ValkeyGlideConverters.toBytes("f"), ValkeyGlideConverters.toBytes("g"));
-		} catch (Exception e) {
+					ValkeyGlideConverters.toBytes("e"), ValkeyGlideConverters.toBytes("f"),
+					ValkeyGlideConverters.toBytes("g"));
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3354,7 +3600,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.zadd(KEY_1, Map.of(VALUE_3, 5D)).get();
 
 			assertThat(clusterConnection.zRangeByScore(KEY_1_BYTES, 10, 20)).contains(VALUE_1_BYTES, VALUE_2_BYTES);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3367,7 +3614,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.zadd(KEY_1, Map.of(VALUE_3, 5D)).get();
 
 			assertThat(clusterConnection.zRangeByScore(KEY_1_BYTES, 10D, 20D, 0L, 1L)).contains(VALUE_1_BYTES);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3380,8 +3628,9 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.zadd(KEY_1, Map.of(VALUE_3, 5D)).get();
 
 			assertThat(clusterConnection.zRangeByScoreWithScores(KEY_1_BYTES, 10, 20))
-					.contains((Tuple) new DefaultTuple(VALUE_1_BYTES, 10D), (Tuple) new DefaultTuple(VALUE_2_BYTES, 20D));
-		} catch (Exception e) {
+				.contains((Tuple) new DefaultTuple(VALUE_1_BYTES, 10D), (Tuple) new DefaultTuple(VALUE_2_BYTES, 20D));
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3394,8 +3643,9 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.zadd(KEY_1, Map.of(VALUE_3, 5D)).get();
 
 			assertThat(clusterConnection.zRangeByScoreWithScores(KEY_1_BYTES, 10D, 20D, 0L, 1L))
-					.contains((Tuple) new DefaultTuple(VALUE_1_BYTES, 10D));
-		} catch (Exception e) {
+				.contains((Tuple) new DefaultTuple(VALUE_1_BYTES, 10D));
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3408,7 +3658,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.zadd(KEY_1, Map.of(VALUE_3, 5D)).get();
 
 			assertThat(clusterConnection.zRange(KEY_1_BYTES, 1, 2)).contains(VALUE_1_BYTES, VALUE_2_BYTES);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3421,8 +3672,9 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.zadd(KEY_1, Map.of(VALUE_3, 5D)).get();
 
 			assertThat(clusterConnection.zRangeWithScores(KEY_1_BYTES, 1, 2))
-					.contains((Tuple) new DefaultTuple(VALUE_1_BYTES, 10D), (Tuple) new DefaultTuple(VALUE_2_BYTES, 20D));
-		} catch (Exception e) {
+				.contains((Tuple) new DefaultTuple(VALUE_1_BYTES, 10D), (Tuple) new DefaultTuple(VALUE_2_BYTES, 20D));
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3434,7 +3686,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.zadd(KEY_1, Map.of(VALUE_2, 20D)).get();
 
 			assertThat(clusterConnection.zRank(KEY_1_BYTES, VALUE_2_BYTES)).isEqualTo(1L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3446,7 +3699,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.zadd(KEY_1, Map.of(VALUE_2, 20D)).get();
 
 			assertThat(clusterConnection.zRevRank(KEY_1_BYTES, VALUE_2_BYTES)).isEqualTo(0L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3462,7 +3716,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(nativeConnection.zcard(KEY_1).get()).isEqualTo(2L);
 			assertThat(nativeConnection.zrange(KEY_1, new RangeByIndex(0, -1)).get()).contains(VALUE_1, VALUE_3);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3478,7 +3733,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			assertThat(nativeConnection.zcard(KEY_1).get()).isEqualTo(1L);
 			assertThat(nativeConnection.zrange(KEY_1, new RangeByIndex(0, -1)).get()).contains(VALUE_1);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3492,7 +3748,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			clusterConnection.zRem(KEY_1_BYTES, VALUE_1_BYTES);
 
 			assertThat(nativeConnection.zcard(KEY_1).get()).isEqualTo(1L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3504,8 +3761,10 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.zadd(KEY_1, Map.of(VALUE_2, 20D)).get();
 			nativeConnection.zadd(KEY_1, Map.of(VALUE_3, 5D)).get();
 
-			assertThat(clusterConnection.zRevRangeByScore(KEY_1_BYTES, 10D, 20D)).contains(VALUE_2_BYTES, VALUE_1_BYTES);
-		} catch (Exception e) {
+			assertThat(clusterConnection.zRevRangeByScore(KEY_1_BYTES, 10D, 20D)).contains(VALUE_2_BYTES,
+					VALUE_1_BYTES);
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3518,7 +3777,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.zadd(KEY_1, Map.of(VALUE_3, 5D)).get();
 
 			assertThat(clusterConnection.zRevRangeByScore(KEY_1_BYTES, 10D, 20D, 0L, 1L)).contains(VALUE_2_BYTES);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3531,8 +3791,9 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.zadd(KEY_1, Map.of(VALUE_3, 5D)).get();
 
 			assertThat(clusterConnection.zRevRangeByScoreWithScores(KEY_1_BYTES, 10D, 20D))
-					.contains((Tuple) new DefaultTuple(VALUE_2_BYTES, 20D), (Tuple) new DefaultTuple(VALUE_1_BYTES, 10D));
-		} catch (Exception e) {
+				.contains((Tuple) new DefaultTuple(VALUE_2_BYTES, 20D), (Tuple) new DefaultTuple(VALUE_1_BYTES, 10D));
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3545,8 +3806,9 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.zadd(KEY_1, Map.of(VALUE_3, 5D)).get();
 
 			assertThat(clusterConnection.zRevRangeByScoreWithScores(KEY_1_BYTES, 10D, 20D, 0L, 1L))
-					.contains((Tuple) new DefaultTuple(VALUE_2_BYTES, 20D));
-		} catch (Exception e) {
+				.contains((Tuple) new DefaultTuple(VALUE_2_BYTES, 20D));
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3559,7 +3821,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.zadd(KEY_1, Map.of(VALUE_3, 5D)).get();
 
 			assertThat(clusterConnection.zRevRange(KEY_1_BYTES, 1, 2)).contains(VALUE_3_BYTES, VALUE_1_BYTES);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3572,8 +3835,9 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.zadd(KEY_1, Map.of(VALUE_3, 5D)).get();
 
 			assertThat(clusterConnection.zRevRangeWithScores(KEY_1_BYTES, 1, 2))
-					.contains((Tuple) new DefaultTuple(VALUE_3_BYTES, 5D), (Tuple) new DefaultTuple(VALUE_1_BYTES, 10D));
-		} catch (Exception e) {
+				.contains((Tuple) new DefaultTuple(VALUE_3_BYTES, 5D), (Tuple) new DefaultTuple(VALUE_1_BYTES, 10D));
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3596,7 +3860,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			}
 
 			assertThat(count).isEqualTo(nrOfValues);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3608,7 +3873,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.zadd(KEY_1, Map.of(VALUE_2, 20D)).get();
 
 			assertThat(clusterConnection.zScore(KEY_1_BYTES, VALUE_2_BYTES)).isEqualTo(20D);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3621,7 +3887,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.zadd(KEY_1, Map.of(VALUE_2, 20D)).get();
 
 			assertThat(clusterConnection.zMScore(KEY_1_BYTES, VALUE_1_BYTES, VALUE_2_BYTES)).containsSequence(10D, 20D);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3629,9 +3896,9 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // GH-2042
 	public void zUnionShouldThrowExceptionWhenKeysDoNotMapToSameSlots() {
 		assertThatExceptionOfType(DataAccessException.class)
-				.isThrownBy(() -> clusterConnection.zUnion(KEY_3_BYTES, KEY_1_BYTES, KEY_2_BYTES));
+			.isThrownBy(() -> clusterConnection.zUnion(KEY_3_BYTES, KEY_1_BYTES, KEY_2_BYTES));
 		assertThatExceptionOfType(DataAccessException.class)
-				.isThrownBy(() -> clusterConnection.zUnionWithScores(KEY_3_BYTES, KEY_1_BYTES, KEY_2_BYTES));
+			.isThrownBy(() -> clusterConnection.zUnionWithScores(KEY_3_BYTES, KEY_1_BYTES, KEY_2_BYTES));
 	}
 
 	@Test // GH-2042
@@ -3647,7 +3914,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			assertThat(clusterConnection.zUnionWithScores(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES)).contains(
 					new DefaultTuple(VALUE_1_BYTES, 10D), new DefaultTuple(VALUE_2_BYTES, 20D),
 					new DefaultTuple(VALUE_3_BYTES, 30D));
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3655,7 +3923,7 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-315
 	public void zUnionStoreShouldThrowExceptionWhenKeysDoNotMapToSameSlots() {
 		assertThatExceptionOfType(DataAccessException.class)
-				.isThrownBy(() -> clusterConnection.zUnionStore(KEY_3_BYTES, KEY_1_BYTES, KEY_2_BYTES));
+			.isThrownBy(() -> clusterConnection.zUnionStore(KEY_3_BYTES, KEY_1_BYTES, KEY_2_BYTES));
 	}
 
 	@Test // DATAREDIS-315
@@ -3667,9 +3935,10 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 
 			clusterConnection.zUnionStore(SAME_SLOT_KEY_3_BYTES, SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES);
 
-			assertThat(nativeConnection.zrange(SAME_SLOT_KEY_3, new RangeByIndex(0, -1)).get()).contains(VALUE_1, VALUE_2,
-					VALUE_3);
-		} catch (Exception e) {
+			assertThat(nativeConnection.zrange(SAME_SLOT_KEY_3, new RangeByIndex(0, -1)).get()).contains(VALUE_1,
+					VALUE_2, VALUE_3);
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3681,7 +3950,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.set(KEY_2, VALUE_1).get();
 
 			assertThat(clusterConnection.keyCommands().touch(KEY_1_BYTES, KEY_2_BYTES, KEY_3_BYTES)).isEqualTo(2L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3698,7 +3968,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.set(KEY_2, VALUE_1).get();
 
 			assertThat(clusterConnection.keyCommands().unlink(KEY_1_BYTES, KEY_2_BYTES, KEY_3_BYTES)).isEqualTo(2L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3711,11 +3982,12 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-697
 	void bitPosShouldReturnPositionCorrectly() {
 		try {
-			nativeConnection.set(GlideString.of(KEY_1.getBytes()), 
-					GlideString.of(HexStringUtils.hexToBytes("fff000"))).get();
+			nativeConnection.set(GlideString.of(KEY_1.getBytes()), GlideString.of(HexStringUtils.hexToBytes("fff000")))
+				.get();
 
 			assertThat(clusterConnection.stringCommands().bitPos(KEY_1_BYTES, false)).isEqualTo(12L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3723,12 +3995,15 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-697
 	void bitPosShouldReturnPositionInRangeCorrectly() {
 		try {
-			nativeConnection.set(GlideString.of(KEY_1.getBytes()), 
-					GlideString.of(HexStringUtils.hexToBytes("fff0f0"))).get();
+			nativeConnection.set(GlideString.of(KEY_1.getBytes()), GlideString.of(HexStringUtils.hexToBytes("fff0f0")))
+				.get();
 
-			assertThat(clusterConnection.stringCommands().bitPos(KEY_1_BYTES, true,
-					org.springframework.data.domain.Range.of(Bound.inclusive(2L), Bound.unbounded()))).isEqualTo(16L);
-		} catch (Exception e) {
+			assertThat(clusterConnection.stringCommands()
+				.bitPos(KEY_1_BYTES, true,
+						org.springframework.data.domain.Range.of(Bound.inclusive(2L), Bound.unbounded())))
+				.isEqualTo(16L);
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3739,7 +4014,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.set(KEY_1, "1000").get();
 
 			assertThat(clusterConnection.keyCommands().encodingOf(KEY_1_BYTES)).isEqualTo(ValkeyValueEncoding.INT);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3756,7 +4032,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 			nativeConnection.get(KEY_1).get();
 
 			assertThat(clusterConnection.keyCommands().idletime(KEY_1_BYTES)).isLessThan(Duration.ofSeconds(5));
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3769,10 +4046,11 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-716
 	void refcountReturnsCorrectly() {
 		try {
-			nativeConnection.lpush(KEY_1, new String[]{VALUE_1}).get();
+			nativeConnection.lpush(KEY_1, new String[] { VALUE_1 }).get();
 
 			assertThat(clusterConnection.keyCommands().refcount(KEY_1_BYTES)).isEqualTo(1L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3785,67 +4063,88 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@Test // DATAREDIS-562
 	void bitFieldSetShouldWorkCorrectly() {
 
-		assertThat(clusterConnection.stringCommands().bitField(ValkeyGlideConverters.toBytes(KEY_1),
-				create().set(INT_8).valueAt(BitFieldSubCommands.Offset.offset(0L)).to(10L))).containsExactly(0L);
-		assertThat(clusterConnection.stringCommands().bitField(ValkeyGlideConverters.toBytes(KEY_1),
-				create().set(INT_8).valueAt(BitFieldSubCommands.Offset.offset(0L)).to(20L))).containsExactly(10L);
+		assertThat(clusterConnection.stringCommands()
+			.bitField(ValkeyGlideConverters.toBytes(KEY_1),
+					create().set(INT_8).valueAt(BitFieldSubCommands.Offset.offset(0L)).to(10L)))
+			.containsExactly(0L);
+		assertThat(clusterConnection.stringCommands()
+			.bitField(ValkeyGlideConverters.toBytes(KEY_1),
+					create().set(INT_8).valueAt(BitFieldSubCommands.Offset.offset(0L)).to(20L)))
+			.containsExactly(10L);
 	}
 
 	@Test // DATAREDIS-562
 	void bitFieldGetShouldWorkCorrectly() {
 
-		assertThat(clusterConnection.stringCommands().bitField(ValkeyGlideConverters.toBytes(KEY_1),
-				create().get(INT_8).valueAt(BitFieldSubCommands.Offset.offset(0L)))).containsExactly(0L);
+		assertThat(clusterConnection.stringCommands()
+			.bitField(ValkeyGlideConverters.toBytes(KEY_1),
+					create().get(INT_8).valueAt(BitFieldSubCommands.Offset.offset(0L))))
+			.containsExactly(0L);
 	}
 
 	@Test // DATAREDIS-562
 	void bitFieldIncrByShouldWorkCorrectly() {
 
-		assertThat(clusterConnection.stringCommands().bitField(ValkeyGlideConverters.toBytes(KEY_1),
-				create().incr(INT_8).valueAt(BitFieldSubCommands.Offset.offset(100L)).by(1L))).containsExactly(1L);
+		assertThat(clusterConnection.stringCommands()
+			.bitField(ValkeyGlideConverters.toBytes(KEY_1),
+					create().incr(INT_8).valueAt(BitFieldSubCommands.Offset.offset(100L)).by(1L)))
+			.containsExactly(1L);
 	}
 
 	@Test // DATAREDIS-562
 	void bitFieldIncrByWithOverflowShouldWorkCorrectly() {
 
-		assertThat(clusterConnection.stringCommands().bitField(ValkeyGlideConverters.toBytes(KEY_1),
-				create().incr(unsigned(2)).valueAt(BitFieldSubCommands.Offset.offset(102L)).overflow(FAIL).by(1L)))
-				.containsExactly(1L);
-		assertThat(clusterConnection.stringCommands().bitField(ValkeyGlideConverters.toBytes(KEY_1),
-				create().incr(unsigned(2)).valueAt(BitFieldSubCommands.Offset.offset(102L)).overflow(FAIL).by(1L)))
-				.containsExactly(2L);
-		assertThat(clusterConnection.stringCommands().bitField(ValkeyGlideConverters.toBytes(KEY_1),
-				create().incr(unsigned(2)).valueAt(BitFieldSubCommands.Offset.offset(102L)).overflow(FAIL).by(1L)))
-				.containsExactly(3L);
+		assertThat(clusterConnection.stringCommands()
+			.bitField(ValkeyGlideConverters.toBytes(KEY_1),
+					create().incr(unsigned(2)).valueAt(BitFieldSubCommands.Offset.offset(102L)).overflow(FAIL).by(1L)))
+			.containsExactly(1L);
+		assertThat(clusterConnection.stringCommands()
+			.bitField(ValkeyGlideConverters.toBytes(KEY_1),
+					create().incr(unsigned(2)).valueAt(BitFieldSubCommands.Offset.offset(102L)).overflow(FAIL).by(1L)))
+			.containsExactly(2L);
+		assertThat(clusterConnection.stringCommands()
+			.bitField(ValkeyGlideConverters.toBytes(KEY_1),
+					create().incr(unsigned(2)).valueAt(BitFieldSubCommands.Offset.offset(102L)).overflow(FAIL).by(1L)))
+			.containsExactly(3L);
 
 		assertThat(clusterConnection.stringCommands()
-				.bitField(ValkeyGlideConverters.toBytes(KEY_1),
-						create().incr(unsigned(2)).valueAt(BitFieldSubCommands.Offset.offset(102L)).overflow(FAIL).by(1L))
-				.get(0)).isNull();
+			.bitField(ValkeyGlideConverters.toBytes(KEY_1),
+					create().incr(unsigned(2)).valueAt(BitFieldSubCommands.Offset.offset(102L)).overflow(FAIL).by(1L))
+			.get(0)).isNull();
 	}
 
 	@Test // DATAREDIS-562
 	void bitfieldShouldAllowMultipleSubcommands() {
 
-		assertThat(clusterConnection.stringCommands().bitField(ValkeyGlideConverters.toBytes(KEY_1),
-				create().incr(signed(5)).valueAt(BitFieldSubCommands.Offset.offset(100L)).by(1L).get(unsigned(4)).valueAt(0L)))
-				.containsExactly(1L, 0L);
+		assertThat(clusterConnection.stringCommands()
+			.bitField(ValkeyGlideConverters.toBytes(KEY_1),
+					create().incr(signed(5))
+						.valueAt(BitFieldSubCommands.Offset.offset(100L))
+						.by(1L)
+						.get(unsigned(4))
+						.valueAt(0L)))
+			.containsExactly(1L, 0L);
 	}
 
 	@Test // DATAREDIS-562
 	void bitfieldShouldWorkUsingNonZeroBasedOffset() {
 
-		assertThat(
-				clusterConnection.stringCommands().bitField(ValkeyGlideConverters.toBytes(KEY_1),
-						create().set(INT_8).valueAt(BitFieldSubCommands.Offset.offset(0L).multipliedByTypeLength()).to(100L)
-								.set(INT_8).valueAt(BitFieldSubCommands.Offset.offset(1L).multipliedByTypeLength()).to(200L)))
-				.containsExactly(0L, 0L);
-		assertThat(
-				clusterConnection.stringCommands()
-						.bitField(ValkeyGlideConverters.toBytes(KEY_1),
-								create().get(INT_8).valueAt(BitFieldSubCommands.Offset.offset(0L).multipliedByTypeLength()).get(INT_8)
-										.valueAt(BitFieldSubCommands.Offset.offset(1L).multipliedByTypeLength())))
-				.containsExactly(100L, -56L);
+		assertThat(clusterConnection.stringCommands()
+			.bitField(ValkeyGlideConverters.toBytes(KEY_1),
+					create().set(INT_8)
+						.valueAt(BitFieldSubCommands.Offset.offset(0L).multipliedByTypeLength())
+						.to(100L)
+						.set(INT_8)
+						.valueAt(BitFieldSubCommands.Offset.offset(1L).multipliedByTypeLength())
+						.to(200L)))
+			.containsExactly(0L, 0L);
+		assertThat(clusterConnection.stringCommands()
+			.bitField(ValkeyGlideConverters.toBytes(KEY_1),
+					create().get(INT_8)
+						.valueAt(BitFieldSubCommands.Offset.offset(0L).multipliedByTypeLength())
+						.get(INT_8)
+						.valueAt(BitFieldSubCommands.Offset.offset(1L).multipliedByTypeLength())))
+			.containsExactly(100L, -56L);
 	}
 
 	@Test // DATAREDIS-1005
@@ -3885,7 +4184,8 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 		try {
 			clusterConnection.scriptingCommands().evalSha(luaScriptBin, ReturnType.VALUE, 1, keyAndArgs);
 			fail("expected InvalidDataAccessApiUsageException");
-		} catch (InvalidDataAccessApiUsageException ex) {
+		}
+		catch (InvalidDataAccessApiUsageException ex) {
 			assertThat(ex.getMessage()).contains("NOSCRIPT");
 		}
 	}
@@ -3907,12 +4207,13 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@EnabledOnCommand("LPOS")
 	void lPos() {
 		try {
-			nativeConnection.rpush(KEY_1, new String[]{"a", "b", "c", "1", "2", "3", "c", "c"}).get();
-			List<Long> result = clusterConnection.listCommands().lPos(KEY_1_BYTES, "c".getBytes(StandardCharsets.UTF_8), null,
-					null);
+			nativeConnection.rpush(KEY_1, new String[] { "a", "b", "c", "1", "2", "3", "c", "c" }).get();
+			List<Long> result = clusterConnection.listCommands()
+				.lPos(KEY_1_BYTES, "c".getBytes(StandardCharsets.UTF_8), null, null);
 
 			assertThat(result).containsOnly(2L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3921,12 +4222,13 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@EnabledOnCommand("LPOS")
 	void lPosRank() {
 		try {
-			nativeConnection.rpush(KEY_1, new String[]{"a", "b", "c", "1", "2", "3", "c", "c"}).get();
-			List<Long> result = clusterConnection.listCommands().lPos(KEY_1_BYTES, "c".getBytes(StandardCharsets.UTF_8), 2,
-					null);
+			nativeConnection.rpush(KEY_1, new String[] { "a", "b", "c", "1", "2", "3", "c", "c" }).get();
+			List<Long> result = clusterConnection.listCommands()
+				.lPos(KEY_1_BYTES, "c".getBytes(StandardCharsets.UTF_8), 2, null);
 
 			assertThat(result).containsExactly(6L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3935,12 +4237,13 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@EnabledOnCommand("LPOS")
 	void lPosNegativeRank() {
 		try {
-			nativeConnection.rpush(KEY_1, new String[]{"a", "b", "c", "1", "2", "3", "c", "c"}).get();
-			List<Long> result = clusterConnection.listCommands().lPos(KEY_1_BYTES, "c".getBytes(StandardCharsets.UTF_8), -1,
-					null);
+			nativeConnection.rpush(KEY_1, new String[] { "a", "b", "c", "1", "2", "3", "c", "c" }).get();
+			List<Long> result = clusterConnection.listCommands()
+				.lPos(KEY_1_BYTES, "c".getBytes(StandardCharsets.UTF_8), -1, null);
 
 			assertThat(result).containsExactly(7L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3949,12 +4252,13 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@EnabledOnCommand("LPOS")
 	void lPosCount() {
 		try {
-			nativeConnection.rpush(KEY_1, new String[]{"a", "b", "c", "1", "2", "3", "c", "c"}).get();
-			List<Long> result = clusterConnection.listCommands().lPos(KEY_1_BYTES, "c".getBytes(StandardCharsets.UTF_8), null,
-					2);
+			nativeConnection.rpush(KEY_1, new String[] { "a", "b", "c", "1", "2", "3", "c", "c" }).get();
+			List<Long> result = clusterConnection.listCommands()
+				.lPos(KEY_1_BYTES, "c".getBytes(StandardCharsets.UTF_8), null, 2);
 
 			assertThat(result).containsExactly(2L, 6L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3963,11 +4267,13 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@EnabledOnCommand("LPOS")
 	void lPosRankCount() {
 		try {
-			nativeConnection.rpush(KEY_1, new String[]{"a", "b", "c", "1", "2", "3", "c", "c"}).get();
-			List<Long> result = clusterConnection.listCommands().lPos(KEY_1_BYTES, "c".getBytes(StandardCharsets.UTF_8), -1, 2);
+			nativeConnection.rpush(KEY_1, new String[] { "a", "b", "c", "1", "2", "3", "c", "c" }).get();
+			List<Long> result = clusterConnection.listCommands()
+				.lPos(KEY_1_BYTES, "c".getBytes(StandardCharsets.UTF_8), -1, 2);
 
 			assertThat(result).containsExactly(7L, 6L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3976,12 +4282,13 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@EnabledOnCommand("LPOS")
 	void lPosCountZero() {
 		try {
-			nativeConnection.rpush(KEY_1, new String[]{"a", "b", "c", "1", "2", "3", "c", "c"}).get();
-			List<Long> result = clusterConnection.listCommands().lPos(KEY_1_BYTES, "c".getBytes(StandardCharsets.UTF_8), null,
-					0);
+			nativeConnection.rpush(KEY_1, new String[] { "a", "b", "c", "1", "2", "3", "c", "c" }).get();
+			List<Long> result = clusterConnection.listCommands()
+				.lPos(KEY_1_BYTES, "c".getBytes(StandardCharsets.UTF_8), null, 0);
 
 			assertThat(result).containsExactly(2L, 6L, 7L);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -3990,12 +4297,13 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	@EnabledOnCommand("LPOS")
 	void lPosNonExisting() {
 		try {
-			nativeConnection.rpush(KEY_1, new String[]{"a", "b", "c", "1", "2", "3", "c", "c"}).get();
-			List<Long> result = clusterConnection.listCommands().lPos(KEY_1_BYTES, "x".getBytes(StandardCharsets.UTF_8), null,
-					null);
+			nativeConnection.rpush(KEY_1, new String[] { "a", "b", "c", "1", "2", "3", "c", "c" }).get();
+			List<Long> result = clusterConnection.listCommands()
+				.lPos(KEY_1_BYTES, "x".getBytes(StandardCharsets.UTF_8), null, null);
 
 			assertThat(result).isEmpty();
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception: " + e.getMessage());
 		}
 	}
@@ -4005,27 +4313,27 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 		// Test 1: Force cache invalidation - no cached topology
 		ReflectionTestUtils.setField(clusterConnection, "cachedTopology", null);
 		ReflectionTestUtils.setField(clusterConnection, "lastCacheTime", 0L);
-		
+
 		// Get fresh topology - should fetch from cluster
 		ClusterTopology topology1 = clusterConnection.getTopology();
 		assertThat(topology1).isNotNull();
-		
+
 		// Verify lastCacheTime was set after fetch
 		Long lastCacheTime = (Long) ReflectionTestUtils.getField(clusterConnection, "lastCacheTime");
 		assertThat(lastCacheTime).isGreaterThan(0L);
-		
+
 		// Test 2: Cached topology with valid timestamp (should use cache)
 		Long currentTime = System.currentTimeMillis();
 		ReflectionTestUtils.setField(clusterConnection, "lastCacheTime", currentTime);
-		
+
 		ClusterTopology topology2 = clusterConnection.getTopology();
 		assertThat(topology2).isSameAs(topology1); // Same instance = used cache
-		
+
 		// Test 3: Cached topology with expired timestamp (should refresh)
 		Long cacheTimeout = (Long) ReflectionTestUtils.getField(clusterConnection, "cacheTimeoutMs");
 		Long expiredTime = currentTime - cacheTimeout - 100; // Expired by 100ms
 		ReflectionTestUtils.setField(clusterConnection, "lastCacheTime", expiredTime);
-		
+
 		ClusterTopology topology3 = clusterConnection.getTopology();
 		assertThat(topology3).isNotSameAs(topology1); // Different instance = refreshed
 	}
@@ -4034,4 +4342,5 @@ public class ValkeyGlideClusterConnectionTests implements ClusterConnectionTests
 	public void pTtlShouldReturValueCorrectly() {
 		// TODO: Implement for GLIDE
 	}
+
 }

--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionClusterServerCommandsIntegrationTests.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionClusterServerCommandsIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,1025 +34,1026 @@ import io.valkey.springframework.data.valkey.test.condition.EnabledOnValkeyClust
 import io.valkey.springframework.data.valkey.test.condition.EnabledOnValkeyVersion;
 
 /**
- * Comprehensive low-level integration tests for {@link ValkeyGlideClusterConnection} 
- * cluster server commands functionality using the ValkeyClusterServerCommands interface directly.
- * 
- * <p>These tests validate the implementation of ValkeyClusterServerCommands methods that extend
- * ValkeyServerCommands with cluster-specific functionality:
- * 
+ * Comprehensive low-level integration tests for {@link ValkeyGlideClusterConnection}
+ * cluster server commands functionality using the ValkeyClusterServerCommands interface
+ * directly.
+ *
+ * <p>
+ * These tests validate the implementation of ValkeyClusterServerCommands methods that
+ * extend ValkeyServerCommands with cluster-specific functionality:
+ *
  * <h3>Node-Specific Operations</h3>
  * <ul>
- *   <li>Background operations (bgReWriteAof, bgSave, lastSave, save) on specific nodes</li>
- *   <li>Database operations (dbSize, flushDb, flushAll) on specific nodes</li>
- *   <li>Server information (info, time) from specific nodes</li>
- *   <li>Configuration management (getConfig, setConfig, resetConfigStats, rewriteConfig) on specific nodes</li>
- *   <li>Client management (getClientList) from specific nodes</li>
+ * <li>Background operations (bgReWriteAof, bgSave, lastSave, save) on specific nodes</li>
+ * <li>Database operations (dbSize, flushDb, flushAll) on specific nodes</li>
+ * <li>Server information (info, time) from specific nodes</li>
+ * <li>Configuration management (getConfig, setConfig, resetConfigStats, rewriteConfig) on
+ * specific nodes</li>
+ * <li>Client management (getClientList) from specific nodes</li>
  * </ul>
- * 
+ *
  * <h3>Cluster-Wide Aggregation</h3>
  * <ul>
- *   <li>Verify cluster-wide info() returns node-prefixed properties from all primaries</li>
- *   <li>Verify cluster-wide dbSize() returns sum of all node sizes</li>
- *   <li>Verify cluster-wide lastSave() returns most recent timestamp</li>
- *   <li>Verify cluster-wide operations execute on all primaries</li>
+ * <li>Verify cluster-wide info() returns node-prefixed properties from all primaries</li>
+ * <li>Verify cluster-wide dbSize() returns sum of all node sizes</li>
+ * <li>Verify cluster-wide lastSave() returns most recent timestamp</li>
+ * <li>Verify cluster-wide operations execute on all primaries</li>
  * </ul>
- * 
- * <p><strong>Note:</strong> Since ValkeyClusterServerCommands extends ValkeyServerCommands and we already have
- * ValkeyGlideConnectionServerCommandsIntegrationTests covering the base interface, these tests focus on
- * the NEW methods specific to cluster mode (those with ValkeyClusterNode parameter) and verifying proper
- * aggregation behavior of inherited methods.
- * 
- * <p><strong>Reference Implementation:</strong> Uses JedisClusterServerCommands as the reference for
- * expected routing and aggregation behavior.
- * 
- * <p><strong>Cluster Topology:</strong> Tests use ClusterTestVariables constants for cluster configuration:
+ *
+ * <p>
+ * <strong>Note:</strong> Since ValkeyClusterServerCommands extends ValkeyServerCommands
+ * and we already have ValkeyGlideConnectionServerCommandsIntegrationTests covering the
+ * base interface, these tests focus on the NEW methods specific to cluster mode (those
+ * with ValkeyClusterNode parameter) and verifying proper aggregation behavior of
+ * inherited methods.
+ *
+ * <p>
+ * <strong>Reference Implementation:</strong> Uses JedisClusterServerCommands as the
+ * reference for expected routing and aggregation behavior.
+ *
+ * <p>
+ * <strong>Cluster Topology:</strong> Tests use ClusterTestVariables constants for cluster
+ * configuration:
  * <ul>
- *   <li>3 Master nodes: 7379, 7380, 7381</li>
- *   <li>1 Replica node: 7382 (replica of 7379)</li>
+ * <li>3 Master nodes: 7379, 7380, 7381</li>
+ * <li>1 Replica node: 7382 (replica of 7379)</li>
  * </ul>
- * 
+ *
  * @author Ilia Kolominsky
  * @since 2.0
  */
 @EnabledOnValkeyClusterAvailable
-public class ValkeyGlideConnectionClusterServerCommandsIntegrationTests extends AbstractValkeyGlideClusterIntegrationTests {
-
-    ValkeyClusterNode allNodes[] = new ValkeyClusterNode[] {
-        CLUSTER_NODE_1, CLUSTER_NODE_2, CLUSTER_NODE_3, REPLICA_OF_NODE_1
-    };
-
-    ValkeyClusterNode allPrimaries[] = new ValkeyClusterNode[] {
-        CLUSTER_NODE_1, CLUSTER_NODE_2, CLUSTER_NODE_3
-    };
-
-
-    @Override
-    protected String[] getTestKeyPatterns() {
-        return new String[]{
-            "test:cluster:server:key1", "test:cluster:server:key2", "test:cluster:server:key3",
-            "{user}:cluster:server:key1", "{user}:cluster:server:key2",
-            "test:cluster:server:flush:key", "test:cluster:server:db:key"
-        };
-    }
-
-    // ==================== Node-Specific Background Operations ====================
-
-    @Test
-    void testBgReWriteAofOnSpecificNode() {
-        for (ValkeyClusterNode node : allPrimaries) {
-            long beforeCount = getCommandCallCount(node, "bgrewriteaof");
-            clusterConnection.serverCommands().bgReWriteAof(node);
-            long afterCount = getCommandCallCount(node, "bgrewriteaof");
-            assertThat(afterCount).isEqualTo(beforeCount + 1);
-        }
-        
-        // sleep 2 seconds before starting next saving test to avoid "saving in progress" errors
-        try {
-            Thread.sleep(2000);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
-    }
-
-    @Test
-    void testBgSaveOnSpecificNode() {
-        for (ValkeyClusterNode node : allPrimaries) {
-            long beforeCount = getCommandCallCount(node, "bgsave");
-            clusterConnection.serverCommands().bgSave(node);
-            long afterCount = getCommandCallCount(node, "bgsave");
-            assertThat(afterCount).isEqualTo(beforeCount + 1);
-        }
-
-        // sleep 2 seconds before starting next saving test to avoid "saving in progress" errors
-        try {
-            Thread.sleep(2000);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
-    }
-
-    @Test
-    void testSaveOnSpecificNode() {
-        for (ValkeyClusterNode node : allPrimaries) {
-            long beforeCount = getCommandCallCount(node, "save");
-            clusterConnection.serverCommands().save(node);
-            long afterCount = getCommandCallCount(node, "save");
-            assertThat(afterCount).isEqualTo(beforeCount + 1);
-        }
-    }
-
-    @Test
-    void testLastSaveOnSpecificNode() {
-        for (ValkeyClusterNode node : allPrimaries) {
-            long beforeCount = getCommandCallCount(node, "lastsave");
-            clusterConnection.serverCommands().lastSave(node);
-            long afterCount = getCommandCallCount(node, "lastsave");
-            assertThat(afterCount).isEqualTo(beforeCount + 1);
-        }
-    }
-
-    // ==================== Node-Specific Database Operations ====================
-
-    @Test
-    void testDbSizeOnSpecificNode() {
-        String key = "test:cluster:server:db:key";
-        
-        try {
-            // Get initial database size from specific node
-            // First, determine which node serves this key
-            ValkeyClusterNode targetNode = clusterConnection.clusterCommands().clusterGetNodeForKey(key.getBytes());
-            assertThat(targetNode).isNotNull();
-            
-            Long initialSize = clusterConnection.serverCommands().dbSize(targetNode);
-            assertThat(initialSize).isNotNull();
-            assertThat(initialSize).isGreaterThanOrEqualTo(0L);
-            
-            // Add a key that routes to this specific node
-            clusterConnection.stringCommands().set(key.getBytes(), "value".getBytes());
-            
-            // Database size on this node should increase
-            Long newSize = clusterConnection.serverCommands().dbSize(targetNode);
-            assertThat(newSize).isNotNull();
-            assertThat(newSize).isGreaterThan(initialSize);
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    @Test
-    void testFlushDbOnSpecificNode() {
-        String key1 = "{user}:cluster:server:key1";
-        String key2 = "{user}:cluster:server:key2";
-        
-        try {
-            // Add test keys (they'll go to same node due to hash tag)
-            clusterConnection.stringCommands().set(key1.getBytes(), "value1".getBytes());
-            clusterConnection.stringCommands().set(key2.getBytes(), "value2".getBytes());
-            
-            // Get the node serving these keys
-            ValkeyClusterNode targetNode = clusterConnection.clusterCommands().clusterGetNodeForKey(key1.getBytes());
-            assertThat(targetNode).isNotNull();
-            
-            // Verify keys exist
-            assertThat(clusterConnection.keyCommands().exists(key1.getBytes())).isTrue();
-            assertThat(clusterConnection.keyCommands().exists(key2.getBytes())).isTrue();
-            
-            // Flush database on specific node
-            clusterConnection.serverCommands().flushDb(targetNode);
-            
-            // Verify keys are gone
-            assertThat(clusterConnection.keyCommands().exists(key1.getBytes())).isFalse();
-            assertThat(clusterConnection.keyCommands().exists(key2.getBytes())).isFalse();
-        } finally {
-            cleanupKeys(key1, key2);
-        }
-    }
-
-    @Test
-    void testFlushDbWithOptionOnSpecificNode() {
-        String key = "test:cluster:server:flush:key";
-        
-        try {
-            // Add test key
-            clusterConnection.stringCommands().set(key.getBytes(), "value".getBytes());
-            
-            // Get the node serving this key
-            ValkeyClusterNode targetNode = clusterConnection.clusterCommands().clusterGetNodeForKey(key.getBytes());
-            assertThat(targetNode).isNotNull();
-            
-            // Verify key exists
-            assertThat(clusterConnection.keyCommands().exists(key.getBytes())).isTrue();
-            
-            // Flush database with ASYNC option on specific node
-            clusterConnection.serverCommands().flushDb(targetNode, FlushOption.ASYNC);
-
-            try {
-                Thread.sleep(2000);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
-            
-            // Verify key is gone (may take a moment with ASYNC)
-            assertThat(clusterConnection.keyCommands().exists(key.getBytes())).isFalse();
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    @Test
-    void testFlushAllOnSpecificNode() {
-        String key = "test:cluster:server:key1";
-        
-        try {
-            // Add test key
-            clusterConnection.stringCommands().set(key.getBytes(), "value".getBytes());
-            
-            // Get the node serving this key
-            ValkeyClusterNode targetNode = clusterConnection.clusterCommands().clusterGetNodeForKey(key.getBytes());
-            assertThat(targetNode).isNotNull();
-            
-            // Get initial database size on this node
-            Long initialSize = clusterConnection.serverCommands().dbSize(targetNode);
-            assertThat(initialSize).isGreaterThan(0L);
-            
-            // Flush all databases on specific node
-            clusterConnection.serverCommands().flushAll(targetNode);
-            
-            // Database on this node should be empty or much smaller
-            Long newSize = clusterConnection.serverCommands().dbSize(targetNode);
-
-            assertThat(newSize).isEqualTo(0L);
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    @Test
-    void testFlushAllWithOptionOnSpecificNode() {
-        String key = "test:cluster:server:key2";
-        
-        try {
-            // Add test key
-            clusterConnection.stringCommands().set(key.getBytes(), "value".getBytes());
-            
-            // Get the node serving this key
-            ValkeyClusterNode targetNode = clusterConnection.clusterCommands().clusterGetNodeForKey(key.getBytes());
-            assertThat(targetNode).isNotNull();
-            
-            // Get initial database size
-            Long initialSize = clusterConnection.serverCommands().dbSize(targetNode);
-            assertThat(initialSize).isGreaterThan(0L);
-            
-            // Flush all databases with SYNC option on specific node
-            clusterConnection.serverCommands().flushAll(targetNode, FlushOption.SYNC);
-            
-            // Database should be empty or much smaller
-            Long newSize = clusterConnection.serverCommands().dbSize(targetNode);
-            assertThat(newSize).isEqualTo(0);
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    // ==================== Node-Specific Information Commands ====================
-
-    @Test
-    void testInfoOnSpecificNode() {
-        for (ValkeyClusterNode node : allNodes) {
-            Long beforeCount = getCommandCallCount(node, "info");
-            Properties info = clusterConnection.serverCommands().info(node);
-            
-            assertThat(info).isNotNull();
-            assertThat(info).isNotEmpty();
-            
-            // Verify basic server info properties
-            assertThat(info.containsKey("valkey_version") || info.containsKey("redis_version")).isTrue();
-
-            Long afterCount = getCommandCallCount(node, "info");
-            assertThat(afterCount).isEqualTo(beforeCount + 2);
-        }
-    }
-
-    @Test
-    void testInfoWithSectionOnSpecificNode() {
-        for (ValkeyClusterNode node : allNodes) {
-            Long beforeCount = getCommandCallCount(node, "info");
-            // Get INFO section from specific master node
-            Properties serverInfo = clusterConnection.serverCommands().info(node, "server");
-            assertThat(serverInfo).isNotNull();
-            assertThat(serverInfo.containsKey("valkey_version") || serverInfo.containsKey("redis_version")).isTrue();
-
-
-            // Test getting memory info
-            Properties memoryInfo = clusterConnection.serverCommands().info(node, "memory");
-            assertThat(memoryInfo).isNotNull();
-            assertThat(memoryInfo.containsKey("used_memory")).isTrue();
-
-            Long afterCount = getCommandCallCount(node, "info");
-            assertThat(afterCount).isEqualTo(beforeCount + 3);
-        }
-    }
-
-    @Test
-    void testTimeOnSpecificNode() throws InterruptedException {
-        for (ValkeyClusterNode node : allNodes) {
-            // Get server time from specific node in different units
-            Long beforeCmdCount = getCommandCallCount(node, "time");
-            Long beforeTimeMillis = clusterConnection.serverCommands().time(node, TimeUnit.MILLISECONDS);
-            Long beforeTimeSeconds = clusterConnection.serverCommands().time(node, TimeUnit.SECONDS);
-            Long beforeTimeMicros = clusterConnection.serverCommands().time(node, TimeUnit.MICROSECONDS);
-
-            Thread.sleep(1000);
-
-            Long afterTimeMillis = clusterConnection.serverCommands().time(node, TimeUnit.MILLISECONDS);
-            Long afterTimeSeconds = clusterConnection.serverCommands().time(node, TimeUnit.SECONDS);
-            Long afterTimeMicros = clusterConnection.serverCommands().time(node, TimeUnit.MICROSECONDS);
-
-            Long afterCmdCount = getCommandCallCount(node, "time");
-            assertThat(afterCmdCount).isEqualTo(beforeCmdCount + 6);
-            assertThat(afterTimeMillis - beforeTimeMillis).isGreaterThanOrEqualTo(1000L);
-            assertThat(afterTimeSeconds - beforeTimeSeconds).isGreaterThanOrEqualTo(1L);
-            assertThat(afterTimeMicros - beforeTimeMicros).isGreaterThanOrEqualTo(1_000_000L);
-        }
-    }
-
-    // ==================== Node-Specific Configuration Management ====================
-
-    @Test
-    void testGetConfigOnSpecificNode() {
-        for (ValkeyClusterNode node : allNodes) {
-            // Get initial command stats for CONFIG GET on the target node
-            String cmdName = getCommandName("config", "get");
-            Long beforeCount = getCommandCallCount(node, cmdName);
-            // Get configuration from specific node
-            Properties maxMemoryConfig = clusterConnection.serverCommands()
-                .getConfig(node, "maxmemory");
-            assertThat(maxMemoryConfig).isNotNull();
-            
-            // Get all configs with wildcard
-            Properties allConfigs = clusterConnection.serverCommands().getConfig(node, "*");
-            assertThat(allConfigs).isNotNull();
-            assertThat(allConfigs).isNotEmpty();
-
-            Long afterCount = getCommandCallCount(node, cmdName);
-            assertThat(afterCount).isEqualTo(beforeCount + 2);
-        }
-    }
-
-    @Test
-    void testSetConfigOnSpecificNode() {
-        for (ValkeyClusterNode node : allNodes) {
-            // Get original timeout for restoration
-            Properties timeoutConfig = clusterConnection.serverCommands()
-                .getConfig(node, "timeout");
-            assertThat(timeoutConfig).isNotNull();
-            
-            Long originalTimeout = Long.parseLong(timeoutConfig.getProperty("timeout", "0"));
-            Long newTimeout = originalTimeout + 10;
-            
-            try {
-                // Set timeout to a safe value on specific node
-                clusterConnection.serverCommands().setConfig(node, "timeout", newTimeout.toString());
-                
-                // Verify it was set on that node
-                Properties newTimeoutConfig = clusterConnection.serverCommands()
-                    .getConfig(node, "timeout");
-                
-                Long updatedTimeout = Long.parseLong(newTimeoutConfig.getProperty("timeout", "0"));
-                assertThat(updatedTimeout).isEqualTo(newTimeout);
-            } finally {
-                // Restore original timeout
-                clusterConnection.serverCommands().setConfig(node, "timeout", originalTimeout.toString());
-            }
-        }
-    }
-
-    @Test
-    void testResetConfigStatsOnSpecificNode() {
-        for (ValkeyClusterNode node : allNodes) {
-            // Execute CONFIG RESETSTAT on specific node
-            clusterConnection.serverCommands().resetConfigStats(node);
-            
-            String cmdName = getCommandName("config", "resetstat");
-            long afterTotalCmdsCnt = getCommandCallCount(node, cmdName);
-            assertThat(afterTotalCmdsCnt).isEqualTo(1);
-        }
-    }
-
-    @Test
-    void testRewriteConfigOnSpecificNode() {
-        for (ValkeyClusterNode node : allNodes) {
-            // Get initial command stats for CONFIG REWRITE on the target node
-            String cmdName = getCommandName("config", "rewrite");
-            long initialCallCount = getCommandCallCount(node, cmdName);
-            
-            // Rewrite config on specific node
-            clusterConnection.serverCommands().rewriteConfig(node);
-            
-            // Get command stats after execution
-            long afterCallCount = getCommandCallCount(node, cmdName);
-            
-            // Verify the command counter increased (by at least 1 for the rewriteConfig call)
-            assertThat(afterCallCount).isEqualTo(initialCallCount + 1);
-        }
-    }
-
-    // ==================== Node-Specific Client Management ====================
-
-    @Test
-    void testGetClientListOnSpecificNode() {
-        for (ValkeyClusterNode node : allNodes) {
-            String cmdName = getCommandName("client", "list");
-            Long beforeCount = getCommandCallCount(node, cmdName);
-            // Get client list from specific node
-            List<ValkeyClientInfo> clientList = clusterConnection.serverCommands()
-                .getClientList(node);
-            
-            assertThat(clientList).isNotNull();
-            assertThat(clientList).isNotEmpty();
-            
-            // Verify client info properties
-            ValkeyClientInfo firstClient = clientList.get(0);
-            assertThat(firstClient).isNotNull();
-            assertThat(firstClient.get("addr")).isNotNull();
-            assertThat(firstClient.get("fd")).isNotNull();
-
-            Long afterCount = getCommandCallCount(node, cmdName);
-            assertThat(afterCount).isEqualTo(beforeCount + 1);
-        }
-    }
-
-    @Test
-    @EnabledOnValkeyVersion("7.2")
-    void testClientLibNameReported() {
-        List<ValkeyClientInfo> clientList = clusterConnection.serverCommands().getClientList();
-        assertThat(clientList).anyMatch(client -> "GlideSpringDataValkey".equals(client.get("lib-name")));
-    }
-
-    // ==================== Cluster-Wide Routing and Aggregation Verification ====================
-
-    @Test
-    void testInfoClusterWideAggregation() {
-        // Get cluster-wide INFO (should aggregate from all primaries)
-        Properties allInfo = clusterConnection.serverCommands().info();
-        
-        assertThat(allInfo).isNotNull();
-        assertThat(allInfo).isNotEmpty();
-        
-        // Verify properties are prefixed with node addresses (format: "host:port.property")
-        // Based on JedisClusterServerCommands reference implementation
-        String node1Prefix = CLUSTER_HOST + ":" + MASTER_NODE_1_PORT;
-        String node2Prefix = CLUSTER_HOST + ":" + MASTER_NODE_2_PORT;
-        String node3Prefix = CLUSTER_HOST + ":" + MASTER_NODE_3_PORT;
-        
-        // Check that we have properties from each master node
-        boolean hasNode1Props = allInfo.stringPropertyNames().stream()
-            .anyMatch(key -> key.startsWith(node1Prefix));
-        boolean hasNode2Props = allInfo.stringPropertyNames().stream()
-            .anyMatch(key -> key.startsWith(node2Prefix));
-        boolean hasNode3Props = allInfo.stringPropertyNames().stream()
-            .anyMatch(key -> key.startsWith(node3Prefix));
-        
-        assertThat(hasNode1Props).isTrue();
-        assertThat(hasNode2Props).isTrue();
-        assertThat(hasNode3Props).isTrue();
-    }
-
-    @Test
-    void testInfoWithSectionClusterWideAggregation() {
-        // Get cluster-wide INFO for specific section
-        Properties serverInfo = clusterConnection.serverCommands().info("server");
-        
-        assertThat(serverInfo).isNotNull();
-        assertThat(serverInfo).isNotEmpty();
-        
-        // Verify properties are prefixed with node addresses
-        String node1Prefix = CLUSTER_HOST + ":" + MASTER_NODE_1_PORT;
-        String node2Prefix = CLUSTER_HOST + ":" + MASTER_NODE_2_PORT;
-        String node3Prefix = CLUSTER_HOST + ":" + MASTER_NODE_3_PORT;
-        
-        // Check for server version property from each node
-        boolean hasNode1Version = serverInfo.stringPropertyNames().stream()
-            .anyMatch(key -> key.startsWith(node1Prefix) && 
-                (key.contains("valkey_version") || key.contains("redis_version")));
-        boolean hasNode2Version = serverInfo.stringPropertyNames().stream()
-            .anyMatch(key -> key.startsWith(node2Prefix) && 
-                (key.contains("valkey_version") || key.contains("redis_version")));
-        boolean hasNode3Version = serverInfo.stringPropertyNames().stream()
-            .anyMatch(key -> key.startsWith(node3Prefix) && 
-                (key.contains("valkey_version") || key.contains("redis_version")));
-        
-        assertThat(hasNode1Version).isTrue();
-        assertThat(hasNode2Version).isTrue();
-        assertThat(hasNode3Version).isTrue();
-    }
-
-    @Test
-    void testDbSizeClusterWideAggregation() {
-        String key1 = "test:cluster:server:key1";
-        String key2 = "test:cluster:server:key2";
-        String key3 = "test:cluster:server:key3";
-        
-        try {
-            // Get cluster-wide dbSize (should sum all nodes)
-            Long initialClusterSize = clusterConnection.serverCommands().dbSize();
-            assertThat(initialClusterSize).isNotNull();
-            assertThat(initialClusterSize).isGreaterThanOrEqualTo(0L);
-            
-            // Add keys that will distribute across different nodes
-            clusterConnection.stringCommands().set(key1.getBytes(), "value1".getBytes());
-            clusterConnection.stringCommands().set(key2.getBytes(), "value2".getBytes());
-            clusterConnection.stringCommands().set(key3.getBytes(), "value3".getBytes());
-            
-            // Cluster-wide dbSize should increase
-            Long newClusterSize = clusterConnection.serverCommands().dbSize();
-            assertThat(newClusterSize).isNotNull();
-            assertThat(newClusterSize).isGreaterThan(initialClusterSize);
-            
-            // Verify it's actually the sum by checking individual nodes
-            Collection<ValkeyClusterNode> masters = getActiveMasterNodes();
-            long manualSum = 0L;
-            for (ValkeyClusterNode master : masters) {
-                Long nodeSize = clusterConnection.serverCommands().dbSize(master);
-                if (nodeSize != null) {
-                    manualSum += nodeSize;
-                }
-            }
-            
-            assertThat(newClusterSize).isEqualTo(manualSum);
-        } finally {
-            cleanupKeys(key1, key2, key3);
-        }
-    }
-
-    @Test
-    void testLastSaveClusterWideAggregation() {
-        // Get cluster-wide lastSave (should return most recent timestamp), should be non-null due to prior saves
-        Long clusterLastSave = clusterConnection.serverCommands().lastSave();
-        
-        assertThat(clusterLastSave).isGreaterThan(0L);
-        
-        // Verify it's the maximum of all node lastSaves
-        long maxLastSave = 0L;
-        for (ValkeyClusterNode node : allPrimaries) {
-            Long nodeLastSave = clusterConnection.serverCommands().lastSave(node);
-            if (nodeLastSave != null && nodeLastSave > maxLastSave) {
-                maxLastSave = nodeLastSave;
-            }
-        }
-        
-        // Cluster-wide lastSave should match the maximum
-        assertThat(clusterLastSave).isEqualTo(maxLastSave);
-    }
-
-    @Test
-    void testGetConfigClusterWideAggregation() {
-        // Get cluster-wide config (should aggregate from all primaries with node prefixes)
-        Properties allConfigs = clusterConnection.serverCommands().getConfig("timeout");
-        
-        assertThat(allConfigs).isNotNull();
-        
-        // Verify properties are prefixed with node addresses
-        String node1Prefix = CLUSTER_HOST + ":" + MASTER_NODE_1_PORT;
-        String node2Prefix = CLUSTER_HOST + ":" + MASTER_NODE_2_PORT;
-        String node3Prefix = CLUSTER_HOST + ":" + MASTER_NODE_3_PORT;
-        
-        // Check that we have timeout config from each master node
-        boolean hasNode1Config = allConfigs.stringPropertyNames().stream()
-            .anyMatch(key -> key.startsWith(node1Prefix) && key.contains("timeout"));
-        boolean hasNode2Config = allConfigs.stringPropertyNames().stream()
-            .anyMatch(key -> key.startsWith(node2Prefix) && key.contains("timeout"));
-        boolean hasNode3Config = allConfigs.stringPropertyNames().stream()
-            .anyMatch(key -> key.startsWith(node3Prefix) && key.contains("timeout"));
-        
-        assertThat(hasNode1Config).isTrue();
-        assertThat(hasNode2Config).isTrue();
-        assertThat(hasNode3Config).isTrue();
-    }
-
-    @Test
-    void testGetClientListClusterWideAggregation() {
-        // Get cluster-wide client list (should combine lists from all primaries)
-        List<ValkeyClientInfo> clusterClientList = clusterConnection.serverCommands().getClientList();
-        
-        assertThat(clusterClientList).isNotNull();
-        assertThat(clusterClientList).isNotEmpty();
-        
-        // Verify cluster-wide count is at least the sum from each node
-        // (>= instead of == to avoid race condition where connections are created between measurements)
-        int minExpectedClients = 0;
-        for (ValkeyClusterNode node : allPrimaries) {
-            List<ValkeyClientInfo> nodeClients = clusterConnection.serverCommands().getClientList(node);
-            minExpectedClients += nodeClients.size();
-        }
-        
-        assertThat(clusterClientList.size()).isGreaterThanOrEqualTo(minExpectedClients);
-    }
-
-    @Test
-    void testFlushOperationsClusterWide() {
-        String key1 = "test:cluster:server:key1";
-        String key2 = "test:cluster:server:key2";
-        String key3 = "test:cluster:server:key3";
-        
-        try {
-            // Add keys that will distribute across different nodes
-            clusterConnection.stringCommands().set(key1.getBytes(), "value1".getBytes());
-            clusterConnection.stringCommands().set(key2.getBytes(), "value2".getBytes());
-            clusterConnection.stringCommands().set(key3.getBytes(), "value3".getBytes());
-            
-            // Get initial cluster-wide dbSize
-            Long initialSize = clusterConnection.serverCommands().dbSize();
-            assertThat(initialSize).isGreaterThan(0L);
-            
-            // Execute cluster-wide flushDb
-            clusterConnection.serverCommands().flushDb();
-            
-            // Cluster-wide dbSize should be 0
-            Long newSize = clusterConnection.serverCommands().dbSize();
-            assertThat(newSize).isEqualTo(0);
-            
-            // Verify keys are gone
-            assertThat(clusterConnection.keyCommands().exists(key1.getBytes())).isFalse();
-            assertThat(clusterConnection.keyCommands().exists(key2.getBytes())).isFalse();
-            assertThat(clusterConnection.keyCommands().exists(key3.getBytes())).isFalse();
-        } finally {
-            cleanupKeys(key1, key2, key3);
-        }
-    }
-
-    @Test
-    void testFlushOperationsWithOptionClusterWide() {
-        String key1 = "test:cluster:server:key1";
-        String key2 = "test:cluster:server:key2";
-        String key3 = "test:cluster:server:key3";
-        
-        try {
-            // Add keys that will distribute across different nodes
-            clusterConnection.stringCommands().set(key1.getBytes(), "value1".getBytes());
-            clusterConnection.stringCommands().set(key2.getBytes(), "value2".getBytes());
-            clusterConnection.stringCommands().set(key3.getBytes(), "value3".getBytes());
-            
-            // Get initial cluster-wide dbSize
-            Long initialSize = clusterConnection.serverCommands().dbSize();
-            assertThat(initialSize).isGreaterThan(0L);
-            
-            // Execute cluster-wide flushDb
-            clusterConnection.serverCommands().flushDb(FlushOption.ASYNC);
-
-            try {
-                Thread.sleep(1000);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
-            
-            // Cluster-wide dbSize should be 0
-            Long newSize = clusterConnection.serverCommands().dbSize();
-            assertThat(newSize).isEqualTo(0);
-            
-            // Verify keys are gone
-            assertThat(clusterConnection.keyCommands().exists(key1.getBytes())).isFalse();
-            assertThat(clusterConnection.keyCommands().exists(key2.getBytes())).isFalse();
-            assertThat(clusterConnection.keyCommands().exists(key3.getBytes())).isFalse();
-        } finally {
-            cleanupKeys(key1, key2, key3);
-        }
-    }
-
-    @Test
-    void testBgReWriteAofClusterWide() {
-        // Reset config stats on all nodes to have a clean slate
-        clusterConnection.serverCommands().resetConfigStats();
-        // Execute cluster-wide bgReWriteAof
-        clusterConnection.serverCommands().bgReWriteAof();
-        for (ValkeyClusterNode node : allPrimaries) {
-            long afterCount = getCommandCallCount(node, "bgrewriteaof");
-            assertThat(afterCount).isEqualTo(1);
-        }
-        
-        // sleep 2 seconds before starting next saving test to avoid "saving in progress" errors
-        try {
-            Thread.sleep(2000);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
-    }
-
-    @Test
-    void testBgSaveClusterWide() {
-        // Reset config stats on all nodes to have a clean slate
-        clusterConnection.serverCommands().resetConfigStats();
-        // Execute cluster-wide bgSave
-        clusterConnection.serverCommands().bgSave();
-        for (ValkeyClusterNode node : allPrimaries) {
-            long afterCount = getCommandCallCount(node, "bgsave");
-            assertThat(afterCount).isEqualTo(1);
-        }
-        
-        // sleep 2 seconds before starting next saving test to avoid "saving in progress" errors
-        try {
-            Thread.sleep(2000);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
-    }
-
-    @Test
-    void testSaveClusterWide() {
-        // Reset config stats on all nodes to have a clean slate
-        clusterConnection.serverCommands().resetConfigStats();
-        // Execute cluster-wide save
-        clusterConnection.serverCommands().save();
-        for (ValkeyClusterNode node : allPrimaries) {
-            long afterCount = getCommandCallCount(node, "save");
-            assertThat(afterCount).isEqualTo(1);
-        }
-    }
-
-    @Test
-    void testFlushAllClusterWide() {
-        String key = "test:cluster:server:key1";
-        
-        try {
-            clusterConnection.stringCommands().set(key.getBytes(), "value".getBytes());
-            assertThat(clusterConnection.keyCommands().exists(key.getBytes())).isTrue();
-            clusterConnection.serverCommands().flushAll();
-            assertThat(clusterConnection.keyCommands().exists(key.getBytes())).isFalse();
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    @Test
-    void testFlushAllWithOptionClusterWide() {
-        String key = "test:cluster:server:key1";
-        
-        try {
-            clusterConnection.stringCommands().set(key.getBytes(), "value".getBytes());
-            assertThat(clusterConnection.keyCommands().exists(key.getBytes())).isTrue();
-            clusterConnection.serverCommands().flushAll(FlushOption.SYNC);
-            assertThat(clusterConnection.keyCommands().exists(key.getBytes())).isFalse();
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    @Test
-    void testSetConfigClusterWide() {
-        for (ValkeyClusterNode node : allNodes) {
-            // Get original timeout for restoration
-            Properties timeoutConfig = clusterConnection.serverCommands()
-                .getConfig(node, "timeout");
-            assertThat(timeoutConfig).isNotNull();
-            
-            Long originalTimeout = Long.parseLong(timeoutConfig.getProperty("timeout", "0"));
-            Long newTimeout = originalTimeout + 10;
-            
-            try {
-                // Set timeout to a safe value on specific node
-                clusterConnection.serverCommands().setConfig(node, "timeout", newTimeout.toString());
-                
-                // Verify it was set on that node
-                Properties newTimeoutConfig = clusterConnection.serverCommands()
-                    .getConfig(node, "timeout");
-                
-                Long updatedTimeout = Long.parseLong(newTimeoutConfig.getProperty("timeout", "0"));
-                assertThat(updatedTimeout).isEqualTo(newTimeout);
-            } finally {
-                // Restore original timeout
-                clusterConnection.serverCommands().setConfig(node, "timeout", originalTimeout.toString());
-            }
-        }
-    }
-
-    @Test
-    void testResetConfigStatsClusterWide() {
-        // Reset config stats on all nodes to have a clean slate
-        clusterConnection.serverCommands().resetConfigStats();
-        String cmdName = getCommandName("config", "resetstat");
-        for (ValkeyClusterNode node : allNodes) {
-            long afterCount = getCommandCallCount(node, cmdName);
-            assertThat(afterCount).isEqualTo(1);
-        }
-    }
-
-    @Test
-    void testRewriteConfigClusterWide() {
-        // Reset config stats on all nodes to have a clean slate
-        clusterConnection.serverCommands().resetConfigStats();
-        clusterConnection.serverCommands().rewriteConfig();
-        String cmdName = getCommandName("config", "rewrite");
-        for (ValkeyClusterNode node : allNodes) {
-            long afterCount = getCommandCallCount(node, cmdName);
-            // 6.2 does not distinguish between rewrite and reset
-            assertThat(afterCount).isEqualTo(isBackend7OrNewer() ? 1 : 2);
-        }
-    }
-
-    @Test
-    void testTimeClusterWide() {
-        // routing policy is random, just verify that we can get time from a node
-        clusterConnection.serverCommands().time(TimeUnit.MILLISECONDS);
-        clusterConnection.serverCommands().time(TimeUnit.SECONDS);
-        clusterConnection.serverCommands().time(TimeUnit.MICROSECONDS);
-    }
-
-    // ==================== MIGRATE Command Tests - Only basic, non intrusive ====================
-
-    @Test
-    void testMigrateBasic() {
-        String key = "test:migrate:basic";
-        
-        try {
-            // Set a key
-            clusterConnection.stringCommands().set(key.getBytes(), "migrateValue".getBytes());
-            
-            // Verify key exists before migration
-            assertThat(clusterConnection.keyCommands().exists(key.getBytes())).isTrue();
-            
-            // Determine source node where key currently resides
-            ValkeyClusterNode sourceNode = clusterConnection.clusterCommands()
-                .clusterGetNodeForKey(key.getBytes());
-            assertThat(sourceNode).isNotNull();
-
-            // Find a different random master node as target
-            final ValkeyClusterNode targetNode = Arrays.stream(allPrimaries)
-                .filter(n -> !n.equals(sourceNode))
-                .findFirst()
-                .orElseThrow();
-            
-            // Attempt to migrate the key; expect a MOVED error since cluster slots are not being changed
-            assertThatThrownBy(() ->
-                clusterConnection.serverCommands().migrate(
-                key.getBytes(),
-                targetNode,
-                0,  // db index (always 0 in cluster)
-                null,  // no option - key will be moved, not copied
-                5000   // 5 second timeout
-            )).hasMessageContaining("MOVED");
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    @Test
-    void testMigrateParameterValidation() {
-        String key = "test:migrate:validation";
-        
-        ValkeyClusterNode targetNode = allPrimaries[0];
-        
-        // Test null key
-        assertThatThrownBy(() ->
-            clusterConnection.serverCommands().migrate(
-                null,
-                targetNode,
-                0,
-                null,
-                5000
-            )
-        ).isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("Key must not be null");
-        
-        // Test null target
-        assertThatThrownBy(() ->
-            clusterConnection.serverCommands().migrate(
-                key.getBytes(),
-                null,
-                0,
-                null,
-                5000
-            )
-        ).isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("Target must not be null");
-    }
-
-    // ==================== Edge Cases & Error Handling ====================
-
-    @Test
-    void testNodeSpecificOperationsWithInvalidNode() {
-        // Test with non-existent node (should fail gracefully)
-        ValkeyClusterNode invalidNode = ValkeyClusterNode.newValkeyClusterNode()
-            .listeningAt("192.168.255.255", 9999)
-            .build();
-        
-        // Attempt operations on invalid node - should throw exception
-        ValkeyClusterServerCommands commands = clusterConnection.serverCommands();
-        assertThatThrownBy(() -> 
-            commands.info(invalidNode))
-            .isInstanceOf(Exception.class);
-        
-        assertThatThrownBy(() -> 
-            commands.dbSize(invalidNode))
-            .isInstanceOf(Exception.class);
-    }
-
-    @Test
-    void testNodeParameterValidation() {
-        // Test null node parameter handling
-        ValkeyClusterServerCommands commands = clusterConnection.serverCommands();
-        ValkeyClusterNode nullNode = null;
-        
-        assertThatThrownBy(() -> 
-            commands.info(nullNode))
-            .isInstanceOf(IllegalArgumentException.class);
-        
-        assertThatThrownBy(() -> 
-            commands.dbSize(nullNode))
-            .isInstanceOf(IllegalArgumentException.class);
-        
-        assertThatThrownBy(() -> 
-            commands.getConfig(nullNode, "maxmemory"))
-            .isInstanceOf(IllegalArgumentException.class);
-        
-        assertThatThrownBy(() -> 
-            commands.setConfig(nullNode, "timeout", "60"))
-            .isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    void testNodeSpecificOperationsWithReplicaNode() {
-        // Some operations might behave differently on replica nodes
-        // Get the replica node
-        ValkeyClusterNode replica = null;
-        Iterable<ValkeyClusterNode> allNodes = clusterConnection.clusterCommands().clusterGetNodes();
-        for (ValkeyClusterNode node : allNodes) {
-            if (!node.isMaster() && node.getPort() == REPLICAOF_NODE_1_PORT) {
-                replica = node;
-                break;
-            }
-        }
-        
-        assertThat(replica).isNotNull();
-        assertThat(replica.isMaster()).isFalse();
-        
-        // Read operations should work on replica
-        ValkeyClusterServerCommands commands = clusterConnection.serverCommands();
-        Properties info = commands.info(replica);
-        assertThat(info).isNotNull();
-        assertThat(info).isNotEmpty();
-        
-        Long dbSize = commands.dbSize(replica);
-        assertThat(dbSize).isNotNull();
-        assertThat(dbSize).isGreaterThanOrEqualTo(0L);
-        
-        List<ValkeyClientInfo> clientList = commands.getClientList(replica);
-        assertThat(clientList).isNotNull();
-    }
-
-    // ==================== Helper Methods ====================
-
-    /**
-     * Lazy-initialized Backend version detection flag.
-     * True if Backend 7.0+, false if Backend 6.x.
-     */
-    private Boolean isBackend7OrNewer = null;
-
-    /**
-     * Detects if the Backend version is 7.0 or newer.
-     * 
-     * @return true if Backend 7.0+, false if Backend 6.x
-     */
-    private boolean isBackend7OrNewer() {
-        if (isBackend7OrNewer == null) {
-            Properties info = clusterConnection.serverCommands().info(allNodes[0], "server");
-            String version = info.getProperty("redis_version", info.getProperty("valkey_version", "0.0.0"));
-            // Parse major version
-            String majorVersion = version.split("\\.")[0];
-            int major = Integer.parseInt(majorVersion);
-            isBackend7OrNewer = major >= 7;
-        }
-        return isBackend7OrNewer;
-    }
-
-    /**
-     * Gets the appropriate command name format based on Backend version.
-     * Backend 7.0+: returns "command|subcommand" format (e.g., "config|get")
-     * Backend 6.x: returns parent command only (e.g., "config")
-     * 
-     * @param parentCommand the parent command (e.g., "config", "client")
-     * @param subCommand the sub-command (e.g., "get", "list"), can be null for simple commands
-     * @return the command name in the appropriate format for the current Backend version
-     */
-    private String getCommandName(String parentCommand, String subCommand) {
-        if (subCommand == null) {
-            return parentCommand;
-        }
-        if (isBackend7OrNewer()) {
-            return parentCommand + "|" + subCommand;
-        } else {
-            return parentCommand;
-        }
-    }
-
-    /**
-     * Gets the call count for a specific command from INFO COMMANDSTATS.
-     * 
-     * @param node the cluster node to query
-     * @param commandName the command name (e.g., "bgrewriteaof", "config", "config|get")
-     * @return the call count, or 0 if command hasn't been executed yet
-     */
-    private long getCommandCallCount(ValkeyClusterNode node, String commandName) {
-        Properties commandStats = clusterConnection.serverCommands().info(node, "commandstats");
-        
-        // Convert command name format: "config|get" -> "config_get" for lookup
-        String statKey = "cmdstat_" + commandName.toLowerCase();
-        String statValue = commandStats.getProperty(statKey);
-        if (statValue == null) {
-            return 0L; // Command not found, assume 0 calls
-        }
-        
-        // Parse the calls value from "calls=5,usec=1234,..."
-        for (String part : statValue.split(",")) {
-            String trimmed = part.trim();
-            if (trimmed.startsWith("calls=")) {
-                return Long.parseLong(trimmed.substring("calls=".length()));
-            }
-        }
-        
-        throw new IllegalStateException(
-            String.format("Failed to parse 'calls' field from command stats for '%s'. Value: %s", 
-                commandName, statValue));
-    }
+public class ValkeyGlideConnectionClusterServerCommandsIntegrationTests
+		extends AbstractValkeyGlideClusterIntegrationTests {
+
+	ValkeyClusterNode allNodes[] = new ValkeyClusterNode[] { CLUSTER_NODE_1, CLUSTER_NODE_2, CLUSTER_NODE_3,
+			REPLICA_OF_NODE_1 };
+
+	ValkeyClusterNode allPrimaries[] = new ValkeyClusterNode[] { CLUSTER_NODE_1, CLUSTER_NODE_2, CLUSTER_NODE_3 };
+
+	@Override
+	protected String[] getTestKeyPatterns() {
+		return new String[] { "test:cluster:server:key1", "test:cluster:server:key2", "test:cluster:server:key3",
+				"{user}:cluster:server:key1", "{user}:cluster:server:key2", "test:cluster:server:flush:key",
+				"test:cluster:server:db:key" };
+	}
+
+	// ==================== Node-Specific Background Operations ====================
+
+	@Test
+	void testBgReWriteAofOnSpecificNode() {
+		for (ValkeyClusterNode node : allPrimaries) {
+			long beforeCount = getCommandCallCount(node, "bgrewriteaof");
+			clusterConnection.serverCommands().bgReWriteAof(node);
+			long afterCount = getCommandCallCount(node, "bgrewriteaof");
+			assertThat(afterCount).isEqualTo(beforeCount + 1);
+		}
+
+		// sleep 2 seconds before starting next saving test to avoid "saving in progress"
+		// errors
+		try {
+			Thread.sleep(2000);
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+	}
+
+	@Test
+	void testBgSaveOnSpecificNode() {
+		for (ValkeyClusterNode node : allPrimaries) {
+			long beforeCount = getCommandCallCount(node, "bgsave");
+			clusterConnection.serverCommands().bgSave(node);
+			long afterCount = getCommandCallCount(node, "bgsave");
+			assertThat(afterCount).isEqualTo(beforeCount + 1);
+		}
+
+		// sleep 2 seconds before starting next saving test to avoid "saving in progress"
+		// errors
+		try {
+			Thread.sleep(2000);
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+	}
+
+	@Test
+	void testSaveOnSpecificNode() {
+		for (ValkeyClusterNode node : allPrimaries) {
+			long beforeCount = getCommandCallCount(node, "save");
+			clusterConnection.serverCommands().save(node);
+			long afterCount = getCommandCallCount(node, "save");
+			assertThat(afterCount).isEqualTo(beforeCount + 1);
+		}
+	}
+
+	@Test
+	void testLastSaveOnSpecificNode() {
+		for (ValkeyClusterNode node : allPrimaries) {
+			long beforeCount = getCommandCallCount(node, "lastsave");
+			clusterConnection.serverCommands().lastSave(node);
+			long afterCount = getCommandCallCount(node, "lastsave");
+			assertThat(afterCount).isEqualTo(beforeCount + 1);
+		}
+	}
+
+	// ==================== Node-Specific Database Operations ====================
+
+	@Test
+	void testDbSizeOnSpecificNode() {
+		String key = "test:cluster:server:db:key";
+
+		try {
+			// Get initial database size from specific node
+			// First, determine which node serves this key
+			ValkeyClusterNode targetNode = clusterConnection.clusterCommands().clusterGetNodeForKey(key.getBytes());
+			assertThat(targetNode).isNotNull();
+
+			Long initialSize = clusterConnection.serverCommands().dbSize(targetNode);
+			assertThat(initialSize).isNotNull();
+			assertThat(initialSize).isGreaterThanOrEqualTo(0L);
+
+			// Add a key that routes to this specific node
+			clusterConnection.stringCommands().set(key.getBytes(), "value".getBytes());
+
+			// Database size on this node should increase
+			Long newSize = clusterConnection.serverCommands().dbSize(targetNode);
+			assertThat(newSize).isNotNull();
+			assertThat(newSize).isGreaterThan(initialSize);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testFlushDbOnSpecificNode() {
+		String key1 = "{user}:cluster:server:key1";
+		String key2 = "{user}:cluster:server:key2";
+
+		try {
+			// Add test keys (they'll go to same node due to hash tag)
+			clusterConnection.stringCommands().set(key1.getBytes(), "value1".getBytes());
+			clusterConnection.stringCommands().set(key2.getBytes(), "value2".getBytes());
+
+			// Get the node serving these keys
+			ValkeyClusterNode targetNode = clusterConnection.clusterCommands().clusterGetNodeForKey(key1.getBytes());
+			assertThat(targetNode).isNotNull();
+
+			// Verify keys exist
+			assertThat(clusterConnection.keyCommands().exists(key1.getBytes())).isTrue();
+			assertThat(clusterConnection.keyCommands().exists(key2.getBytes())).isTrue();
+
+			// Flush database on specific node
+			clusterConnection.serverCommands().flushDb(targetNode);
+
+			// Verify keys are gone
+			assertThat(clusterConnection.keyCommands().exists(key1.getBytes())).isFalse();
+			assertThat(clusterConnection.keyCommands().exists(key2.getBytes())).isFalse();
+		}
+		finally {
+			cleanupKeys(key1, key2);
+		}
+	}
+
+	@Test
+	void testFlushDbWithOptionOnSpecificNode() {
+		String key = "test:cluster:server:flush:key";
+
+		try {
+			// Add test key
+			clusterConnection.stringCommands().set(key.getBytes(), "value".getBytes());
+
+			// Get the node serving this key
+			ValkeyClusterNode targetNode = clusterConnection.clusterCommands().clusterGetNodeForKey(key.getBytes());
+			assertThat(targetNode).isNotNull();
+
+			// Verify key exists
+			assertThat(clusterConnection.keyCommands().exists(key.getBytes())).isTrue();
+
+			// Flush database with ASYNC option on specific node
+			clusterConnection.serverCommands().flushDb(targetNode, FlushOption.ASYNC);
+
+			try {
+				Thread.sleep(2000);
+			}
+			catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+
+			// Verify key is gone (may take a moment with ASYNC)
+			assertThat(clusterConnection.keyCommands().exists(key.getBytes())).isFalse();
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testFlushAllOnSpecificNode() {
+		String key = "test:cluster:server:key1";
+
+		try {
+			// Add test key
+			clusterConnection.stringCommands().set(key.getBytes(), "value".getBytes());
+
+			// Get the node serving this key
+			ValkeyClusterNode targetNode = clusterConnection.clusterCommands().clusterGetNodeForKey(key.getBytes());
+			assertThat(targetNode).isNotNull();
+
+			// Get initial database size on this node
+			Long initialSize = clusterConnection.serverCommands().dbSize(targetNode);
+			assertThat(initialSize).isGreaterThan(0L);
+
+			// Flush all databases on specific node
+			clusterConnection.serverCommands().flushAll(targetNode);
+
+			// Database on this node should be empty or much smaller
+			Long newSize = clusterConnection.serverCommands().dbSize(targetNode);
+
+			assertThat(newSize).isEqualTo(0L);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testFlushAllWithOptionOnSpecificNode() {
+		String key = "test:cluster:server:key2";
+
+		try {
+			// Add test key
+			clusterConnection.stringCommands().set(key.getBytes(), "value".getBytes());
+
+			// Get the node serving this key
+			ValkeyClusterNode targetNode = clusterConnection.clusterCommands().clusterGetNodeForKey(key.getBytes());
+			assertThat(targetNode).isNotNull();
+
+			// Get initial database size
+			Long initialSize = clusterConnection.serverCommands().dbSize(targetNode);
+			assertThat(initialSize).isGreaterThan(0L);
+
+			// Flush all databases with SYNC option on specific node
+			clusterConnection.serverCommands().flushAll(targetNode, FlushOption.SYNC);
+
+			// Database should be empty or much smaller
+			Long newSize = clusterConnection.serverCommands().dbSize(targetNode);
+			assertThat(newSize).isEqualTo(0);
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== Node-Specific Information Commands ====================
+
+	@Test
+	void testInfoOnSpecificNode() {
+		for (ValkeyClusterNode node : allNodes) {
+			Long beforeCount = getCommandCallCount(node, "info");
+			Properties info = clusterConnection.serverCommands().info(node);
+
+			assertThat(info).isNotNull();
+			assertThat(info).isNotEmpty();
+
+			// Verify basic server info properties
+			assertThat(info.containsKey("valkey_version") || info.containsKey("redis_version")).isTrue();
+
+			Long afterCount = getCommandCallCount(node, "info");
+			assertThat(afterCount).isEqualTo(beforeCount + 2);
+		}
+	}
+
+	@Test
+	void testInfoWithSectionOnSpecificNode() {
+		for (ValkeyClusterNode node : allNodes) {
+			Long beforeCount = getCommandCallCount(node, "info");
+			// Get INFO section from specific master node
+			Properties serverInfo = clusterConnection.serverCommands().info(node, "server");
+			assertThat(serverInfo).isNotNull();
+			assertThat(serverInfo.containsKey("valkey_version") || serverInfo.containsKey("redis_version")).isTrue();
+
+			// Test getting memory info
+			Properties memoryInfo = clusterConnection.serverCommands().info(node, "memory");
+			assertThat(memoryInfo).isNotNull();
+			assertThat(memoryInfo.containsKey("used_memory")).isTrue();
+
+			Long afterCount = getCommandCallCount(node, "info");
+			assertThat(afterCount).isEqualTo(beforeCount + 3);
+		}
+	}
+
+	@Test
+	void testTimeOnSpecificNode() throws InterruptedException {
+		for (ValkeyClusterNode node : allNodes) {
+			// Get server time from specific node in different units
+			Long beforeCmdCount = getCommandCallCount(node, "time");
+			Long beforeTimeMillis = clusterConnection.serverCommands().time(node, TimeUnit.MILLISECONDS);
+			Long beforeTimeSeconds = clusterConnection.serverCommands().time(node, TimeUnit.SECONDS);
+			Long beforeTimeMicros = clusterConnection.serverCommands().time(node, TimeUnit.MICROSECONDS);
+
+			Thread.sleep(1000);
+
+			Long afterTimeMillis = clusterConnection.serverCommands().time(node, TimeUnit.MILLISECONDS);
+			Long afterTimeSeconds = clusterConnection.serverCommands().time(node, TimeUnit.SECONDS);
+			Long afterTimeMicros = clusterConnection.serverCommands().time(node, TimeUnit.MICROSECONDS);
+
+			Long afterCmdCount = getCommandCallCount(node, "time");
+			assertThat(afterCmdCount).isEqualTo(beforeCmdCount + 6);
+			assertThat(afterTimeMillis - beforeTimeMillis).isGreaterThanOrEqualTo(1000L);
+			assertThat(afterTimeSeconds - beforeTimeSeconds).isGreaterThanOrEqualTo(1L);
+			assertThat(afterTimeMicros - beforeTimeMicros).isGreaterThanOrEqualTo(1_000_000L);
+		}
+	}
+
+	// ==================== Node-Specific Configuration Management ====================
+
+	@Test
+	void testGetConfigOnSpecificNode() {
+		for (ValkeyClusterNode node : allNodes) {
+			// Get initial command stats for CONFIG GET on the target node
+			String cmdName = getCommandName("config", "get");
+			Long beforeCount = getCommandCallCount(node, cmdName);
+			// Get configuration from specific node
+			Properties maxMemoryConfig = clusterConnection.serverCommands().getConfig(node, "maxmemory");
+			assertThat(maxMemoryConfig).isNotNull();
+
+			// Get all configs with wildcard
+			Properties allConfigs = clusterConnection.serverCommands().getConfig(node, "*");
+			assertThat(allConfigs).isNotNull();
+			assertThat(allConfigs).isNotEmpty();
+
+			Long afterCount = getCommandCallCount(node, cmdName);
+			assertThat(afterCount).isEqualTo(beforeCount + 2);
+		}
+	}
+
+	@Test
+	void testSetConfigOnSpecificNode() {
+		for (ValkeyClusterNode node : allNodes) {
+			// Get original timeout for restoration
+			Properties timeoutConfig = clusterConnection.serverCommands().getConfig(node, "timeout");
+			assertThat(timeoutConfig).isNotNull();
+
+			Long originalTimeout = Long.parseLong(timeoutConfig.getProperty("timeout", "0"));
+			Long newTimeout = originalTimeout + 10;
+
+			try {
+				// Set timeout to a safe value on specific node
+				clusterConnection.serverCommands().setConfig(node, "timeout", newTimeout.toString());
+
+				// Verify it was set on that node
+				Properties newTimeoutConfig = clusterConnection.serverCommands().getConfig(node, "timeout");
+
+				Long updatedTimeout = Long.parseLong(newTimeoutConfig.getProperty("timeout", "0"));
+				assertThat(updatedTimeout).isEqualTo(newTimeout);
+			}
+			finally {
+				// Restore original timeout
+				clusterConnection.serverCommands().setConfig(node, "timeout", originalTimeout.toString());
+			}
+		}
+	}
+
+	@Test
+	void testResetConfigStatsOnSpecificNode() {
+		for (ValkeyClusterNode node : allNodes) {
+			// Execute CONFIG RESETSTAT on specific node
+			clusterConnection.serverCommands().resetConfigStats(node);
+
+			String cmdName = getCommandName("config", "resetstat");
+			long afterTotalCmdsCnt = getCommandCallCount(node, cmdName);
+			assertThat(afterTotalCmdsCnt).isEqualTo(1);
+		}
+	}
+
+	@Test
+	void testRewriteConfigOnSpecificNode() {
+		for (ValkeyClusterNode node : allNodes) {
+			// Get initial command stats for CONFIG REWRITE on the target node
+			String cmdName = getCommandName("config", "rewrite");
+			long initialCallCount = getCommandCallCount(node, cmdName);
+
+			// Rewrite config on specific node
+			clusterConnection.serverCommands().rewriteConfig(node);
+
+			// Get command stats after execution
+			long afterCallCount = getCommandCallCount(node, cmdName);
+
+			// Verify the command counter increased (by at least 1 for the rewriteConfig
+			// call)
+			assertThat(afterCallCount).isEqualTo(initialCallCount + 1);
+		}
+	}
+
+	// ==================== Node-Specific Client Management ====================
+
+	@Test
+	void testGetClientListOnSpecificNode() {
+		for (ValkeyClusterNode node : allNodes) {
+			String cmdName = getCommandName("client", "list");
+			Long beforeCount = getCommandCallCount(node, cmdName);
+			// Get client list from specific node
+			List<ValkeyClientInfo> clientList = clusterConnection.serverCommands().getClientList(node);
+
+			assertThat(clientList).isNotNull();
+			assertThat(clientList).isNotEmpty();
+
+			// Verify client info properties
+			ValkeyClientInfo firstClient = clientList.get(0);
+			assertThat(firstClient).isNotNull();
+			assertThat(firstClient.get("addr")).isNotNull();
+			assertThat(firstClient.get("fd")).isNotNull();
+
+			Long afterCount = getCommandCallCount(node, cmdName);
+			assertThat(afterCount).isEqualTo(beforeCount + 1);
+		}
+	}
+
+	@Test
+	@EnabledOnValkeyVersion("7.2")
+	void testClientLibNameReported() {
+		List<ValkeyClientInfo> clientList = clusterConnection.serverCommands().getClientList();
+		assertThat(clientList).anyMatch(client -> "GlideSpringDataValkey".equals(client.get("lib-name")));
+	}
+
+	// ==================== Cluster-Wide Routing and Aggregation Verification
+	// ====================
+
+	@Test
+	void testInfoClusterWideAggregation() {
+		// Get cluster-wide INFO (should aggregate from all primaries)
+		Properties allInfo = clusterConnection.serverCommands().info();
+
+		assertThat(allInfo).isNotNull();
+		assertThat(allInfo).isNotEmpty();
+
+		// Verify properties are prefixed with node addresses (format:
+		// "host:port.property")
+		// Based on JedisClusterServerCommands reference implementation
+		String node1Prefix = CLUSTER_HOST + ":" + MASTER_NODE_1_PORT;
+		String node2Prefix = CLUSTER_HOST + ":" + MASTER_NODE_2_PORT;
+		String node3Prefix = CLUSTER_HOST + ":" + MASTER_NODE_3_PORT;
+
+		// Check that we have properties from each master node
+		boolean hasNode1Props = allInfo.stringPropertyNames().stream().anyMatch(key -> key.startsWith(node1Prefix));
+		boolean hasNode2Props = allInfo.stringPropertyNames().stream().anyMatch(key -> key.startsWith(node2Prefix));
+		boolean hasNode3Props = allInfo.stringPropertyNames().stream().anyMatch(key -> key.startsWith(node3Prefix));
+
+		assertThat(hasNode1Props).isTrue();
+		assertThat(hasNode2Props).isTrue();
+		assertThat(hasNode3Props).isTrue();
+	}
+
+	@Test
+	void testInfoWithSectionClusterWideAggregation() {
+		// Get cluster-wide INFO for specific section
+		Properties serverInfo = clusterConnection.serverCommands().info("server");
+
+		assertThat(serverInfo).isNotNull();
+		assertThat(serverInfo).isNotEmpty();
+
+		// Verify properties are prefixed with node addresses
+		String node1Prefix = CLUSTER_HOST + ":" + MASTER_NODE_1_PORT;
+		String node2Prefix = CLUSTER_HOST + ":" + MASTER_NODE_2_PORT;
+		String node3Prefix = CLUSTER_HOST + ":" + MASTER_NODE_3_PORT;
+
+		// Check for server version property from each node
+		boolean hasNode1Version = serverInfo.stringPropertyNames()
+			.stream()
+			.anyMatch(key -> key.startsWith(node1Prefix)
+					&& (key.contains("valkey_version") || key.contains("redis_version")));
+		boolean hasNode2Version = serverInfo.stringPropertyNames()
+			.stream()
+			.anyMatch(key -> key.startsWith(node2Prefix)
+					&& (key.contains("valkey_version") || key.contains("redis_version")));
+		boolean hasNode3Version = serverInfo.stringPropertyNames()
+			.stream()
+			.anyMatch(key -> key.startsWith(node3Prefix)
+					&& (key.contains("valkey_version") || key.contains("redis_version")));
+
+		assertThat(hasNode1Version).isTrue();
+		assertThat(hasNode2Version).isTrue();
+		assertThat(hasNode3Version).isTrue();
+	}
+
+	@Test
+	void testDbSizeClusterWideAggregation() {
+		String key1 = "test:cluster:server:key1";
+		String key2 = "test:cluster:server:key2";
+		String key3 = "test:cluster:server:key3";
+
+		try {
+			// Get cluster-wide dbSize (should sum all nodes)
+			Long initialClusterSize = clusterConnection.serverCommands().dbSize();
+			assertThat(initialClusterSize).isNotNull();
+			assertThat(initialClusterSize).isGreaterThanOrEqualTo(0L);
+
+			// Add keys that will distribute across different nodes
+			clusterConnection.stringCommands().set(key1.getBytes(), "value1".getBytes());
+			clusterConnection.stringCommands().set(key2.getBytes(), "value2".getBytes());
+			clusterConnection.stringCommands().set(key3.getBytes(), "value3".getBytes());
+
+			// Cluster-wide dbSize should increase
+			Long newClusterSize = clusterConnection.serverCommands().dbSize();
+			assertThat(newClusterSize).isNotNull();
+			assertThat(newClusterSize).isGreaterThan(initialClusterSize);
+
+			// Verify it's actually the sum by checking individual nodes
+			Collection<ValkeyClusterNode> masters = getActiveMasterNodes();
+			long manualSum = 0L;
+			for (ValkeyClusterNode master : masters) {
+				Long nodeSize = clusterConnection.serverCommands().dbSize(master);
+				if (nodeSize != null) {
+					manualSum += nodeSize;
+				}
+			}
+
+			assertThat(newClusterSize).isEqualTo(manualSum);
+		}
+		finally {
+			cleanupKeys(key1, key2, key3);
+		}
+	}
+
+	@Test
+	void testLastSaveClusterWideAggregation() {
+		// Get cluster-wide lastSave (should return most recent timestamp), should be
+		// non-null due to prior saves
+		Long clusterLastSave = clusterConnection.serverCommands().lastSave();
+
+		assertThat(clusterLastSave).isGreaterThan(0L);
+
+		// Verify it's the maximum of all node lastSaves
+		long maxLastSave = 0L;
+		for (ValkeyClusterNode node : allPrimaries) {
+			Long nodeLastSave = clusterConnection.serverCommands().lastSave(node);
+			if (nodeLastSave != null && nodeLastSave > maxLastSave) {
+				maxLastSave = nodeLastSave;
+			}
+		}
+
+		// Cluster-wide lastSave should match the maximum
+		assertThat(clusterLastSave).isEqualTo(maxLastSave);
+	}
+
+	@Test
+	void testGetConfigClusterWideAggregation() {
+		// Get cluster-wide config (should aggregate from all primaries with node
+		// prefixes)
+		Properties allConfigs = clusterConnection.serverCommands().getConfig("timeout");
+
+		assertThat(allConfigs).isNotNull();
+
+		// Verify properties are prefixed with node addresses
+		String node1Prefix = CLUSTER_HOST + ":" + MASTER_NODE_1_PORT;
+		String node2Prefix = CLUSTER_HOST + ":" + MASTER_NODE_2_PORT;
+		String node3Prefix = CLUSTER_HOST + ":" + MASTER_NODE_3_PORT;
+
+		// Check that we have timeout config from each master node
+		boolean hasNode1Config = allConfigs.stringPropertyNames()
+			.stream()
+			.anyMatch(key -> key.startsWith(node1Prefix) && key.contains("timeout"));
+		boolean hasNode2Config = allConfigs.stringPropertyNames()
+			.stream()
+			.anyMatch(key -> key.startsWith(node2Prefix) && key.contains("timeout"));
+		boolean hasNode3Config = allConfigs.stringPropertyNames()
+			.stream()
+			.anyMatch(key -> key.startsWith(node3Prefix) && key.contains("timeout"));
+
+		assertThat(hasNode1Config).isTrue();
+		assertThat(hasNode2Config).isTrue();
+		assertThat(hasNode3Config).isTrue();
+	}
+
+	@Test
+	void testGetClientListClusterWideAggregation() {
+		// Get cluster-wide client list (should combine lists from all primaries)
+		List<ValkeyClientInfo> clusterClientList = clusterConnection.serverCommands().getClientList();
+
+		assertThat(clusterClientList).isNotNull();
+		assertThat(clusterClientList).isNotEmpty();
+
+		// Verify cluster-wide count is at least the sum from each node
+		// (>= instead of == to avoid race condition where connections are created between
+		// measurements)
+		int minExpectedClients = 0;
+		for (ValkeyClusterNode node : allPrimaries) {
+			List<ValkeyClientInfo> nodeClients = clusterConnection.serverCommands().getClientList(node);
+			minExpectedClients += nodeClients.size();
+		}
+
+		assertThat(clusterClientList.size()).isGreaterThanOrEqualTo(minExpectedClients);
+	}
+
+	@Test
+	void testFlushOperationsClusterWide() {
+		String key1 = "test:cluster:server:key1";
+		String key2 = "test:cluster:server:key2";
+		String key3 = "test:cluster:server:key3";
+
+		try {
+			// Add keys that will distribute across different nodes
+			clusterConnection.stringCommands().set(key1.getBytes(), "value1".getBytes());
+			clusterConnection.stringCommands().set(key2.getBytes(), "value2".getBytes());
+			clusterConnection.stringCommands().set(key3.getBytes(), "value3".getBytes());
+
+			// Get initial cluster-wide dbSize
+			Long initialSize = clusterConnection.serverCommands().dbSize();
+			assertThat(initialSize).isGreaterThan(0L);
+
+			// Execute cluster-wide flushDb
+			clusterConnection.serverCommands().flushDb();
+
+			// Cluster-wide dbSize should be 0
+			Long newSize = clusterConnection.serverCommands().dbSize();
+			assertThat(newSize).isEqualTo(0);
+
+			// Verify keys are gone
+			assertThat(clusterConnection.keyCommands().exists(key1.getBytes())).isFalse();
+			assertThat(clusterConnection.keyCommands().exists(key2.getBytes())).isFalse();
+			assertThat(clusterConnection.keyCommands().exists(key3.getBytes())).isFalse();
+		}
+		finally {
+			cleanupKeys(key1, key2, key3);
+		}
+	}
+
+	@Test
+	void testFlushOperationsWithOptionClusterWide() {
+		String key1 = "test:cluster:server:key1";
+		String key2 = "test:cluster:server:key2";
+		String key3 = "test:cluster:server:key3";
+
+		try {
+			// Add keys that will distribute across different nodes
+			clusterConnection.stringCommands().set(key1.getBytes(), "value1".getBytes());
+			clusterConnection.stringCommands().set(key2.getBytes(), "value2".getBytes());
+			clusterConnection.stringCommands().set(key3.getBytes(), "value3".getBytes());
+
+			// Get initial cluster-wide dbSize
+			Long initialSize = clusterConnection.serverCommands().dbSize();
+			assertThat(initialSize).isGreaterThan(0L);
+
+			// Execute cluster-wide flushDb
+			clusterConnection.serverCommands().flushDb(FlushOption.ASYNC);
+
+			try {
+				Thread.sleep(1000);
+			}
+			catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+
+			// Cluster-wide dbSize should be 0
+			Long newSize = clusterConnection.serverCommands().dbSize();
+			assertThat(newSize).isEqualTo(0);
+
+			// Verify keys are gone
+			assertThat(clusterConnection.keyCommands().exists(key1.getBytes())).isFalse();
+			assertThat(clusterConnection.keyCommands().exists(key2.getBytes())).isFalse();
+			assertThat(clusterConnection.keyCommands().exists(key3.getBytes())).isFalse();
+		}
+		finally {
+			cleanupKeys(key1, key2, key3);
+		}
+	}
+
+	@Test
+	void testBgReWriteAofClusterWide() {
+		// Reset config stats on all nodes to have a clean slate
+		clusterConnection.serverCommands().resetConfigStats();
+		// Execute cluster-wide bgReWriteAof
+		clusterConnection.serverCommands().bgReWriteAof();
+		for (ValkeyClusterNode node : allPrimaries) {
+			long afterCount = getCommandCallCount(node, "bgrewriteaof");
+			assertThat(afterCount).isEqualTo(1);
+		}
+
+		// sleep 2 seconds before starting next saving test to avoid "saving in progress"
+		// errors
+		try {
+			Thread.sleep(2000);
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+	}
+
+	@Test
+	void testBgSaveClusterWide() {
+		// Reset config stats on all nodes to have a clean slate
+		clusterConnection.serverCommands().resetConfigStats();
+		// Execute cluster-wide bgSave
+		clusterConnection.serverCommands().bgSave();
+		for (ValkeyClusterNode node : allPrimaries) {
+			long afterCount = getCommandCallCount(node, "bgsave");
+			assertThat(afterCount).isEqualTo(1);
+		}
+
+		// sleep 2 seconds before starting next saving test to avoid "saving in progress"
+		// errors
+		try {
+			Thread.sleep(2000);
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+	}
+
+	@Test
+	void testSaveClusterWide() {
+		// Reset config stats on all nodes to have a clean slate
+		clusterConnection.serverCommands().resetConfigStats();
+		// Execute cluster-wide save
+		clusterConnection.serverCommands().save();
+		for (ValkeyClusterNode node : allPrimaries) {
+			long afterCount = getCommandCallCount(node, "save");
+			assertThat(afterCount).isEqualTo(1);
+		}
+	}
+
+	@Test
+	void testFlushAllClusterWide() {
+		String key = "test:cluster:server:key1";
+
+		try {
+			clusterConnection.stringCommands().set(key.getBytes(), "value".getBytes());
+			assertThat(clusterConnection.keyCommands().exists(key.getBytes())).isTrue();
+			clusterConnection.serverCommands().flushAll();
+			assertThat(clusterConnection.keyCommands().exists(key.getBytes())).isFalse();
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testFlushAllWithOptionClusterWide() {
+		String key = "test:cluster:server:key1";
+
+		try {
+			clusterConnection.stringCommands().set(key.getBytes(), "value".getBytes());
+			assertThat(clusterConnection.keyCommands().exists(key.getBytes())).isTrue();
+			clusterConnection.serverCommands().flushAll(FlushOption.SYNC);
+			assertThat(clusterConnection.keyCommands().exists(key.getBytes())).isFalse();
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testSetConfigClusterWide() {
+		for (ValkeyClusterNode node : allNodes) {
+			// Get original timeout for restoration
+			Properties timeoutConfig = clusterConnection.serverCommands().getConfig(node, "timeout");
+			assertThat(timeoutConfig).isNotNull();
+
+			Long originalTimeout = Long.parseLong(timeoutConfig.getProperty("timeout", "0"));
+			Long newTimeout = originalTimeout + 10;
+
+			try {
+				// Set timeout to a safe value on specific node
+				clusterConnection.serverCommands().setConfig(node, "timeout", newTimeout.toString());
+
+				// Verify it was set on that node
+				Properties newTimeoutConfig = clusterConnection.serverCommands().getConfig(node, "timeout");
+
+				Long updatedTimeout = Long.parseLong(newTimeoutConfig.getProperty("timeout", "0"));
+				assertThat(updatedTimeout).isEqualTo(newTimeout);
+			}
+			finally {
+				// Restore original timeout
+				clusterConnection.serverCommands().setConfig(node, "timeout", originalTimeout.toString());
+			}
+		}
+	}
+
+	@Test
+	void testResetConfigStatsClusterWide() {
+		// Reset config stats on all nodes to have a clean slate
+		clusterConnection.serverCommands().resetConfigStats();
+		String cmdName = getCommandName("config", "resetstat");
+		for (ValkeyClusterNode node : allNodes) {
+			long afterCount = getCommandCallCount(node, cmdName);
+			assertThat(afterCount).isEqualTo(1);
+		}
+	}
+
+	@Test
+	void testRewriteConfigClusterWide() {
+		// Reset config stats on all nodes to have a clean slate
+		clusterConnection.serverCommands().resetConfigStats();
+		clusterConnection.serverCommands().rewriteConfig();
+		String cmdName = getCommandName("config", "rewrite");
+		for (ValkeyClusterNode node : allNodes) {
+			long afterCount = getCommandCallCount(node, cmdName);
+			// 6.2 does not distinguish between rewrite and reset
+			assertThat(afterCount).isEqualTo(isBackend7OrNewer() ? 1 : 2);
+		}
+	}
+
+	@Test
+	void testTimeClusterWide() {
+		// routing policy is random, just verify that we can get time from a node
+		clusterConnection.serverCommands().time(TimeUnit.MILLISECONDS);
+		clusterConnection.serverCommands().time(TimeUnit.SECONDS);
+		clusterConnection.serverCommands().time(TimeUnit.MICROSECONDS);
+	}
+
+	// ==================== MIGRATE Command Tests - Only basic, non intrusive
+	// ====================
+
+	@Test
+	void testMigrateBasic() {
+		String key = "test:migrate:basic";
+
+		try {
+			// Set a key
+			clusterConnection.stringCommands().set(key.getBytes(), "migrateValue".getBytes());
+
+			// Verify key exists before migration
+			assertThat(clusterConnection.keyCommands().exists(key.getBytes())).isTrue();
+
+			// Determine source node where key currently resides
+			ValkeyClusterNode sourceNode = clusterConnection.clusterCommands().clusterGetNodeForKey(key.getBytes());
+			assertThat(sourceNode).isNotNull();
+
+			// Find a different random master node as target
+			final ValkeyClusterNode targetNode = Arrays.stream(allPrimaries)
+				.filter(n -> !n.equals(sourceNode))
+				.findFirst()
+				.orElseThrow();
+
+			// Attempt to migrate the key; expect a MOVED error since cluster slots are
+			// not being changed
+			assertThatThrownBy(() -> clusterConnection.serverCommands()
+				.migrate(key.getBytes(), targetNode, 0, // db index (always 0 in cluster)
+						null, // no option - key will be moved, not copied
+						5000 // 5 second timeout
+				)).hasMessageContaining("MOVED");
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testMigrateParameterValidation() {
+		String key = "test:migrate:validation";
+
+		ValkeyClusterNode targetNode = allPrimaries[0];
+
+		// Test null key
+		assertThatThrownBy(() -> clusterConnection.serverCommands().migrate(null, targetNode, 0, null, 5000))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Key must not be null");
+
+		// Test null target
+		assertThatThrownBy(() -> clusterConnection.serverCommands().migrate(key.getBytes(), null, 0, null, 5000))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Target must not be null");
+	}
+
+	// ==================== Edge Cases & Error Handling ====================
+
+	@Test
+	void testNodeSpecificOperationsWithInvalidNode() {
+		// Test with non-existent node (should fail gracefully)
+		ValkeyClusterNode invalidNode = ValkeyClusterNode.newValkeyClusterNode()
+			.listeningAt("192.168.255.255", 9999)
+			.build();
+
+		// Attempt operations on invalid node - should throw exception
+		ValkeyClusterServerCommands commands = clusterConnection.serverCommands();
+		assertThatThrownBy(() -> commands.info(invalidNode)).isInstanceOf(Exception.class);
+
+		assertThatThrownBy(() -> commands.dbSize(invalidNode)).isInstanceOf(Exception.class);
+	}
+
+	@Test
+	void testNodeParameterValidation() {
+		// Test null node parameter handling
+		ValkeyClusterServerCommands commands = clusterConnection.serverCommands();
+		ValkeyClusterNode nullNode = null;
+
+		assertThatThrownBy(() -> commands.info(nullNode)).isInstanceOf(IllegalArgumentException.class);
+
+		assertThatThrownBy(() -> commands.dbSize(nullNode)).isInstanceOf(IllegalArgumentException.class);
+
+		assertThatThrownBy(() -> commands.getConfig(nullNode, "maxmemory"))
+			.isInstanceOf(IllegalArgumentException.class);
+
+		assertThatThrownBy(() -> commands.setConfig(nullNode, "timeout", "60"))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	void testNodeSpecificOperationsWithReplicaNode() {
+		// Some operations might behave differently on replica nodes
+		// Get the replica node
+		ValkeyClusterNode replica = null;
+		Iterable<ValkeyClusterNode> allNodes = clusterConnection.clusterCommands().clusterGetNodes();
+		for (ValkeyClusterNode node : allNodes) {
+			if (!node.isMaster() && node.getPort() == REPLICAOF_NODE_1_PORT) {
+				replica = node;
+				break;
+			}
+		}
+
+		assertThat(replica).isNotNull();
+		assertThat(replica.isMaster()).isFalse();
+
+		// Read operations should work on replica
+		ValkeyClusterServerCommands commands = clusterConnection.serverCommands();
+		Properties info = commands.info(replica);
+		assertThat(info).isNotNull();
+		assertThat(info).isNotEmpty();
+
+		Long dbSize = commands.dbSize(replica);
+		assertThat(dbSize).isNotNull();
+		assertThat(dbSize).isGreaterThanOrEqualTo(0L);
+
+		List<ValkeyClientInfo> clientList = commands.getClientList(replica);
+		assertThat(clientList).isNotNull();
+	}
+
+	// ==================== Helper Methods ====================
+
+	/**
+	 * Lazy-initialized Backend version detection flag. True if Backend 7.0+, false if
+	 * Backend 6.x.
+	 */
+	private Boolean isBackend7OrNewer = null;
+
+	/**
+	 * Detects if the Backend version is 7.0 or newer.
+	 * @return true if Backend 7.0+, false if Backend 6.x
+	 */
+	private boolean isBackend7OrNewer() {
+		if (isBackend7OrNewer == null) {
+			Properties info = clusterConnection.serverCommands().info(allNodes[0], "server");
+			String version = info.getProperty("redis_version", info.getProperty("valkey_version", "0.0.0"));
+			// Parse major version
+			String majorVersion = version.split("\\.")[0];
+			int major = Integer.parseInt(majorVersion);
+			isBackend7OrNewer = major >= 7;
+		}
+		return isBackend7OrNewer;
+	}
+
+	/**
+	 * Gets the appropriate command name format based on Backend version. Backend 7.0+:
+	 * returns "command|subcommand" format (e.g., "config|get") Backend 6.x: returns
+	 * parent command only (e.g., "config")
+	 * @param parentCommand the parent command (e.g., "config", "client")
+	 * @param subCommand the sub-command (e.g., "get", "list"), can be null for simple
+	 * commands
+	 * @return the command name in the appropriate format for the current Backend version
+	 */
+	private String getCommandName(String parentCommand, String subCommand) {
+		if (subCommand == null) {
+			return parentCommand;
+		}
+		if (isBackend7OrNewer()) {
+			return parentCommand + "|" + subCommand;
+		}
+		else {
+			return parentCommand;
+		}
+	}
+
+	/**
+	 * Gets the call count for a specific command from INFO COMMANDSTATS.
+	 * @param node the cluster node to query
+	 * @param commandName the command name (e.g., "bgrewriteaof", "config", "config|get")
+	 * @return the call count, or 0 if command hasn't been executed yet
+	 */
+	private long getCommandCallCount(ValkeyClusterNode node, String commandName) {
+		Properties commandStats = clusterConnection.serverCommands().info(node, "commandstats");
+
+		// Convert command name format: "config|get" -> "config_get" for lookup
+		String statKey = "cmdstat_" + commandName.toLowerCase();
+		String statValue = commandStats.getProperty(statKey);
+		if (statValue == null) {
+			return 0L; // Command not found, assume 0 calls
+		}
+
+		// Parse the calls value from "calls=5,usec=1234,..."
+		for (String part : statValue.split(",")) {
+			String trimmed = part.trim();
+			if (trimmed.startsWith("calls=")) {
+				return Long.parseLong(trimmed.substring("calls=".length()));
+			}
+		}
+
+		throw new IllegalStateException(String
+			.format("Failed to parse 'calls' field from command stats for '%s'. Value: %s", commandName, statValue));
+	}
+
 }

--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionFactoryIntegrationTests.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionFactoryIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,1072 +43,1095 @@ import io.valkey.springframework.data.valkey.serializer.StringValkeySerializer;
 
 /**
  * Integration tests for {@link ValkeyGlideConnectionFactory}.
- * 
+ *
  * @author Ilia Kolominsky
  */
 @TestInstance(Lifecycle.PER_CLASS)
 public class ValkeyGlideConnectionFactoryIntegrationTests {
 
-    private ValkeyGlideConnectionFactory connectionFactory;
-    private ValkeyTemplate<String, String> template;
-
-    @BeforeAll
-    void setup() {
-        // Create a connection factory for tests
-        connectionFactory = createConnectionFactory();
-
-        // Create a template for easier testing
-        template = new ValkeyTemplate<>();
-        template.setConnectionFactory(connectionFactory);
-        template.setKeySerializer(StringValkeySerializer.UTF_8);
-        template.setValueSerializer(StringValkeySerializer.UTF_8);
-        template.setHashKeySerializer(StringValkeySerializer.UTF_8);
-        template.setHashValueSerializer(StringValkeySerializer.UTF_8);
-        template.afterPropertiesSet();
-
-        // Check if server is available and log the result
-        validateServerExistance(connectionFactory);
-    }
-
-    @AfterAll
-    void teardown() {
-        if (connectionFactory != null) {
-            connectionFactory.destroy();
-        }
-    }
-
-    @Test
-    void testGetConnection() throws InterruptedException {
-        ValkeyConnection connection = connectionFactory.getConnection();
-        assertThat(connection).isNotNull();
-        assertThat(connection).isInstanceOf(ValkeyGlideConnection.class);
-        connection.close();
-    }
-
-    @Test
-    @EnabledOnCommand("HEXPIRE")
-    void testHashOperations() {
-        String key1 = "test:hash:basic";
-        String key2 = "test:hash:putall";
-        String key3 = "test:hash:putifabsent";
-        String key4 = "test:hash:increment";
-        String key5 = "test:hash:length";
-        String key6 = "test:hash:delete";
-        String key7 = "test:hash:random";
-        String key8 = "test:hash:scan";
-        String key9 = "test:hash:expiration";
-        
-        try {
-            template.opsForHash().put(key1, "field1", "value1");
-            template.opsForHash().put(key1, "field2", "value2");
-
-            assertThat(template.opsForHash().get(key1, "field1")).isEqualTo("value1");
-            assertThat(template.opsForHash().get(key1, "field2")).isEqualTo("value2");
-
-            // PUTALL operation
-            Map<String, String> hashMap = Map.of(
-                "field1", "value1",
-                "field2", "value2",
-                "field3", "value3"
-            );
-            template.opsForHash().putAll(key2, hashMap);
-            
-            assertThat(template.opsForHash().get(key2, "field1")).isEqualTo("value1");
-            assertThat(template.opsForHash().get(key2, "field2")).isEqualTo("value2");
-            assertThat(template.opsForHash().get(key2, "field3")).isEqualTo("value3");
-
-            // PUTIFABSENT operation
-            Boolean putResult1 = template.opsForHash().putIfAbsent(key3, "field1", "value1");
-            assertThat(putResult1).isTrue();
-            Boolean putResult2 = template.opsForHash().putIfAbsent(key3, "field1", "different_value");
-            assertThat(putResult2).isFalse();
-            assertThat(template.opsForHash().get(key3, "field1")).isEqualTo("value1");
-
-            // HASKEY operation
-            assertThat(template.opsForHash().hasKey(key1, "field1")).isTrue();
-            assertThat(template.opsForHash().hasKey(key1, "nonexistent")).isFalse();
-
-            // MULTIGET operation
-            List<Object> hashKeys = List.of("field1", "field2", "nonexistent");
-            List<Object> multiGetResult = template.opsForHash().multiGet(key1, hashKeys);
-            assertThat(multiGetResult).containsExactly("value1", "value2", null);
-
-            // SIZE operation
-            assertThat(template.opsForHash().size(key1)).isEqualTo(2);
-            assertThat(template.opsForHash().size(key2)).isEqualTo(3);
-
-            // KEYS operation
-            Set<Object> keys = template.opsForHash().keys(key2);
-            assertThat(keys).containsExactlyInAnyOrder("field1", "field2", "field3");
-
-            // VALUES operation
-            List<Object> values = template.opsForHash().values(key2);
-            assertThat(values).containsExactlyInAnyOrder("value1", "value2", "value3");
-
-            // ENTRIES operation (HGETALL)
-            Map<Object, Object> entries = template.opsForHash().entries(key2);
-            assertThat(entries).hasSize(3);
-            assertThat(entries.get("field1")).isEqualTo("value1");
-            assertThat(entries.get("field2")).isEqualTo("value2");
-            assertThat(entries.get("field3")).isEqualTo("value3");
-
-            // INCREMENT operations
-            template.opsForHash().put(key4, "counter", "10");
-            
-            // Long increment
-            Long incrResult1 = template.opsForHash().increment(key4, "counter", 5L);
-            assertThat(incrResult1).isEqualTo(15L);
-            
-            Long incrResult2 = template.opsForHash().increment(key4, "counter", -3L);
-            assertThat(incrResult2).isEqualTo(12L);
-            
-            // Double increment (using different field to avoid conflicts)
-            template.opsForHash().put(key4, "floatcounter", "10.5");
-            Double floatIncrResult = template.opsForHash().increment(key4, "floatcounter", 2.5);
-            assertThat(floatIncrResult).isEqualTo(13.0);
-
-            // LENGTHOFVALUE operation
-            template.opsForHash().put(key5, "field1", "Hello World!");
-            Long lengthResult = template.opsForHash().lengthOfValue(key5, "field1");
-            assertThat(lengthResult).isEqualTo(12L);
-            
-            // Length of non-existent field
-            Long lengthNonExistent = template.opsForHash().lengthOfValue(key5, "nonexistent");
-            assertThat(lengthNonExistent).isEqualTo(0L);
-
-            // DELETE hash fields operation
-            template.opsForHash().put(key6, "field1", "value1");
-            template.opsForHash().put(key6, "field2", "value2");
-            template.opsForHash().put(key6, "field3", "value3");
-            
-            Long deleteResult = template.opsForHash().delete(key6, "field1", "field2");
-            assertThat(deleteResult).isEqualTo(2L);
-            assertThat(template.opsForHash().hasKey(key6, "field1")).isFalse();
-            assertThat(template.opsForHash().hasKey(key6, "field2")).isFalse();
-            assertThat(template.opsForHash().hasKey(key6, "field3")).isTrue();
-
-            // RANDOM operations
-            template.opsForHash().putAll(key7, Map.of(
-                "field1", "value1",
-                "field2", "value2",
-                "field3", "value3",
-                "field4", "value4"
-            ));
-
-            // Random key
-            Object randomKey = template.opsForHash().randomKey(key7);
-            assertThat(randomKey).isIn("field1", "field2", "field3", "field4");
-            
-            // Random entry
-            Map.Entry<Object, Object> randomEntry = template.opsForHash().randomEntry(key7);
-            assertThat(randomEntry.getKey()).isIn("field1", "field2", "field3", "field4");
-            assertThat(randomEntry.getValue().toString()).startsWith("value");
-            
-            // Random keys with count
-            List<Object> randomKeys = template.opsForHash().randomKeys(key7, 2);
-            assertThat(randomKeys).hasSize(2);
-            assertThat(randomKeys).allMatch(key -> List.of("field1", "field2", "field3", "field4").contains(key));
-
-            // Random entries with count
-            Map<Object, Object> randomEntries = template.opsForHash().randomEntries(key7, 2);
-            assertThat(randomEntries).hasSize(2);
-            randomEntries.forEach((k, v) -> {
-                assertThat(k).isIn("field1", "field2", "field3", "field4");
-                assertThat(v.toString()).startsWith("value");
-            });
-
-            // SCAN operation (using ValkeyCallback for direct access to connection)
-            template.opsForHash().putAll(key8, Map.of(
-                "scanfield1", "scanvalue1",
-                "scanfield2", "scanvalue2",
-                "scanfield3", "scanvalue3"
-            ));
-            
-            // Test hScan using connection directly
-            template.execute((ValkeyCallback<Void>) connection -> {
-                try (var cursor = connection.hashCommands().hScan(key8.getBytes(), 
-                        io.valkey.springframework.data.valkey.core.ScanOptions.scanOptions().count(10).build())) {
-                    int count = 0;
-                    while (cursor.hasNext()) {
-                        Map.Entry<byte[], byte[]> entry = cursor.next();
-                        String field = new String(entry.getKey());
-                        String value = new String(entry.getValue());
-                        assertThat(field).startsWith("scanfield");
-                        assertThat(value).startsWith("scanvalue");
-                        count++;
-                    }
-                    assertThat(count).isEqualTo(3);
-                }
-                return null;
-            });
-
-            // Test hash field expiration operations (requires Valkey/Valkey 7.4+)
-            if (isServerVersionAtLeast(7, 4)) {
-                template.opsForHash().putAll(key9, Map.of(
-                    "expirefield1", "expirevalue1",
-                    "expirefield2", "expirevalue2",
-                    "persistfield", "persistvalue"
-                ));
-
-                // Test hExpire - Set TTL in seconds
-                template.execute((ValkeyCallback<List<Long>>) connection -> {
-                    List<Long> result = connection.hashCommands().hExpire(key9.getBytes(), 60L, 
-                        "expirefield1".getBytes(), "expirefield2".getBytes());
-                    assertThat(result).containsExactly(1L, 1L); // Both fields should have expiration set
-                    return result;
-                });
-
-                // Test hpExpire - Set TTL in milliseconds  
-                template.execute((ValkeyCallback<List<Long>>) connection -> {
-                    List<Long> result = connection.hashCommands().hpExpire(key9.getBytes(), 60000L,
-                        "expirefield1".getBytes());
-                    assertThat(result).containsExactly(1L); // Field should have expiration updated
-                    return result;
-                });
-
-                // Test hExpireAt - Set expiration at specific timestamp
-                long futureTimestamp = System.currentTimeMillis() / 1000 + 120; // 2 minutes from now
-                template.execute((ValkeyCallback<List<Long>>) connection -> {
-                    List<Long> result = connection.hashCommands().hExpireAt(key9.getBytes(), futureTimestamp,
-                        "expirefield1".getBytes());
-                    assertThat(result).containsExactly(1L); // Field should have expiration set
-                    return result;
-                });
-
-                // Test hpExpireAt - Set expiration at specific timestamp in milliseconds
-                long futureTimestampMillis = System.currentTimeMillis() + 120000; // 2 minutes from now
-                template.execute((ValkeyCallback<List<Long>>) connection -> {
-                    List<Long> result = connection.hashCommands().hpExpireAt(key9.getBytes(), futureTimestampMillis,
-                        "expirefield2".getBytes());
-                    assertThat(result).containsExactly(1L); // Field should have expiration set
-                    return result;
-                });
-
-                // Test hTtl - Get TTL in seconds
-                template.execute((ValkeyCallback<List<Long>>) connection -> {
-                    List<Long> result = connection.hashCommands().hTtl(key9.getBytes(), 
-                        "expirefield1".getBytes(), "persistfield".getBytes());
-                    assertThat(result).hasSize(2);
-                    assertThat(result.get(0)).isGreaterThan(0L); // expirefield1 should have TTL
-                    assertThat(result.get(1)).isEqualTo(-1L); // persistfield should have no expiration
-                    return result;
-                });
-
-                template.execute((ValkeyCallback<List<Long>>) connection -> {
-                    List<Long> result = connection.hashCommands().hpTtl(key9.getBytes(),
-                        "expirefield1".getBytes(), "persistfield".getBytes());
-                    assertThat(result).hasSize(2);
-                    assertThat(result.get(0)).isGreaterThan(0L); // expirefield1 should have TTL in milliseconds
-                    assertThat(result.get(1)).isEqualTo(-1L); // persistfield should have no expiration
-                    return result;
-                });
-
-                // Test hPersist - Remove expiration from fields
-                template.execute((ValkeyCallback<List<Long>>) connection -> {
-                    List<Long> result = connection.hashCommands().hPersist(key9.getBytes(),
-                        "expirefield1".getBytes(), "expirefield2".getBytes());
-                    assertThat(result).containsExactly(1L, 1L); // Both fields should have expiration removed
-                    return result;
-                });
-
-                // Verify fields no longer have expiration after hPersist
-                template.execute((ValkeyCallback<List<Long>>) connection -> {
-                    List<Long> result = connection.hashCommands().hTtl(key9.getBytes(),
-                        "expirefield1".getBytes(), "expirefield2".getBytes());
-                    assertThat(result).containsExactly(-1L, -1L); // Both fields should have no expiration
-                    return result;
-                });
-            }
-        } finally {
-            // Clean up all test keys - this will execute even if an exception occurs
-            template.delete(key1);
-            template.delete(key2);
-            template.delete(key3);
-            template.delete(key4);
-            template.delete(key5);
-            template.delete(key6);
-            template.delete(key7);
-            template.delete(key8);
-            template.delete(key9);
-        }
-    }
-
-    @Test
-    void testListOperations() {
-        String key1 = "test:list:basic";
-        String key2 = "test:list:push";
-        String key3 = "test:list:range";
-        String key4 = "test:list:insert";
-        String key5 = "test:list:move";
-        String key6 = "test:list:set";
-        String key7 = "test:list:remove";
-        String key8 = "test:list:blocking";
-        String key9 = "test:list:rpoplpush";
-        String srcKey = "test:list:src";
-        String dstKey = "test:list:dst";
-
-        try {
-            // Basic LPUSH/RPUSH operations
-            template.opsForList().leftPush(key1, "value1");
-            template.opsForList().leftPush(key1, "value2");
-            template.opsForList().rightPush(key1, "value3");
-
-            assertThat(template.opsForList().size(key1)).isEqualTo(3);
-            
-            // Test LRANGE to verify order
-            List<String> range = template.opsForList().range(key1, 0, -1);
-            assertThat(range).containsExactly("value2", "value1", "value3");
-
-            // Test LINDEX - get element at index
-            assertThat(template.opsForList().index(key1, 0)).isEqualTo("value2");
-            assertThat(template.opsForList().index(key1, 1)).isEqualTo("value1");
-            assertThat(template.opsForList().index(key1, 2)).isEqualTo("value3");
-            
-            // Test convenience methods getFirst and getLast
-            String firstLastKey = "test:list:firstlast";
-            template.opsForList().rightPushAll(firstLastKey, "first", "middle", "last");
-            
-            String firstElement = template.opsForList().getFirst(firstLastKey);
-            assertThat(firstElement).isEqualTo("first");
-            
-            String lastElement = template.opsForList().getLast(firstLastKey);
-            assertThat(lastElement).isEqualTo("last");
-            
-            // Test with empty list
-            String emptyKey = "test:list:empty";
-            String firstEmpty = template.opsForList().getFirst(emptyKey);
-            assertThat(firstEmpty).isNull();
-            
-            String lastEmpty = template.opsForList().getLast(emptyKey);
-            assertThat(lastEmpty).isNull();
-            
-            template.delete(firstLastKey);
-
-            // Test LPOP/RPOP
-            assertThat(template.opsForList().leftPop(key1)).isEqualTo("value2");
-            assertThat(template.opsForList().rightPop(key1)).isEqualTo("value3");
-            assertThat(template.opsForList().size(key1)).isEqualTo(1);
-
-            // Test LPUSHX/RPUSHX (push only if key exists)
-            template.opsForList().leftPushIfPresent(key2, "shouldnotwork"); // key doesn't exist
-            assertThat(template.opsForList().size(key2)).isEqualTo(0);
-            
-            template.opsForList().leftPush(key2, "initial");
-            template.opsForList().leftPushIfPresent(key2, "shouldwork");
-            template.opsForList().rightPushIfPresent(key2, "alsowork");
-            
-            List<String> key2Range = template.opsForList().range(key2, 0, -1);
-            assertThat(key2Range).containsExactly("shouldwork", "initial", "alsowork");
-
-            // Test LEFTPUSHALL operations (both varargs and Collection variants)
-            String leftPushAllKey = "test:list:leftpushall";
-            
-            // Test leftPushAll with varargs
-            template.opsForList().leftPushAll(leftPushAllKey, "first", "second", "third");
-            List<String> leftPushAllResult1 = template.opsForList().range(leftPushAllKey, 0, -1);
-            assertThat(leftPushAllResult1).containsExactly("third", "second", "first"); // Reverse order due to left push
-            
-            // Test leftPushAll with Collection
-            template.delete(leftPushAllKey);
-            template.opsForList().leftPushAll(leftPushAllKey, List.of("a", "b", "c"));
-            List<String> leftPushAllResult2 = template.opsForList().range(leftPushAllKey, 0, -1);
-            assertThat(leftPushAllResult2).containsExactly("c", "b", "a"); // Reverse order due to left push
-            
-            template.delete(leftPushAllKey);
-
-            // Test LRANGE and LTRIM
-            template.opsForList().rightPushAll(key3, "a", "b", "c", "d", "e");
-            List<String> beforeTrim = template.opsForList().range(key3, 0, -1);
-            assertThat(beforeTrim).containsExactly("a", "b", "c", "d", "e");
-            
-            template.opsForList().trim(key3, 1, 3);
-            List<String> afterTrim = template.opsForList().range(key3, 0, -1);
-            assertThat(afterTrim).containsExactly("b", "c", "d");
-
-            // Test LINSERT - insert before/after pivot
-            template.opsForList().rightPushAll(key4, "first", "pivot", "last");
-            
-            // Insert before pivot
-            template.execute((ValkeyCallback<Long>) connection -> 
-                connection.listCommands().lInsert(key4.getBytes(), 
-                    ValkeyListCommands.Position.BEFORE, "pivot".getBytes(), "before_pivot".getBytes()));
-            
-            // Insert after pivot
-            template.execute((ValkeyCallback<Long>) connection -> 
-                connection.listCommands().lInsert(key4.getBytes(), 
-                    ValkeyListCommands.Position.AFTER, "pivot".getBytes(), "after_pivot".getBytes()));
-            
-            List<String> insertResult = template.opsForList().range(key4, 0, -1);
-            assertThat(insertResult).containsExactly("first", "before_pivot", "pivot", "after_pivot", "last");
-
-            // Test LMOVE (move element between lists) - both low-level and high-level APIs
-            template.opsForList().rightPushAll(key5, "move1", "move2", "move3");
-            String dstKey5 = key5 + "_dst";
-            
-            // Test low-level lMove via connection
-            template.execute((ValkeyCallback<byte[]>) connection -> 
-                connection.listCommands().lMove(key5.getBytes(), dstKey5.getBytes(), 
-                    ValkeyListCommands.Direction.LEFT, ValkeyListCommands.Direction.RIGHT));
-            
-            assertThat(template.opsForList().range(key5, 0, -1)).containsExactly("move2", "move3");
-            assertThat(template.opsForList().range(dstKey5, 0, -1)).containsExactly("move1");
-            
-            // Test high-level move operations using MoveFrom/MoveTo objects
-            String moveHighKey1 = "test:list:movehigh1";
-            String moveHighKey2 = "test:list:movehigh2";
-            template.opsForList().rightPushAll(moveHighKey1, "high1", "high2", "high3");
-            
-            // Move from tail of moveHighKey1 to head of moveHighKey2
-            String movedValue1 = template.opsForList().move(
-                io.valkey.springframework.data.valkey.core.ListOperations.MoveFrom.fromTail(moveHighKey1),
-                io.valkey.springframework.data.valkey.core.ListOperations.MoveTo.toHead(moveHighKey2)
-            );
-            assertThat(movedValue1).isEqualTo("high3");
-            assertThat(template.opsForList().range(moveHighKey1, 0, -1)).containsExactly("high1", "high2");
-            assertThat(template.opsForList().range(moveHighKey2, 0, -1)).containsExactly("high3");
-            
-            // Move from head of moveHighKey1 to tail of moveHighKey2
-            String movedValue2 = template.opsForList().move(
-                io.valkey.springframework.data.valkey.core.ListOperations.MoveFrom.fromHead(moveHighKey1),
-                io.valkey.springframework.data.valkey.core.ListOperations.MoveTo.toTail(moveHighKey2)
-            );
-            assertThat(movedValue2).isEqualTo("high1");
-            assertThat(template.opsForList().range(moveHighKey1, 0, -1)).containsExactly("high2");
-            assertThat(template.opsForList().range(moveHighKey2, 0, -1)).containsExactly("high3", "high1");
-            
-            template.delete(moveHighKey1);
-            template.delete(moveHighKey2);
-
-            // Test LSET - set element at index
-            template.opsForList().rightPushAll(key6, "original1", "original2", "original3");
-            template.opsForList().set(key6, 1, "modified");
-            
-            List<String> setResult = template.opsForList().range(key6, 0, -1);
-            assertThat(setResult).containsExactly("original1", "modified", "original3");
-
-            // Test LREM - remove occurrences of value
-            template.opsForList().rightPushAll(key7, "remove", "keep", "remove", "keep", "remove");
-            Long removedCount = template.opsForList().remove(key7, 2, "remove"); // Remove first 2 occurrences
-            assertThat(removedCount).isEqualTo(2L);
-            
-            List<String> removeResult = template.opsForList().range(key7, 0, -1);
-            assertThat(removeResult).containsExactly("keep", "keep", "remove");
-
-            // Test LPOP/RPOP with count (Valkey 6.2+)
-            template.opsForList().rightPushAll(key8, "pop1", "pop2", "pop3", "pop4", "pop5");
-            
-            // Left pop multiple elements
-            List<String> leftPopped = template.opsForList().leftPop(key8, 2);
-            if (leftPopped != null) { // Some Valkey versions might not support count parameter
-                assertThat(leftPopped).containsExactly("pop1", "pop2");
-                
-                // Right pop multiple elements
-                List<String> rightPopped = template.opsForList().rightPop(key8, 2);
-                assertThat(rightPopped).containsExactly("pop5", "pop4");
-                
-                assertThat(template.opsForList().range(key8, 0, -1)).containsExactly("pop3");
-            }
-
-            // Test RPOPLPUSH - atomically move from end of one list to beginning of another
-            template.opsForList().rightPushAll(srcKey, "src1", "src2", "src3");
-            template.opsForList().rightPushAll(dstKey, "dst1");
-            
-            String moved = template.opsForList().rightPopAndLeftPush(srcKey, dstKey);
-            assertThat(moved).isEqualTo("src3");
-            assertThat(template.opsForList().range(srcKey, 0, -1)).containsExactly("src1", "src2");
-            assertThat(template.opsForList().range(dstKey, 0, -1)).containsExactly("src3", "dst1");
-
-            // Test LPOS - find position of element (Valkey 6.0.6+)
-            if (isServerVersionAtLeast(6, 1)) {
-                String posKey = "test:list:position";
-                template.opsForList().rightPushAll(posKey, "a", "b", "c", "b", "d");
-                
-                // Find first occurrence - indexOf
-                Long firstPos = template.opsForList().indexOf(posKey, "b");
-                assertThat(firstPos).isEqualTo(1L);
-                
-                // Find last occurrence - lastIndexOf
-                Long lastPos = template.opsForList().lastIndexOf(posKey, "b");
-                assertThat(lastPos).isEqualTo(3L);
-                
-                // Test with non-existent value
-                Long notFoundPos = template.opsForList().indexOf(posKey, "z");
-                assertThat(notFoundPos).isNull();
-                
-                Long notFoundLastPos = template.opsForList().lastIndexOf(posKey, "z");
-                assertThat(notFoundLastPos).isNull();
-                
-                // Test direct connection access for multiple occurrences
-                List<Long> positions = template.execute((ValkeyCallback<List<Long>>) connection -> 
-                    connection.listCommands().lPos(posKey.getBytes(), "b".getBytes(), null, 2));
-                assertThat(positions).containsExactly(1L, 3L);
-                
-                template.delete(posKey);
-            }
-
-            // Test blocking operations with very short timeout to avoid long waits
-            // BLPOP - blocking left pop
-            template.opsForList().rightPush("temp_key", "temp_value");
-            List<String> blockedPop = template.execute((ValkeyCallback<List<String>>) connection -> {
-                List<byte[]> result = connection.listCommands().bLPop(1, "temp_key".getBytes());
-                if (result != null && result.size() >= 2) {
-                    return List.of(new String(result.get(0)), new String(result.get(1)));
-                }
-                return null;
-            });
-            
-            if (blockedPop != null) {
-                assertThat(blockedPop.get(0)).isEqualTo("temp_key");
-                assertThat(blockedPop.get(1)).isEqualTo("temp_value");
-            }
-
-            // BRPOP - blocking right pop
-            template.opsForList().rightPush("temp_key2", "temp_value2");
-            List<String> blockedRightPop = template.execute((ValkeyCallback<List<String>>) connection -> {
-                List<byte[]> result = connection.listCommands().bRPop(1, "temp_key2".getBytes());
-                if (result != null && result.size() >= 2) {
-                    return List.of(new String(result.get(0)), new String(result.get(1)));
-                }
-                return null;
-            });
-            
-            if (blockedRightPop != null) {
-                assertThat(blockedRightPop.get(0)).isEqualTo("temp_key2");
-                assertThat(blockedRightPop.get(1)).isEqualTo("temp_value2");
-            }
-
-            // BRPOPLPUSH - blocking version of RPOPLPUSH
-            String blockSrc = "test:block:src";
-            String blockDst = "test:block:dst";
-            template.opsForList().rightPush(blockSrc, "block_value");
-            
-            String blockMoved = template.execute((ValkeyCallback<String>) connection -> {
-                byte[] result = connection.listCommands().bRPopLPush(1, blockSrc.getBytes(), blockDst.getBytes());
-                return result != null ? new String(result) : null;
-            });
-            
-            if (blockMoved != null) {
-                assertThat(blockMoved).isEqualTo("block_value");
-                assertThat(template.opsForList().size(blockSrc)).isEqualTo(0);
-                assertThat(template.opsForList().range(blockDst, 0, -1)).containsExactly("block_value");
-            }
-            
-            template.delete(blockSrc);
-            template.delete(blockDst);
-
-            // Test BLMOVE - blocking version of LMOVE (Valkey 6.2+)
-            if (isServerVersionAtLeast(6, 2)) {
-                String blmoveSrc = "test:blmove:src";
-                String blmoveDst = "test:blmove:dst";
-                template.opsForList().rightPush(blmoveSrc, "blmove_value");
-                
-                String blockMoveResult = template.execute((ValkeyCallback<String>) connection -> {
-                    byte[] result = connection.listCommands().bLMove(blmoveSrc.getBytes(), blmoveDst.getBytes(),
-                        ValkeyListCommands.Direction.LEFT, ValkeyListCommands.Direction.RIGHT, 1.0);
-                    return result != null ? new String(result) : null;
-                });
-                
-                if (blockMoveResult != null) {
-                    assertThat(blockMoveResult).isEqualTo("blmove_value");
-                    assertThat(template.opsForList().size(blmoveSrc)).isEqualTo(0);
-                    assertThat(template.opsForList().range(blmoveDst, 0, -1)).containsExactly("blmove_value");
-                }
-                
-                template.delete(blmoveSrc);
-                template.delete(blmoveDst);
-            }
-
-        } finally {
-            // Clean up all test keys
-            template.delete(key1);
-            template.delete(key2);
-            template.delete(key3);
-            template.delete(key4);
-            template.delete(key5);
-            template.delete(key5 + "_dst");
-            template.delete(key6);
-            template.delete(key7);
-            template.delete(key8);
-            template.delete(key9);
-            template.delete(srcKey);
-            template.delete(dstKey);
-            template.delete("temp_key");
-            template.delete("temp_key2");
-        }
-    }
-
-    @Test
-    void testSetOperations() {
-        String key1 = "test:set:basic";
-        String key2 = "test:set:operations";
-        String key3 = "test:set:union";
-        String key4 = "test:set:intersection";
-        String key5 = "test:set:difference";
-        String key6 = "test:set:random";
-        String key7 = "test:set:pop";
-        String key8 = "test:set:move";
-        String key9 = "test:set:scan";
-        String key10 = "test:set:scanhigh";
-        String destKey = "test:set:dest";
-
-        try {
-            // Basic SADD operations
-            Long addResult1 = template.opsForSet().add(key1, "value1", "value2", "value3");
-            assertThat(addResult1).isEqualTo(3L);
-
-            // Add duplicate - should return 0
-            Long addResult2 = template.opsForSet().add(key1, "value2");
-            assertThat(addResult2).isEqualTo(0L);
-
-            // SCARD - Set cardinality (size)
-            assertThat(template.opsForSet().size(key1)).isEqualTo(3);
-
-            // SISMEMBER - Check membership
-            assertThat(template.opsForSet().isMember(key1, "value2")).isTrue();
-            assertThat(template.opsForSet().isMember(key1, "nonexistent")).isFalse();
-
-            // SMISMEMBER - Check multiple membership (Valkey 6.2+)
-            if (isServerVersionAtLeast(6, 2)) {
-                template.execute((ValkeyCallback<List<Boolean>>) connection -> {
-                    Map<Object, Boolean> membershipMap = template.opsForSet().isMember(key1, "value1", "nonexistent", "value3");
-                    assertThat(membershipMap.get("value1")).isTrue();
-                    assertThat(membershipMap.get("nonexistent")).isFalse();
-                    assertThat(membershipMap.get("value3")).isTrue();
-                    return null;
-                });
-            }
-
-            // SMEMBERS - Get all members
-            Set<String> members = template.opsForSet().members(key1);
-            assertThat(members).containsExactlyInAnyOrder("value1", "value2", "value3");
-
-            // SREM - Remove members
-            Long remResult1 = template.opsForSet().remove(key1, "value2");
-            assertThat(remResult1).isEqualTo(1L);
-            assertThat(template.opsForSet().size(key1)).isEqualTo(2);
-
-            Long remResult2 = template.opsForSet().remove(key1, "value1", "nonexistent");
-            assertThat(remResult2).isEqualTo(1L); // Only value1 was actually removed
-            assertThat(template.opsForSet().size(key1)).isEqualTo(1);
-
-            // Set up sets for set operations
-            template.opsForSet().add(key2, "a", "b", "c");
-            template.opsForSet().add(key3, "b", "c", "d");
-            template.opsForSet().add(key4, "c", "d", "e");
-
-            // SUNION - Union of sets
-            Set<String> unionResult = template.opsForSet().union(key2, key3);
-            assertThat(unionResult).containsExactlyInAnyOrder("a", "b", "c", "d");
-
-            // SUNION with multiple keys
-            Set<String> unionMultiResult = template.opsForSet().union(key2, List.of(key3, key4));
-            assertThat(unionMultiResult).containsExactlyInAnyOrder("a", "b", "c", "d", "e");
-
-            // SUNIONSTORE - Store union result
-            Long unionStoreResult = template.opsForSet().unionAndStore(key2, key3, destKey);
-            assertThat(unionStoreResult).isEqualTo(4L);
-            assertThat(template.opsForSet().members(destKey)).containsExactlyInAnyOrder("a", "b", "c", "d");
-            template.delete(destKey);
-
-            // SUNIONSTORE with multiple keys
-            Long unionStoreMultiResult = template.opsForSet().unionAndStore(key2, List.of(key3, key4), destKey);
-            assertThat(unionStoreMultiResult).isEqualTo(5L);
-            assertThat(template.opsForSet().members(destKey)).containsExactlyInAnyOrder("a", "b", "c", "d", "e");
-            template.delete(destKey);
-
-            // SINTER - Intersection of sets
-            Set<String> intersectResult = template.opsForSet().intersect(key2, key3);
-            assertThat(intersectResult).containsExactlyInAnyOrder("b", "c");
-
-            // SINTER with multiple keys
-            Set<String> intersectMultiResult = template.opsForSet().intersect(key2, List.of(key3, key4));
-            assertThat(intersectMultiResult).containsExactlyInAnyOrder("c");
-
-            // SINTERSTORE - Store intersection result
-            Long intersectStoreResult = template.opsForSet().intersectAndStore(key2, key3, destKey);
-            assertThat(intersectStoreResult).isEqualTo(2L);
-            assertThat(template.opsForSet().members(destKey)).containsExactlyInAnyOrder("b", "c");
-            template.delete(destKey);
-
-            // SINTERSTORE with multiple keys
-            Long intersectStoreMultiResult = template.opsForSet().intersectAndStore(key2, List.of(key3, key4), destKey);
-            assertThat(intersectStoreMultiResult).isEqualTo(1L);
-            assertThat(template.opsForSet().members(destKey)).containsExactlyInAnyOrder("c");
-            template.delete(destKey);
-
-            // SDIFF - Difference of sets (elements in first set but not in others)
-            Set<String> diffResult = template.opsForSet().difference(key2, key3);
-            assertThat(diffResult).containsExactlyInAnyOrder("a");
-
-            // SDIFF with multiple keys
-            Set<String> diffMultiResult = template.opsForSet().difference(key2, List.of(key3, key4));
-            assertThat(diffMultiResult).containsExactlyInAnyOrder("a");
-
-            // SDIFFSTORE - Store difference result
-            Long diffStoreResult = template.opsForSet().differenceAndStore(key2, key3, destKey);
-            assertThat(diffStoreResult).isEqualTo(1L);
-            assertThat(template.opsForSet().members(destKey)).containsExactlyInAnyOrder("a");
-            template.delete(destKey);
-
-            // SDIFFSTORE with multiple keys
-            Long diffStoreMultiResult = template.opsForSet().differenceAndStore(key2, List.of(key3, key4), destKey);
-            assertThat(diffStoreMultiResult).isEqualTo(1L);
-            assertThat(template.opsForSet().members(destKey)).containsExactlyInAnyOrder("a");
-            template.delete(destKey);
-
-            // SRANDMEMBER operations
-            template.opsForSet().add(key6, "rand1", "rand2", "rand3", "rand4", "rand5");
-            
-            // SRANDMEMBER - Single random member
-            String randomMember = template.opsForSet().randomMember(key6);
-            assertThat(randomMember).isIn("rand1", "rand2", "rand3", "rand4", "rand5");
-
-            // SRANDMEMBER with count (positive - distinct elements)
-            List<String> randomMembers = template.opsForSet().randomMembers(key6, 3);
-            assertThat(randomMembers).hasSize(3);
-            assertThat(randomMembers).allMatch(member -> 
-                List.of("rand1", "rand2", "rand3", "rand4", "rand5").contains(member));
-            
-            // SRANDMEMBER with negative count (allow duplicates)
-            Set<String> randomDistinct = template.opsForSet().distinctRandomMembers(key6, 3);
-            assertThat(randomDistinct).hasSizeLessThanOrEqualTo(3);
-            assertThat(randomDistinct).allMatch(member -> 
-                List.of("rand1", "rand2", "rand3", "rand4", "rand5").contains(member));
-
-            // SPOP operations
-            template.opsForSet().add(key7, "pop1", "pop2", "pop3", "pop4");
-            
-            // SPOP - Single pop
-            String poppedMember = template.opsForSet().pop(key7);
-            assertThat(poppedMember).isIn("pop1", "pop2", "pop3", "pop4");
-            assertThat(template.opsForSet().size(key7)).isEqualTo(3);
-
-            // SPOP with count (Valkey 3.2+)
-            List<String> poppedMembers = template.opsForSet().pop(key7, 2);
-            if (poppedMembers != null) { // Some versions might not support count parameter
-                assertThat(poppedMembers).hasSize(2);
-                assertThat(template.opsForSet().size(key7)).isEqualTo(1);
-            }
-
-            // SMOVE - Move member between sets
-            template.opsForSet().add(key8, "move1", "move2", "move3");
-            String moveDestKey = key8 + "_dest";
-            
-            Boolean moveResult = template.opsForSet().move(key8, "move2", moveDestKey);
-            assertThat(moveResult).isTrue();
-            assertThat(template.opsForSet().isMember(key8, "move2")).isFalse();
-            assertThat(template.opsForSet().isMember(moveDestKey, "move2")).isTrue();
-
-            // Try to move non-existent member
-            Boolean moveResult2 = template.opsForSet().move(key8, "nonexistent", moveDestKey);
-            assertThat(moveResult2).isFalse();
-            
-            template.delete(moveDestKey);
-
-            // SSCAN operation (using ValkeyCallback for direct access to connection)
-            template.opsForSet().add(key9, "scan1", "scan2", "scan3", "scan4", "scan5");
-            
-            // Test sScan using connection directly
-            template.execute((ValkeyCallback<Void>) connection -> {
-                try (var cursor = connection.setCommands().sScan(key9.getBytes(), 
-                        io.valkey.springframework.data.valkey.core.ScanOptions.scanOptions().count(10).build())) {
-                    Set<String> scannedMembers = new java.util.HashSet<>();
-                    while (cursor.hasNext()) {
-                        byte[] member = cursor.next();
-                        scannedMembers.add(new String(member));
-                    }
-                    assertThat(scannedMembers).containsExactlyInAnyOrder("scan1", "scan2", "scan3", "scan4", "scan5");
-                }
-                return null;
-            });
-
-            // Test high-level SetOperations.scan() method
-            template.opsForSet().add(key10, "high1", "high2", "high3", "high4", "high5");
-            
-            try (io.valkey.springframework.data.valkey.core.Cursor<String> cursor = 
-                    template.opsForSet().scan(key10, 
-                        io.valkey.springframework.data.valkey.core.ScanOptions.scanOptions().count(10).build())) {
-                Set<String> scannedHighMembers = new java.util.HashSet<>();
-                while (cursor.hasNext()) {
-                    String member = cursor.next();
-                    scannedHighMembers.add(member);
-                }
-                assertThat(scannedHighMembers).containsExactlyInAnyOrder("high1", "high2", "high3", "high4", "high5");
-            }
-
-        } finally {
-            // Clean up all test keys
-            template.delete(key1);
-            template.delete(key2);
-            template.delete(key3);
-            template.delete(key4);
-            template.delete(key5);
-            template.delete(key6);
-            template.delete(key7);
-            template.delete(key8);
-            template.delete(key9);
-            template.delete(key10);
-            template.delete(destKey);
-            template.delete(key8 + "_dest");
-        }
-    }
-
-    @Test
-    void testStringOperations() {
-        // Basic SET/GET operations
-        String key1 = "test:string:basic";
-        String key2 = "test:string:expire";
-        String key3 = "test:string:setnx";
-        String key4 = "test:string:getset";
-        String multi1Key = "test:string:multi1";
-        String multi2Key = "test:string:multi2";
-        String multi3Key = "test:string:multi3";
-        String msetnx1Key = "test:string:msetnx1";
-        String msetnx2Key = "test:string:msetnx2";
-        String counterKey = "test:string:counter";
-        String floatCounterKey = "test:string:floatcounter";
-        String appendKey = "test:string:append";
-        String setRangeKey = "test:string:setrange";
-        String bitKey = "test:string:bits";
-        String bitKey1 = "test:string:bit1";
-        String bitKey2 = "test:string:bit2";
-        String bitDestKey = "test:string:bitop";
-        
-        try {
-            String value1 = "Hello, valkey-glide!";
-            
-            template.opsForValue().set(key1, value1);
-            String retrieved1 = template.opsForValue().get(key1);
-            assertThat(retrieved1).isEqualTo(value1);
-
-            // SET with expiration
-            String value2 = "Expiring value";
-            template.opsForValue().set(key2, value2, Duration.ofSeconds(60));
-            String retrieved2 = template.opsForValue().get(key2);
-            assertThat(retrieved2).isEqualTo(value2);
-
-            // SETNX (Set if Not eXists)
-            String value3 = "New value";
-            Boolean setResult1 = template.opsForValue().setIfAbsent(key3, value3);
-            assertThat(setResult1).isTrue();
-            Boolean setResult2 = template.opsForValue().setIfAbsent(key3, "Different value");
-            assertThat(setResult2).isFalse();
-            assertThat(template.opsForValue().get(key3)).isEqualTo(value3);
-
-            // GETSET operation
-            template.opsForValue().set(key4, "old value");
-            String oldValue = template.opsForValue().getAndSet(key4, "new value");
-            assertThat(oldValue).isEqualTo("old value");
-            assertThat(template.opsForValue().get(key4)).isEqualTo("new value");
-
-            // MGET/MSET operations
-            Map<String, String> multiValues = Map.of(
-                multi1Key, "value1",
-                multi2Key, "value2",
-                multi3Key, "value3"
-            );
-            template.opsForValue().multiSet(multiValues);
-            
-            List<String> multiRetrieved = template.opsForValue().multiGet(List.of(
-                multi1Key, multi2Key, multi3Key));
-            assertThat(multiRetrieved).containsExactly("value1", "value2", "value3");
-         
-            // MSETNX operation (set multiple if none exist)
-            Map<String, String> msetnxValues = Map.of(
-                msetnx1Key, "msetnx_value1",
-                msetnx2Key, "msetnx_value2"
-            );
-            Boolean msetnxResult = template.opsForValue().multiSetIfAbsent(msetnxValues);
-            assertThat(msetnxResult).isTrue();
-            assertThat(template.opsForValue().get(msetnx1Key)).isEqualTo("msetnx_value1");
-
-            // INCR/DECR operations
-            template.opsForValue().set(counterKey, "10");
-            
-            Long incResult1 = template.opsForValue().increment(counterKey);
-            assertThat(incResult1).isEqualTo(11L);
-            
-            Long incResult2 = template.opsForValue().increment(counterKey, 5L);
-            assertThat(incResult2).isEqualTo(16L);
-            
-            Long decrResult1 = template.opsForValue().decrement(counterKey);
-            assertThat(decrResult1).isEqualTo(15L);
-            
-            Long decrResult2 = template.opsForValue().decrement(counterKey, 3L);
-            assertThat(decrResult2).isEqualTo(12L);
-            
-            // Floating point increment operations (using separate key to avoid DECR issues)
-            template.opsForValue().set(floatCounterKey, "10");
-            Double incFloatResult = template.opsForValue().increment(floatCounterKey, 2.5);
-            assertThat(incFloatResult).isEqualTo(12.5);
-
-            // APPEND operation
-            template.opsForValue().set(appendKey, "Hello");
-            Integer appendResult = template.opsForValue().append(appendKey, " World!");
-            assertThat(appendResult).isEqualTo(12); // Length of "Hello World!"
-            assertThat(template.opsForValue().get(appendKey)).isEqualTo("Hello World!");
-
-            // STRING LENGTH operation
-            Long strlenResult = template.opsForValue().size(appendKey);
-            assertThat(strlenResult).isEqualTo(12L);
-
-            // GETRANGE operation (substring)
-            String rangeResult = template.opsForValue().get(appendKey, 0, 4);
-            assertThat(rangeResult).isEqualTo("Hello");
-            
-            // SETRANGE operation
-            template.opsForValue().set(appendKey, "Hello World!", 6);
-            // This would set from position 6, but let's test a simpler case
-            template.opsForValue().set(setRangeKey, "Hello");
-            template.opsForValue().set(setRangeKey, " Valkey", 5);
-            assertThat(template.opsForValue().get(setRangeKey)).startsWith("Hello");
-            
-            // BIT operations (using ValkeyTemplate's execute for direct access to connection)
-            template.opsForValue().set(bitKey, "a"); // 'a' = 01100001 in binary
-            
-            // Use connection directly for bit operations
-            Boolean getBitResult = template.execute((ValkeyCallback<Boolean>) connection -> 
-                connection.stringCommands().getBit(bitKey.getBytes(), 1));
-            assertThat(getBitResult).isTrue(); // Second bit of 'a' is 1
-            
-            Boolean setBitResult = template.execute((ValkeyCallback<Boolean>) connection -> 
-                connection.stringCommands().setBit(bitKey.getBytes(), 0, true));
-            assertThat(setBitResult).isFalse(); // Original first bit was 0
-            
-            Long bitCountResult = template.execute((ValkeyCallback<Long>) connection -> 
-                connection.stringCommands().bitCount(bitKey.getBytes()));
-            assertThat(bitCountResult).isGreaterThan(0L);
-
-            // BITOP operation
-            template.opsForValue().set(bitKey1, "a");
-            template.opsForValue().set(bitKey2, "b");
-            
-            Long bitOpResult = template.execute((ValkeyCallback<Long>) connection -> 
-                connection.stringCommands().bitOp(ValkeyStringCommands.BitOperation.AND, 
-                    bitDestKey.getBytes(), bitKey1.getBytes(), bitKey2.getBytes()));
-            assertThat(bitOpResult).isEqualTo(1L); // Result length
-        } finally {
-            // Clean up all test keys - this will execute even if an exception occurs
-            template.delete(key1);
-            template.delete(key2);
-            template.delete(key3);
-            template.delete(key4);
-            template.delete(multi1Key);
-            template.delete(multi2Key);
-            template.delete(multi3Key);
-            template.delete(msetnx1Key);
-            template.delete(msetnx2Key);
-            template.delete(counterKey);
-            template.delete(floatCounterKey);
-            template.delete(appendKey);
-            template.delete(setRangeKey);
-            template.delete(bitKey);
-            template.delete(bitKey1);
-            template.delete(bitKey2);
-            template.delete(bitDestKey);
-        }
-    }
-
-    @Test
-    void testTransactional() {
-        String key1 = "test:tx:key1";
-        String key2 = "test:tx:key2";
-
-        template.opsForValue().set(key1, "initial1");
-        template.opsForValue().set(key2, "initial2");
-
-        // Using SessionCallback for transactions
-        template.execute(new SessionCallback<Object>() {
-            @SuppressWarnings({ "unchecked", "rawtypes" })
-            public Object execute(ValkeyOperations operations) {
-                operations.multi();
-                
-                operations.opsForValue().set(key1, "updated1");
-                operations.opsForValue().set(key2, "updated2");
-                
-                return operations.exec();
-            }
-        });
-
-        assertThat(template.opsForValue().get(key1)).isEqualTo("updated1");
-        assertThat(template.opsForValue().get(key2)).isEqualTo("updated2");
-        
-        template.delete(key1);
-        template.delete(key2);
-    }
-
-    /**
-     * Creates a connection factory for testing.
-     */
-    private ValkeyGlideConnectionFactory createConnectionFactory() {
-        ValkeyStandaloneConfiguration config = new ValkeyStandaloneConfiguration();
-        config.setHostName(getValkeyHost());
-        config.setPort(getValkeyPort());
-        return new ValkeyGlideConnectionFactory(config);
-    }
-
-    /**
-     * Validates that the Valkey server exists and is accessible.
-     */
-    private void validateServerExistance(ValkeyConnectionFactory factory) {
-        try (ValkeyConnection connection = factory.getConnection()) {
-            assertThat(connection.ping()).isEqualTo("PONG");
-        }
-    }
-
-    /**
-     * Gets the Valkey host from environment or uses default.
-     */
-    private String getValkeyHost() {
-        return System.getProperty("valkey.host", "localhost");
-    }
-
-    /**
-     * Gets the Valkey port from environment or uses default.
-     */
-    private int getValkeyPort() {
-        return Integer.parseInt(System.getProperty("valkey.port", "6379"));
-    }
-
-    /**
-     * Checks if the server version is at least the specified major.minor version.
-     * Uses the INFO server command to get server version information.
-     */
-    private boolean isServerVersionAtLeast(int majorVersion, int minorVersion) {
-        return template.execute((ValkeyCallback<Boolean>) connection -> {
-                // Execute INFO server command
-                Properties serverInfo = connection.serverCommands().info("server");
-                // Check for valkey_version or redis_version
-                String versionString = serverInfo.getProperty("valkey_version",
-                        serverInfo.getProperty("redis_version"));
-                
-                // If valkey_version is not found, try server_version (for Valkey)
-                if (versionString == null) {
-                    versionString = serverInfo.getProperty("server_version");
-                }
-                
-                if (versionString == null) {
-                    return false;
-                }
-                
-                // Parse version string (e.g., "7.4.0" or "8.0.1")
-                String[] versionParts = versionString.split("\\.");
-                if (versionParts.length < 2) {
-                    return false;
-                }
-                
-                int serverMajor = Integer.parseInt(versionParts[0]);
-                int serverMinor = Integer.parseInt(versionParts[1]);
-                
-                // Compare versions
-                if (serverMajor > majorVersion) {
-                    return true;
-                } else if (serverMajor == majorVersion) {
-                    return serverMinor >= minorVersion;
-                } else {
-                    return false;
-                }
-            }
-        );
-    }
+	private ValkeyGlideConnectionFactory connectionFactory;
+
+	private ValkeyTemplate<String, String> template;
+
+	@BeforeAll
+	void setup() {
+		// Create a connection factory for tests
+		connectionFactory = createConnectionFactory();
+
+		// Create a template for easier testing
+		template = new ValkeyTemplate<>();
+		template.setConnectionFactory(connectionFactory);
+		template.setKeySerializer(StringValkeySerializer.UTF_8);
+		template.setValueSerializer(StringValkeySerializer.UTF_8);
+		template.setHashKeySerializer(StringValkeySerializer.UTF_8);
+		template.setHashValueSerializer(StringValkeySerializer.UTF_8);
+		template.afterPropertiesSet();
+
+		// Check if server is available and log the result
+		validateServerExistance(connectionFactory);
+	}
+
+	@AfterAll
+	void teardown() {
+		if (connectionFactory != null) {
+			connectionFactory.destroy();
+		}
+	}
+
+	@Test
+	void testGetConnection() throws InterruptedException {
+		ValkeyConnection connection = connectionFactory.getConnection();
+		assertThat(connection).isNotNull();
+		assertThat(connection).isInstanceOf(ValkeyGlideConnection.class);
+		connection.close();
+	}
+
+	@Test
+	@EnabledOnCommand("HEXPIRE")
+	void testHashOperations() {
+		String key1 = "test:hash:basic";
+		String key2 = "test:hash:putall";
+		String key3 = "test:hash:putifabsent";
+		String key4 = "test:hash:increment";
+		String key5 = "test:hash:length";
+		String key6 = "test:hash:delete";
+		String key7 = "test:hash:random";
+		String key8 = "test:hash:scan";
+		String key9 = "test:hash:expiration";
+
+		try {
+			template.opsForHash().put(key1, "field1", "value1");
+			template.opsForHash().put(key1, "field2", "value2");
+
+			assertThat(template.opsForHash().get(key1, "field1")).isEqualTo("value1");
+			assertThat(template.opsForHash().get(key1, "field2")).isEqualTo("value2");
+
+			// PUTALL operation
+			Map<String, String> hashMap = Map.of("field1", "value1", "field2", "value2", "field3", "value3");
+			template.opsForHash().putAll(key2, hashMap);
+
+			assertThat(template.opsForHash().get(key2, "field1")).isEqualTo("value1");
+			assertThat(template.opsForHash().get(key2, "field2")).isEqualTo("value2");
+			assertThat(template.opsForHash().get(key2, "field3")).isEqualTo("value3");
+
+			// PUTIFABSENT operation
+			Boolean putResult1 = template.opsForHash().putIfAbsent(key3, "field1", "value1");
+			assertThat(putResult1).isTrue();
+			Boolean putResult2 = template.opsForHash().putIfAbsent(key3, "field1", "different_value");
+			assertThat(putResult2).isFalse();
+			assertThat(template.opsForHash().get(key3, "field1")).isEqualTo("value1");
+
+			// HASKEY operation
+			assertThat(template.opsForHash().hasKey(key1, "field1")).isTrue();
+			assertThat(template.opsForHash().hasKey(key1, "nonexistent")).isFalse();
+
+			// MULTIGET operation
+			List<Object> hashKeys = List.of("field1", "field2", "nonexistent");
+			List<Object> multiGetResult = template.opsForHash().multiGet(key1, hashKeys);
+			assertThat(multiGetResult).containsExactly("value1", "value2", null);
+
+			// SIZE operation
+			assertThat(template.opsForHash().size(key1)).isEqualTo(2);
+			assertThat(template.opsForHash().size(key2)).isEqualTo(3);
+
+			// KEYS operation
+			Set<Object> keys = template.opsForHash().keys(key2);
+			assertThat(keys).containsExactlyInAnyOrder("field1", "field2", "field3");
+
+			// VALUES operation
+			List<Object> values = template.opsForHash().values(key2);
+			assertThat(values).containsExactlyInAnyOrder("value1", "value2", "value3");
+
+			// ENTRIES operation (HGETALL)
+			Map<Object, Object> entries = template.opsForHash().entries(key2);
+			assertThat(entries).hasSize(3);
+			assertThat(entries.get("field1")).isEqualTo("value1");
+			assertThat(entries.get("field2")).isEqualTo("value2");
+			assertThat(entries.get("field3")).isEqualTo("value3");
+
+			// INCREMENT operations
+			template.opsForHash().put(key4, "counter", "10");
+
+			// Long increment
+			Long incrResult1 = template.opsForHash().increment(key4, "counter", 5L);
+			assertThat(incrResult1).isEqualTo(15L);
+
+			Long incrResult2 = template.opsForHash().increment(key4, "counter", -3L);
+			assertThat(incrResult2).isEqualTo(12L);
+
+			// Double increment (using different field to avoid conflicts)
+			template.opsForHash().put(key4, "floatcounter", "10.5");
+			Double floatIncrResult = template.opsForHash().increment(key4, "floatcounter", 2.5);
+			assertThat(floatIncrResult).isEqualTo(13.0);
+
+			// LENGTHOFVALUE operation
+			template.opsForHash().put(key5, "field1", "Hello World!");
+			Long lengthResult = template.opsForHash().lengthOfValue(key5, "field1");
+			assertThat(lengthResult).isEqualTo(12L);
+
+			// Length of non-existent field
+			Long lengthNonExistent = template.opsForHash().lengthOfValue(key5, "nonexistent");
+			assertThat(lengthNonExistent).isEqualTo(0L);
+
+			// DELETE hash fields operation
+			template.opsForHash().put(key6, "field1", "value1");
+			template.opsForHash().put(key6, "field2", "value2");
+			template.opsForHash().put(key6, "field3", "value3");
+
+			Long deleteResult = template.opsForHash().delete(key6, "field1", "field2");
+			assertThat(deleteResult).isEqualTo(2L);
+			assertThat(template.opsForHash().hasKey(key6, "field1")).isFalse();
+			assertThat(template.opsForHash().hasKey(key6, "field2")).isFalse();
+			assertThat(template.opsForHash().hasKey(key6, "field3")).isTrue();
+
+			// RANDOM operations
+			template.opsForHash()
+				.putAll(key7, Map.of("field1", "value1", "field2", "value2", "field3", "value3", "field4", "value4"));
+
+			// Random key
+			Object randomKey = template.opsForHash().randomKey(key7);
+			assertThat(randomKey).isIn("field1", "field2", "field3", "field4");
+
+			// Random entry
+			Map.Entry<Object, Object> randomEntry = template.opsForHash().randomEntry(key7);
+			assertThat(randomEntry.getKey()).isIn("field1", "field2", "field3", "field4");
+			assertThat(randomEntry.getValue().toString()).startsWith("value");
+
+			// Random keys with count
+			List<Object> randomKeys = template.opsForHash().randomKeys(key7, 2);
+			assertThat(randomKeys).hasSize(2);
+			assertThat(randomKeys).allMatch(key -> List.of("field1", "field2", "field3", "field4").contains(key));
+
+			// Random entries with count
+			Map<Object, Object> randomEntries = template.opsForHash().randomEntries(key7, 2);
+			assertThat(randomEntries).hasSize(2);
+			randomEntries.forEach((k, v) -> {
+				assertThat(k).isIn("field1", "field2", "field3", "field4");
+				assertThat(v.toString()).startsWith("value");
+			});
+
+			// SCAN operation (using ValkeyCallback for direct access to connection)
+			template.opsForHash()
+				.putAll(key8,
+						Map.of("scanfield1", "scanvalue1", "scanfield2", "scanvalue2", "scanfield3", "scanvalue3"));
+
+			// Test hScan using connection directly
+			template.execute((ValkeyCallback<Void>) connection -> {
+				try (var cursor = connection.hashCommands()
+					.hScan(key8.getBytes(),
+							io.valkey.springframework.data.valkey.core.ScanOptions.scanOptions().count(10).build())) {
+					int count = 0;
+					while (cursor.hasNext()) {
+						Map.Entry<byte[], byte[]> entry = cursor.next();
+						String field = new String(entry.getKey());
+						String value = new String(entry.getValue());
+						assertThat(field).startsWith("scanfield");
+						assertThat(value).startsWith("scanvalue");
+						count++;
+					}
+					assertThat(count).isEqualTo(3);
+				}
+				return null;
+			});
+
+			// Test hash field expiration operations (requires Valkey/Valkey 7.4+)
+			if (isServerVersionAtLeast(7, 4)) {
+				template.opsForHash()
+					.putAll(key9, Map.of("expirefield1", "expirevalue1", "expirefield2", "expirevalue2", "persistfield",
+							"persistvalue"));
+
+				// Test hExpire - Set TTL in seconds
+				template.execute((ValkeyCallback<List<Long>>) connection -> {
+					List<Long> result = connection.hashCommands()
+						.hExpire(key9.getBytes(), 60L, "expirefield1".getBytes(), "expirefield2".getBytes());
+					assertThat(result).containsExactly(1L, 1L); // Both fields should have
+																// expiration set
+					return result;
+				});
+
+				// Test hpExpire - Set TTL in milliseconds
+				template.execute((ValkeyCallback<List<Long>>) connection -> {
+					List<Long> result = connection.hashCommands()
+						.hpExpire(key9.getBytes(), 60000L, "expirefield1".getBytes());
+					assertThat(result).containsExactly(1L); // Field should have
+															// expiration updated
+					return result;
+				});
+
+				// Test hExpireAt - Set expiration at specific timestamp
+				long futureTimestamp = System.currentTimeMillis() / 1000 + 120; // 2
+																				// minutes
+																				// from
+																				// now
+				template.execute((ValkeyCallback<List<Long>>) connection -> {
+					List<Long> result = connection.hashCommands()
+						.hExpireAt(key9.getBytes(), futureTimestamp, "expirefield1".getBytes());
+					assertThat(result).containsExactly(1L); // Field should have
+															// expiration set
+					return result;
+				});
+
+				// Test hpExpireAt - Set expiration at specific timestamp in milliseconds
+				long futureTimestampMillis = System.currentTimeMillis() + 120000; // 2
+																					// minutes
+																					// from
+																					// now
+				template.execute((ValkeyCallback<List<Long>>) connection -> {
+					List<Long> result = connection.hashCommands()
+						.hpExpireAt(key9.getBytes(), futureTimestampMillis, "expirefield2".getBytes());
+					assertThat(result).containsExactly(1L); // Field should have
+															// expiration set
+					return result;
+				});
+
+				// Test hTtl - Get TTL in seconds
+				template.execute((ValkeyCallback<List<Long>>) connection -> {
+					List<Long> result = connection.hashCommands()
+						.hTtl(key9.getBytes(), "expirefield1".getBytes(), "persistfield".getBytes());
+					assertThat(result).hasSize(2);
+					assertThat(result.get(0)).isGreaterThan(0L); // expirefield1 should
+																	// have TTL
+					assertThat(result.get(1)).isEqualTo(-1L); // persistfield should have
+																// no expiration
+					return result;
+				});
+
+				template.execute((ValkeyCallback<List<Long>>) connection -> {
+					List<Long> result = connection.hashCommands()
+						.hpTtl(key9.getBytes(), "expirefield1".getBytes(), "persistfield".getBytes());
+					assertThat(result).hasSize(2);
+					assertThat(result.get(0)).isGreaterThan(0L); // expirefield1 should
+																	// have TTL in
+																	// milliseconds
+					assertThat(result.get(1)).isEqualTo(-1L); // persistfield should have
+																// no expiration
+					return result;
+				});
+
+				// Test hPersist - Remove expiration from fields
+				template.execute((ValkeyCallback<List<Long>>) connection -> {
+					List<Long> result = connection.hashCommands()
+						.hPersist(key9.getBytes(), "expirefield1".getBytes(), "expirefield2".getBytes());
+					assertThat(result).containsExactly(1L, 1L); // Both fields should have
+																// expiration removed
+					return result;
+				});
+
+				// Verify fields no longer have expiration after hPersist
+				template.execute((ValkeyCallback<List<Long>>) connection -> {
+					List<Long> result = connection.hashCommands()
+						.hTtl(key9.getBytes(), "expirefield1".getBytes(), "expirefield2".getBytes());
+					assertThat(result).containsExactly(-1L, -1L); // Both fields should
+																	// have no expiration
+					return result;
+				});
+			}
+		}
+		finally {
+			// Clean up all test keys - this will execute even if an exception occurs
+			template.delete(key1);
+			template.delete(key2);
+			template.delete(key3);
+			template.delete(key4);
+			template.delete(key5);
+			template.delete(key6);
+			template.delete(key7);
+			template.delete(key8);
+			template.delete(key9);
+		}
+	}
+
+	@Test
+	void testListOperations() {
+		String key1 = "test:list:basic";
+		String key2 = "test:list:push";
+		String key3 = "test:list:range";
+		String key4 = "test:list:insert";
+		String key5 = "test:list:move";
+		String key6 = "test:list:set";
+		String key7 = "test:list:remove";
+		String key8 = "test:list:blocking";
+		String key9 = "test:list:rpoplpush";
+		String srcKey = "test:list:src";
+		String dstKey = "test:list:dst";
+
+		try {
+			// Basic LPUSH/RPUSH operations
+			template.opsForList().leftPush(key1, "value1");
+			template.opsForList().leftPush(key1, "value2");
+			template.opsForList().rightPush(key1, "value3");
+
+			assertThat(template.opsForList().size(key1)).isEqualTo(3);
+
+			// Test LRANGE to verify order
+			List<String> range = template.opsForList().range(key1, 0, -1);
+			assertThat(range).containsExactly("value2", "value1", "value3");
+
+			// Test LINDEX - get element at index
+			assertThat(template.opsForList().index(key1, 0)).isEqualTo("value2");
+			assertThat(template.opsForList().index(key1, 1)).isEqualTo("value1");
+			assertThat(template.opsForList().index(key1, 2)).isEqualTo("value3");
+
+			// Test convenience methods getFirst and getLast
+			String firstLastKey = "test:list:firstlast";
+			template.opsForList().rightPushAll(firstLastKey, "first", "middle", "last");
+
+			String firstElement = template.opsForList().getFirst(firstLastKey);
+			assertThat(firstElement).isEqualTo("first");
+
+			String lastElement = template.opsForList().getLast(firstLastKey);
+			assertThat(lastElement).isEqualTo("last");
+
+			// Test with empty list
+			String emptyKey = "test:list:empty";
+			String firstEmpty = template.opsForList().getFirst(emptyKey);
+			assertThat(firstEmpty).isNull();
+
+			String lastEmpty = template.opsForList().getLast(emptyKey);
+			assertThat(lastEmpty).isNull();
+
+			template.delete(firstLastKey);
+
+			// Test LPOP/RPOP
+			assertThat(template.opsForList().leftPop(key1)).isEqualTo("value2");
+			assertThat(template.opsForList().rightPop(key1)).isEqualTo("value3");
+			assertThat(template.opsForList().size(key1)).isEqualTo(1);
+
+			// Test LPUSHX/RPUSHX (push only if key exists)
+			template.opsForList().leftPushIfPresent(key2, "shouldnotwork"); // key doesn't
+																			// exist
+			assertThat(template.opsForList().size(key2)).isEqualTo(0);
+
+			template.opsForList().leftPush(key2, "initial");
+			template.opsForList().leftPushIfPresent(key2, "shouldwork");
+			template.opsForList().rightPushIfPresent(key2, "alsowork");
+
+			List<String> key2Range = template.opsForList().range(key2, 0, -1);
+			assertThat(key2Range).containsExactly("shouldwork", "initial", "alsowork");
+
+			// Test LEFTPUSHALL operations (both varargs and Collection variants)
+			String leftPushAllKey = "test:list:leftpushall";
+
+			// Test leftPushAll with varargs
+			template.opsForList().leftPushAll(leftPushAllKey, "first", "second", "third");
+			List<String> leftPushAllResult1 = template.opsForList().range(leftPushAllKey, 0, -1);
+			assertThat(leftPushAllResult1).containsExactly("third", "second", "first"); // Reverse
+																						// order
+																						// due
+																						// to
+																						// left
+																						// push
+
+			// Test leftPushAll with Collection
+			template.delete(leftPushAllKey);
+			template.opsForList().leftPushAll(leftPushAllKey, List.of("a", "b", "c"));
+			List<String> leftPushAllResult2 = template.opsForList().range(leftPushAllKey, 0, -1);
+			assertThat(leftPushAllResult2).containsExactly("c", "b", "a"); // Reverse
+																			// order due
+																			// to left
+																			// push
+
+			template.delete(leftPushAllKey);
+
+			// Test LRANGE and LTRIM
+			template.opsForList().rightPushAll(key3, "a", "b", "c", "d", "e");
+			List<String> beforeTrim = template.opsForList().range(key3, 0, -1);
+			assertThat(beforeTrim).containsExactly("a", "b", "c", "d", "e");
+
+			template.opsForList().trim(key3, 1, 3);
+			List<String> afterTrim = template.opsForList().range(key3, 0, -1);
+			assertThat(afterTrim).containsExactly("b", "c", "d");
+
+			// Test LINSERT - insert before/after pivot
+			template.opsForList().rightPushAll(key4, "first", "pivot", "last");
+
+			// Insert before pivot
+			template.execute((ValkeyCallback<Long>) connection -> connection.listCommands()
+				.lInsert(key4.getBytes(), ValkeyListCommands.Position.BEFORE, "pivot".getBytes(),
+						"before_pivot".getBytes()));
+
+			// Insert after pivot
+			template.execute((ValkeyCallback<Long>) connection -> connection.listCommands()
+				.lInsert(key4.getBytes(), ValkeyListCommands.Position.AFTER, "pivot".getBytes(),
+						"after_pivot".getBytes()));
+
+			List<String> insertResult = template.opsForList().range(key4, 0, -1);
+			assertThat(insertResult).containsExactly("first", "before_pivot", "pivot", "after_pivot", "last");
+
+			// Test LMOVE (move element between lists) - both low-level and high-level
+			// APIs
+			template.opsForList().rightPushAll(key5, "move1", "move2", "move3");
+			String dstKey5 = key5 + "_dst";
+
+			// Test low-level lMove via connection
+			template.execute((ValkeyCallback<byte[]>) connection -> connection.listCommands()
+				.lMove(key5.getBytes(), dstKey5.getBytes(), ValkeyListCommands.Direction.LEFT,
+						ValkeyListCommands.Direction.RIGHT));
+
+			assertThat(template.opsForList().range(key5, 0, -1)).containsExactly("move2", "move3");
+			assertThat(template.opsForList().range(dstKey5, 0, -1)).containsExactly("move1");
+
+			// Test high-level move operations using MoveFrom/MoveTo objects
+			String moveHighKey1 = "test:list:movehigh1";
+			String moveHighKey2 = "test:list:movehigh2";
+			template.opsForList().rightPushAll(moveHighKey1, "high1", "high2", "high3");
+
+			// Move from tail of moveHighKey1 to head of moveHighKey2
+			String movedValue1 = template.opsForList()
+				.move(io.valkey.springframework.data.valkey.core.ListOperations.MoveFrom.fromTail(moveHighKey1),
+						io.valkey.springframework.data.valkey.core.ListOperations.MoveTo.toHead(moveHighKey2));
+			assertThat(movedValue1).isEqualTo("high3");
+			assertThat(template.opsForList().range(moveHighKey1, 0, -1)).containsExactly("high1", "high2");
+			assertThat(template.opsForList().range(moveHighKey2, 0, -1)).containsExactly("high3");
+
+			// Move from head of moveHighKey1 to tail of moveHighKey2
+			String movedValue2 = template.opsForList()
+				.move(io.valkey.springframework.data.valkey.core.ListOperations.MoveFrom.fromHead(moveHighKey1),
+						io.valkey.springframework.data.valkey.core.ListOperations.MoveTo.toTail(moveHighKey2));
+			assertThat(movedValue2).isEqualTo("high1");
+			assertThat(template.opsForList().range(moveHighKey1, 0, -1)).containsExactly("high2");
+			assertThat(template.opsForList().range(moveHighKey2, 0, -1)).containsExactly("high3", "high1");
+
+			template.delete(moveHighKey1);
+			template.delete(moveHighKey2);
+
+			// Test LSET - set element at index
+			template.opsForList().rightPushAll(key6, "original1", "original2", "original3");
+			template.opsForList().set(key6, 1, "modified");
+
+			List<String> setResult = template.opsForList().range(key6, 0, -1);
+			assertThat(setResult).containsExactly("original1", "modified", "original3");
+
+			// Test LREM - remove occurrences of value
+			template.opsForList().rightPushAll(key7, "remove", "keep", "remove", "keep", "remove");
+			Long removedCount = template.opsForList().remove(key7, 2, "remove"); // Remove
+																					// first
+																					// 2
+																					// occurrences
+			assertThat(removedCount).isEqualTo(2L);
+
+			List<String> removeResult = template.opsForList().range(key7, 0, -1);
+			assertThat(removeResult).containsExactly("keep", "keep", "remove");
+
+			// Test LPOP/RPOP with count (Valkey 6.2+)
+			template.opsForList().rightPushAll(key8, "pop1", "pop2", "pop3", "pop4", "pop5");
+
+			// Left pop multiple elements
+			List<String> leftPopped = template.opsForList().leftPop(key8, 2);
+			if (leftPopped != null) { // Some Valkey versions might not support count
+										// parameter
+				assertThat(leftPopped).containsExactly("pop1", "pop2");
+
+				// Right pop multiple elements
+				List<String> rightPopped = template.opsForList().rightPop(key8, 2);
+				assertThat(rightPopped).containsExactly("pop5", "pop4");
+
+				assertThat(template.opsForList().range(key8, 0, -1)).containsExactly("pop3");
+			}
+
+			// Test RPOPLPUSH - atomically move from end of one list to beginning of
+			// another
+			template.opsForList().rightPushAll(srcKey, "src1", "src2", "src3");
+			template.opsForList().rightPushAll(dstKey, "dst1");
+
+			String moved = template.opsForList().rightPopAndLeftPush(srcKey, dstKey);
+			assertThat(moved).isEqualTo("src3");
+			assertThat(template.opsForList().range(srcKey, 0, -1)).containsExactly("src1", "src2");
+			assertThat(template.opsForList().range(dstKey, 0, -1)).containsExactly("src3", "dst1");
+
+			// Test LPOS - find position of element (Valkey 6.0.6+)
+			if (isServerVersionAtLeast(6, 1)) {
+				String posKey = "test:list:position";
+				template.opsForList().rightPushAll(posKey, "a", "b", "c", "b", "d");
+
+				// Find first occurrence - indexOf
+				Long firstPos = template.opsForList().indexOf(posKey, "b");
+				assertThat(firstPos).isEqualTo(1L);
+
+				// Find last occurrence - lastIndexOf
+				Long lastPos = template.opsForList().lastIndexOf(posKey, "b");
+				assertThat(lastPos).isEqualTo(3L);
+
+				// Test with non-existent value
+				Long notFoundPos = template.opsForList().indexOf(posKey, "z");
+				assertThat(notFoundPos).isNull();
+
+				Long notFoundLastPos = template.opsForList().lastIndexOf(posKey, "z");
+				assertThat(notFoundLastPos).isNull();
+
+				// Test direct connection access for multiple occurrences
+				List<Long> positions = template
+					.execute((ValkeyCallback<List<Long>>) connection -> connection.listCommands()
+						.lPos(posKey.getBytes(), "b".getBytes(), null, 2));
+				assertThat(positions).containsExactly(1L, 3L);
+
+				template.delete(posKey);
+			}
+
+			// Test blocking operations with very short timeout to avoid long waits
+			// BLPOP - blocking left pop
+			template.opsForList().rightPush("temp_key", "temp_value");
+			List<String> blockedPop = template.execute((ValkeyCallback<List<String>>) connection -> {
+				List<byte[]> result = connection.listCommands().bLPop(1, "temp_key".getBytes());
+				if (result != null && result.size() >= 2) {
+					return List.of(new String(result.get(0)), new String(result.get(1)));
+				}
+				return null;
+			});
+
+			if (blockedPop != null) {
+				assertThat(blockedPop.get(0)).isEqualTo("temp_key");
+				assertThat(blockedPop.get(1)).isEqualTo("temp_value");
+			}
+
+			// BRPOP - blocking right pop
+			template.opsForList().rightPush("temp_key2", "temp_value2");
+			List<String> blockedRightPop = template.execute((ValkeyCallback<List<String>>) connection -> {
+				List<byte[]> result = connection.listCommands().bRPop(1, "temp_key2".getBytes());
+				if (result != null && result.size() >= 2) {
+					return List.of(new String(result.get(0)), new String(result.get(1)));
+				}
+				return null;
+			});
+
+			if (blockedRightPop != null) {
+				assertThat(blockedRightPop.get(0)).isEqualTo("temp_key2");
+				assertThat(blockedRightPop.get(1)).isEqualTo("temp_value2");
+			}
+
+			// BRPOPLPUSH - blocking version of RPOPLPUSH
+			String blockSrc = "test:block:src";
+			String blockDst = "test:block:dst";
+			template.opsForList().rightPush(blockSrc, "block_value");
+
+			String blockMoved = template.execute((ValkeyCallback<String>) connection -> {
+				byte[] result = connection.listCommands().bRPopLPush(1, blockSrc.getBytes(), blockDst.getBytes());
+				return result != null ? new String(result) : null;
+			});
+
+			if (blockMoved != null) {
+				assertThat(blockMoved).isEqualTo("block_value");
+				assertThat(template.opsForList().size(blockSrc)).isEqualTo(0);
+				assertThat(template.opsForList().range(blockDst, 0, -1)).containsExactly("block_value");
+			}
+
+			template.delete(blockSrc);
+			template.delete(blockDst);
+
+			// Test BLMOVE - blocking version of LMOVE (Valkey 6.2+)
+			if (isServerVersionAtLeast(6, 2)) {
+				String blmoveSrc = "test:blmove:src";
+				String blmoveDst = "test:blmove:dst";
+				template.opsForList().rightPush(blmoveSrc, "blmove_value");
+
+				String blockMoveResult = template.execute((ValkeyCallback<String>) connection -> {
+					byte[] result = connection.listCommands()
+						.bLMove(blmoveSrc.getBytes(), blmoveDst.getBytes(), ValkeyListCommands.Direction.LEFT,
+								ValkeyListCommands.Direction.RIGHT, 1.0);
+					return result != null ? new String(result) : null;
+				});
+
+				if (blockMoveResult != null) {
+					assertThat(blockMoveResult).isEqualTo("blmove_value");
+					assertThat(template.opsForList().size(blmoveSrc)).isEqualTo(0);
+					assertThat(template.opsForList().range(blmoveDst, 0, -1)).containsExactly("blmove_value");
+				}
+
+				template.delete(blmoveSrc);
+				template.delete(blmoveDst);
+			}
+
+		}
+		finally {
+			// Clean up all test keys
+			template.delete(key1);
+			template.delete(key2);
+			template.delete(key3);
+			template.delete(key4);
+			template.delete(key5);
+			template.delete(key5 + "_dst");
+			template.delete(key6);
+			template.delete(key7);
+			template.delete(key8);
+			template.delete(key9);
+			template.delete(srcKey);
+			template.delete(dstKey);
+			template.delete("temp_key");
+			template.delete("temp_key2");
+		}
+	}
+
+	@Test
+	void testSetOperations() {
+		String key1 = "test:set:basic";
+		String key2 = "test:set:operations";
+		String key3 = "test:set:union";
+		String key4 = "test:set:intersection";
+		String key5 = "test:set:difference";
+		String key6 = "test:set:random";
+		String key7 = "test:set:pop";
+		String key8 = "test:set:move";
+		String key9 = "test:set:scan";
+		String key10 = "test:set:scanhigh";
+		String destKey = "test:set:dest";
+
+		try {
+			// Basic SADD operations
+			Long addResult1 = template.opsForSet().add(key1, "value1", "value2", "value3");
+			assertThat(addResult1).isEqualTo(3L);
+
+			// Add duplicate - should return 0
+			Long addResult2 = template.opsForSet().add(key1, "value2");
+			assertThat(addResult2).isEqualTo(0L);
+
+			// SCARD - Set cardinality (size)
+			assertThat(template.opsForSet().size(key1)).isEqualTo(3);
+
+			// SISMEMBER - Check membership
+			assertThat(template.opsForSet().isMember(key1, "value2")).isTrue();
+			assertThat(template.opsForSet().isMember(key1, "nonexistent")).isFalse();
+
+			// SMISMEMBER - Check multiple membership (Valkey 6.2+)
+			if (isServerVersionAtLeast(6, 2)) {
+				template.execute((ValkeyCallback<List<Boolean>>) connection -> {
+					Map<Object, Boolean> membershipMap = template.opsForSet()
+						.isMember(key1, "value1", "nonexistent", "value3");
+					assertThat(membershipMap.get("value1")).isTrue();
+					assertThat(membershipMap.get("nonexistent")).isFalse();
+					assertThat(membershipMap.get("value3")).isTrue();
+					return null;
+				});
+			}
+
+			// SMEMBERS - Get all members
+			Set<String> members = template.opsForSet().members(key1);
+			assertThat(members).containsExactlyInAnyOrder("value1", "value2", "value3");
+
+			// SREM - Remove members
+			Long remResult1 = template.opsForSet().remove(key1, "value2");
+			assertThat(remResult1).isEqualTo(1L);
+			assertThat(template.opsForSet().size(key1)).isEqualTo(2);
+
+			Long remResult2 = template.opsForSet().remove(key1, "value1", "nonexistent");
+			assertThat(remResult2).isEqualTo(1L); // Only value1 was actually removed
+			assertThat(template.opsForSet().size(key1)).isEqualTo(1);
+
+			// Set up sets for set operations
+			template.opsForSet().add(key2, "a", "b", "c");
+			template.opsForSet().add(key3, "b", "c", "d");
+			template.opsForSet().add(key4, "c", "d", "e");
+
+			// SUNION - Union of sets
+			Set<String> unionResult = template.opsForSet().union(key2, key3);
+			assertThat(unionResult).containsExactlyInAnyOrder("a", "b", "c", "d");
+
+			// SUNION with multiple keys
+			Set<String> unionMultiResult = template.opsForSet().union(key2, List.of(key3, key4));
+			assertThat(unionMultiResult).containsExactlyInAnyOrder("a", "b", "c", "d", "e");
+
+			// SUNIONSTORE - Store union result
+			Long unionStoreResult = template.opsForSet().unionAndStore(key2, key3, destKey);
+			assertThat(unionStoreResult).isEqualTo(4L);
+			assertThat(template.opsForSet().members(destKey)).containsExactlyInAnyOrder("a", "b", "c", "d");
+			template.delete(destKey);
+
+			// SUNIONSTORE with multiple keys
+			Long unionStoreMultiResult = template.opsForSet().unionAndStore(key2, List.of(key3, key4), destKey);
+			assertThat(unionStoreMultiResult).isEqualTo(5L);
+			assertThat(template.opsForSet().members(destKey)).containsExactlyInAnyOrder("a", "b", "c", "d", "e");
+			template.delete(destKey);
+
+			// SINTER - Intersection of sets
+			Set<String> intersectResult = template.opsForSet().intersect(key2, key3);
+			assertThat(intersectResult).containsExactlyInAnyOrder("b", "c");
+
+			// SINTER with multiple keys
+			Set<String> intersectMultiResult = template.opsForSet().intersect(key2, List.of(key3, key4));
+			assertThat(intersectMultiResult).containsExactlyInAnyOrder("c");
+
+			// SINTERSTORE - Store intersection result
+			Long intersectStoreResult = template.opsForSet().intersectAndStore(key2, key3, destKey);
+			assertThat(intersectStoreResult).isEqualTo(2L);
+			assertThat(template.opsForSet().members(destKey)).containsExactlyInAnyOrder("b", "c");
+			template.delete(destKey);
+
+			// SINTERSTORE with multiple keys
+			Long intersectStoreMultiResult = template.opsForSet().intersectAndStore(key2, List.of(key3, key4), destKey);
+			assertThat(intersectStoreMultiResult).isEqualTo(1L);
+			assertThat(template.opsForSet().members(destKey)).containsExactlyInAnyOrder("c");
+			template.delete(destKey);
+
+			// SDIFF - Difference of sets (elements in first set but not in others)
+			Set<String> diffResult = template.opsForSet().difference(key2, key3);
+			assertThat(diffResult).containsExactlyInAnyOrder("a");
+
+			// SDIFF with multiple keys
+			Set<String> diffMultiResult = template.opsForSet().difference(key2, List.of(key3, key4));
+			assertThat(diffMultiResult).containsExactlyInAnyOrder("a");
+
+			// SDIFFSTORE - Store difference result
+			Long diffStoreResult = template.opsForSet().differenceAndStore(key2, key3, destKey);
+			assertThat(diffStoreResult).isEqualTo(1L);
+			assertThat(template.opsForSet().members(destKey)).containsExactlyInAnyOrder("a");
+			template.delete(destKey);
+
+			// SDIFFSTORE with multiple keys
+			Long diffStoreMultiResult = template.opsForSet().differenceAndStore(key2, List.of(key3, key4), destKey);
+			assertThat(diffStoreMultiResult).isEqualTo(1L);
+			assertThat(template.opsForSet().members(destKey)).containsExactlyInAnyOrder("a");
+			template.delete(destKey);
+
+			// SRANDMEMBER operations
+			template.opsForSet().add(key6, "rand1", "rand2", "rand3", "rand4", "rand5");
+
+			// SRANDMEMBER - Single random member
+			String randomMember = template.opsForSet().randomMember(key6);
+			assertThat(randomMember).isIn("rand1", "rand2", "rand3", "rand4", "rand5");
+
+			// SRANDMEMBER with count (positive - distinct elements)
+			List<String> randomMembers = template.opsForSet().randomMembers(key6, 3);
+			assertThat(randomMembers).hasSize(3);
+			assertThat(randomMembers)
+				.allMatch(member -> List.of("rand1", "rand2", "rand3", "rand4", "rand5").contains(member));
+
+			// SRANDMEMBER with negative count (allow duplicates)
+			Set<String> randomDistinct = template.opsForSet().distinctRandomMembers(key6, 3);
+			assertThat(randomDistinct).hasSizeLessThanOrEqualTo(3);
+			assertThat(randomDistinct)
+				.allMatch(member -> List.of("rand1", "rand2", "rand3", "rand4", "rand5").contains(member));
+
+			// SPOP operations
+			template.opsForSet().add(key7, "pop1", "pop2", "pop3", "pop4");
+
+			// SPOP - Single pop
+			String poppedMember = template.opsForSet().pop(key7);
+			assertThat(poppedMember).isIn("pop1", "pop2", "pop3", "pop4");
+			assertThat(template.opsForSet().size(key7)).isEqualTo(3);
+
+			// SPOP with count (Valkey 3.2+)
+			List<String> poppedMembers = template.opsForSet().pop(key7, 2);
+			if (poppedMembers != null) { // Some versions might not support count
+											// parameter
+				assertThat(poppedMembers).hasSize(2);
+				assertThat(template.opsForSet().size(key7)).isEqualTo(1);
+			}
+
+			// SMOVE - Move member between sets
+			template.opsForSet().add(key8, "move1", "move2", "move3");
+			String moveDestKey = key8 + "_dest";
+
+			Boolean moveResult = template.opsForSet().move(key8, "move2", moveDestKey);
+			assertThat(moveResult).isTrue();
+			assertThat(template.opsForSet().isMember(key8, "move2")).isFalse();
+			assertThat(template.opsForSet().isMember(moveDestKey, "move2")).isTrue();
+
+			// Try to move non-existent member
+			Boolean moveResult2 = template.opsForSet().move(key8, "nonexistent", moveDestKey);
+			assertThat(moveResult2).isFalse();
+
+			template.delete(moveDestKey);
+
+			// SSCAN operation (using ValkeyCallback for direct access to connection)
+			template.opsForSet().add(key9, "scan1", "scan2", "scan3", "scan4", "scan5");
+
+			// Test sScan using connection directly
+			template.execute((ValkeyCallback<Void>) connection -> {
+				try (var cursor = connection.setCommands()
+					.sScan(key9.getBytes(),
+							io.valkey.springframework.data.valkey.core.ScanOptions.scanOptions().count(10).build())) {
+					Set<String> scannedMembers = new java.util.HashSet<>();
+					while (cursor.hasNext()) {
+						byte[] member = cursor.next();
+						scannedMembers.add(new String(member));
+					}
+					assertThat(scannedMembers).containsExactlyInAnyOrder("scan1", "scan2", "scan3", "scan4", "scan5");
+				}
+				return null;
+			});
+
+			// Test high-level SetOperations.scan() method
+			template.opsForSet().add(key10, "high1", "high2", "high3", "high4", "high5");
+
+			try (io.valkey.springframework.data.valkey.core.Cursor<String> cursor = template.opsForSet()
+				.scan(key10, io.valkey.springframework.data.valkey.core.ScanOptions.scanOptions().count(10).build())) {
+				Set<String> scannedHighMembers = new java.util.HashSet<>();
+				while (cursor.hasNext()) {
+					String member = cursor.next();
+					scannedHighMembers.add(member);
+				}
+				assertThat(scannedHighMembers).containsExactlyInAnyOrder("high1", "high2", "high3", "high4", "high5");
+			}
+
+		}
+		finally {
+			// Clean up all test keys
+			template.delete(key1);
+			template.delete(key2);
+			template.delete(key3);
+			template.delete(key4);
+			template.delete(key5);
+			template.delete(key6);
+			template.delete(key7);
+			template.delete(key8);
+			template.delete(key9);
+			template.delete(key10);
+			template.delete(destKey);
+			template.delete(key8 + "_dest");
+		}
+	}
+
+	@Test
+	void testStringOperations() {
+		// Basic SET/GET operations
+		String key1 = "test:string:basic";
+		String key2 = "test:string:expire";
+		String key3 = "test:string:setnx";
+		String key4 = "test:string:getset";
+		String multi1Key = "test:string:multi1";
+		String multi2Key = "test:string:multi2";
+		String multi3Key = "test:string:multi3";
+		String msetnx1Key = "test:string:msetnx1";
+		String msetnx2Key = "test:string:msetnx2";
+		String counterKey = "test:string:counter";
+		String floatCounterKey = "test:string:floatcounter";
+		String appendKey = "test:string:append";
+		String setRangeKey = "test:string:setrange";
+		String bitKey = "test:string:bits";
+		String bitKey1 = "test:string:bit1";
+		String bitKey2 = "test:string:bit2";
+		String bitDestKey = "test:string:bitop";
+
+		try {
+			String value1 = "Hello, valkey-glide!";
+
+			template.opsForValue().set(key1, value1);
+			String retrieved1 = template.opsForValue().get(key1);
+			assertThat(retrieved1).isEqualTo(value1);
+
+			// SET with expiration
+			String value2 = "Expiring value";
+			template.opsForValue().set(key2, value2, Duration.ofSeconds(60));
+			String retrieved2 = template.opsForValue().get(key2);
+			assertThat(retrieved2).isEqualTo(value2);
+
+			// SETNX (Set if Not eXists)
+			String value3 = "New value";
+			Boolean setResult1 = template.opsForValue().setIfAbsent(key3, value3);
+			assertThat(setResult1).isTrue();
+			Boolean setResult2 = template.opsForValue().setIfAbsent(key3, "Different value");
+			assertThat(setResult2).isFalse();
+			assertThat(template.opsForValue().get(key3)).isEqualTo(value3);
+
+			// GETSET operation
+			template.opsForValue().set(key4, "old value");
+			String oldValue = template.opsForValue().getAndSet(key4, "new value");
+			assertThat(oldValue).isEqualTo("old value");
+			assertThat(template.opsForValue().get(key4)).isEqualTo("new value");
+
+			// MGET/MSET operations
+			Map<String, String> multiValues = Map.of(multi1Key, "value1", multi2Key, "value2", multi3Key, "value3");
+			template.opsForValue().multiSet(multiValues);
+
+			List<String> multiRetrieved = template.opsForValue().multiGet(List.of(multi1Key, multi2Key, multi3Key));
+			assertThat(multiRetrieved).containsExactly("value1", "value2", "value3");
+
+			// MSETNX operation (set multiple if none exist)
+			Map<String, String> msetnxValues = Map.of(msetnx1Key, "msetnx_value1", msetnx2Key, "msetnx_value2");
+			Boolean msetnxResult = template.opsForValue().multiSetIfAbsent(msetnxValues);
+			assertThat(msetnxResult).isTrue();
+			assertThat(template.opsForValue().get(msetnx1Key)).isEqualTo("msetnx_value1");
+
+			// INCR/DECR operations
+			template.opsForValue().set(counterKey, "10");
+
+			Long incResult1 = template.opsForValue().increment(counterKey);
+			assertThat(incResult1).isEqualTo(11L);
+
+			Long incResult2 = template.opsForValue().increment(counterKey, 5L);
+			assertThat(incResult2).isEqualTo(16L);
+
+			Long decrResult1 = template.opsForValue().decrement(counterKey);
+			assertThat(decrResult1).isEqualTo(15L);
+
+			Long decrResult2 = template.opsForValue().decrement(counterKey, 3L);
+			assertThat(decrResult2).isEqualTo(12L);
+
+			// Floating point increment operations (using separate key to avoid DECR
+			// issues)
+			template.opsForValue().set(floatCounterKey, "10");
+			Double incFloatResult = template.opsForValue().increment(floatCounterKey, 2.5);
+			assertThat(incFloatResult).isEqualTo(12.5);
+
+			// APPEND operation
+			template.opsForValue().set(appendKey, "Hello");
+			Integer appendResult = template.opsForValue().append(appendKey, " World!");
+			assertThat(appendResult).isEqualTo(12); // Length of "Hello World!"
+			assertThat(template.opsForValue().get(appendKey)).isEqualTo("Hello World!");
+
+			// STRING LENGTH operation
+			Long strlenResult = template.opsForValue().size(appendKey);
+			assertThat(strlenResult).isEqualTo(12L);
+
+			// GETRANGE operation (substring)
+			String rangeResult = template.opsForValue().get(appendKey, 0, 4);
+			assertThat(rangeResult).isEqualTo("Hello");
+
+			// SETRANGE operation
+			template.opsForValue().set(appendKey, "Hello World!", 6);
+			// This would set from position 6, but let's test a simpler case
+			template.opsForValue().set(setRangeKey, "Hello");
+			template.opsForValue().set(setRangeKey, " Valkey", 5);
+			assertThat(template.opsForValue().get(setRangeKey)).startsWith("Hello");
+
+			// BIT operations (using ValkeyTemplate's execute for direct access to
+			// connection)
+			template.opsForValue().set(bitKey, "a"); // 'a' = 01100001 in binary
+
+			// Use connection directly for bit operations
+			Boolean getBitResult = template.execute(
+					(ValkeyCallback<Boolean>) connection -> connection.stringCommands().getBit(bitKey.getBytes(), 1));
+			assertThat(getBitResult).isTrue(); // Second bit of 'a' is 1
+
+			Boolean setBitResult = template.execute((ValkeyCallback<Boolean>) connection -> connection.stringCommands()
+				.setBit(bitKey.getBytes(), 0, true));
+			assertThat(setBitResult).isFalse(); // Original first bit was 0
+
+			Long bitCountResult = template
+				.execute((ValkeyCallback<Long>) connection -> connection.stringCommands().bitCount(bitKey.getBytes()));
+			assertThat(bitCountResult).isGreaterThan(0L);
+
+			// BITOP operation
+			template.opsForValue().set(bitKey1, "a");
+			template.opsForValue().set(bitKey2, "b");
+
+			Long bitOpResult = template.execute((ValkeyCallback<Long>) connection -> connection.stringCommands()
+				.bitOp(ValkeyStringCommands.BitOperation.AND, bitDestKey.getBytes(), bitKey1.getBytes(),
+						bitKey2.getBytes()));
+			assertThat(bitOpResult).isEqualTo(1L); // Result length
+		}
+		finally {
+			// Clean up all test keys - this will execute even if an exception occurs
+			template.delete(key1);
+			template.delete(key2);
+			template.delete(key3);
+			template.delete(key4);
+			template.delete(multi1Key);
+			template.delete(multi2Key);
+			template.delete(multi3Key);
+			template.delete(msetnx1Key);
+			template.delete(msetnx2Key);
+			template.delete(counterKey);
+			template.delete(floatCounterKey);
+			template.delete(appendKey);
+			template.delete(setRangeKey);
+			template.delete(bitKey);
+			template.delete(bitKey1);
+			template.delete(bitKey2);
+			template.delete(bitDestKey);
+		}
+	}
+
+	@Test
+	void testTransactional() {
+		String key1 = "test:tx:key1";
+		String key2 = "test:tx:key2";
+
+		template.opsForValue().set(key1, "initial1");
+		template.opsForValue().set(key2, "initial2");
+
+		// Using SessionCallback for transactions
+		template.execute(new SessionCallback<Object>() {
+			@SuppressWarnings({ "unchecked", "rawtypes" })
+			public Object execute(ValkeyOperations operations) {
+				operations.multi();
+
+				operations.opsForValue().set(key1, "updated1");
+				operations.opsForValue().set(key2, "updated2");
+
+				return operations.exec();
+			}
+		});
+
+		assertThat(template.opsForValue().get(key1)).isEqualTo("updated1");
+		assertThat(template.opsForValue().get(key2)).isEqualTo("updated2");
+
+		template.delete(key1);
+		template.delete(key2);
+	}
+
+	/**
+	 * Creates a connection factory for testing.
+	 */
+	private ValkeyGlideConnectionFactory createConnectionFactory() {
+		ValkeyStandaloneConfiguration config = new ValkeyStandaloneConfiguration();
+		config.setHostName(getValkeyHost());
+		config.setPort(getValkeyPort());
+		return new ValkeyGlideConnectionFactory(config);
+	}
+
+	/**
+	 * Validates that the Valkey server exists and is accessible.
+	 */
+	private void validateServerExistance(ValkeyConnectionFactory factory) {
+		try (ValkeyConnection connection = factory.getConnection()) {
+			assertThat(connection.ping()).isEqualTo("PONG");
+		}
+	}
+
+	/**
+	 * Gets the Valkey host from environment or uses default.
+	 */
+	private String getValkeyHost() {
+		return System.getProperty("valkey.host", "localhost");
+	}
+
+	/**
+	 * Gets the Valkey port from environment or uses default.
+	 */
+	private int getValkeyPort() {
+		return Integer.parseInt(System.getProperty("valkey.port", "6379"));
+	}
+
+	/**
+	 * Checks if the server version is at least the specified major.minor version. Uses
+	 * the INFO server command to get server version information.
+	 */
+	private boolean isServerVersionAtLeast(int majorVersion, int minorVersion) {
+		return template.execute((ValkeyCallback<Boolean>) connection -> {
+			// Execute INFO server command
+			Properties serverInfo = connection.serverCommands().info("server");
+			// Check for valkey_version or redis_version
+			String versionString = serverInfo.getProperty("valkey_version", serverInfo.getProperty("redis_version"));
+
+			// If valkey_version is not found, try server_version (for Valkey)
+			if (versionString == null) {
+				versionString = serverInfo.getProperty("server_version");
+			}
+
+			if (versionString == null) {
+				return false;
+			}
+
+			// Parse version string (e.g., "7.4.0" or "8.0.1")
+			String[] versionParts = versionString.split("\\.");
+			if (versionParts.length < 2) {
+				return false;
+			}
+
+			int serverMajor = Integer.parseInt(versionParts[0]);
+			int serverMinor = Integer.parseInt(versionParts[1]);
+
+			// Compare versions
+			if (serverMajor > majorVersion) {
+				return true;
+			}
+			else if (serverMajor == majorVersion) {
+				return serverMinor >= minorVersion;
+			}
+			else {
+				return false;
+			}
+		});
+	}
+
 }

--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionGeoCommandsIntegrationTests.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionGeoCommandsIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,1864 +41,1961 @@ import io.valkey.springframework.data.valkey.domain.geo.GeoReference;
 import io.valkey.springframework.data.valkey.domain.geo.GeoShape;
 
 /**
- * Comprehensive low-level integration tests for {@link ValkeyGlideConnection} 
- * geospatial functionality using the ValkeyGeoCommands interface directly.
- * 
- * These tests validate the implementation of all ValkeyGeoCommands methods:
- * - Basic geo operations (geoAdd, geoRemove, geoPos, geoHash)
- * - Distance calculations (geoDist)
- * - Radius searches (geoRadius, geoRadiusByMember)
- * - Advanced search operations (geoSearch, geoSearchStore)
- * - Various argument combinations and edge cases
- * - Error handling and validation
+ * Comprehensive low-level integration tests for {@link ValkeyGlideConnection} geospatial
+ * functionality using the ValkeyGeoCommands interface directly.
+ *
+ * These tests validate the implementation of all ValkeyGeoCommands methods: - Basic geo
+ * operations (geoAdd, geoRemove, geoPos, geoHash) - Distance calculations (geoDist) -
+ * Radius searches (geoRadius, geoRadiusByMember) - Advanced search operations (geoSearch,
+ * geoSearchStore) - Various argument combinations and edge cases - Error handling and
+ * validation
  *
  * @author Ilia Kolominsky
  * @since 2.0
  */
 public class ValkeyGlideConnectionGeoCommandsIntegrationTests extends AbstractValkeyGlideIntegrationTests {
 
-    @Override
-    protected String[] getTestKeyPatterns() {
-        return new String[]{
-            "test:geo:add:key", "test:geo:add:map:key", "test:geo:add:iterable:key",
-            "test:geo:dist:key", "test:geo:hash:key", "test:geo:pos:key",
-            "test:geo:radius:key", "test:geo:radius:member:key", "test:geo:remove:key",
-            "test:geo:search:key", "test:geo:search:store:key", "test:geo:search:dest:key",
-            "test:geo:mixed:key", "test:geo:empty:key", "test:geo:validation:key",
-            "test:geo:large:key", "test:geo:edge:cases:key", "test:geo:precision:key",
-            // Pipeline mode test keys
-            "test:pipeline:geo1", "test:pipeline:geo2", "test:pipeline:geo3",
-            "test:pipeline:geosearch", "test:pipeline:geodest", "test:pipeline:mixed:1",
-            // Transaction mode test keys
-            "test:tx:geo1", "test:tx:geo2", "test:tx:geosearch", "test:tx:geodest",
-            "test:tx:geo:watched", "test:tx:geo:value", "test:tx:geo:mixed:1", 
-            "test:tx:geo:mixed:2", "test:tx:geo:source", "test:tx:geo:target", "test:tx:geo:log"
-        };
-    }
+	@Override
+	protected String[] getTestKeyPatterns() {
+		return new String[] { "test:geo:add:key", "test:geo:add:map:key", "test:geo:add:iterable:key",
+				"test:geo:dist:key", "test:geo:hash:key", "test:geo:pos:key", "test:geo:radius:key",
+				"test:geo:radius:member:key", "test:geo:remove:key", "test:geo:search:key", "test:geo:search:store:key",
+				"test:geo:search:dest:key", "test:geo:mixed:key", "test:geo:empty:key", "test:geo:validation:key",
+				"test:geo:large:key", "test:geo:edge:cases:key", "test:geo:precision:key",
+				// Pipeline mode test keys
+				"test:pipeline:geo1", "test:pipeline:geo2", "test:pipeline:geo3", "test:pipeline:geosearch",
+				"test:pipeline:geodest", "test:pipeline:mixed:1",
+				// Transaction mode test keys
+				"test:tx:geo1", "test:tx:geo2", "test:tx:geosearch", "test:tx:geodest", "test:tx:geo:watched",
+				"test:tx:geo:value", "test:tx:geo:mixed:1", "test:tx:geo:mixed:2", "test:tx:geo:source",
+				"test:tx:geo:target", "test:tx:geo:log" };
+	}
 
-    // Test data using real world locations
-    private static final Point PALERMO = new Point(13.361389, 38.115556);
-    private static final Point CATANIA = new Point(15.087269, 37.502669);
-    private static final Point EDGE = new Point(12.758489, 38.788135);
-    private static final Point NEW_YORK = new Point(-74.0059, 40.7128);
-    private static final Point LONDON = new Point(-0.1278, 51.5074);
-    private static final Point PARIS = new Point(2.3522, 48.8566);
-    private static final Point ROME = new Point(12.4964, 41.9028);
+	// Test data using real world locations
+	private static final Point PALERMO = new Point(13.361389, 38.115556);
 
-    // ==================== Basic Geo Operations ====================
+	private static final Point CATANIA = new Point(15.087269, 37.502669);
 
-    @Test
-    void testGeoAddSinglePoint() {
-        String key = "test:geo:add:key";
-        
-        try {
-            // Test adding single point
-            Long result = connection.geoCommands().geoAdd(key.getBytes(), PALERMO, "Palermo".getBytes());
-            assertThat(result).isEqualTo(1L);
-            
-            // Test adding another point
-            Long result2 = connection.geoCommands().geoAdd(key.getBytes(), CATANIA, "Catania".getBytes());
-            assertThat(result2).isEqualTo(1L);
-            
-            // Test adding duplicate point (should update)
-            Long result3 = connection.geoCommands().geoAdd(key.getBytes(), EDGE, "Palermo".getBytes());
-            assertThat(result3).isEqualTo(0L); // Should update existing, not add new
-            
-            // Verify the updated position
-            List<Point> positions = connection.geoCommands().geoPos(key.getBytes(), "Palermo".getBytes());
-            assertThat(positions).hasSize(1);
-            assertThat(positions.get(0).getX()).isCloseTo(EDGE.getX(), within(0.01));
-            assertThat(positions.get(0).getY()).isCloseTo(EDGE.getY(), within(0.01));
-        } finally {
-            cleanupKey(key);
-        }
-    }
+	private static final Point EDGE = new Point(12.758489, 38.788135);
 
-    @Test
-    void testGeoAddMap() {
-        String key = "test:geo:add:map:key";
-        
-        try {
-            // Test adding map of member-coordinate pairs
-            Map<byte[], Point> memberCoordinateMap = new HashMap<>();
-            memberCoordinateMap.put("Palermo".getBytes(), PALERMO);
-            memberCoordinateMap.put("Catania".getBytes(), CATANIA);
-            memberCoordinateMap.put("NewYork".getBytes(), NEW_YORK);
-            
-            Long result = connection.geoCommands().geoAdd(key.getBytes(), memberCoordinateMap);
-            assertThat(result).isEqualTo(3L);
-            
-            // Test adding empty map
-            Map<byte[], Point> emptyMap = new HashMap<>();
-            assertThatThrownBy(() -> connection.geoCommands().geoAdd(key.getBytes(), emptyMap))
-                .isInstanceOf(ValkeySystemException.class)
-                .hasMessageContaining("wrong number of arguments for 'geoadd' command");
+	private static final Point NEW_YORK = new Point(-74.0059, 40.7128);
 
-            // Verify all members were added
-            List<Point> positions = connection.geoCommands().geoPos(key.getBytes(), 
-                "Palermo".getBytes(), "Catania".getBytes(), "NewYork".getBytes());
-            assertThat(positions).hasSize(3);
-            assertThat(positions.get(0)).isNotNull();
-            assertThat(positions.get(1)).isNotNull();
-            assertThat(positions.get(2)).isNotNull();
-        } finally {
-            cleanupKey(key);
-        }
-    }
+	private static final Point LONDON = new Point(-0.1278, 51.5074);
 
-    @Test
-    void testGeoAddIterable() {
-        String key = "test:geo:add:iterable:key";
-        
-        try {
-            // Test adding iterable of GeoLocations
-            List<GeoLocation<byte[]>> locations = new ArrayList<>();
-            locations.add(new GeoLocation<>("Palermo".getBytes(), PALERMO));
-            locations.add(new GeoLocation<>("Catania".getBytes(), CATANIA));
-            locations.add(new GeoLocation<>("Rome".getBytes(), ROME));
-            
-            Long result = connection.geoCommands().geoAdd(key.getBytes(), locations);
-            assertThat(result).isEqualTo(3L);
-            
-            // Test adding empty iterable
-            List<GeoLocation<byte[]>> emptyList = new ArrayList<>();
-            assertThatThrownBy(() -> connection.geoCommands().geoAdd(key.getBytes(), emptyList))
-                .isInstanceOf(ValkeySystemException.class)
-                .hasMessageContaining("wrong number of arguments for 'geoadd' command");
+	private static final Point PARIS = new Point(2.3522, 48.8566);
 
-            
-            // Verify all members were added
-            List<Point> positions = connection.geoCommands().geoPos(key.getBytes(), 
-                "Palermo".getBytes(), "Catania".getBytes(), "Rome".getBytes());
-            assertThat(positions).hasSize(3);
-            assertThat(positions.get(0)).isNotNull();
-            assertThat(positions.get(1)).isNotNull();
-            assertThat(positions.get(2)).isNotNull();
-        } finally {
-            cleanupKey(key);
-        }
-    }
+	private static final Point ROME = new Point(12.4964, 41.9028);
 
-    @Test
-    void testGeoRemove() {
-        String key = "test:geo:remove:key";
-        
-        try {
-            // Setup test data
-            Map<byte[], Point> memberCoordinateMap = new HashMap<>();
-            memberCoordinateMap.put("Palermo".getBytes(), PALERMO);
-            memberCoordinateMap.put("Catania".getBytes(), CATANIA);
-            memberCoordinateMap.put("Rome".getBytes(), ROME);
-            
-            connection.geoCommands().geoAdd(key.getBytes(), memberCoordinateMap);
-            
-            // Test removing single member
-            Long result1 = connection.geoCommands().geoRemove(key.getBytes(), "Palermo".getBytes());
-            assertThat(result1).isEqualTo(1L);
-            
-            // Test removing multiple members
-            Long result2 = connection.geoCommands().geoRemove(key.getBytes(), 
-                "Catania".getBytes(), "Rome".getBytes());
-            assertThat(result2).isEqualTo(2L);
-            
-            // Test removing non-existent member
-            Long result3 = connection.geoCommands().geoRemove(key.getBytes(), "NonExistent".getBytes());
-            assertThat(result3).isEqualTo(0L);
-            
-            // Verify all members were removed
-            List<Point> positions = connection.geoCommands().geoPos(key.getBytes(), 
-                "Palermo".getBytes(), "Catania".getBytes(), "Rome".getBytes());
-            assertThat(positions).hasSize(3);
-            assertThat(positions.get(0)).isNull();
-            assertThat(positions.get(1)).isNull();
-            assertThat(positions.get(2)).isNull();
-        } finally {
-            cleanupKey(key);
-        }
-    }
+	// ==================== Basic Geo Operations ====================
 
-    // ==================== Position and Hash Operations ====================
+	@Test
+	void testGeoAddSinglePoint() {
+		String key = "test:geo:add:key";
 
-    @Test
-    void testGeoPos() {
-        String key = "test:geo:pos:key";
-        
-        try {
-            // Test geoPos on empty key
-            List<Point> emptyPositions = connection.geoCommands().geoPos(key.getBytes(), "NonExistent".getBytes());
-            assertThat(emptyPositions).hasSize(1);
-            assertThat(emptyPositions.get(0)).isNull();
-            
-            // Setup test data
-            Map<byte[], Point> memberCoordinateMap = new HashMap<>();
-            memberCoordinateMap.put("Palermo".getBytes(), PALERMO);
-            memberCoordinateMap.put("Catania".getBytes(), CATANIA);
-            memberCoordinateMap.put("NewYork".getBytes(), NEW_YORK);
-            
-            connection.geoCommands().geoAdd(key.getBytes(), memberCoordinateMap);
-            
-            // Test getting single position
-            List<Point> singlePos = connection.geoCommands().geoPos(key.getBytes(), "Palermo".getBytes());
-            assertThat(singlePos).hasSize(1);
-            assertThat(singlePos.get(0).getX()).isCloseTo(PALERMO.getX(), within(0.01));
-            assertThat(singlePos.get(0).getY()).isCloseTo(PALERMO.getY(), within(0.01));
-            
-            // Test getting multiple positions
-            List<Point> multiPos = connection.geoCommands().geoPos(key.getBytes(), 
-                "Palermo".getBytes(), "Catania".getBytes(), "NonExistent".getBytes());
-            assertThat(multiPos).hasSize(3);
-            assertThat(multiPos.get(0)).isNotNull();
-            assertThat(multiPos.get(1)).isNotNull();
-            assertThat(multiPos.get(2)).isNull(); // Non-existent member
-        } finally {
-            cleanupKey(key);
-        }
-    }
+		try {
+			// Test adding single point
+			Long result = connection.geoCommands().geoAdd(key.getBytes(), PALERMO, "Palermo".getBytes());
+			assertThat(result).isEqualTo(1L);
 
-    @Test
-    void testGeoHash() {
-        String key = "test:geo:hash:key";
-        
-        try {
-            // Test geoHash on empty key
-            List<String> emptyHashes = connection.geoCommands().geoHash(key.getBytes(), "NonExistent".getBytes());
-            assertThat(emptyHashes).hasSize(1);
-            assertThat(emptyHashes.get(0)).isNull();
+			// Test adding another point
+			Long result2 = connection.geoCommands().geoAdd(key.getBytes(), CATANIA, "Catania".getBytes());
+			assertThat(result2).isEqualTo(1L);
 
-            // Setup test data
-            Map<byte[], Point> memberCoordinateMap = new HashMap<>();
-            memberCoordinateMap.put("Palermo".getBytes(), PALERMO);
-            memberCoordinateMap.put("Catania".getBytes(), CATANIA);
-            
-            connection.geoCommands().geoAdd(key.getBytes(), memberCoordinateMap);
-            
-            // Test getting single hash
-            List<String> singleHash = connection.geoCommands().geoHash(key.getBytes(), "Palermo".getBytes());
-            assertThat(singleHash).hasSize(1);
-            assertThat(singleHash.get(0)).isNotNull();
-            assertThat(singleHash.get(0)).isNotEmpty();
-            
-            // Test getting multiple hashes
-            List<String> multiHash = connection.geoCommands().geoHash(key.getBytes(), 
-                "Palermo".getBytes(), "Catania".getBytes(), "NonExistent".getBytes());
-            assertThat(multiHash).hasSize(3);
-            assertThat(multiHash.get(0)).isNotNull();
-            assertThat(multiHash.get(1)).isNotNull();
-            assertThat(multiHash.get(2)).isNull(); // Non-existent member
-            
-            // Verify different locations have different hashes
-            assertThat(multiHash.get(0)).isNotEqualTo(multiHash.get(1));
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test adding duplicate point (should update)
+			Long result3 = connection.geoCommands().geoAdd(key.getBytes(), EDGE, "Palermo".getBytes());
+			assertThat(result3).isEqualTo(0L); // Should update existing, not add new
 
-    // ==================== Distance Calculations ====================
+			// Verify the updated position
+			List<Point> positions = connection.geoCommands().geoPos(key.getBytes(), "Palermo".getBytes());
+			assertThat(positions).hasSize(1);
+			assertThat(positions.get(0).getX()).isCloseTo(EDGE.getX(), within(0.01));
+			assertThat(positions.get(0).getY()).isCloseTo(EDGE.getY(), within(0.01));
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
 
-    @Test
-    void testGeoDist() {
-        String key = "test:geo:dist:key";
-        
-        try {
-            // Test geoDist on empty key
-            Distance emptyDist = connection.geoCommands().geoDist(key.getBytes(), 
-                "NonExistent1".getBytes(), "NonExistent2".getBytes());
-            assertThat(emptyDist).isNull();
-            
-            // Setup test data
-            Map<byte[], Point> memberCoordinateMap = new HashMap<>();
-            memberCoordinateMap.put("Palermo".getBytes(), PALERMO);
-            memberCoordinateMap.put("Catania".getBytes(), CATANIA);
-            memberCoordinateMap.put("NewYork".getBytes(), NEW_YORK);
-            
-            connection.geoCommands().geoAdd(key.getBytes(), memberCoordinateMap);
-            
-            // Test distance with default metric (meters)
-            Distance dist1 = connection.geoCommands().geoDist(key.getBytes(), 
-                "Palermo".getBytes(), "Catania".getBytes());
-            assertThat(dist1).isNotNull();
-            assertThat(dist1.getValue()).isGreaterThan(0);
-            assertThat(dist1.getMetric()).isEqualTo(DistanceUnit.METERS);
-            
-            // Test distance with specific metric
-            Distance dist2 = connection.geoCommands().geoDist(key.getBytes(), 
-                "Palermo".getBytes(), "Catania".getBytes(), DistanceUnit.KILOMETERS);
-            assertThat(dist2).isNotNull();
-            assertThat(dist2.getValue()).isGreaterThan(0);
-            assertThat(dist2.getMetric()).isEqualTo(DistanceUnit.KILOMETERS);
-            
-            // Distance in kilometers should be less than distance in meters
-            assertThat(dist2.getValue()).isLessThan(dist1.getValue());
-            
-            // Test distance with non-existent member
-            Distance distNonExistent = connection.geoCommands().geoDist(key.getBytes(), 
-                "Palermo".getBytes(), "NonExistent".getBytes());
-            assertThat(distNonExistent).isNull();
-            
-            // Test distance between distant locations
-            Distance distTransAtlantic = connection.geoCommands().geoDist(key.getBytes(), 
-                "Palermo".getBytes(), "NewYork".getBytes(), DistanceUnit.KILOMETERS);
-            assertThat(distTransAtlantic).isNotNull();
-            assertThat(distTransAtlantic.getValue()).isGreaterThan(1000); // Should be thousands of kilometers
-        } finally {
-            cleanupKey(key);
-        }
-    }
+	@Test
+	void testGeoAddMap() {
+		String key = "test:geo:add:map:key";
 
-    // ==================== Radius Search Operations ====================
+		try {
+			// Test adding map of member-coordinate pairs
+			Map<byte[], Point> memberCoordinateMap = new HashMap<>();
+			memberCoordinateMap.put("Palermo".getBytes(), PALERMO);
+			memberCoordinateMap.put("Catania".getBytes(), CATANIA);
+			memberCoordinateMap.put("NewYork".getBytes(), NEW_YORK);
 
-    @Test
-    void testGeoRadius() {
-        String key = "test:geo:radius:key";
-        
-        try {
-            // Setup test data
-            Map<byte[], Point> memberCoordinateMap = new HashMap<>();
-            memberCoordinateMap.put("Palermo".getBytes(), PALERMO);
-            memberCoordinateMap.put("Catania".getBytes(), CATANIA);
-            memberCoordinateMap.put("Edge".getBytes(), EDGE);
-            memberCoordinateMap.put("NewYork".getBytes(), NEW_YORK);
-            
-            connection.geoCommands().geoAdd(key.getBytes(), memberCoordinateMap);
-            
-            // Test basic radius search
-            Circle searchArea = new Circle(PALERMO, new Distance(200, DistanceUnit.KILOMETERS));
-            GeoResults<GeoLocation<byte[]>> results1 = connection.geoCommands().geoRadius(key.getBytes(), searchArea);
-            assertThat(results1).isNotNull();
-            assertThat(results1.getContent()).isNotEmpty();
-            
-            // Should find Palermo and Catania, but not NewYork
-            List<String> memberNames = results1.getContent().stream()
-                .map(result -> new String(result.getContent().getName()))
-                .collect(java.util.stream.Collectors.toList());
-            assertThat(memberNames).contains("Palermo");
-            assertThat(memberNames).doesNotContain("NewYork");
-            
-            // Test radius search with arguments
-            GeoRadiusCommandArgs args = GeoRadiusCommandArgs.newGeoRadiusArgs()
-                .includeDistance()
-                .includeCoordinates()
-                .sortAscending()
-                .limit(10);
-            
-            GeoResults<GeoLocation<byte[]>> results2 = connection.geoCommands().geoRadius(key.getBytes(), searchArea, args);
-            assertThat(results2).isNotNull();
-            assertThat(results2.getContent()).isNotEmpty();
-            
-            // Verify distance and coordinates are included
-            for (GeoResult<GeoLocation<byte[]>> result : results2.getContent()) {
-                assertThat(result.getDistance()).isNotNull();
-                assertThat(result.getContent().getPoint()).isNotNull();
-            }
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			Long result = connection.geoCommands().geoAdd(key.getBytes(), memberCoordinateMap);
+			assertThat(result).isEqualTo(3L);
 
-    @Test
-    void testGeoRadiusByMember() {
-        String key = "test:geo:radius:member:key";
-        
-        try {
-            // Setup test data
-            Map<byte[], Point> memberCoordinateMap = new HashMap<>();
-            memberCoordinateMap.put("Palermo".getBytes(), PALERMO);
-            memberCoordinateMap.put("Catania".getBytes(), CATANIA);
-            memberCoordinateMap.put("Edge".getBytes(), EDGE);
-            memberCoordinateMap.put("NewYork".getBytes(), NEW_YORK);
-            
-            connection.geoCommands().geoAdd(key.getBytes(), memberCoordinateMap);
-            
-            // Test basic radius search by member
-            Distance radius = new Distance(200, DistanceUnit.KILOMETERS);
-            GeoResults<GeoLocation<byte[]>> results1 = connection.geoCommands().geoRadiusByMember(
-                key.getBytes(), "Palermo".getBytes(), radius);
-            assertThat(results1).isNotNull();
-            assertThat(results1.getContent()).isNotEmpty();
-            
-            // Should find Palermo itself and nearby cities
-            List<String> memberNames = results1.getContent().stream()
-                .map(result -> new String(result.getContent().getName()))
-                .collect(java.util.stream.Collectors.toList());
-            assertThat(memberNames).contains("Palermo");
-            
-            // Test radius search by member with arguments
-            GeoRadiusCommandArgs args = GeoRadiusCommandArgs.newGeoRadiusArgs()
-                .includeDistance()
-                .includeCoordinates()
-                .sortDescending()
-                .limit(5);
-            
-            GeoResults<GeoLocation<byte[]>> results2 = connection.geoCommands().geoRadiusByMember(
-                key.getBytes(), "Palermo".getBytes(), radius, args);
-            assertThat(results2).isNotNull();
-            assertThat(results2.getContent()).isNotEmpty();
-            
-            // Verify distance and coordinates are included
-            for (GeoResult<GeoLocation<byte[]>> result : results2.getContent()) {
-                assertThat(result.getDistance()).isNotNull();
-                assertThat(result.getContent().getPoint()).isNotNull();
-            }
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test adding empty map
+			Map<byte[], Point> emptyMap = new HashMap<>();
+			assertThatThrownBy(() -> connection.geoCommands().geoAdd(key.getBytes(), emptyMap))
+				.isInstanceOf(ValkeySystemException.class)
+				.hasMessageContaining("wrong number of arguments for 'geoadd' command");
 
-    // ==================== Advanced Search Operations ====================
+			// Verify all members were added
+			List<Point> positions = connection.geoCommands()
+				.geoPos(key.getBytes(), "Palermo".getBytes(), "Catania".getBytes(), "NewYork".getBytes());
+			assertThat(positions).hasSize(3);
+			assertThat(positions.get(0)).isNotNull();
+			assertThat(positions.get(1)).isNotNull();
+			assertThat(positions.get(2)).isNotNull();
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
 
-    @Test
-    void testGeoSearch() {
-        String key = "test:geo:search:key";
-        
-        try {
-            // Setup test data
-            Map<byte[], Point> memberCoordinateMap = new HashMap<>();
-            memberCoordinateMap.put("Palermo".getBytes(), PALERMO);
-            memberCoordinateMap.put("Catania".getBytes(), CATANIA);
-            memberCoordinateMap.put("Rome".getBytes(), ROME);
-            memberCoordinateMap.put("NewYork".getBytes(), NEW_YORK);
-            
-            connection.geoCommands().geoAdd(key.getBytes(), memberCoordinateMap);
-            
-            // Test search from member reference
-            GeoReference<byte[]> memberRef = GeoReference.fromMember("Palermo".getBytes());
-            GeoShape radiusShape = GeoShape.byRadius(new Distance(300, DistanceUnit.KILOMETERS));
-            GeoSearchCommandArgs args = GeoSearchCommandArgs.newGeoSearchArgs()
-                .includeDistance()
-                .includeCoordinates()
-                .sortAscending()
-                .limit(10);
-            
-            GeoResults<GeoLocation<byte[]>> results1 = connection.geoCommands().geoSearch(
-                key.getBytes(), memberRef, radiusShape, args);
-            assertThat(results1).isNotNull();
-            assertThat(results1.getContent()).isNotEmpty();
-            
-            // Should find nearby locations
-            List<String> memberNames = results1.getContent().stream()
-                .map(result -> new String(result.getContent().getName()))
-                .collect(java.util.stream.Collectors.toList());
-            assertThat(memberNames).contains("Palermo");
-            assertThat(memberNames).doesNotContain("NewYork");
-            
-            // Test search from coordinate reference
-            GeoReference<byte[]> coordRef = GeoReference.fromCoordinate(PALERMO);
-            GeoResults<GeoLocation<byte[]>> results2 = connection.geoCommands().geoSearch(
-                key.getBytes(), coordRef, radiusShape, args);
-            assertThat(results2).isNotNull();
-            assertThat(results2.getContent()).isNotEmpty();
-            
-            // Results should be similar to member reference search
-            assertThat(results2.getContent().size()).isGreaterThan(0);
-            
-            // Test with box shape
-            GeoShape boxShape = GeoShape.byBox(200, 200, DistanceUnit.KILOMETERS);
-            GeoResults<GeoLocation<byte[]>> results3 = connection.geoCommands().geoSearch(
-                key.getBytes(), memberRef, boxShape, args);
-            assertThat(results3).isNotNull();
-            assertThat(results3.getContent()).isNotEmpty();
-        } finally {
-            cleanupKey(key);
-        }
-    }
+	@Test
+	void testGeoAddIterable() {
+		String key = "test:geo:add:iterable:key";
 
-    @Test
-    void testGeoSearchStore() {
-        String key = "test:geo:search:store:key";
-        String destKey = "test:geo:search:dest:key";
-        
-        try {
-            // Setup test data
-            Map<byte[], Point> memberCoordinateMap = new HashMap<>();
-            memberCoordinateMap.put("Palermo".getBytes(), PALERMO);
-            memberCoordinateMap.put("Catania".getBytes(), CATANIA);
-            memberCoordinateMap.put("Rome".getBytes(), ROME);
-            memberCoordinateMap.put("NewYork".getBytes(), NEW_YORK);
-            
-            connection.geoCommands().geoAdd(key.getBytes(), memberCoordinateMap);
-            
-            // Test search and store
-            GeoReference<byte[]> memberRef = GeoReference.fromMember("Palermo".getBytes());
-            GeoShape radiusShape = GeoShape.byRadius(new Distance(300, DistanceUnit.KILOMETERS));
-            GeoSearchStoreCommandArgs args = GeoSearchStoreCommandArgs.newGeoSearchStoreArgs()
-                .sortAscending()
-                .limit(10);
-            
-            Long storeResult = connection.geoCommands().geoSearchStore(
-                destKey.getBytes(), key.getBytes(), memberRef, radiusShape, args);
-            assertThat(storeResult).isNotNull();
-            assertThat(storeResult).isGreaterThan(0L);
-            
-            // Verify stored results by checking positions
-            List<Point> storedPositions = connection.geoCommands().geoPos(destKey.getBytes(), "Palermo".getBytes());
-            assertThat(storedPositions).hasSize(1);
-            assertThat(storedPositions.get(0)).isNotNull();
-            
-            // Test with store distance option
-            GeoSearchStoreCommandArgs storeDistArgs = GeoSearchStoreCommandArgs.newGeoSearchStoreArgs()
-                .storeDistance()
-                .sortDescending()
-                .limit(5);
-            
-            Long storeDistResult = connection.geoCommands().geoSearchStore(
-                destKey.getBytes(), key.getBytes(), memberRef, radiusShape, storeDistArgs);
-            assertThat(storeDistResult).isNotNull();
-            assertThat(storeDistResult).isGreaterThan(0L);
-        } finally {
-            cleanupKey(key);
-            cleanupKey(destKey);
-        }
-    }
+		try {
+			// Test adding iterable of GeoLocations
+			List<GeoLocation<byte[]>> locations = new ArrayList<>();
+			locations.add(new GeoLocation<>("Palermo".getBytes(), PALERMO));
+			locations.add(new GeoLocation<>("Catania".getBytes(), CATANIA));
+			locations.add(new GeoLocation<>("Rome".getBytes(), ROME));
 
-    // ==================== Edge Cases and Error Handling ====================
+			Long result = connection.geoCommands().geoAdd(key.getBytes(), locations);
+			assertThat(result).isEqualTo(3L);
 
-    @Test
-    void testEmptyKeyOperations() {
-        String key = "test:geo:empty:key";
-        
-        try {
-            // Test operations on empty key
-            List<Point> emptyPos = connection.geoCommands().geoPos(key.getBytes(), "NonExistent".getBytes());
-            assertThat(emptyPos).hasSize(1);
-            assertThat(emptyPos.get(0)).isNull();
+			// Test adding empty iterable
+			List<GeoLocation<byte[]>> emptyList = new ArrayList<>();
+			assertThatThrownBy(() -> connection.geoCommands().geoAdd(key.getBytes(), emptyList))
+				.isInstanceOf(ValkeySystemException.class)
+				.hasMessageContaining("wrong number of arguments for 'geoadd' command");
 
-            List<String> emptyHash = connection.geoCommands().geoHash(key.getBytes(), "NonExistent".getBytes());
-            assertThat(emptyHash).hasSize(1);
-            assertThat(emptyHash.get(0)).isNull();
+			// Verify all members were added
+			List<Point> positions = connection.geoCommands()
+				.geoPos(key.getBytes(), "Palermo".getBytes(), "Catania".getBytes(), "Rome".getBytes());
+			assertThat(positions).hasSize(3);
+			assertThat(positions.get(0)).isNotNull();
+			assertThat(positions.get(1)).isNotNull();
+			assertThat(positions.get(2)).isNotNull();
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
 
-            Distance emptyDist = connection.geoCommands().geoDist(key.getBytes(), 
-                "NonExistent1".getBytes(), "NonExistent2".getBytes());
-            assertThat(emptyDist).isNull();
-            
-            Circle searchArea = new Circle(PALERMO, new Distance(100, DistanceUnit.KILOMETERS));
-            GeoResults<GeoLocation<byte[]>> emptyRadius = connection.geoCommands().geoRadius(key.getBytes(), searchArea);
-            assertThat(emptyRadius).isNotNull();
-            assertThat(emptyRadius.getContent()).isEmpty();
-            
-            Long emptyRemove = connection.geoCommands().geoRemove(key.getBytes(), "NonExistent".getBytes());
-            assertThat(emptyRemove).isEqualTo(0L);
-        } finally {
-            cleanupKey(key);
-        }
-    }
+	@Test
+	void testGeoRemove() {
+		String key = "test:geo:remove:key";
 
-    @Test
-    void testMixedOperations() {
-        String key = "test:geo:mixed:key";
-        
-        try {
-            // Add some locations
-            Map<byte[], Point> memberCoordinateMap = new HashMap<>();
-            memberCoordinateMap.put("Palermo".getBytes(), PALERMO);
-            memberCoordinateMap.put("Catania".getBytes(), CATANIA);
-            memberCoordinateMap.put("Rome".getBytes(), ROME);
-            
-            connection.geoCommands().geoAdd(key.getBytes(), memberCoordinateMap);
-            
-            // Test mixed operations
-            Distance dist = connection.geoCommands().geoDist(key.getBytes(), 
-                "Palermo".getBytes(), "Rome".getBytes(), DistanceUnit.KILOMETERS);
-            assertThat(dist).isNotNull();
-            assertThat(dist.getValue()).isGreaterThan(0);
-            
-            // Remove one location
-            Long removeResult = connection.geoCommands().geoRemove(key.getBytes(), "Catania".getBytes());
-            assertThat(removeResult).isEqualTo(1L);
-            
-            // Verify it's removed
-            List<Point> positions = connection.geoCommands().geoPos(key.getBytes(), "Catania".getBytes());
-            assertThat(positions.get(0)).isNull();
-            
-            // But other locations should still be there
-            List<Point> remainingPositions = connection.geoCommands().geoPos(key.getBytes(),
-                "Palermo".getBytes(), "Rome".getBytes());
-            assertThat(remainingPositions).hasSize(2);
-            assertThat(remainingPositions.get(0)).isNotNull();
-            assertThat(remainingPositions.get(1)).isNotNull();
-            
-            // Test radius search after removal
-            Circle searchArea = new Circle(PALERMO, new Distance(500, DistanceUnit.KILOMETERS));
-            GeoResults<GeoLocation<byte[]>> radiusResults = connection.geoCommands().geoRadius(key.getBytes(), searchArea);
-            assertThat(radiusResults).isNotNull();
-            assertThat(radiusResults.getContent()).hasSize(2); // Only Palermo and Rome should remain
-            
-            List<String> remainingNames = radiusResults.getContent().stream()
-                .map(result -> new String(result.getContent().getName()))
-                .collect(java.util.stream.Collectors.toList());
-            assertThat(remainingNames).containsExactlyInAnyOrder("Palermo", "Rome");
-            assertThat(remainingNames).doesNotContain("Catania");
-        } finally {
-            cleanupKey(key);
-        }
-    }
+		try {
+			// Setup test data
+			Map<byte[], Point> memberCoordinateMap = new HashMap<>();
+			memberCoordinateMap.put("Palermo".getBytes(), PALERMO);
+			memberCoordinateMap.put("Catania".getBytes(), CATANIA);
+			memberCoordinateMap.put("Rome".getBytes(), ROME);
 
-    // ==================== Parameter Validation Tests ====================
+			connection.geoCommands().geoAdd(key.getBytes(), memberCoordinateMap);
 
-    @Test
-    void testParameterValidation() {
-        String key = "test:geo:validation:key";
-        
-        try {
-            // Test null key validation
-            assertThatThrownBy(() -> connection.geoCommands().geoAdd(null, PALERMO, "member".getBytes()))
-                .isInstanceOf(IllegalArgumentException.class);
-            
-            // Test null point validation
-            assertThatThrownBy(() -> connection.geoCommands().geoAdd(key.getBytes(), null, "member".getBytes()))
-                .isInstanceOf(IllegalArgumentException.class);
-            
-            // Test null member validation
-            assertThatThrownBy(() -> connection.geoCommands().geoAdd(key.getBytes(), PALERMO, null))
-                .isInstanceOf(IllegalArgumentException.class);
-            
-            // Test null members array validation
-            assertThatThrownBy(() -> connection.geoCommands().geoPos(key.getBytes(), (byte[][]) null))
-                .isInstanceOf(IllegalArgumentException.class);
-            
-            // Test null elements in members array
-            assertThatThrownBy(() -> connection.geoCommands().geoPos(key.getBytes(), "member1".getBytes(), null))
-                .isInstanceOf(IllegalArgumentException.class);
-            
-            // Test null metric validation
-            connection.geoCommands().geoAdd(key.getBytes(), PALERMO, "member1".getBytes());
-            connection.geoCommands().geoAdd(key.getBytes(), CATANIA, "member2".getBytes());
-            
-            assertThatThrownBy(() -> connection.geoCommands().geoDist(key.getBytes(), 
-                "member1".getBytes(), "member2".getBytes(), null))
-                .isInstanceOf(IllegalArgumentException.class);
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test removing single member
+			Long result1 = connection.geoCommands().geoRemove(key.getBytes(), "Palermo".getBytes());
+			assertThat(result1).isEqualTo(1L);
 
-    // ==================== Performance and Stress Tests ====================
+			// Test removing multiple members
+			Long result2 = connection.geoCommands().geoRemove(key.getBytes(), "Catania".getBytes(), "Rome".getBytes());
+			assertThat(result2).isEqualTo(2L);
 
-    @Test
-    void testLargeDataset() {
-        String key = "test:geo:large:key";
-        
-        try {
-            // Add a large number of locations with valid coordinates
-            // Valkey geo commands have latitude limits of approximately -85.05 to 85.05 degrees
-            Map<byte[], Point> largeDataset = new HashMap<>();
-            for (int i = 0; i < 100; i++) {
-                double longitude = -180 + (360.0 * i / 100);
-                double latitude = -85 + (170.0 * i / 100); // Valid latitude range: -85 to 85
-                largeDataset.put(("location" + i).getBytes(), new Point(longitude, latitude));
-            }
-            
-            Long addResult = connection.geoCommands().geoAdd(key.getBytes(), largeDataset);
-            assertThat(addResult).isEqualTo(100L);
-            
-            // Test operations on large dataset
-            List<Point> positions = connection.geoCommands().geoPos(key.getBytes(), "location50".getBytes());
-            assertThat(positions).hasSize(1);
-            assertThat(positions.get(0)).isNotNull();
-            
-            // Test radius search on large dataset
-            Circle largeSearchArea = new Circle(new Point(0, 0), new Distance(5000, DistanceUnit.KILOMETERS));
-            GeoResults<GeoLocation<byte[]>> largeResults = connection.geoCommands().geoRadius(key.getBytes(), largeSearchArea);
-            assertThat(largeResults).isNotNull();
-            assertThat(largeResults.getContent()).isNotEmpty();
-            
-            // Test bulk removal
-            byte[][] membersToRemove = new byte[50][];
-            for (int i = 0; i < 50; i++) {
-                membersToRemove[i] = ("location" + i).getBytes();
-            }
-            Long removeResult = connection.geoCommands().geoRemove(key.getBytes(), membersToRemove);
-            assertThat(removeResult).isEqualTo(50L);
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test removing non-existent member
+			Long result3 = connection.geoCommands().geoRemove(key.getBytes(), "NonExistent".getBytes());
+			assertThat(result3).isEqualTo(0L);
 
-    // ==================== Geographic Edge Cases ====================
+			// Verify all members were removed
+			List<Point> positions = connection.geoCommands()
+				.geoPos(key.getBytes(), "Palermo".getBytes(), "Catania".getBytes(), "Rome".getBytes());
+			assertThat(positions).hasSize(3);
+			assertThat(positions.get(0)).isNull();
+			assertThat(positions.get(1)).isNull();
+			assertThat(positions.get(2)).isNull();
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
 
-    @Test
-    void testGeographicEdgeCases() {
-        String key = "test:geo:edge:cases:key";
-        
-        try {
-            // Test locations at extreme but valid coordinates
-            // Valkey geo commands have latitude limits, so we use realistic extreme coordinates
-            Map<byte[], Point> edgeCases = new HashMap<>();
-            edgeCases.put("NearNorthPole".getBytes(), new Point(0, 85));  // Close to North Pole
-            edgeCases.put("NearSouthPole".getBytes(), new Point(0, -85)); // Close to South Pole
-            edgeCases.put("DateLine".getBytes(), new Point(179, 0));      // Close to Date Line
-            edgeCases.put("AntiMeridian".getBytes(), new Point(-179, 0)); // Close to Anti-Meridian
-            edgeCases.put("Equator".getBytes(), new Point(0, 0));
-            
-            Long addResult = connection.geoCommands().geoAdd(key.getBytes(), edgeCases);
-            assertThat(addResult).isEqualTo(5L);
-            
-            // Test distance between extreme points
-            Distance poleDistance = connection.geoCommands().geoDist(key.getBytes(), 
-                "NearNorthPole".getBytes(), "NearSouthPole".getBytes(), DistanceUnit.KILOMETERS);
-            assertThat(poleDistance).isNotNull();
-            assertThat(poleDistance.getValue()).isGreaterThan(15000); // Should be ~18,000+ km
-            
-            // Test positions of extreme coordinates
-            List<Point> extremePositions = connection.geoCommands().geoPos(key.getBytes(), 
-                "NearNorthPole".getBytes(), "NearSouthPole".getBytes());
-            assertThat(extremePositions).hasSize(2);
-            assertThat(extremePositions.get(0)).isNotNull();
-            assertThat(extremePositions.get(1)).isNotNull();
-            
-            // Test radius search from extreme location
-            Circle poleSearch = new Circle(new Point(0, 85), new Distance(1000, DistanceUnit.KILOMETERS));
-            GeoResults<GeoLocation<byte[]>> poleResults = connection.geoCommands().geoRadius(key.getBytes(), poleSearch);
-            assertThat(poleResults).isNotNull();
-            assertThat(poleResults.getContent()).isNotEmpty();
-            
-            // Test distance across date line
-            Distance dateLineDistance = connection.geoCommands().geoDist(key.getBytes(), 
-                "DateLine".getBytes(), "AntiMeridian".getBytes(), DistanceUnit.KILOMETERS);
-            assertThat(dateLineDistance).isNotNull();
-            assertThat(dateLineDistance.getValue()).isGreaterThan(0);
-        } finally {
-            cleanupKey(key);
-        }
-    }
+	// ==================== Position and Hash Operations ====================
 
-    // ==================== Precision Tests ====================
+	@Test
+	void testGeoPos() {
+		String key = "test:geo:pos:key";
 
-    @Test
-    void testCoordinatePrecision() {
-        String key = "test:geo:precision:key";
-        
-        try {
-            // Test with high precision coordinates
-            // Valkey geo commands use geohash which has limited precision
-            Point highPrecision = new Point(13.361389123456789, 38.115556987654321);
-            connection.geoCommands().geoAdd(key.getBytes(), highPrecision, "HighPrecision".getBytes());
-            
-            // Verify coordinates are stored with reasonable precision
-            // Valkey geo precision is limited by geohash, so we use a more realistic tolerance
-            List<Point> retrievedPositions = connection.geoCommands().geoPos(key.getBytes(), "HighPrecision".getBytes());
-            assertThat(retrievedPositions).hasSize(1);
-            Point retrieved = retrievedPositions.get(0);
-            assertThat(retrieved.getX()).isCloseTo(highPrecision.getX(), within(0.01)); // More realistic tolerance
-            assertThat(retrieved.getY()).isCloseTo(highPrecision.getY(), within(0.01));
-            
-            // Test with moderately close coordinates (more realistic for geo applications)
-            Point close1 = new Point(13.361389, 38.115556);
-            Point close2 = new Point(13.361489, 38.115656); // 100m apart approximately
-            
-            connection.geoCommands().geoAdd(key.getBytes(), close1, "Close1".getBytes());
-            connection.geoCommands().geoAdd(key.getBytes(), close2, "Close2".getBytes());
-            
-            Distance closeDistance = connection.geoCommands().geoDist(key.getBytes(), 
-                "Close1".getBytes(), "Close2".getBytes(), DistanceUnit.METERS);
-            assertThat(closeDistance).isNotNull();
-            assertThat(closeDistance.getValue()).isGreaterThan(0);
-            assertThat(closeDistance.getValue()).isLessThan(200); // Should be ~100m
-            
-            // Test coordinate retrieval accuracy
-            List<Point> closePositions = connection.geoCommands().geoPos(key.getBytes(), 
-                "Close1".getBytes(), "Close2".getBytes());
-            assertThat(closePositions).hasSize(2);
-            assertThat(closePositions.get(0)).isNotNull();
-            assertThat(closePositions.get(1)).isNotNull();
-            
-            // Verify the positions are reasonably close to what we stored
-            assertThat(closePositions.get(0).getX()).isCloseTo(close1.getX(), within(0.01));
-            assertThat(closePositions.get(0).getY()).isCloseTo(close1.getY(), within(0.01));
-            assertThat(closePositions.get(1).getX()).isCloseTo(close2.getX(), within(0.01));
-            assertThat(closePositions.get(1).getY()).isCloseTo(close2.getY(), within(0.01));
-            
-            // Test with coordinates that have meaningful differences (larger difference for geohash precision)
-            Point precise1 = new Point(13.361389, 38.115556);
-            Point precise2 = new Point(13.362389, 38.115556); // Longitude differs by 0.001 degrees (~100m)
-            
-            connection.geoCommands().geoAdd(key.getBytes(), precise1, "Precise1".getBytes());
-            connection.geoCommands().geoAdd(key.getBytes(), precise2, "Precise2".getBytes());
-            
-            // Verify coordinates were stored correctly
-            List<Point> precisePositions = connection.geoCommands().geoPos(key.getBytes(), 
-                "Precise1".getBytes(), "Precise2".getBytes());
-            assertThat(precisePositions).hasSize(2);
-            assertThat(precisePositions.get(0)).isNotNull();
-            assertThat(precisePositions.get(1)).isNotNull();
-            
-            Distance preciseDistance = connection.geoCommands().geoDist(key.getBytes(), 
-                "Precise1".getBytes(), "Precise2".getBytes(), DistanceUnit.METERS);
-            assertThat(preciseDistance).isNotNull();
-            
-            // With larger coordinate differences, we should get a measurable distance
-            assertThat(preciseDistance.getValue()).isGreaterThan(0);
-            assertThat(preciseDistance.getValue()).isLessThan(500); // Should be around 100m
-            
-            // Test Valkey geohash precision limitations with very small differences
-            Point veryClose1 = new Point(13.361389, 38.115556);
-            Point veryClose2 = new Point(13.361390, 38.115556); // Very small difference
-            
-            connection.geoCommands().geoAdd(key.getBytes(), veryClose1, "VeryClose1".getBytes());
-            connection.geoCommands().geoAdd(key.getBytes(), veryClose2, "VeryClose2".getBytes());
-            
-            Distance veryCloseDistance = connection.geoCommands().geoDist(key.getBytes(), 
-                "VeryClose1".getBytes(), "VeryClose2".getBytes(), DistanceUnit.METERS);
-            assertThat(veryCloseDistance).isNotNull();
-            
-            // For very small differences, distance might be 0 due to geohash precision
-            // This is expected behavior for Valkey geo commands
-            assertThat(veryCloseDistance.getValue()).isGreaterThanOrEqualTo(0);
-        } finally {
-            cleanupKey(key);
-        }
-    }
+		try {
+			// Test geoPos on empty key
+			List<Point> emptyPositions = connection.geoCommands().geoPos(key.getBytes(), "NonExistent".getBytes());
+			assertThat(emptyPositions).hasSize(1);
+			assertThat(emptyPositions.get(0)).isNull();
 
-    // ==================== Comprehensive Pipeline Mode Tests ====================
+			// Setup test data
+			Map<byte[], Point> memberCoordinateMap = new HashMap<>();
+			memberCoordinateMap.put("Palermo".getBytes(), PALERMO);
+			memberCoordinateMap.put("Catania".getBytes(), CATANIA);
+			memberCoordinateMap.put("NewYork".getBytes(), NEW_YORK);
 
-    @Test
-    void testAllGeoAddVariantsInPipelineMode() {
-        String key1 = "test:pipeline:geoadd:single";
-        String key2 = "test:pipeline:geoadd:map";
-        String key3 = "test:pipeline:geoadd:iterable";
-        
-        try {
-            connection.openPipeline();
-            
-            // Test all geoAdd variants return null during pipeline
-            Long result1 = connection.geoCommands().geoAdd(key1.getBytes(), PALERMO, "Palermo".getBytes());
-            assertThat(result1).isNull(); // Should be null during pipeline
-            
-            Map<byte[], Point> memberMap = new HashMap<>();
-            memberMap.put("Rome".getBytes(), ROME);
-            memberMap.put("Milan".getBytes(), new Point(9.1900, 45.4642));
-            Long result2 = connection.geoCommands().geoAdd(key2.getBytes(), memberMap);
-            assertThat(result2).isNull(); // Should be null during pipeline
-            
-            List<GeoLocation<byte[]>> locations = new ArrayList<>();
-            locations.add(new GeoLocation<>("Venice".getBytes(), new Point(12.3155, 45.4408)));
-            locations.add(new GeoLocation<>("Naples".getBytes(), new Point(14.2681, 40.8518)));
-            Long result3 = connection.geoCommands().geoAdd(key3.getBytes(), locations);
-            assertThat(result3).isNull(); // Should be null during pipeline
-            
-            List<Object> results = connection.closePipeline();
-            
-            // Verify pipeline results
-            assertThat(results).hasSize(3);
-            assertThat(results.get(0)).isEqualTo(1L); // Single point add
-            assertThat(results.get(1)).isEqualTo(2L); // Map add
-            assertThat(results.get(2)).isEqualTo(2L); // Iterable add
-            
-            // Verify final state
-            List<Point> pos1 = connection.geoCommands().geoPos(key1.getBytes(), "Palermo".getBytes());
-            assertThat(pos1.get(0)).isNotNull();
-            
-            List<Point> pos2 = connection.geoCommands().geoPos(key2.getBytes(), "Rome".getBytes(), "Milan".getBytes());
-            assertThat(pos2).hasSize(2);
-            assertThat(pos2.get(0)).isNotNull();
-            assertThat(pos2.get(1)).isNotNull();
-            
-            List<Point> pos3 = connection.geoCommands().geoPos(key3.getBytes(), "Venice".getBytes(), "Naples".getBytes());
-            assertThat(pos3).hasSize(2);
-            assertThat(pos3.get(0)).isNotNull();
-            assertThat(pos3.get(1)).isNotNull();
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-            cleanupKey(key3);
-        }
-    }
+			connection.geoCommands().geoAdd(key.getBytes(), memberCoordinateMap);
 
-    @Test
-    void testGeoDistVariantsInPipelineMode() {
-        String key = "test:pipeline:geodist";
-        
-        try {
-            // Setup data
-            connection.geoCommands().geoAdd(key.getBytes(), PALERMO, "Palermo".getBytes());
-            connection.geoCommands().geoAdd(key.getBytes(), CATANIA, "Catania".getBytes());
-            connection.geoCommands().geoAdd(key.getBytes(), ROME, "Rome".getBytes());
-            
-            connection.openPipeline();
-            
-            // Test both geoDist variants return null during pipeline
-            Distance result1 = connection.geoCommands().geoDist(key.getBytes(), "Palermo".getBytes(), "Catania".getBytes());
-            assertThat(result1).isNull(); // Should be null during pipeline
-            
-            Distance result2 = connection.geoCommands().geoDist(key.getBytes(), "Palermo".getBytes(), "Rome".getBytes(), DistanceUnit.KILOMETERS);
-            assertThat(result2).isNull(); // Should be null during pipeline
-            
-            List<Object> results = connection.closePipeline();
-            
-            // Verify pipeline results
-            assertThat(results).hasSize(2);
-            assertThat(results.get(0)).isInstanceOf(Distance.class);
-            assertThat(results.get(1)).isInstanceOf(Distance.class);
-            
-            Distance dist1 = (Distance) results.get(0);
-            Distance dist2 = (Distance) results.get(1);
-            assertThat(dist1.getValue()).isGreaterThan(0);
-            assertThat(dist2.getValue()).isGreaterThan(0);
-            assertThat(dist1.getMetric()).isEqualTo(DistanceUnit.METERS);
-            assertThat(dist2.getMetric()).isEqualTo(DistanceUnit.KILOMETERS);
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test getting single position
+			List<Point> singlePos = connection.geoCommands().geoPos(key.getBytes(), "Palermo".getBytes());
+			assertThat(singlePos).hasSize(1);
+			assertThat(singlePos.get(0).getX()).isCloseTo(PALERMO.getX(), within(0.01));
+			assertThat(singlePos.get(0).getY()).isCloseTo(PALERMO.getY(), within(0.01));
 
-    @Test
-    void testGeoHashAndGeoPosInPipelineMode() {
-        String key = "test:pipeline:geohashpos";
-        
-        try {
-            // Setup data
-            connection.geoCommands().geoAdd(key.getBytes(), PALERMO, "Palermo".getBytes());
-            connection.geoCommands().geoAdd(key.getBytes(), CATANIA, "Catania".getBytes());
-            connection.geoCommands().geoAdd(key.getBytes(), ROME, "Rome".getBytes());
-            
-            connection.openPipeline();
-            
-            // Test geoHash returns null during pipeline
-            List<String> hashResult = connection.geoCommands().geoHash(key.getBytes(), "Palermo".getBytes(), "Catania".getBytes());
-            assertThat(hashResult).isNull(); // Should be null during pipeline
-            
-            // Test geoPos returns null during pipeline
-            List<Point> posResult = connection.geoCommands().geoPos(key.getBytes(), "Palermo".getBytes(), "Rome".getBytes());
-            assertThat(posResult).isNull(); // Should be null during pipeline
-            
-            List<Object> results = connection.closePipeline();
-            
-            // Verify pipeline results
-            assertThat(results).hasSize(2);
-            
-            @SuppressWarnings("unchecked")
-            List<String> hashes = (List<String>) results.get(0);
-            assertThat(hashes).hasSize(2);
-            assertThat(hashes.get(0)).isNotNull();
-            assertThat(hashes.get(1)).isNotNull();
-            
-            @SuppressWarnings("unchecked")
-            List<Point> positions = (List<Point>) results.get(1);
-            assertThat(positions).hasSize(2);
-            assertThat(positions.get(0)).isNotNull();
-            assertThat(positions.get(1)).isNotNull();
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test getting multiple positions
+			List<Point> multiPos = connection.geoCommands()
+				.geoPos(key.getBytes(), "Palermo".getBytes(), "Catania".getBytes(), "NonExistent".getBytes());
+			assertThat(multiPos).hasSize(3);
+			assertThat(multiPos.get(0)).isNotNull();
+			assertThat(multiPos.get(1)).isNotNull();
+			assertThat(multiPos.get(2)).isNull(); // Non-existent member
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
 
-    @Test
-    void testGeoRadiusVariantsInPipelineMode() {
-        String key = "test:pipeline:georadius";
-        
-        try {
-            // Setup data
-            connection.geoCommands().geoAdd(key.getBytes(), PALERMO, "Palermo".getBytes());
-            connection.geoCommands().geoAdd(key.getBytes(), CATANIA, "Catania".getBytes());
-            connection.geoCommands().geoAdd(key.getBytes(), ROME, "Rome".getBytes());
-            
-            connection.openPipeline();
-            
-            // Test basic geoRadius returns null during pipeline
-            Circle searchArea = new Circle(PALERMO, new Distance(300, DistanceUnit.KILOMETERS));
-            GeoResults<GeoLocation<byte[]>> result1 = connection.geoCommands().geoRadius(key.getBytes(), searchArea);
-            assertThat(result1).isNull(); // Should be null during pipeline
-            
-            // Test geoRadius with args returns null during pipeline
-            GeoRadiusCommandArgs args = GeoRadiusCommandArgs.newGeoRadiusArgs()
-                .includeDistance()
-                .includeCoordinates()
-                .sortAscending()
-                .limit(10);
-            GeoResults<GeoLocation<byte[]>> result2 = connection.geoCommands().geoRadius(key.getBytes(), searchArea, args);
-            assertThat(result2).isNull(); // Should be null during pipeline
-            
-            List<Object> results = connection.closePipeline();
-            
-            // Verify pipeline results
-            assertThat(results).hasSize(2);
-            for (Object result : results) {
-                assertThat(result).isInstanceOf(GeoResults.class);
-                @SuppressWarnings("unchecked")
-                GeoResults<GeoLocation<byte[]>> geoResults = (GeoResults<GeoLocation<byte[]>>) result;
-                assertThat(geoResults.getContent()).isNotEmpty();
-            }
-        } finally {
-            cleanupKey(key);
-        }
-    }
+	@Test
+	void testGeoHash() {
+		String key = "test:geo:hash:key";
 
-    @Test
-    void testGeoRadiusByMemberVariantsInPipelineMode() {
-        String key = "test:pipeline:georadiusbymember";
-        
-        try {
-            // Setup data
-            connection.geoCommands().geoAdd(key.getBytes(), PALERMO, "Palermo".getBytes());
-            connection.geoCommands().geoAdd(key.getBytes(), CATANIA, "Catania".getBytes());
-            connection.geoCommands().geoAdd(key.getBytes(), ROME, "Rome".getBytes());
-            
-            connection.openPipeline();
-            
-            // Test basic geoRadiusByMember returns null during pipeline
-            Distance radius = new Distance(300, DistanceUnit.KILOMETERS);
-            GeoResults<GeoLocation<byte[]>> result1 = connection.geoCommands().geoRadiusByMember(key.getBytes(), "Palermo".getBytes(), radius);
-            assertThat(result1).isNull(); // Should be null during pipeline
-            
-            // Test geoRadiusByMember with args returns null during pipeline
-            GeoRadiusCommandArgs args = GeoRadiusCommandArgs.newGeoRadiusArgs()
-                .includeDistance()
-                .includeCoordinates()
-                .sortDescending()
-                .limit(5);
-            GeoResults<GeoLocation<byte[]>> result2 = connection.geoCommands().geoRadiusByMember(key.getBytes(), "Rome".getBytes(), radius, args);
-            assertThat(result2).isNull(); // Should be null during pipeline
-            
-            List<Object> results = connection.closePipeline();
-            
-            // Verify pipeline results
-            assertThat(results).hasSize(2);
-            for (Object result : results) {
-                assertThat(result).isInstanceOf(GeoResults.class);
-                @SuppressWarnings("unchecked")
-                GeoResults<GeoLocation<byte[]>> geoResults = (GeoResults<GeoLocation<byte[]>>) result;
-                assertThat(geoResults.getContent()).isNotEmpty();
-            }
-        } finally {
-            cleanupKey(key);
-        }
-    }
+		try {
+			// Test geoHash on empty key
+			List<String> emptyHashes = connection.geoCommands().geoHash(key.getBytes(), "NonExistent".getBytes());
+			assertThat(emptyHashes).hasSize(1);
+			assertThat(emptyHashes.get(0)).isNull();
 
-    @Test
-    void testGeoRemoveInPipelineMode() {
-        String key = "test:pipeline:georemove";
-        
-        try {
-            // Setup data
-            connection.geoCommands().geoAdd(key.getBytes(), PALERMO, "Palermo".getBytes());
-            connection.geoCommands().geoAdd(key.getBytes(), CATANIA, "Catania".getBytes());
-            connection.geoCommands().geoAdd(key.getBytes(), ROME, "Rome".getBytes());
-            
-            connection.openPipeline();
-            
-            // Test geoRemove returns null during pipeline
-            Long result1 = connection.geoCommands().geoRemove(key.getBytes(), "Catania".getBytes());
-            assertThat(result1).isNull(); // Should be null during pipeline
-            
-            Long result2 = connection.geoCommands().geoRemove(key.getBytes(), "Palermo".getBytes(), "Rome".getBytes());
-            assertThat(result2).isNull(); // Should be null during pipeline
-            
-            List<Object> results = connection.closePipeline();
-            
-            // Verify pipeline results
-            assertThat(results).hasSize(2);
-            assertThat(results.get(0)).isEqualTo(1L); // Single removal
-            assertThat(results.get(1)).isEqualTo(2L); // Multiple removal
-            
-            // Verify final state - all should be removed
-            List<Point> positions = connection.geoCommands().geoPos(key.getBytes(), 
-                "Palermo".getBytes(), "Catania".getBytes(), "Rome".getBytes());
-            assertThat(positions).hasSize(3);
-            assertThat(positions.get(0)).isNull();
-            assertThat(positions.get(1)).isNull();
-            assertThat(positions.get(2)).isNull();
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Setup test data
+			Map<byte[], Point> memberCoordinateMap = new HashMap<>();
+			memberCoordinateMap.put("Palermo".getBytes(), PALERMO);
+			memberCoordinateMap.put("Catania".getBytes(), CATANIA);
 
-    @Test
-    void testGeoSearchInPipelineMode() {
-        String key = "test:pipeline:geosearch";
-        
-        try {
-            // Setup data
-            connection.geoCommands().geoAdd(key.getBytes(), PALERMO, "Palermo".getBytes());
-            connection.geoCommands().geoAdd(key.getBytes(), CATANIA, "Catania".getBytes());
-            connection.geoCommands().geoAdd(key.getBytes(), ROME, "Rome".getBytes());
-            
-            connection.openPipeline();
-            
-            // Test geoSearch returns null during pipeline
-            GeoReference<byte[]> memberRef = GeoReference.fromMember("Palermo".getBytes());
-            GeoShape radiusShape = GeoShape.byRadius(new Distance(300, DistanceUnit.KILOMETERS));
-            GeoSearchCommandArgs args = GeoSearchCommandArgs.newGeoSearchArgs()
-                .includeDistance()
-                .includeCoordinates()
-                .sortAscending()
-                .limit(10);
-            
-            GeoResults<GeoLocation<byte[]>> result = connection.geoCommands().geoSearch(key.getBytes(), memberRef, radiusShape, args);
-            assertThat(result).isNull(); // Should be null during pipeline
-            
-            List<Object> results = connection.closePipeline();
-            
-            // Verify pipeline results
-            assertThat(results).hasSize(1);
-            assertThat(results.get(0)).isInstanceOf(GeoResults.class);
-            
-            @SuppressWarnings("unchecked")
-            GeoResults<GeoLocation<byte[]>> geoResults = (GeoResults<GeoLocation<byte[]>>) results.get(0);
-            assertThat(geoResults.getContent()).isNotEmpty();
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			connection.geoCommands().geoAdd(key.getBytes(), memberCoordinateMap);
 
-    @Test
-    void testGeoSearchStoreInPipelineMode() {
-        String sourceKey = "test:pipeline:geosearchstore:source";
-        String destKey = "test:pipeline:geosearchstore:dest";
-        
-        try {
-            // Setup data
-            connection.geoCommands().geoAdd(sourceKey.getBytes(), PALERMO, "Palermo".getBytes());
-            connection.geoCommands().geoAdd(sourceKey.getBytes(), CATANIA, "Catania".getBytes());
-            connection.geoCommands().geoAdd(sourceKey.getBytes(), ROME, "Rome".getBytes());
-            
-            connection.openPipeline();
-            
-            // Test geoSearchStore returns null during pipeline
-            GeoReference<byte[]> memberRef = GeoReference.fromMember("Palermo".getBytes());
-            GeoShape radiusShape = GeoShape.byRadius(new Distance(300, DistanceUnit.KILOMETERS));
-            GeoSearchStoreCommandArgs args = GeoSearchStoreCommandArgs.newGeoSearchStoreArgs()
-                .sortAscending()
-                .limit(10);
-            
-            Long result = connection.geoCommands().geoSearchStore(destKey.getBytes(), sourceKey.getBytes(), memberRef, radiusShape, args);
-            assertThat(result).isNull(); // Should be null during pipeline
-            
-            List<Object> results = connection.closePipeline();
-            
-            // Verify pipeline results
-            assertThat(results).hasSize(1);
-            assertThat(results.get(0)).isInstanceOf(Number.class);
-            assertThat(((Number) results.get(0)).longValue()).isGreaterThan(0L);
-            
-            // Verify final state - results stored in destination
-            List<Point> storedPositions = connection.geoCommands().geoPos(destKey.getBytes(), "Palermo".getBytes());
-            assertThat(storedPositions.get(0)).isNotNull();
-        } finally {
-            cleanupKey(sourceKey);
-            cleanupKey(destKey);
-        }
-    }
+			// Test getting single hash
+			List<String> singleHash = connection.geoCommands().geoHash(key.getBytes(), "Palermo".getBytes());
+			assertThat(singleHash).hasSize(1);
+			assertThat(singleHash.get(0)).isNotNull();
+			assertThat(singleHash.get(0)).isNotEmpty();
 
-    // ==================== Comprehensive Transaction Mode Tests ====================
+			// Test getting multiple hashes
+			List<String> multiHash = connection.geoCommands()
+				.geoHash(key.getBytes(), "Palermo".getBytes(), "Catania".getBytes(), "NonExistent".getBytes());
+			assertThat(multiHash).hasSize(3);
+			assertThat(multiHash.get(0)).isNotNull();
+			assertThat(multiHash.get(1)).isNotNull();
+			assertThat(multiHash.get(2)).isNull(); // Non-existent member
 
-    @Test
-    void testAllGeoAddVariantsInTransactionMode() {
-        String key1 = "test:tx:geoadd:single";
-        String key2 = "test:tx:geoadd:map";
-        String key3 = "test:tx:geoadd:iterable";
-        
-        try {
-            connection.multi();
-            
-            // Test all geoAdd variants return null during transaction
-            Long result1 = connection.geoCommands().geoAdd(key1.getBytes(), PALERMO, "Palermo".getBytes());
-            assertThat(result1).isNull(); // Should be null during transaction
-            
-            Map<byte[], Point> memberMap = new HashMap<>();
-            memberMap.put("Rome".getBytes(), ROME);
-            memberMap.put("Milan".getBytes(), new Point(9.1900, 45.4642));
-            Long result2 = connection.geoCommands().geoAdd(key2.getBytes(), memberMap);
-            assertThat(result2).isNull(); // Should be null during transaction
-            
-            List<GeoLocation<byte[]>> locations = new ArrayList<>();
-            locations.add(new GeoLocation<>("Venice".getBytes(), new Point(12.3155, 45.4408)));
-            locations.add(new GeoLocation<>("Naples".getBytes(), new Point(14.2681, 40.8518)));
-            Long result3 = connection.geoCommands().geoAdd(key3.getBytes(), locations);
-            assertThat(result3).isNull(); // Should be null during transaction
-            
-            List<Object> results = connection.exec();
-            
-            // Verify transaction results
-            assertThat(results).hasSize(3);
-            assertThat(results.get(0)).isEqualTo(1L); // Single point add
-            assertThat(results.get(1)).isEqualTo(2L); // Map add
-            assertThat(results.get(2)).isEqualTo(2L); // Iterable add
-            
-            // Verify final state
-            List<Point> pos1 = connection.geoCommands().geoPos(key1.getBytes(), "Palermo".getBytes());
-            assertThat(pos1.get(0)).isNotNull();
-            
-            List<Point> pos2 = connection.geoCommands().geoPos(key2.getBytes(), "Rome".getBytes(), "Milan".getBytes());
-            assertThat(pos2).hasSize(2);
-            assertThat(pos2.get(0)).isNotNull();
-            assertThat(pos2.get(1)).isNotNull();
-            
-            List<Point> pos3 = connection.geoCommands().geoPos(key3.getBytes(), "Venice".getBytes(), "Naples".getBytes());
-            assertThat(pos3).hasSize(2);
-            assertThat(pos3.get(0)).isNotNull();
-            assertThat(pos3.get(1)).isNotNull();
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-            cleanupKey(key3);
-        }
-    }
+			// Verify different locations have different hashes
+			assertThat(multiHash.get(0)).isNotEqualTo(multiHash.get(1));
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
 
-    @Test
-    void testGeoDistVariantsInTransactionMode() {
-        String key = "test:tx:geodist";
-        
-        try {
-            // Setup data outside transaction
-            connection.geoCommands().geoAdd(key.getBytes(), PALERMO, "Palermo".getBytes());
-            connection.geoCommands().geoAdd(key.getBytes(), CATANIA, "Catania".getBytes());
-            connection.geoCommands().geoAdd(key.getBytes(), ROME, "Rome".getBytes());
-            
-            connection.multi();
-            
-            // Test both geoDist variants return null during transaction
-            Distance result1 = connection.geoCommands().geoDist(key.getBytes(), "Palermo".getBytes(), "Catania".getBytes());
-            assertThat(result1).isNull(); // Should be null during transaction
-            
-            Distance result2 = connection.geoCommands().geoDist(key.getBytes(), "Palermo".getBytes(), "Rome".getBytes(), DistanceUnit.KILOMETERS);
-            assertThat(result2).isNull(); // Should be null during transaction
-            
-            List<Object> results = connection.exec();
-            
-            // Verify transaction results
-            assertThat(results).hasSize(2);
-            assertThat(results.get(0)).isInstanceOf(Distance.class);
-            assertThat(results.get(1)).isInstanceOf(Distance.class);
-            
-            Distance dist1 = (Distance) results.get(0);
-            Distance dist2 = (Distance) results.get(1);
-            assertThat(dist1.getValue()).isGreaterThan(0);
-            assertThat(dist2.getValue()).isGreaterThan(0);
-            assertThat(dist1.getMetric()).isEqualTo(DistanceUnit.METERS);
-            assertThat(dist2.getMetric()).isEqualTo(DistanceUnit.KILOMETERS);
-        } finally {
-            cleanupKey(key);
-        }
-    }
+	// ==================== Distance Calculations ====================
 
-    @Test
-    void testGeoHashAndGeoPosInTransactionMode() {
-        String key = "test:tx:geohashpos";
-        
-        try {
-            // Setup data outside transaction
-            connection.geoCommands().geoAdd(key.getBytes(), PALERMO, "Palermo".getBytes());
-            connection.geoCommands().geoAdd(key.getBytes(), CATANIA, "Catania".getBytes());
-            connection.geoCommands().geoAdd(key.getBytes(), ROME, "Rome".getBytes());
-            
-            connection.multi();
-            
-            // Test geoHash returns null during transaction
-            List<String> hashResult = connection.geoCommands().geoHash(key.getBytes(), "Palermo".getBytes(), "Catania".getBytes());
-            assertThat(hashResult).isNull(); // Should be null during transaction
-            
-            // Test geoPos returns null during transaction
-            List<Point> posResult = connection.geoCommands().geoPos(key.getBytes(), "Palermo".getBytes(), "Rome".getBytes());
-            assertThat(posResult).isNull(); // Should be null during transaction
-            
-            List<Object> results = connection.exec();
-            
-            // Verify transaction results
-            assertThat(results).hasSize(2);
-            
-            @SuppressWarnings("unchecked")
-            List<String> hashes = (List<String>) results.get(0);
-            assertThat(hashes).hasSize(2);
-            assertThat(hashes.get(0)).isNotNull();
-            assertThat(hashes.get(1)).isNotNull();
-            
-            @SuppressWarnings("unchecked")
-            List<Point> positions = (List<Point>) results.get(1);
-            assertThat(positions).hasSize(2);
-            assertThat(positions.get(0)).isNotNull();
-            assertThat(positions.get(1)).isNotNull();
-        } finally {
-            cleanupKey(key);
-        }
-    }
+	@Test
+	void testGeoDist() {
+		String key = "test:geo:dist:key";
 
-    @Test
-    void testGeoRadiusVariantsInTransactionMode() {
-        String key = "test:tx:georadius";
-        
-        try {
-            // Setup data outside transaction
-            connection.geoCommands().geoAdd(key.getBytes(), PALERMO, "Palermo".getBytes());
-            connection.geoCommands().geoAdd(key.getBytes(), CATANIA, "Catania".getBytes());
-            connection.geoCommands().geoAdd(key.getBytes(), ROME, "Rome".getBytes());
-            
-            connection.multi();
-            
-            // Test basic geoRadius returns null during transaction
-            Circle searchArea = new Circle(PALERMO, new Distance(300, DistanceUnit.KILOMETERS));
-            GeoResults<GeoLocation<byte[]>> result1 = connection.geoCommands().geoRadius(key.getBytes(), searchArea);
-            assertThat(result1).isNull(); // Should be null during transaction
-            
-            // Test geoRadius with args returns null during transaction
-            GeoRadiusCommandArgs args = GeoRadiusCommandArgs.newGeoRadiusArgs()
-                .includeDistance()
-                .includeCoordinates()
-                .sortAscending()
-                .limit(10);
-            GeoResults<GeoLocation<byte[]>> result2 = connection.geoCommands().geoRadius(key.getBytes(), searchArea, args);
-            assertThat(result2).isNull(); // Should be null during transaction
-            
-            List<Object> results = connection.exec();
-            
-            // Verify transaction results
-            assertThat(results).hasSize(2);
-            for (Object result : results) {
-                assertThat(result).isInstanceOf(GeoResults.class);
-                @SuppressWarnings("unchecked")
-                GeoResults<GeoLocation<byte[]>> geoResults = (GeoResults<GeoLocation<byte[]>>) result;
-                assertThat(geoResults.getContent()).isNotEmpty();
-            }
-        } finally {
-            cleanupKey(key);
-        }
-    }
+		try {
+			// Test geoDist on empty key
+			Distance emptyDist = connection.geoCommands()
+				.geoDist(key.getBytes(), "NonExistent1".getBytes(), "NonExistent2".getBytes());
+			assertThat(emptyDist).isNull();
 
-    @Test
-    void testGeoRadiusByMemberVariantsInTransactionMode() {
-        String key = "test:tx:georadiusbymember";
-        
-        try {
-            // Setup data outside transaction
-            connection.geoCommands().geoAdd(key.getBytes(), PALERMO, "Palermo".getBytes());
-            connection.geoCommands().geoAdd(key.getBytes(), CATANIA, "Catania".getBytes());
-            connection.geoCommands().geoAdd(key.getBytes(), ROME, "Rome".getBytes());
-            
-            connection.multi();
-            
-            // Test basic geoRadiusByMember returns null during transaction
-            Distance radius = new Distance(300, DistanceUnit.KILOMETERS);
-            GeoResults<GeoLocation<byte[]>> result1 = connection.geoCommands().geoRadiusByMember(key.getBytes(), "Palermo".getBytes(), radius);
-            assertThat(result1).isNull(); // Should be null during transaction
-            
-            // Test geoRadiusByMember with args returns null during transaction
-            GeoRadiusCommandArgs args = GeoRadiusCommandArgs.newGeoRadiusArgs()
-                .includeDistance()
-                .includeCoordinates()
-                .sortDescending()
-                .limit(5);
-            GeoResults<GeoLocation<byte[]>> result2 = connection.geoCommands().geoRadiusByMember(key.getBytes(), "Rome".getBytes(), radius, args);
-            assertThat(result2).isNull(); // Should be null during transaction
-            
-            List<Object> results = connection.exec();
-            
-            // Verify transaction results
-            assertThat(results).hasSize(2);
-            for (Object result : results) {
-                assertThat(result).isInstanceOf(GeoResults.class);
-                @SuppressWarnings("unchecked")
-                GeoResults<GeoLocation<byte[]>> geoResults = (GeoResults<GeoLocation<byte[]>>) result;
-                assertThat(geoResults.getContent()).isNotEmpty();
-            }
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Setup test data
+			Map<byte[], Point> memberCoordinateMap = new HashMap<>();
+			memberCoordinateMap.put("Palermo".getBytes(), PALERMO);
+			memberCoordinateMap.put("Catania".getBytes(), CATANIA);
+			memberCoordinateMap.put("NewYork".getBytes(), NEW_YORK);
 
-    // ==================== Transaction Mode Tests ====================
+			connection.geoCommands().geoAdd(key.getBytes(), memberCoordinateMap);
 
-    @Test
-    void testGeoRemoveInTransactionMode() {
-        String key = "test:tx:georemove";
-        
-        try {
-            // Setup data outside transaction
-            connection.geoCommands().geoAdd(key.getBytes(), PALERMO, "Palermo".getBytes());
-            connection.geoCommands().geoAdd(key.getBytes(), CATANIA, "Catania".getBytes());
-            connection.geoCommands().geoAdd(key.getBytes(), ROME, "Rome".getBytes());
-            
-            connection.multi();
-            
-            // Test geoRemove returns null during transaction
-            Long result1 = connection.geoCommands().geoRemove(key.getBytes(), "Catania".getBytes());
-            assertThat(result1).isNull(); // Should be null during transaction
-            
-            Long result2 = connection.geoCommands().geoRemove(key.getBytes(), "Palermo".getBytes(), "Rome".getBytes());
-            assertThat(result2).isNull(); // Should be null during transaction
-            
-            List<Object> results = connection.exec();
-            
-            // Verify transaction results
-            assertThat(results).hasSize(2);
-            assertThat(results.get(0)).isEqualTo(1L); // Single removal
-            assertThat(results.get(1)).isEqualTo(2L); // Multiple removal
-            
-            // Verify final state - all should be removed
-            List<Point> positions = connection.geoCommands().geoPos(key.getBytes(), 
-                "Palermo".getBytes(), "Catania".getBytes(), "Rome".getBytes());
-            assertThat(positions).hasSize(3);
-            assertThat(positions.get(0)).isNull();
-            assertThat(positions.get(1)).isNull();
-            assertThat(positions.get(2)).isNull();
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test distance with default metric (meters)
+			Distance dist1 = connection.geoCommands()
+				.geoDist(key.getBytes(), "Palermo".getBytes(), "Catania".getBytes());
+			assertThat(dist1).isNotNull();
+			assertThat(dist1.getValue()).isGreaterThan(0);
+			assertThat(dist1.getMetric()).isEqualTo(DistanceUnit.METERS);
 
-    @Test
-    void testGeoSearchInTransactionMode() {
-        String key = "test:tx:geosearch";
-        
-        try {
-            // Setup data outside transaction
-            connection.geoCommands().geoAdd(key.getBytes(), PALERMO, "Palermo".getBytes());
-            connection.geoCommands().geoAdd(key.getBytes(), CATANIA, "Catania".getBytes());
-            connection.geoCommands().geoAdd(key.getBytes(), ROME, "Rome".getBytes());
-            
-            connection.multi();
-            
-            // Test geoSearch returns null during transaction
-            GeoReference<byte[]> memberRef = GeoReference.fromMember("Palermo".getBytes());
-            GeoShape radiusShape = GeoShape.byRadius(new Distance(300, DistanceUnit.KILOMETERS));
-            GeoSearchCommandArgs args = GeoSearchCommandArgs.newGeoSearchArgs()
-                .includeDistance()
-                .includeCoordinates()
-                .sortAscending()
-                .limit(10);
-            
-            GeoResults<GeoLocation<byte[]>> result = connection.geoCommands().geoSearch(key.getBytes(), memberRef, radiusShape, args);
-            assertThat(result).isNull(); // Should be null during transaction
-            
-            List<Object> results = connection.exec();
-            
-            // Verify transaction results
-            assertThat(results).hasSize(1);
-            assertThat(results.get(0)).isInstanceOf(GeoResults.class);
-            
-            @SuppressWarnings("unchecked")
-            GeoResults<GeoLocation<byte[]>> geoResults = (GeoResults<GeoLocation<byte[]>>) results.get(0);
-            assertThat(geoResults.getContent()).isNotEmpty();
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test distance with specific metric
+			Distance dist2 = connection.geoCommands()
+				.geoDist(key.getBytes(), "Palermo".getBytes(), "Catania".getBytes(), DistanceUnit.KILOMETERS);
+			assertThat(dist2).isNotNull();
+			assertThat(dist2.getValue()).isGreaterThan(0);
+			assertThat(dist2.getMetric()).isEqualTo(DistanceUnit.KILOMETERS);
 
-    @Test
-    void testGeoSearchStoreInTransactionMode() {
-        String sourceKey = "test:tx:geosearchstore:source";
-        String destKey = "test:tx:geosearchstore:dest";
-        
-        try {
-            // Setup data outside transaction
-            connection.geoCommands().geoAdd(sourceKey.getBytes(), PALERMO, "Palermo".getBytes());
-            connection.geoCommands().geoAdd(sourceKey.getBytes(), CATANIA, "Catania".getBytes());
-            connection.geoCommands().geoAdd(sourceKey.getBytes(), ROME, "Rome".getBytes());
-            
-            connection.multi();
-            
-            // Test geoSearchStore returns null during transaction
-            GeoReference<byte[]> memberRef = GeoReference.fromMember("Palermo".getBytes());
-            GeoShape radiusShape = GeoShape.byRadius(new Distance(300, DistanceUnit.KILOMETERS));
-            GeoSearchStoreCommandArgs args = GeoSearchStoreCommandArgs.newGeoSearchStoreArgs()
-                .sortAscending()
-                .limit(10);
-            
-            Long result = connection.geoCommands().geoSearchStore(destKey.getBytes(), sourceKey.getBytes(), memberRef, radiusShape, args);
-            assertThat(result).isNull(); // Should be null during transaction
-            
-            List<Object> results = connection.exec();
-            
-            // Verify transaction results
-            assertThat(results).hasSize(1);
-            assertThat(results.get(0)).isInstanceOf(Number.class);
-            assertThat(((Number) results.get(0)).longValue()).isGreaterThan(0L);
-            
-            // Verify final state - results stored in destination
-            List<Point> storedPositions = connection.geoCommands().geoPos(destKey.getBytes(), "Palermo".getBytes());
-            assertThat(storedPositions.get(0)).isNotNull();
-        } finally {
-            cleanupKey(sourceKey);
-            cleanupKey(destKey);
-        }
-    }
+			// Distance in kilometers should be less than distance in meters
+			assertThat(dist2.getValue()).isLessThan(dist1.getValue());
 
-    @Test
-    void testGeoOperationsInPipelineMode() {
-        String key1 = "test:pipeline:geo1";
-        String key2 = "test:pipeline:geo2";
-        String key3 = "test:pipeline:geo3";
-        
-        try {
-            // Set up initial data
-            connection.geoCommands().geoAdd(key1.getBytes(), PALERMO, "Palermo".getBytes());
-            connection.geoCommands().geoAdd(key1.getBytes(), CATANIA, "Catania".getBytes());
-            
-            // Open pipeline
-            connection.openPipeline();
-            
-            // Queue several geo operations
-            connection.geoCommands().geoAdd(key2.getBytes(), ROME, "Rome".getBytes());
-            connection.geoCommands().geoAdd(key2.getBytes(), NEW_YORK, "NewYork".getBytes());
-            connection.geoCommands().geoDist(key1.getBytes(), "Palermo".getBytes(), "Catania".getBytes(), DistanceUnit.KILOMETERS);
-            connection.geoCommands().geoPos(key1.getBytes(), "Palermo".getBytes(), "Catania".getBytes());
-            connection.geoCommands().geoHash(key1.getBytes(), "Palermo".getBytes());
-            connection.geoCommands().geoRemove(key2.getBytes(), "NewYork".getBytes());
-            
-            // Execute pipeline
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(6);
-            assertThat(results.get(0)).isEqualTo(1L); // GEOADD result
-            assertThat(results.get(1)).isEqualTo(1L); // GEOADD result
-            
-            // GEODIST result should be a Distance object or converted value
-            assertThat(results.get(2)).isNotNull(); // GEODIST result
-            
-            // GEOPOS result should be a list of Points
-            @SuppressWarnings("unchecked")
-            List<Point> posResults = (List<Point>) results.get(3);
-            assertThat(posResults).hasSize(2);
-            assertThat(posResults.get(0)).isNotNull();
-            assertThat(posResults.get(1)).isNotNull();
-            
-            // GEOHASH result should be a list of strings
-            @SuppressWarnings("unchecked")
-            List<String> hashResults = (List<String>) results.get(4);
-            assertThat(hashResults).hasSize(1);
-            assertThat(hashResults.get(0)).isNotNull();
-            
-            assertThat(results.get(5)).isEqualTo(1L); // ZREM result
-            
-            // Verify final state outside pipeline
-            List<Point> finalPos = connection.geoCommands().geoPos(key1.getBytes(), "Palermo".getBytes());
-            assertThat(finalPos.get(0)).isNotNull();
-            
-            List<Point> removedPos = connection.geoCommands().geoPos(key2.getBytes(), "NewYork".getBytes());
-            assertThat(removedPos.get(0)).isNull(); // Should be removed
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-            cleanupKey(key3);
-        }
-    }
+			// Test distance with non-existent member
+			Distance distNonExistent = connection.geoCommands()
+				.geoDist(key.getBytes(), "Palermo".getBytes(), "NonExistent".getBytes());
+			assertThat(distNonExistent).isNull();
 
-    @Test
-    void testGeoSearchOperationsInPipelineMode() {
-        String key = "test:pipeline:geosearch";
-        String destKey = "test:pipeline:geodest";
-        
-        try {
-            // Set up initial data
-            Map<byte[], Point> memberCoordinateMap = new HashMap<>();
-            memberCoordinateMap.put("Palermo".getBytes(), PALERMO);
-            memberCoordinateMap.put("Catania".getBytes(), CATANIA);
-            memberCoordinateMap.put("Rome".getBytes(), ROME);
-            connection.geoCommands().geoAdd(key.getBytes(), memberCoordinateMap);
-            
-            connection.openPipeline();
-            
-            // Test various geo search operations
-            Circle searchArea = new Circle(PALERMO, new Distance(300, DistanceUnit.KILOMETERS));
-            connection.geoCommands().geoRadius(key.getBytes(), searchArea);
-            
-            Distance radius = new Distance(300, DistanceUnit.KILOMETERS);
-            connection.geoCommands().geoRadiusByMember(key.getBytes(), "Palermo".getBytes(), radius);
-            
-            // Test geoSearch if available
-            GeoReference<byte[]> memberRef = GeoReference.fromMember("Palermo".getBytes());
-            GeoShape radiusShape = GeoShape.byRadius(new Distance(300, DistanceUnit.KILOMETERS));
-            GeoSearchCommandArgs args = GeoSearchCommandArgs.newGeoSearchArgs().limit(10);
-            connection.geoCommands().geoSearch(key.getBytes(), memberRef, radiusShape, args);
-            
-            List<Object> results = connection.closePipeline();
-            
-            assertThat(results).hasSize(3);
-            
-            // All results should be GeoResults objects
-            for (Object result : results) {
-                if (result != null) {
-                    assertThat(result).isInstanceOf(GeoResults.class);
-                    @SuppressWarnings("unchecked")
-                    GeoResults<GeoLocation<byte[]>> geoResults = (GeoResults<GeoLocation<byte[]>>) result;
-                    assertThat(geoResults.getContent()).isNotEmpty();
-                }
-            }
-        } finally {
-            cleanupKey(key);
-            cleanupKey(destKey);
-        }
-    }
+			// Test distance between distant locations
+			Distance distTransAtlantic = connection.geoCommands()
+				.geoDist(key.getBytes(), "Palermo".getBytes(), "NewYork".getBytes(), DistanceUnit.KILOMETERS);
+			assertThat(distTransAtlantic).isNotNull();
+			assertThat(distTransAtlantic.getValue()).isGreaterThan(1000); // Should be
+																			// thousands
+																			// of
+																			// kilometers
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
 
-    @Test
-    void testMixedGeoOperationsInPipelineMode() {
-        String baseKey = "test:pipeline:mixed";
-        
-        try {
-            connection.openPipeline();
-            
-            // Mix of different geo operations
-            connection.geoCommands().geoAdd((baseKey + ":1").getBytes(), PALERMO, "Palermo".getBytes());
-            connection.geoCommands().geoAdd((baseKey + ":1").getBytes(), CATANIA, "Catania".getBytes());
-            connection.geoCommands().geoPos((baseKey + ":1").getBytes(), "Palermo".getBytes());
-            connection.geoCommands().geoHash((baseKey + ":1").getBytes(), "Palermo".getBytes(), "Catania".getBytes());
-            connection.geoCommands().geoDist((baseKey + ":1").getBytes(), "Palermo".getBytes(), "Catania".getBytes());
-            
-            List<Object> results = connection.closePipeline();
-            
-            assertThat(results).hasSize(5);
-            assertThat(results.get(0)).isEqualTo(1L); // GEOADD
-            assertThat(results.get(1)).isEqualTo(1L); // GEOADD
-            
-            @SuppressWarnings("unchecked")
-            List<Point> posResult = (List<Point>) results.get(2);
-            assertThat(posResult).hasSize(1);
-            assertThat(posResult.get(0)).isNotNull();
-            
-            @SuppressWarnings("unchecked")
-            List<String> hashResult = (List<String>) results.get(3);
-            assertThat(hashResult).hasSize(2);
-            assertThat(hashResult.get(0)).isNotNull();
-            assertThat(hashResult.get(1)).isNotNull();
-            
-            assertThat(results.get(4)).isNotNull(); // GEODIST
-            
-            // Verify final state
-            List<Point> finalPositions = connection.geoCommands().geoPos((baseKey + ":1").getBytes(), 
-                "Palermo".getBytes(), "Catania".getBytes());
-            assertThat(finalPositions).hasSize(2);
-            assertThat(finalPositions.get(0)).isNotNull();
-            assertThat(finalPositions.get(1)).isNotNull();
-        } finally {
-            cleanupKey(baseKey + ":1");
-        }
-    }
+	// ==================== Radius Search Operations ====================
 
-    // ==================== Transaction Mode Tests ====================
+	@Test
+	void testGeoRadius() {
+		String key = "test:geo:radius:key";
 
-    @Test
-    void testGeoOperationsInTransactionMode() {
-        String key1 = "test:tx:geo1";
-        String key2 = "test:tx:geo2";
-        
-        try {
-            // Start transaction
-            connection.multi();
-            
-            // Queue several geo operations
-            connection.geoCommands().geoAdd(key1.getBytes(), PALERMO, "Palermo".getBytes());
-            connection.geoCommands().geoAdd(key1.getBytes(), CATANIA, "Catania".getBytes());
-            connection.geoCommands().geoAdd(key2.getBytes(), ROME, "Rome".getBytes());
-            connection.geoCommands().geoPos(key1.getBytes(), "Palermo".getBytes());
-            connection.geoCommands().geoDist(key1.getBytes(), "Palermo".getBytes(), "Catania".getBytes());
-            
-            // Execute transaction
-            List<Object> results = connection.exec();
-            
-            // Verify results
-            assertThat(results).hasSize(5);
-            assertThat(results.get(0)).isEqualTo(1L); // GEOADD result
-            assertThat(results.get(1)).isEqualTo(1L); // GEOADD result
-            assertThat(results.get(2)).isEqualTo(1L); // GEOADD result
-            
-            @SuppressWarnings("unchecked")
-            List<Point> posResult = (List<Point>) results.get(3);
-            assertThat(posResult).hasSize(1);
-            assertThat(posResult.get(0)).isNotNull();
-            
-            assertThat(results.get(4)).isNotNull(); // GEODIST result
-            
-            // Verify final state outside transaction
-            List<Point> finalPos1 = connection.geoCommands().geoPos(key1.getBytes(), "Palermo".getBytes(), "Catania".getBytes());
-            assertThat(finalPos1).hasSize(2);
-            assertThat(finalPos1.get(0)).isNotNull();
-            assertThat(finalPos1.get(1)).isNotNull();
-            
-            List<Point> finalPos2 = connection.geoCommands().geoPos(key2.getBytes(), "Rome".getBytes());
-            assertThat(finalPos2).hasSize(1);
-            assertThat(finalPos2.get(0)).isNotNull();
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-        }
-    }
+		try {
+			// Setup test data
+			Map<byte[], Point> memberCoordinateMap = new HashMap<>();
+			memberCoordinateMap.put("Palermo".getBytes(), PALERMO);
+			memberCoordinateMap.put("Catania".getBytes(), CATANIA);
+			memberCoordinateMap.put("Edge".getBytes(), EDGE);
+			memberCoordinateMap.put("NewYork".getBytes(), NEW_YORK);
 
-    @Test
-    void testGeoSearchOperationsInTransactionMode() {
-        String key = "test:tx:geosearch";
-        String destKey = "test:tx:geodest";
-        
-        try {
-            // Set up initial data outside transaction
-            Map<byte[], Point> memberCoordinateMap = new HashMap<>();
-            memberCoordinateMap.put("Palermo".getBytes(), PALERMO);
-            memberCoordinateMap.put("Catania".getBytes(), CATANIA);
-            memberCoordinateMap.put("Rome".getBytes(), ROME);
-            connection.geoCommands().geoAdd(key.getBytes(), memberCoordinateMap);
-            
-            connection.multi();
-            
-            // Test geo search operations in transaction
-            Circle searchArea = new Circle(PALERMO, new Distance(300, DistanceUnit.KILOMETERS));
-            GeoRadiusCommandArgs radiusArgs = GeoRadiusCommandArgs.newGeoRadiusArgs().limit(10);
-            connection.geoCommands().geoRadius(key.getBytes(), searchArea, radiusArgs);
-            
-            Distance radius = new Distance(300, DistanceUnit.KILOMETERS);
-            connection.geoCommands().geoRadiusByMember(key.getBytes(), "Palermo".getBytes(), radius, radiusArgs);
-            
-            // Test geoSearchStore if available
-            GeoReference<byte[]> memberRef = GeoReference.fromMember("Palermo".getBytes());
-            GeoShape radiusShape = GeoShape.byRadius(new Distance(300, DistanceUnit.KILOMETERS));
-            GeoSearchStoreCommandArgs storeArgs = GeoSearchStoreCommandArgs.newGeoSearchStoreArgs().limit(10);
-            connection.geoCommands().geoSearchStore(destKey.getBytes(), key.getBytes(), memberRef, radiusShape, storeArgs);
-            
-            List<Object> results = connection.exec();
-            
-            assertThat(results).hasSize(3);
-            
-            // First two should be GeoResults
-            for (int i = 0; i < 2; i++) {
-                if (results.get(i) != null) {
-                    assertThat(results.get(i)).isInstanceOf(GeoResults.class);
-                    @SuppressWarnings("unchecked")
-                    GeoResults<GeoLocation<byte[]>> geoResults = (GeoResults<GeoLocation<byte[]>>) results.get(i);
-                    assertThat(geoResults.getContent()).isNotEmpty();
-                }
-            }
-            
-            // Third should be count of stored results
-            assertThat(results.get(2)).isInstanceOf(Number.class);
-            assertThat(((Number) results.get(2)).longValue()).isGreaterThan(0L);
-            
-            // Verify stored results exist
-            List<Point> storedPos = connection.geoCommands().geoPos(destKey.getBytes(), "Palermo".getBytes());
-            assertThat(storedPos.get(0)).isNotNull();
-        } finally {
-            cleanupKey(key);
-            cleanupKey(destKey);
-        }
-    }
+			connection.geoCommands().geoAdd(key.getBytes(), memberCoordinateMap);
 
-    @Test
-    void testTransactionWithWatchedGeoKeys() {
-        String watchedKey = "test:tx:geo:watched";
-        String valueKey = "test:tx:geo:value";
-        
-        try {
-            // Set initial geo data
-            connection.geoCommands().geoAdd(watchedKey.getBytes(), PALERMO, "Palermo".getBytes());
-            
-            // Watch the key
-            connection.watch(watchedKey.getBytes());
-            
-            // Start transaction
-            connection.multi();
-            connection.geoCommands().geoAdd(valueKey.getBytes(), CATANIA, "Catania".getBytes());
-            
-            // Execute transaction (should succeed since key wasn't modified)
-            List<Object> results = connection.exec();
-            
-            assertThat(results).hasSize(1);
-            assertThat(results.get(0)).isEqualTo(1L);
-            
-            // Verify the conditional add worked
-            List<Point> positions = connection.geoCommands().geoPos(valueKey.getBytes(), "Catania".getBytes());
-            assertThat(positions.get(0)).isNotNull();
-        } finally {
-            cleanupKey(watchedKey);
-            cleanupKey(valueKey);
-        }
-    }
+			// Test basic radius search
+			Circle searchArea = new Circle(PALERMO, new Distance(200, DistanceUnit.KILOMETERS));
+			GeoResults<GeoLocation<byte[]>> results1 = connection.geoCommands().geoRadius(key.getBytes(), searchArea);
+			assertThat(results1).isNotNull();
+			assertThat(results1.getContent()).isNotEmpty();
 
-    @Test
-    void testMixedGeoOperationsInTransaction() {
-        String baseKey = "test:tx:geo:mixed";
-        
-        try {
-            connection.multi();
-            
-            // Mix of different geo operations
-            connection.geoCommands().geoAdd((baseKey + ":1").getBytes(), PALERMO, "Palermo".getBytes());
-            connection.geoCommands().geoAdd((baseKey + ":1").getBytes(), CATANIA, "Catania".getBytes());
-            connection.geoCommands().geoAdd((baseKey + ":2").getBytes(), ROME, "Rome".getBytes());
-            connection.geoCommands().geoPos((baseKey + ":1").getBytes(), "Palermo".getBytes(), "Catania".getBytes());
-            connection.geoCommands().geoHash((baseKey + ":1").getBytes(), "Palermo".getBytes());
-            connection.geoCommands().geoDist((baseKey + ":1").getBytes(), "Palermo".getBytes(), "Catania".getBytes(), DistanceUnit.KILOMETERS);
-            connection.geoCommands().geoRemove((baseKey + ":2").getBytes(), "Rome".getBytes());
-            
-            List<Object> results = connection.exec();
-            
-            assertThat(results).hasSize(7);
-            assertThat(results.get(0)).isEqualTo(1L); // GEOADD
-            assertThat(results.get(1)).isEqualTo(1L); // GEOADD
-            assertThat(results.get(2)).isEqualTo(1L); // GEOADD
-            
-            @SuppressWarnings("unchecked")
-            List<Point> posResults = (List<Point>) results.get(3);
-            assertThat(posResults).hasSize(2);
-            assertThat(posResults.get(0)).isNotNull();
-            assertThat(posResults.get(1)).isNotNull();
-            
-            @SuppressWarnings("unchecked")
-            List<String> hashResults = (List<String>) results.get(4);
-            assertThat(hashResults).hasSize(1);
-            assertThat(hashResults.get(0)).isNotNull();
-            
-            assertThat(results.get(5)).isNotNull(); // GEODIST
-            assertThat(results.get(6)).isEqualTo(1L); // ZREM
-            
-            // Verify final state
-            List<Point> finalPos1 = connection.geoCommands().geoPos((baseKey + ":1").getBytes(), 
-                "Palermo".getBytes(), "Catania".getBytes());
-            assertThat(finalPos1).hasSize(2);
-            assertThat(finalPos1.get(0)).isNotNull();
-            assertThat(finalPos1.get(1)).isNotNull();
-            
-            // Verify removal worked
-            List<Point> finalPos2 = connection.geoCommands().geoPos((baseKey + ":2").getBytes(), "Rome".getBytes());
-            assertThat(finalPos2.get(0)).isNull(); // Should be removed
-        } finally {
-            cleanupKey(baseKey + ":1");
-            cleanupKey(baseKey + ":2");
-        }
-    }
+			// Should find Palermo and Catania, but not NewYork
+			List<String> memberNames = results1.getContent()
+				.stream()
+				.map(result -> new String(result.getContent().getName()))
+				.collect(java.util.stream.Collectors.toList());
+			assertThat(memberNames).contains("Palermo");
+			assertThat(memberNames).doesNotContain("NewYork");
 
-    @Test
-    void testGeoOperationsWithComplexTransactionScenario() {
-        String sourceKey = "test:tx:geo:source";
-        String targetKey = "test:tx:geo:target";
-        String logKey = "test:tx:geo:log";
-        
-        try {
-            connection.multi();
-            
-            // Complex scenario: Add locations, perform searches, store results
-            Map<byte[], Point> locations = new HashMap<>();
-            locations.put("Milan".getBytes(), new Point(9.1900, 45.4642));
-            locations.put("Naples".getBytes(), new Point(14.2681, 40.8518));
-            locations.put("Venice".getBytes(), new Point(12.3155, 45.4408));
-            connection.geoCommands().geoAdd(sourceKey.getBytes(), locations);
-            
-            // Search and store nearby locations
-            GeoReference<byte[]> milanRef = GeoReference.fromMember("Milan".getBytes());
-            GeoShape searchArea = GeoShape.byRadius(new Distance(500, DistanceUnit.KILOMETERS));
-            GeoSearchStoreCommandArgs storeArgs = GeoSearchStoreCommandArgs.newGeoSearchStoreArgs().limit(10);
-            connection.geoCommands().geoSearchStore(targetKey.getBytes(), sourceKey.getBytes(), milanRef, searchArea, storeArgs);
-            
-            // Log the operation (using a simple key-value)
-            connection.stringCommands().set(logKey.getBytes(), "geo_search_completed".getBytes());
-            
-            List<Object> results = connection.exec();
-            
-            assertThat(results).hasSize(3);
-            assertThat(results.get(0)).isEqualTo(3L); // GEOADD count
-            assertThat(((Number) results.get(1)).longValue()).isGreaterThan(0L); // GEOSEARCHSTORE count
-            assertThat(results.get(2)).isEqualTo(true); // SET result
-            
-            // Verify all operations completed successfully
-            List<Point> sourcePositions = connection.geoCommands().geoPos(sourceKey.getBytes(), 
-                "Milan".getBytes(), "Naples".getBytes(), "Venice".getBytes());
-            assertThat(sourcePositions).hasSize(3);
-            assertThat(sourcePositions.get(0)).isNotNull();
-            assertThat(sourcePositions.get(1)).isNotNull();
-            assertThat(sourcePositions.get(2)).isNotNull();
-            
-            List<Point> targetPositions = connection.geoCommands().geoPos(targetKey.getBytes(), "Milan".getBytes());
-            assertThat(targetPositions.get(0)).isNotNull();
-            
-            assertThat(connection.stringCommands().get(logKey.getBytes())).isEqualTo("geo_search_completed".getBytes());
-        } finally {
-            cleanupKey(sourceKey);
-            cleanupKey(targetKey);
-            cleanupKey(logKey);
-        }
-    }
+			// Test radius search with arguments
+			GeoRadiusCommandArgs args = GeoRadiusCommandArgs.newGeoRadiusArgs()
+				.includeDistance()
+				.includeCoordinates()
+				.sortAscending()
+				.limit(10);
+
+			GeoResults<GeoLocation<byte[]>> results2 = connection.geoCommands()
+				.geoRadius(key.getBytes(), searchArea, args);
+			assertThat(results2).isNotNull();
+			assertThat(results2.getContent()).isNotEmpty();
+
+			// Verify distance and coordinates are included
+			for (GeoResult<GeoLocation<byte[]>> result : results2.getContent()) {
+				assertThat(result.getDistance()).isNotNull();
+				assertThat(result.getContent().getPoint()).isNotNull();
+			}
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testGeoRadiusByMember() {
+		String key = "test:geo:radius:member:key";
+
+		try {
+			// Setup test data
+			Map<byte[], Point> memberCoordinateMap = new HashMap<>();
+			memberCoordinateMap.put("Palermo".getBytes(), PALERMO);
+			memberCoordinateMap.put("Catania".getBytes(), CATANIA);
+			memberCoordinateMap.put("Edge".getBytes(), EDGE);
+			memberCoordinateMap.put("NewYork".getBytes(), NEW_YORK);
+
+			connection.geoCommands().geoAdd(key.getBytes(), memberCoordinateMap);
+
+			// Test basic radius search by member
+			Distance radius = new Distance(200, DistanceUnit.KILOMETERS);
+			GeoResults<GeoLocation<byte[]>> results1 = connection.geoCommands()
+				.geoRadiusByMember(key.getBytes(), "Palermo".getBytes(), radius);
+			assertThat(results1).isNotNull();
+			assertThat(results1.getContent()).isNotEmpty();
+
+			// Should find Palermo itself and nearby cities
+			List<String> memberNames = results1.getContent()
+				.stream()
+				.map(result -> new String(result.getContent().getName()))
+				.collect(java.util.stream.Collectors.toList());
+			assertThat(memberNames).contains("Palermo");
+
+			// Test radius search by member with arguments
+			GeoRadiusCommandArgs args = GeoRadiusCommandArgs.newGeoRadiusArgs()
+				.includeDistance()
+				.includeCoordinates()
+				.sortDescending()
+				.limit(5);
+
+			GeoResults<GeoLocation<byte[]>> results2 = connection.geoCommands()
+				.geoRadiusByMember(key.getBytes(), "Palermo".getBytes(), radius, args);
+			assertThat(results2).isNotNull();
+			assertThat(results2.getContent()).isNotEmpty();
+
+			// Verify distance and coordinates are included
+			for (GeoResult<GeoLocation<byte[]>> result : results2.getContent()) {
+				assertThat(result.getDistance()).isNotNull();
+				assertThat(result.getContent().getPoint()).isNotNull();
+			}
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== Advanced Search Operations ====================
+
+	@Test
+	void testGeoSearch() {
+		String key = "test:geo:search:key";
+
+		try {
+			// Setup test data
+			Map<byte[], Point> memberCoordinateMap = new HashMap<>();
+			memberCoordinateMap.put("Palermo".getBytes(), PALERMO);
+			memberCoordinateMap.put("Catania".getBytes(), CATANIA);
+			memberCoordinateMap.put("Rome".getBytes(), ROME);
+			memberCoordinateMap.put("NewYork".getBytes(), NEW_YORK);
+
+			connection.geoCommands().geoAdd(key.getBytes(), memberCoordinateMap);
+
+			// Test search from member reference
+			GeoReference<byte[]> memberRef = GeoReference.fromMember("Palermo".getBytes());
+			GeoShape radiusShape = GeoShape.byRadius(new Distance(300, DistanceUnit.KILOMETERS));
+			GeoSearchCommandArgs args = GeoSearchCommandArgs.newGeoSearchArgs()
+				.includeDistance()
+				.includeCoordinates()
+				.sortAscending()
+				.limit(10);
+
+			GeoResults<GeoLocation<byte[]>> results1 = connection.geoCommands()
+				.geoSearch(key.getBytes(), memberRef, radiusShape, args);
+			assertThat(results1).isNotNull();
+			assertThat(results1.getContent()).isNotEmpty();
+
+			// Should find nearby locations
+			List<String> memberNames = results1.getContent()
+				.stream()
+				.map(result -> new String(result.getContent().getName()))
+				.collect(java.util.stream.Collectors.toList());
+			assertThat(memberNames).contains("Palermo");
+			assertThat(memberNames).doesNotContain("NewYork");
+
+			// Test search from coordinate reference
+			GeoReference<byte[]> coordRef = GeoReference.fromCoordinate(PALERMO);
+			GeoResults<GeoLocation<byte[]>> results2 = connection.geoCommands()
+				.geoSearch(key.getBytes(), coordRef, radiusShape, args);
+			assertThat(results2).isNotNull();
+			assertThat(results2.getContent()).isNotEmpty();
+
+			// Results should be similar to member reference search
+			assertThat(results2.getContent().size()).isGreaterThan(0);
+
+			// Test with box shape
+			GeoShape boxShape = GeoShape.byBox(200, 200, DistanceUnit.KILOMETERS);
+			GeoResults<GeoLocation<byte[]>> results3 = connection.geoCommands()
+				.geoSearch(key.getBytes(), memberRef, boxShape, args);
+			assertThat(results3).isNotNull();
+			assertThat(results3.getContent()).isNotEmpty();
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testGeoSearchStore() {
+		String key = "test:geo:search:store:key";
+		String destKey = "test:geo:search:dest:key";
+
+		try {
+			// Setup test data
+			Map<byte[], Point> memberCoordinateMap = new HashMap<>();
+			memberCoordinateMap.put("Palermo".getBytes(), PALERMO);
+			memberCoordinateMap.put("Catania".getBytes(), CATANIA);
+			memberCoordinateMap.put("Rome".getBytes(), ROME);
+			memberCoordinateMap.put("NewYork".getBytes(), NEW_YORK);
+
+			connection.geoCommands().geoAdd(key.getBytes(), memberCoordinateMap);
+
+			// Test search and store
+			GeoReference<byte[]> memberRef = GeoReference.fromMember("Palermo".getBytes());
+			GeoShape radiusShape = GeoShape.byRadius(new Distance(300, DistanceUnit.KILOMETERS));
+			GeoSearchStoreCommandArgs args = GeoSearchStoreCommandArgs.newGeoSearchStoreArgs()
+				.sortAscending()
+				.limit(10);
+
+			Long storeResult = connection.geoCommands()
+				.geoSearchStore(destKey.getBytes(), key.getBytes(), memberRef, radiusShape, args);
+			assertThat(storeResult).isNotNull();
+			assertThat(storeResult).isGreaterThan(0L);
+
+			// Verify stored results by checking positions
+			List<Point> storedPositions = connection.geoCommands().geoPos(destKey.getBytes(), "Palermo".getBytes());
+			assertThat(storedPositions).hasSize(1);
+			assertThat(storedPositions.get(0)).isNotNull();
+
+			// Test with store distance option
+			GeoSearchStoreCommandArgs storeDistArgs = GeoSearchStoreCommandArgs.newGeoSearchStoreArgs()
+				.storeDistance()
+				.sortDescending()
+				.limit(5);
+
+			Long storeDistResult = connection.geoCommands()
+				.geoSearchStore(destKey.getBytes(), key.getBytes(), memberRef, radiusShape, storeDistArgs);
+			assertThat(storeDistResult).isNotNull();
+			assertThat(storeDistResult).isGreaterThan(0L);
+		}
+		finally {
+			cleanupKey(key);
+			cleanupKey(destKey);
+		}
+	}
+
+	// ==================== Edge Cases and Error Handling ====================
+
+	@Test
+	void testEmptyKeyOperations() {
+		String key = "test:geo:empty:key";
+
+		try {
+			// Test operations on empty key
+			List<Point> emptyPos = connection.geoCommands().geoPos(key.getBytes(), "NonExistent".getBytes());
+			assertThat(emptyPos).hasSize(1);
+			assertThat(emptyPos.get(0)).isNull();
+
+			List<String> emptyHash = connection.geoCommands().geoHash(key.getBytes(), "NonExistent".getBytes());
+			assertThat(emptyHash).hasSize(1);
+			assertThat(emptyHash.get(0)).isNull();
+
+			Distance emptyDist = connection.geoCommands()
+				.geoDist(key.getBytes(), "NonExistent1".getBytes(), "NonExistent2".getBytes());
+			assertThat(emptyDist).isNull();
+
+			Circle searchArea = new Circle(PALERMO, new Distance(100, DistanceUnit.KILOMETERS));
+			GeoResults<GeoLocation<byte[]>> emptyRadius = connection.geoCommands()
+				.geoRadius(key.getBytes(), searchArea);
+			assertThat(emptyRadius).isNotNull();
+			assertThat(emptyRadius.getContent()).isEmpty();
+
+			Long emptyRemove = connection.geoCommands().geoRemove(key.getBytes(), "NonExistent".getBytes());
+			assertThat(emptyRemove).isEqualTo(0L);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testMixedOperations() {
+		String key = "test:geo:mixed:key";
+
+		try {
+			// Add some locations
+			Map<byte[], Point> memberCoordinateMap = new HashMap<>();
+			memberCoordinateMap.put("Palermo".getBytes(), PALERMO);
+			memberCoordinateMap.put("Catania".getBytes(), CATANIA);
+			memberCoordinateMap.put("Rome".getBytes(), ROME);
+
+			connection.geoCommands().geoAdd(key.getBytes(), memberCoordinateMap);
+
+			// Test mixed operations
+			Distance dist = connection.geoCommands()
+				.geoDist(key.getBytes(), "Palermo".getBytes(), "Rome".getBytes(), DistanceUnit.KILOMETERS);
+			assertThat(dist).isNotNull();
+			assertThat(dist.getValue()).isGreaterThan(0);
+
+			// Remove one location
+			Long removeResult = connection.geoCommands().geoRemove(key.getBytes(), "Catania".getBytes());
+			assertThat(removeResult).isEqualTo(1L);
+
+			// Verify it's removed
+			List<Point> positions = connection.geoCommands().geoPos(key.getBytes(), "Catania".getBytes());
+			assertThat(positions.get(0)).isNull();
+
+			// But other locations should still be there
+			List<Point> remainingPositions = connection.geoCommands()
+				.geoPos(key.getBytes(), "Palermo".getBytes(), "Rome".getBytes());
+			assertThat(remainingPositions).hasSize(2);
+			assertThat(remainingPositions.get(0)).isNotNull();
+			assertThat(remainingPositions.get(1)).isNotNull();
+
+			// Test radius search after removal
+			Circle searchArea = new Circle(PALERMO, new Distance(500, DistanceUnit.KILOMETERS));
+			GeoResults<GeoLocation<byte[]>> radiusResults = connection.geoCommands()
+				.geoRadius(key.getBytes(), searchArea);
+			assertThat(radiusResults).isNotNull();
+			assertThat(radiusResults.getContent()).hasSize(2); // Only Palermo and Rome
+																// should remain
+
+			List<String> remainingNames = radiusResults.getContent()
+				.stream()
+				.map(result -> new String(result.getContent().getName()))
+				.collect(java.util.stream.Collectors.toList());
+			assertThat(remainingNames).containsExactlyInAnyOrder("Palermo", "Rome");
+			assertThat(remainingNames).doesNotContain("Catania");
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== Parameter Validation Tests ====================
+
+	@Test
+	void testParameterValidation() {
+		String key = "test:geo:validation:key";
+
+		try {
+			// Test null key validation
+			assertThatThrownBy(() -> connection.geoCommands().geoAdd(null, PALERMO, "member".getBytes()))
+				.isInstanceOf(IllegalArgumentException.class);
+
+			// Test null point validation
+			assertThatThrownBy(() -> connection.geoCommands().geoAdd(key.getBytes(), null, "member".getBytes()))
+				.isInstanceOf(IllegalArgumentException.class);
+
+			// Test null member validation
+			assertThatThrownBy(() -> connection.geoCommands().geoAdd(key.getBytes(), PALERMO, null))
+				.isInstanceOf(IllegalArgumentException.class);
+
+			// Test null members array validation
+			assertThatThrownBy(() -> connection.geoCommands().geoPos(key.getBytes(), (byte[][]) null))
+				.isInstanceOf(IllegalArgumentException.class);
+
+			// Test null elements in members array
+			assertThatThrownBy(() -> connection.geoCommands().geoPos(key.getBytes(), "member1".getBytes(), null))
+				.isInstanceOf(IllegalArgumentException.class);
+
+			// Test null metric validation
+			connection.geoCommands().geoAdd(key.getBytes(), PALERMO, "member1".getBytes());
+			connection.geoCommands().geoAdd(key.getBytes(), CATANIA, "member2".getBytes());
+
+			assertThatThrownBy(() -> connection.geoCommands()
+				.geoDist(key.getBytes(), "member1".getBytes(), "member2".getBytes(), null))
+				.isInstanceOf(IllegalArgumentException.class);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== Performance and Stress Tests ====================
+
+	@Test
+	void testLargeDataset() {
+		String key = "test:geo:large:key";
+
+		try {
+			// Add a large number of locations with valid coordinates
+			// Valkey geo commands have latitude limits of approximately -85.05 to 85.05
+			// degrees
+			Map<byte[], Point> largeDataset = new HashMap<>();
+			for (int i = 0; i < 100; i++) {
+				double longitude = -180 + (360.0 * i / 100);
+				double latitude = -85 + (170.0 * i / 100); // Valid latitude range: -85 to
+															// 85
+				largeDataset.put(("location" + i).getBytes(), new Point(longitude, latitude));
+			}
+
+			Long addResult = connection.geoCommands().geoAdd(key.getBytes(), largeDataset);
+			assertThat(addResult).isEqualTo(100L);
+
+			// Test operations on large dataset
+			List<Point> positions = connection.geoCommands().geoPos(key.getBytes(), "location50".getBytes());
+			assertThat(positions).hasSize(1);
+			assertThat(positions.get(0)).isNotNull();
+
+			// Test radius search on large dataset
+			Circle largeSearchArea = new Circle(new Point(0, 0), new Distance(5000, DistanceUnit.KILOMETERS));
+			GeoResults<GeoLocation<byte[]>> largeResults = connection.geoCommands()
+				.geoRadius(key.getBytes(), largeSearchArea);
+			assertThat(largeResults).isNotNull();
+			assertThat(largeResults.getContent()).isNotEmpty();
+
+			// Test bulk removal
+			byte[][] membersToRemove = new byte[50][];
+			for (int i = 0; i < 50; i++) {
+				membersToRemove[i] = ("location" + i).getBytes();
+			}
+			Long removeResult = connection.geoCommands().geoRemove(key.getBytes(), membersToRemove);
+			assertThat(removeResult).isEqualTo(50L);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== Geographic Edge Cases ====================
+
+	@Test
+	void testGeographicEdgeCases() {
+		String key = "test:geo:edge:cases:key";
+
+		try {
+			// Test locations at extreme but valid coordinates
+			// Valkey geo commands have latitude limits, so we use realistic extreme
+			// coordinates
+			Map<byte[], Point> edgeCases = new HashMap<>();
+			edgeCases.put("NearNorthPole".getBytes(), new Point(0, 85)); // Close to North
+																			// Pole
+			edgeCases.put("NearSouthPole".getBytes(), new Point(0, -85)); // Close to
+																			// South Pole
+			edgeCases.put("DateLine".getBytes(), new Point(179, 0)); // Close to Date Line
+			edgeCases.put("AntiMeridian".getBytes(), new Point(-179, 0)); // Close to
+																			// Anti-Meridian
+			edgeCases.put("Equator".getBytes(), new Point(0, 0));
+
+			Long addResult = connection.geoCommands().geoAdd(key.getBytes(), edgeCases);
+			assertThat(addResult).isEqualTo(5L);
+
+			// Test distance between extreme points
+			Distance poleDistance = connection.geoCommands()
+				.geoDist(key.getBytes(), "NearNorthPole".getBytes(), "NearSouthPole".getBytes(),
+						DistanceUnit.KILOMETERS);
+			assertThat(poleDistance).isNotNull();
+			assertThat(poleDistance.getValue()).isGreaterThan(15000); // Should be
+																		// ~18,000+ km
+
+			// Test positions of extreme coordinates
+			List<Point> extremePositions = connection.geoCommands()
+				.geoPos(key.getBytes(), "NearNorthPole".getBytes(), "NearSouthPole".getBytes());
+			assertThat(extremePositions).hasSize(2);
+			assertThat(extremePositions.get(0)).isNotNull();
+			assertThat(extremePositions.get(1)).isNotNull();
+
+			// Test radius search from extreme location
+			Circle poleSearch = new Circle(new Point(0, 85), new Distance(1000, DistanceUnit.KILOMETERS));
+			GeoResults<GeoLocation<byte[]>> poleResults = connection.geoCommands()
+				.geoRadius(key.getBytes(), poleSearch);
+			assertThat(poleResults).isNotNull();
+			assertThat(poleResults.getContent()).isNotEmpty();
+
+			// Test distance across date line
+			Distance dateLineDistance = connection.geoCommands()
+				.geoDist(key.getBytes(), "DateLine".getBytes(), "AntiMeridian".getBytes(), DistanceUnit.KILOMETERS);
+			assertThat(dateLineDistance).isNotNull();
+			assertThat(dateLineDistance.getValue()).isGreaterThan(0);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== Precision Tests ====================
+
+	@Test
+	void testCoordinatePrecision() {
+		String key = "test:geo:precision:key";
+
+		try {
+			// Test with high precision coordinates
+			// Valkey geo commands use geohash which has limited precision
+			Point highPrecision = new Point(13.361389123456789, 38.115556987654321);
+			connection.geoCommands().geoAdd(key.getBytes(), highPrecision, "HighPrecision".getBytes());
+
+			// Verify coordinates are stored with reasonable precision
+			// Valkey geo precision is limited by geohash, so we use a more realistic
+			// tolerance
+			List<Point> retrievedPositions = connection.geoCommands()
+				.geoPos(key.getBytes(), "HighPrecision".getBytes());
+			assertThat(retrievedPositions).hasSize(1);
+			Point retrieved = retrievedPositions.get(0);
+			assertThat(retrieved.getX()).isCloseTo(highPrecision.getX(), within(0.01)); // More
+																						// realistic
+																						// tolerance
+			assertThat(retrieved.getY()).isCloseTo(highPrecision.getY(), within(0.01));
+
+			// Test with moderately close coordinates (more realistic for geo
+			// applications)
+			Point close1 = new Point(13.361389, 38.115556);
+			Point close2 = new Point(13.361489, 38.115656); // 100m apart approximately
+
+			connection.geoCommands().geoAdd(key.getBytes(), close1, "Close1".getBytes());
+			connection.geoCommands().geoAdd(key.getBytes(), close2, "Close2".getBytes());
+
+			Distance closeDistance = connection.geoCommands()
+				.geoDist(key.getBytes(), "Close1".getBytes(), "Close2".getBytes(), DistanceUnit.METERS);
+			assertThat(closeDistance).isNotNull();
+			assertThat(closeDistance.getValue()).isGreaterThan(0);
+			assertThat(closeDistance.getValue()).isLessThan(200); // Should be ~100m
+
+			// Test coordinate retrieval accuracy
+			List<Point> closePositions = connection.geoCommands()
+				.geoPos(key.getBytes(), "Close1".getBytes(), "Close2".getBytes());
+			assertThat(closePositions).hasSize(2);
+			assertThat(closePositions.get(0)).isNotNull();
+			assertThat(closePositions.get(1)).isNotNull();
+
+			// Verify the positions are reasonably close to what we stored
+			assertThat(closePositions.get(0).getX()).isCloseTo(close1.getX(), within(0.01));
+			assertThat(closePositions.get(0).getY()).isCloseTo(close1.getY(), within(0.01));
+			assertThat(closePositions.get(1).getX()).isCloseTo(close2.getX(), within(0.01));
+			assertThat(closePositions.get(1).getY()).isCloseTo(close2.getY(), within(0.01));
+
+			// Test with coordinates that have meaningful differences (larger difference
+			// for geohash precision)
+			Point precise1 = new Point(13.361389, 38.115556);
+			Point precise2 = new Point(13.362389, 38.115556); // Longitude differs by
+																// 0.001 degrees (~100m)
+
+			connection.geoCommands().geoAdd(key.getBytes(), precise1, "Precise1".getBytes());
+			connection.geoCommands().geoAdd(key.getBytes(), precise2, "Precise2".getBytes());
+
+			// Verify coordinates were stored correctly
+			List<Point> precisePositions = connection.geoCommands()
+				.geoPos(key.getBytes(), "Precise1".getBytes(), "Precise2".getBytes());
+			assertThat(precisePositions).hasSize(2);
+			assertThat(precisePositions.get(0)).isNotNull();
+			assertThat(precisePositions.get(1)).isNotNull();
+
+			Distance preciseDistance = connection.geoCommands()
+				.geoDist(key.getBytes(), "Precise1".getBytes(), "Precise2".getBytes(), DistanceUnit.METERS);
+			assertThat(preciseDistance).isNotNull();
+
+			// With larger coordinate differences, we should get a measurable distance
+			assertThat(preciseDistance.getValue()).isGreaterThan(0);
+			assertThat(preciseDistance.getValue()).isLessThan(500); // Should be around
+																	// 100m
+
+			// Test Valkey geohash precision limitations with very small differences
+			Point veryClose1 = new Point(13.361389, 38.115556);
+			Point veryClose2 = new Point(13.361390, 38.115556); // Very small difference
+
+			connection.geoCommands().geoAdd(key.getBytes(), veryClose1, "VeryClose1".getBytes());
+			connection.geoCommands().geoAdd(key.getBytes(), veryClose2, "VeryClose2".getBytes());
+
+			Distance veryCloseDistance = connection.geoCommands()
+				.geoDist(key.getBytes(), "VeryClose1".getBytes(), "VeryClose2".getBytes(), DistanceUnit.METERS);
+			assertThat(veryCloseDistance).isNotNull();
+
+			// For very small differences, distance might be 0 due to geohash precision
+			// This is expected behavior for Valkey geo commands
+			assertThat(veryCloseDistance.getValue()).isGreaterThanOrEqualTo(0);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== Comprehensive Pipeline Mode Tests ====================
+
+	@Test
+	void testAllGeoAddVariantsInPipelineMode() {
+		String key1 = "test:pipeline:geoadd:single";
+		String key2 = "test:pipeline:geoadd:map";
+		String key3 = "test:pipeline:geoadd:iterable";
+
+		try {
+			connection.openPipeline();
+
+			// Test all geoAdd variants return null during pipeline
+			Long result1 = connection.geoCommands().geoAdd(key1.getBytes(), PALERMO, "Palermo".getBytes());
+			assertThat(result1).isNull(); // Should be null during pipeline
+
+			Map<byte[], Point> memberMap = new HashMap<>();
+			memberMap.put("Rome".getBytes(), ROME);
+			memberMap.put("Milan".getBytes(), new Point(9.1900, 45.4642));
+			Long result2 = connection.geoCommands().geoAdd(key2.getBytes(), memberMap);
+			assertThat(result2).isNull(); // Should be null during pipeline
+
+			List<GeoLocation<byte[]>> locations = new ArrayList<>();
+			locations.add(new GeoLocation<>("Venice".getBytes(), new Point(12.3155, 45.4408)));
+			locations.add(new GeoLocation<>("Naples".getBytes(), new Point(14.2681, 40.8518)));
+			Long result3 = connection.geoCommands().geoAdd(key3.getBytes(), locations);
+			assertThat(result3).isNull(); // Should be null during pipeline
+
+			List<Object> results = connection.closePipeline();
+
+			// Verify pipeline results
+			assertThat(results).hasSize(3);
+			assertThat(results.get(0)).isEqualTo(1L); // Single point add
+			assertThat(results.get(1)).isEqualTo(2L); // Map add
+			assertThat(results.get(2)).isEqualTo(2L); // Iterable add
+
+			// Verify final state
+			List<Point> pos1 = connection.geoCommands().geoPos(key1.getBytes(), "Palermo".getBytes());
+			assertThat(pos1.get(0)).isNotNull();
+
+			List<Point> pos2 = connection.geoCommands().geoPos(key2.getBytes(), "Rome".getBytes(), "Milan".getBytes());
+			assertThat(pos2).hasSize(2);
+			assertThat(pos2.get(0)).isNotNull();
+			assertThat(pos2.get(1)).isNotNull();
+
+			List<Point> pos3 = connection.geoCommands()
+				.geoPos(key3.getBytes(), "Venice".getBytes(), "Naples".getBytes());
+			assertThat(pos3).hasSize(2);
+			assertThat(pos3.get(0)).isNotNull();
+			assertThat(pos3.get(1)).isNotNull();
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+			cleanupKey(key3);
+		}
+	}
+
+	@Test
+	void testGeoDistVariantsInPipelineMode() {
+		String key = "test:pipeline:geodist";
+
+		try {
+			// Setup data
+			connection.geoCommands().geoAdd(key.getBytes(), PALERMO, "Palermo".getBytes());
+			connection.geoCommands().geoAdd(key.getBytes(), CATANIA, "Catania".getBytes());
+			connection.geoCommands().geoAdd(key.getBytes(), ROME, "Rome".getBytes());
+
+			connection.openPipeline();
+
+			// Test both geoDist variants return null during pipeline
+			Distance result1 = connection.geoCommands()
+				.geoDist(key.getBytes(), "Palermo".getBytes(), "Catania".getBytes());
+			assertThat(result1).isNull(); // Should be null during pipeline
+
+			Distance result2 = connection.geoCommands()
+				.geoDist(key.getBytes(), "Palermo".getBytes(), "Rome".getBytes(), DistanceUnit.KILOMETERS);
+			assertThat(result2).isNull(); // Should be null during pipeline
+
+			List<Object> results = connection.closePipeline();
+
+			// Verify pipeline results
+			assertThat(results).hasSize(2);
+			assertThat(results.get(0)).isInstanceOf(Distance.class);
+			assertThat(results.get(1)).isInstanceOf(Distance.class);
+
+			Distance dist1 = (Distance) results.get(0);
+			Distance dist2 = (Distance) results.get(1);
+			assertThat(dist1.getValue()).isGreaterThan(0);
+			assertThat(dist2.getValue()).isGreaterThan(0);
+			assertThat(dist1.getMetric()).isEqualTo(DistanceUnit.METERS);
+			assertThat(dist2.getMetric()).isEqualTo(DistanceUnit.KILOMETERS);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testGeoHashAndGeoPosInPipelineMode() {
+		String key = "test:pipeline:geohashpos";
+
+		try {
+			// Setup data
+			connection.geoCommands().geoAdd(key.getBytes(), PALERMO, "Palermo".getBytes());
+			connection.geoCommands().geoAdd(key.getBytes(), CATANIA, "Catania".getBytes());
+			connection.geoCommands().geoAdd(key.getBytes(), ROME, "Rome".getBytes());
+
+			connection.openPipeline();
+
+			// Test geoHash returns null during pipeline
+			List<String> hashResult = connection.geoCommands()
+				.geoHash(key.getBytes(), "Palermo".getBytes(), "Catania".getBytes());
+			assertThat(hashResult).isNull(); // Should be null during pipeline
+
+			// Test geoPos returns null during pipeline
+			List<Point> posResult = connection.geoCommands()
+				.geoPos(key.getBytes(), "Palermo".getBytes(), "Rome".getBytes());
+			assertThat(posResult).isNull(); // Should be null during pipeline
+
+			List<Object> results = connection.closePipeline();
+
+			// Verify pipeline results
+			assertThat(results).hasSize(2);
+
+			@SuppressWarnings("unchecked")
+			List<String> hashes = (List<String>) results.get(0);
+			assertThat(hashes).hasSize(2);
+			assertThat(hashes.get(0)).isNotNull();
+			assertThat(hashes.get(1)).isNotNull();
+
+			@SuppressWarnings("unchecked")
+			List<Point> positions = (List<Point>) results.get(1);
+			assertThat(positions).hasSize(2);
+			assertThat(positions.get(0)).isNotNull();
+			assertThat(positions.get(1)).isNotNull();
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testGeoRadiusVariantsInPipelineMode() {
+		String key = "test:pipeline:georadius";
+
+		try {
+			// Setup data
+			connection.geoCommands().geoAdd(key.getBytes(), PALERMO, "Palermo".getBytes());
+			connection.geoCommands().geoAdd(key.getBytes(), CATANIA, "Catania".getBytes());
+			connection.geoCommands().geoAdd(key.getBytes(), ROME, "Rome".getBytes());
+
+			connection.openPipeline();
+
+			// Test basic geoRadius returns null during pipeline
+			Circle searchArea = new Circle(PALERMO, new Distance(300, DistanceUnit.KILOMETERS));
+			GeoResults<GeoLocation<byte[]>> result1 = connection.geoCommands().geoRadius(key.getBytes(), searchArea);
+			assertThat(result1).isNull(); // Should be null during pipeline
+
+			// Test geoRadius with args returns null during pipeline
+			GeoRadiusCommandArgs args = GeoRadiusCommandArgs.newGeoRadiusArgs()
+				.includeDistance()
+				.includeCoordinates()
+				.sortAscending()
+				.limit(10);
+			GeoResults<GeoLocation<byte[]>> result2 = connection.geoCommands()
+				.geoRadius(key.getBytes(), searchArea, args);
+			assertThat(result2).isNull(); // Should be null during pipeline
+
+			List<Object> results = connection.closePipeline();
+
+			// Verify pipeline results
+			assertThat(results).hasSize(2);
+			for (Object result : results) {
+				assertThat(result).isInstanceOf(GeoResults.class);
+				@SuppressWarnings("unchecked")
+				GeoResults<GeoLocation<byte[]>> geoResults = (GeoResults<GeoLocation<byte[]>>) result;
+				assertThat(geoResults.getContent()).isNotEmpty();
+			}
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testGeoRadiusByMemberVariantsInPipelineMode() {
+		String key = "test:pipeline:georadiusbymember";
+
+		try {
+			// Setup data
+			connection.geoCommands().geoAdd(key.getBytes(), PALERMO, "Palermo".getBytes());
+			connection.geoCommands().geoAdd(key.getBytes(), CATANIA, "Catania".getBytes());
+			connection.geoCommands().geoAdd(key.getBytes(), ROME, "Rome".getBytes());
+
+			connection.openPipeline();
+
+			// Test basic geoRadiusByMember returns null during pipeline
+			Distance radius = new Distance(300, DistanceUnit.KILOMETERS);
+			GeoResults<GeoLocation<byte[]>> result1 = connection.geoCommands()
+				.geoRadiusByMember(key.getBytes(), "Palermo".getBytes(), radius);
+			assertThat(result1).isNull(); // Should be null during pipeline
+
+			// Test geoRadiusByMember with args returns null during pipeline
+			GeoRadiusCommandArgs args = GeoRadiusCommandArgs.newGeoRadiusArgs()
+				.includeDistance()
+				.includeCoordinates()
+				.sortDescending()
+				.limit(5);
+			GeoResults<GeoLocation<byte[]>> result2 = connection.geoCommands()
+				.geoRadiusByMember(key.getBytes(), "Rome".getBytes(), radius, args);
+			assertThat(result2).isNull(); // Should be null during pipeline
+
+			List<Object> results = connection.closePipeline();
+
+			// Verify pipeline results
+			assertThat(results).hasSize(2);
+			for (Object result : results) {
+				assertThat(result).isInstanceOf(GeoResults.class);
+				@SuppressWarnings("unchecked")
+				GeoResults<GeoLocation<byte[]>> geoResults = (GeoResults<GeoLocation<byte[]>>) result;
+				assertThat(geoResults.getContent()).isNotEmpty();
+			}
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testGeoRemoveInPipelineMode() {
+		String key = "test:pipeline:georemove";
+
+		try {
+			// Setup data
+			connection.geoCommands().geoAdd(key.getBytes(), PALERMO, "Palermo".getBytes());
+			connection.geoCommands().geoAdd(key.getBytes(), CATANIA, "Catania".getBytes());
+			connection.geoCommands().geoAdd(key.getBytes(), ROME, "Rome".getBytes());
+
+			connection.openPipeline();
+
+			// Test geoRemove returns null during pipeline
+			Long result1 = connection.geoCommands().geoRemove(key.getBytes(), "Catania".getBytes());
+			assertThat(result1).isNull(); // Should be null during pipeline
+
+			Long result2 = connection.geoCommands().geoRemove(key.getBytes(), "Palermo".getBytes(), "Rome".getBytes());
+			assertThat(result2).isNull(); // Should be null during pipeline
+
+			List<Object> results = connection.closePipeline();
+
+			// Verify pipeline results
+			assertThat(results).hasSize(2);
+			assertThat(results.get(0)).isEqualTo(1L); // Single removal
+			assertThat(results.get(1)).isEqualTo(2L); // Multiple removal
+
+			// Verify final state - all should be removed
+			List<Point> positions = connection.geoCommands()
+				.geoPos(key.getBytes(), "Palermo".getBytes(), "Catania".getBytes(), "Rome".getBytes());
+			assertThat(positions).hasSize(3);
+			assertThat(positions.get(0)).isNull();
+			assertThat(positions.get(1)).isNull();
+			assertThat(positions.get(2)).isNull();
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testGeoSearchInPipelineMode() {
+		String key = "test:pipeline:geosearch";
+
+		try {
+			// Setup data
+			connection.geoCommands().geoAdd(key.getBytes(), PALERMO, "Palermo".getBytes());
+			connection.geoCommands().geoAdd(key.getBytes(), CATANIA, "Catania".getBytes());
+			connection.geoCommands().geoAdd(key.getBytes(), ROME, "Rome".getBytes());
+
+			connection.openPipeline();
+
+			// Test geoSearch returns null during pipeline
+			GeoReference<byte[]> memberRef = GeoReference.fromMember("Palermo".getBytes());
+			GeoShape radiusShape = GeoShape.byRadius(new Distance(300, DistanceUnit.KILOMETERS));
+			GeoSearchCommandArgs args = GeoSearchCommandArgs.newGeoSearchArgs()
+				.includeDistance()
+				.includeCoordinates()
+				.sortAscending()
+				.limit(10);
+
+			GeoResults<GeoLocation<byte[]>> result = connection.geoCommands()
+				.geoSearch(key.getBytes(), memberRef, radiusShape, args);
+			assertThat(result).isNull(); // Should be null during pipeline
+
+			List<Object> results = connection.closePipeline();
+
+			// Verify pipeline results
+			assertThat(results).hasSize(1);
+			assertThat(results.get(0)).isInstanceOf(GeoResults.class);
+
+			@SuppressWarnings("unchecked")
+			GeoResults<GeoLocation<byte[]>> geoResults = (GeoResults<GeoLocation<byte[]>>) results.get(0);
+			assertThat(geoResults.getContent()).isNotEmpty();
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testGeoSearchStoreInPipelineMode() {
+		String sourceKey = "test:pipeline:geosearchstore:source";
+		String destKey = "test:pipeline:geosearchstore:dest";
+
+		try {
+			// Setup data
+			connection.geoCommands().geoAdd(sourceKey.getBytes(), PALERMO, "Palermo".getBytes());
+			connection.geoCommands().geoAdd(sourceKey.getBytes(), CATANIA, "Catania".getBytes());
+			connection.geoCommands().geoAdd(sourceKey.getBytes(), ROME, "Rome".getBytes());
+
+			connection.openPipeline();
+
+			// Test geoSearchStore returns null during pipeline
+			GeoReference<byte[]> memberRef = GeoReference.fromMember("Palermo".getBytes());
+			GeoShape radiusShape = GeoShape.byRadius(new Distance(300, DistanceUnit.KILOMETERS));
+			GeoSearchStoreCommandArgs args = GeoSearchStoreCommandArgs.newGeoSearchStoreArgs()
+				.sortAscending()
+				.limit(10);
+
+			Long result = connection.geoCommands()
+				.geoSearchStore(destKey.getBytes(), sourceKey.getBytes(), memberRef, radiusShape, args);
+			assertThat(result).isNull(); // Should be null during pipeline
+
+			List<Object> results = connection.closePipeline();
+
+			// Verify pipeline results
+			assertThat(results).hasSize(1);
+			assertThat(results.get(0)).isInstanceOf(Number.class);
+			assertThat(((Number) results.get(0)).longValue()).isGreaterThan(0L);
+
+			// Verify final state - results stored in destination
+			List<Point> storedPositions = connection.geoCommands().geoPos(destKey.getBytes(), "Palermo".getBytes());
+			assertThat(storedPositions.get(0)).isNotNull();
+		}
+		finally {
+			cleanupKey(sourceKey);
+			cleanupKey(destKey);
+		}
+	}
+
+	// ==================== Comprehensive Transaction Mode Tests ====================
+
+	@Test
+	void testAllGeoAddVariantsInTransactionMode() {
+		String key1 = "test:tx:geoadd:single";
+		String key2 = "test:tx:geoadd:map";
+		String key3 = "test:tx:geoadd:iterable";
+
+		try {
+			connection.multi();
+
+			// Test all geoAdd variants return null during transaction
+			Long result1 = connection.geoCommands().geoAdd(key1.getBytes(), PALERMO, "Palermo".getBytes());
+			assertThat(result1).isNull(); // Should be null during transaction
+
+			Map<byte[], Point> memberMap = new HashMap<>();
+			memberMap.put("Rome".getBytes(), ROME);
+			memberMap.put("Milan".getBytes(), new Point(9.1900, 45.4642));
+			Long result2 = connection.geoCommands().geoAdd(key2.getBytes(), memberMap);
+			assertThat(result2).isNull(); // Should be null during transaction
+
+			List<GeoLocation<byte[]>> locations = new ArrayList<>();
+			locations.add(new GeoLocation<>("Venice".getBytes(), new Point(12.3155, 45.4408)));
+			locations.add(new GeoLocation<>("Naples".getBytes(), new Point(14.2681, 40.8518)));
+			Long result3 = connection.geoCommands().geoAdd(key3.getBytes(), locations);
+			assertThat(result3).isNull(); // Should be null during transaction
+
+			List<Object> results = connection.exec();
+
+			// Verify transaction results
+			assertThat(results).hasSize(3);
+			assertThat(results.get(0)).isEqualTo(1L); // Single point add
+			assertThat(results.get(1)).isEqualTo(2L); // Map add
+			assertThat(results.get(2)).isEqualTo(2L); // Iterable add
+
+			// Verify final state
+			List<Point> pos1 = connection.geoCommands().geoPos(key1.getBytes(), "Palermo".getBytes());
+			assertThat(pos1.get(0)).isNotNull();
+
+			List<Point> pos2 = connection.geoCommands().geoPos(key2.getBytes(), "Rome".getBytes(), "Milan".getBytes());
+			assertThat(pos2).hasSize(2);
+			assertThat(pos2.get(0)).isNotNull();
+			assertThat(pos2.get(1)).isNotNull();
+
+			List<Point> pos3 = connection.geoCommands()
+				.geoPos(key3.getBytes(), "Venice".getBytes(), "Naples".getBytes());
+			assertThat(pos3).hasSize(2);
+			assertThat(pos3.get(0)).isNotNull();
+			assertThat(pos3.get(1)).isNotNull();
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+			cleanupKey(key3);
+		}
+	}
+
+	@Test
+	void testGeoDistVariantsInTransactionMode() {
+		String key = "test:tx:geodist";
+
+		try {
+			// Setup data outside transaction
+			connection.geoCommands().geoAdd(key.getBytes(), PALERMO, "Palermo".getBytes());
+			connection.geoCommands().geoAdd(key.getBytes(), CATANIA, "Catania".getBytes());
+			connection.geoCommands().geoAdd(key.getBytes(), ROME, "Rome".getBytes());
+
+			connection.multi();
+
+			// Test both geoDist variants return null during transaction
+			Distance result1 = connection.geoCommands()
+				.geoDist(key.getBytes(), "Palermo".getBytes(), "Catania".getBytes());
+			assertThat(result1).isNull(); // Should be null during transaction
+
+			Distance result2 = connection.geoCommands()
+				.geoDist(key.getBytes(), "Palermo".getBytes(), "Rome".getBytes(), DistanceUnit.KILOMETERS);
+			assertThat(result2).isNull(); // Should be null during transaction
+
+			List<Object> results = connection.exec();
+
+			// Verify transaction results
+			assertThat(results).hasSize(2);
+			assertThat(results.get(0)).isInstanceOf(Distance.class);
+			assertThat(results.get(1)).isInstanceOf(Distance.class);
+
+			Distance dist1 = (Distance) results.get(0);
+			Distance dist2 = (Distance) results.get(1);
+			assertThat(dist1.getValue()).isGreaterThan(0);
+			assertThat(dist2.getValue()).isGreaterThan(0);
+			assertThat(dist1.getMetric()).isEqualTo(DistanceUnit.METERS);
+			assertThat(dist2.getMetric()).isEqualTo(DistanceUnit.KILOMETERS);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testGeoHashAndGeoPosInTransactionMode() {
+		String key = "test:tx:geohashpos";
+
+		try {
+			// Setup data outside transaction
+			connection.geoCommands().geoAdd(key.getBytes(), PALERMO, "Palermo".getBytes());
+			connection.geoCommands().geoAdd(key.getBytes(), CATANIA, "Catania".getBytes());
+			connection.geoCommands().geoAdd(key.getBytes(), ROME, "Rome".getBytes());
+
+			connection.multi();
+
+			// Test geoHash returns null during transaction
+			List<String> hashResult = connection.geoCommands()
+				.geoHash(key.getBytes(), "Palermo".getBytes(), "Catania".getBytes());
+			assertThat(hashResult).isNull(); // Should be null during transaction
+
+			// Test geoPos returns null during transaction
+			List<Point> posResult = connection.geoCommands()
+				.geoPos(key.getBytes(), "Palermo".getBytes(), "Rome".getBytes());
+			assertThat(posResult).isNull(); // Should be null during transaction
+
+			List<Object> results = connection.exec();
+
+			// Verify transaction results
+			assertThat(results).hasSize(2);
+
+			@SuppressWarnings("unchecked")
+			List<String> hashes = (List<String>) results.get(0);
+			assertThat(hashes).hasSize(2);
+			assertThat(hashes.get(0)).isNotNull();
+			assertThat(hashes.get(1)).isNotNull();
+
+			@SuppressWarnings("unchecked")
+			List<Point> positions = (List<Point>) results.get(1);
+			assertThat(positions).hasSize(2);
+			assertThat(positions.get(0)).isNotNull();
+			assertThat(positions.get(1)).isNotNull();
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testGeoRadiusVariantsInTransactionMode() {
+		String key = "test:tx:georadius";
+
+		try {
+			// Setup data outside transaction
+			connection.geoCommands().geoAdd(key.getBytes(), PALERMO, "Palermo".getBytes());
+			connection.geoCommands().geoAdd(key.getBytes(), CATANIA, "Catania".getBytes());
+			connection.geoCommands().geoAdd(key.getBytes(), ROME, "Rome".getBytes());
+
+			connection.multi();
+
+			// Test basic geoRadius returns null during transaction
+			Circle searchArea = new Circle(PALERMO, new Distance(300, DistanceUnit.KILOMETERS));
+			GeoResults<GeoLocation<byte[]>> result1 = connection.geoCommands().geoRadius(key.getBytes(), searchArea);
+			assertThat(result1).isNull(); // Should be null during transaction
+
+			// Test geoRadius with args returns null during transaction
+			GeoRadiusCommandArgs args = GeoRadiusCommandArgs.newGeoRadiusArgs()
+				.includeDistance()
+				.includeCoordinates()
+				.sortAscending()
+				.limit(10);
+			GeoResults<GeoLocation<byte[]>> result2 = connection.geoCommands()
+				.geoRadius(key.getBytes(), searchArea, args);
+			assertThat(result2).isNull(); // Should be null during transaction
+
+			List<Object> results = connection.exec();
+
+			// Verify transaction results
+			assertThat(results).hasSize(2);
+			for (Object result : results) {
+				assertThat(result).isInstanceOf(GeoResults.class);
+				@SuppressWarnings("unchecked")
+				GeoResults<GeoLocation<byte[]>> geoResults = (GeoResults<GeoLocation<byte[]>>) result;
+				assertThat(geoResults.getContent()).isNotEmpty();
+			}
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testGeoRadiusByMemberVariantsInTransactionMode() {
+		String key = "test:tx:georadiusbymember";
+
+		try {
+			// Setup data outside transaction
+			connection.geoCommands().geoAdd(key.getBytes(), PALERMO, "Palermo".getBytes());
+			connection.geoCommands().geoAdd(key.getBytes(), CATANIA, "Catania".getBytes());
+			connection.geoCommands().geoAdd(key.getBytes(), ROME, "Rome".getBytes());
+
+			connection.multi();
+
+			// Test basic geoRadiusByMember returns null during transaction
+			Distance radius = new Distance(300, DistanceUnit.KILOMETERS);
+			GeoResults<GeoLocation<byte[]>> result1 = connection.geoCommands()
+				.geoRadiusByMember(key.getBytes(), "Palermo".getBytes(), radius);
+			assertThat(result1).isNull(); // Should be null during transaction
+
+			// Test geoRadiusByMember with args returns null during transaction
+			GeoRadiusCommandArgs args = GeoRadiusCommandArgs.newGeoRadiusArgs()
+				.includeDistance()
+				.includeCoordinates()
+				.sortDescending()
+				.limit(5);
+			GeoResults<GeoLocation<byte[]>> result2 = connection.geoCommands()
+				.geoRadiusByMember(key.getBytes(), "Rome".getBytes(), radius, args);
+			assertThat(result2).isNull(); // Should be null during transaction
+
+			List<Object> results = connection.exec();
+
+			// Verify transaction results
+			assertThat(results).hasSize(2);
+			for (Object result : results) {
+				assertThat(result).isInstanceOf(GeoResults.class);
+				@SuppressWarnings("unchecked")
+				GeoResults<GeoLocation<byte[]>> geoResults = (GeoResults<GeoLocation<byte[]>>) result;
+				assertThat(geoResults.getContent()).isNotEmpty();
+			}
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== Transaction Mode Tests ====================
+
+	@Test
+	void testGeoRemoveInTransactionMode() {
+		String key = "test:tx:georemove";
+
+		try {
+			// Setup data outside transaction
+			connection.geoCommands().geoAdd(key.getBytes(), PALERMO, "Palermo".getBytes());
+			connection.geoCommands().geoAdd(key.getBytes(), CATANIA, "Catania".getBytes());
+			connection.geoCommands().geoAdd(key.getBytes(), ROME, "Rome".getBytes());
+
+			connection.multi();
+
+			// Test geoRemove returns null during transaction
+			Long result1 = connection.geoCommands().geoRemove(key.getBytes(), "Catania".getBytes());
+			assertThat(result1).isNull(); // Should be null during transaction
+
+			Long result2 = connection.geoCommands().geoRemove(key.getBytes(), "Palermo".getBytes(), "Rome".getBytes());
+			assertThat(result2).isNull(); // Should be null during transaction
+
+			List<Object> results = connection.exec();
+
+			// Verify transaction results
+			assertThat(results).hasSize(2);
+			assertThat(results.get(0)).isEqualTo(1L); // Single removal
+			assertThat(results.get(1)).isEqualTo(2L); // Multiple removal
+
+			// Verify final state - all should be removed
+			List<Point> positions = connection.geoCommands()
+				.geoPos(key.getBytes(), "Palermo".getBytes(), "Catania".getBytes(), "Rome".getBytes());
+			assertThat(positions).hasSize(3);
+			assertThat(positions.get(0)).isNull();
+			assertThat(positions.get(1)).isNull();
+			assertThat(positions.get(2)).isNull();
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testGeoSearchInTransactionMode() {
+		String key = "test:tx:geosearch";
+
+		try {
+			// Setup data outside transaction
+			connection.geoCommands().geoAdd(key.getBytes(), PALERMO, "Palermo".getBytes());
+			connection.geoCommands().geoAdd(key.getBytes(), CATANIA, "Catania".getBytes());
+			connection.geoCommands().geoAdd(key.getBytes(), ROME, "Rome".getBytes());
+
+			connection.multi();
+
+			// Test geoSearch returns null during transaction
+			GeoReference<byte[]> memberRef = GeoReference.fromMember("Palermo".getBytes());
+			GeoShape radiusShape = GeoShape.byRadius(new Distance(300, DistanceUnit.KILOMETERS));
+			GeoSearchCommandArgs args = GeoSearchCommandArgs.newGeoSearchArgs()
+				.includeDistance()
+				.includeCoordinates()
+				.sortAscending()
+				.limit(10);
+
+			GeoResults<GeoLocation<byte[]>> result = connection.geoCommands()
+				.geoSearch(key.getBytes(), memberRef, radiusShape, args);
+			assertThat(result).isNull(); // Should be null during transaction
+
+			List<Object> results = connection.exec();
+
+			// Verify transaction results
+			assertThat(results).hasSize(1);
+			assertThat(results.get(0)).isInstanceOf(GeoResults.class);
+
+			@SuppressWarnings("unchecked")
+			GeoResults<GeoLocation<byte[]>> geoResults = (GeoResults<GeoLocation<byte[]>>) results.get(0);
+			assertThat(geoResults.getContent()).isNotEmpty();
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testGeoSearchStoreInTransactionMode() {
+		String sourceKey = "test:tx:geosearchstore:source";
+		String destKey = "test:tx:geosearchstore:dest";
+
+		try {
+			// Setup data outside transaction
+			connection.geoCommands().geoAdd(sourceKey.getBytes(), PALERMO, "Palermo".getBytes());
+			connection.geoCommands().geoAdd(sourceKey.getBytes(), CATANIA, "Catania".getBytes());
+			connection.geoCommands().geoAdd(sourceKey.getBytes(), ROME, "Rome".getBytes());
+
+			connection.multi();
+
+			// Test geoSearchStore returns null during transaction
+			GeoReference<byte[]> memberRef = GeoReference.fromMember("Palermo".getBytes());
+			GeoShape radiusShape = GeoShape.byRadius(new Distance(300, DistanceUnit.KILOMETERS));
+			GeoSearchStoreCommandArgs args = GeoSearchStoreCommandArgs.newGeoSearchStoreArgs()
+				.sortAscending()
+				.limit(10);
+
+			Long result = connection.geoCommands()
+				.geoSearchStore(destKey.getBytes(), sourceKey.getBytes(), memberRef, radiusShape, args);
+			assertThat(result).isNull(); // Should be null during transaction
+
+			List<Object> results = connection.exec();
+
+			// Verify transaction results
+			assertThat(results).hasSize(1);
+			assertThat(results.get(0)).isInstanceOf(Number.class);
+			assertThat(((Number) results.get(0)).longValue()).isGreaterThan(0L);
+
+			// Verify final state - results stored in destination
+			List<Point> storedPositions = connection.geoCommands().geoPos(destKey.getBytes(), "Palermo".getBytes());
+			assertThat(storedPositions.get(0)).isNotNull();
+		}
+		finally {
+			cleanupKey(sourceKey);
+			cleanupKey(destKey);
+		}
+	}
+
+	@Test
+	void testGeoOperationsInPipelineMode() {
+		String key1 = "test:pipeline:geo1";
+		String key2 = "test:pipeline:geo2";
+		String key3 = "test:pipeline:geo3";
+
+		try {
+			// Set up initial data
+			connection.geoCommands().geoAdd(key1.getBytes(), PALERMO, "Palermo".getBytes());
+			connection.geoCommands().geoAdd(key1.getBytes(), CATANIA, "Catania".getBytes());
+
+			// Open pipeline
+			connection.openPipeline();
+
+			// Queue several geo operations
+			connection.geoCommands().geoAdd(key2.getBytes(), ROME, "Rome".getBytes());
+			connection.geoCommands().geoAdd(key2.getBytes(), NEW_YORK, "NewYork".getBytes());
+			connection.geoCommands()
+				.geoDist(key1.getBytes(), "Palermo".getBytes(), "Catania".getBytes(), DistanceUnit.KILOMETERS);
+			connection.geoCommands().geoPos(key1.getBytes(), "Palermo".getBytes(), "Catania".getBytes());
+			connection.geoCommands().geoHash(key1.getBytes(), "Palermo".getBytes());
+			connection.geoCommands().geoRemove(key2.getBytes(), "NewYork".getBytes());
+
+			// Execute pipeline
+			List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(6);
+			assertThat(results.get(0)).isEqualTo(1L); // GEOADD result
+			assertThat(results.get(1)).isEqualTo(1L); // GEOADD result
+
+			// GEODIST result should be a Distance object or converted value
+			assertThat(results.get(2)).isNotNull(); // GEODIST result
+
+			// GEOPOS result should be a list of Points
+			@SuppressWarnings("unchecked")
+			List<Point> posResults = (List<Point>) results.get(3);
+			assertThat(posResults).hasSize(2);
+			assertThat(posResults.get(0)).isNotNull();
+			assertThat(posResults.get(1)).isNotNull();
+
+			// GEOHASH result should be a list of strings
+			@SuppressWarnings("unchecked")
+			List<String> hashResults = (List<String>) results.get(4);
+			assertThat(hashResults).hasSize(1);
+			assertThat(hashResults.get(0)).isNotNull();
+
+			assertThat(results.get(5)).isEqualTo(1L); // ZREM result
+
+			// Verify final state outside pipeline
+			List<Point> finalPos = connection.geoCommands().geoPos(key1.getBytes(), "Palermo".getBytes());
+			assertThat(finalPos.get(0)).isNotNull();
+
+			List<Point> removedPos = connection.geoCommands().geoPos(key2.getBytes(), "NewYork".getBytes());
+			assertThat(removedPos.get(0)).isNull(); // Should be removed
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+			cleanupKey(key3);
+		}
+	}
+
+	@Test
+	void testGeoSearchOperationsInPipelineMode() {
+		String key = "test:pipeline:geosearch";
+		String destKey = "test:pipeline:geodest";
+
+		try {
+			// Set up initial data
+			Map<byte[], Point> memberCoordinateMap = new HashMap<>();
+			memberCoordinateMap.put("Palermo".getBytes(), PALERMO);
+			memberCoordinateMap.put("Catania".getBytes(), CATANIA);
+			memberCoordinateMap.put("Rome".getBytes(), ROME);
+			connection.geoCommands().geoAdd(key.getBytes(), memberCoordinateMap);
+
+			connection.openPipeline();
+
+			// Test various geo search operations
+			Circle searchArea = new Circle(PALERMO, new Distance(300, DistanceUnit.KILOMETERS));
+			connection.geoCommands().geoRadius(key.getBytes(), searchArea);
+
+			Distance radius = new Distance(300, DistanceUnit.KILOMETERS);
+			connection.geoCommands().geoRadiusByMember(key.getBytes(), "Palermo".getBytes(), radius);
+
+			// Test geoSearch if available
+			GeoReference<byte[]> memberRef = GeoReference.fromMember("Palermo".getBytes());
+			GeoShape radiusShape = GeoShape.byRadius(new Distance(300, DistanceUnit.KILOMETERS));
+			GeoSearchCommandArgs args = GeoSearchCommandArgs.newGeoSearchArgs().limit(10);
+			connection.geoCommands().geoSearch(key.getBytes(), memberRef, radiusShape, args);
+
+			List<Object> results = connection.closePipeline();
+
+			assertThat(results).hasSize(3);
+
+			// All results should be GeoResults objects
+			for (Object result : results) {
+				if (result != null) {
+					assertThat(result).isInstanceOf(GeoResults.class);
+					@SuppressWarnings("unchecked")
+					GeoResults<GeoLocation<byte[]>> geoResults = (GeoResults<GeoLocation<byte[]>>) result;
+					assertThat(geoResults.getContent()).isNotEmpty();
+				}
+			}
+		}
+		finally {
+			cleanupKey(key);
+			cleanupKey(destKey);
+		}
+	}
+
+	@Test
+	void testMixedGeoOperationsInPipelineMode() {
+		String baseKey = "test:pipeline:mixed";
+
+		try {
+			connection.openPipeline();
+
+			// Mix of different geo operations
+			connection.geoCommands().geoAdd((baseKey + ":1").getBytes(), PALERMO, "Palermo".getBytes());
+			connection.geoCommands().geoAdd((baseKey + ":1").getBytes(), CATANIA, "Catania".getBytes());
+			connection.geoCommands().geoPos((baseKey + ":1").getBytes(), "Palermo".getBytes());
+			connection.geoCommands().geoHash((baseKey + ":1").getBytes(), "Palermo".getBytes(), "Catania".getBytes());
+			connection.geoCommands().geoDist((baseKey + ":1").getBytes(), "Palermo".getBytes(), "Catania".getBytes());
+
+			List<Object> results = connection.closePipeline();
+
+			assertThat(results).hasSize(5);
+			assertThat(results.get(0)).isEqualTo(1L); // GEOADD
+			assertThat(results.get(1)).isEqualTo(1L); // GEOADD
+
+			@SuppressWarnings("unchecked")
+			List<Point> posResult = (List<Point>) results.get(2);
+			assertThat(posResult).hasSize(1);
+			assertThat(posResult.get(0)).isNotNull();
+
+			@SuppressWarnings("unchecked")
+			List<String> hashResult = (List<String>) results.get(3);
+			assertThat(hashResult).hasSize(2);
+			assertThat(hashResult.get(0)).isNotNull();
+			assertThat(hashResult.get(1)).isNotNull();
+
+			assertThat(results.get(4)).isNotNull(); // GEODIST
+
+			// Verify final state
+			List<Point> finalPositions = connection.geoCommands()
+				.geoPos((baseKey + ":1").getBytes(), "Palermo".getBytes(), "Catania".getBytes());
+			assertThat(finalPositions).hasSize(2);
+			assertThat(finalPositions.get(0)).isNotNull();
+			assertThat(finalPositions.get(1)).isNotNull();
+		}
+		finally {
+			cleanupKey(baseKey + ":1");
+		}
+	}
+
+	// ==================== Transaction Mode Tests ====================
+
+	@Test
+	void testGeoOperationsInTransactionMode() {
+		String key1 = "test:tx:geo1";
+		String key2 = "test:tx:geo2";
+
+		try {
+			// Start transaction
+			connection.multi();
+
+			// Queue several geo operations
+			connection.geoCommands().geoAdd(key1.getBytes(), PALERMO, "Palermo".getBytes());
+			connection.geoCommands().geoAdd(key1.getBytes(), CATANIA, "Catania".getBytes());
+			connection.geoCommands().geoAdd(key2.getBytes(), ROME, "Rome".getBytes());
+			connection.geoCommands().geoPos(key1.getBytes(), "Palermo".getBytes());
+			connection.geoCommands().geoDist(key1.getBytes(), "Palermo".getBytes(), "Catania".getBytes());
+
+			// Execute transaction
+			List<Object> results = connection.exec();
+
+			// Verify results
+			assertThat(results).hasSize(5);
+			assertThat(results.get(0)).isEqualTo(1L); // GEOADD result
+			assertThat(results.get(1)).isEqualTo(1L); // GEOADD result
+			assertThat(results.get(2)).isEqualTo(1L); // GEOADD result
+
+			@SuppressWarnings("unchecked")
+			List<Point> posResult = (List<Point>) results.get(3);
+			assertThat(posResult).hasSize(1);
+			assertThat(posResult.get(0)).isNotNull();
+
+			assertThat(results.get(4)).isNotNull(); // GEODIST result
+
+			// Verify final state outside transaction
+			List<Point> finalPos1 = connection.geoCommands()
+				.geoPos(key1.getBytes(), "Palermo".getBytes(), "Catania".getBytes());
+			assertThat(finalPos1).hasSize(2);
+			assertThat(finalPos1.get(0)).isNotNull();
+			assertThat(finalPos1.get(1)).isNotNull();
+
+			List<Point> finalPos2 = connection.geoCommands().geoPos(key2.getBytes(), "Rome".getBytes());
+			assertThat(finalPos2).hasSize(1);
+			assertThat(finalPos2.get(0)).isNotNull();
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+		}
+	}
+
+	@Test
+	void testGeoSearchOperationsInTransactionMode() {
+		String key = "test:tx:geosearch";
+		String destKey = "test:tx:geodest";
+
+		try {
+			// Set up initial data outside transaction
+			Map<byte[], Point> memberCoordinateMap = new HashMap<>();
+			memberCoordinateMap.put("Palermo".getBytes(), PALERMO);
+			memberCoordinateMap.put("Catania".getBytes(), CATANIA);
+			memberCoordinateMap.put("Rome".getBytes(), ROME);
+			connection.geoCommands().geoAdd(key.getBytes(), memberCoordinateMap);
+
+			connection.multi();
+
+			// Test geo search operations in transaction
+			Circle searchArea = new Circle(PALERMO, new Distance(300, DistanceUnit.KILOMETERS));
+			GeoRadiusCommandArgs radiusArgs = GeoRadiusCommandArgs.newGeoRadiusArgs().limit(10);
+			connection.geoCommands().geoRadius(key.getBytes(), searchArea, radiusArgs);
+
+			Distance radius = new Distance(300, DistanceUnit.KILOMETERS);
+			connection.geoCommands().geoRadiusByMember(key.getBytes(), "Palermo".getBytes(), radius, radiusArgs);
+
+			// Test geoSearchStore if available
+			GeoReference<byte[]> memberRef = GeoReference.fromMember("Palermo".getBytes());
+			GeoShape radiusShape = GeoShape.byRadius(new Distance(300, DistanceUnit.KILOMETERS));
+			GeoSearchStoreCommandArgs storeArgs = GeoSearchStoreCommandArgs.newGeoSearchStoreArgs().limit(10);
+			connection.geoCommands()
+				.geoSearchStore(destKey.getBytes(), key.getBytes(), memberRef, radiusShape, storeArgs);
+
+			List<Object> results = connection.exec();
+
+			assertThat(results).hasSize(3);
+
+			// First two should be GeoResults
+			for (int i = 0; i < 2; i++) {
+				if (results.get(i) != null) {
+					assertThat(results.get(i)).isInstanceOf(GeoResults.class);
+					@SuppressWarnings("unchecked")
+					GeoResults<GeoLocation<byte[]>> geoResults = (GeoResults<GeoLocation<byte[]>>) results.get(i);
+					assertThat(geoResults.getContent()).isNotEmpty();
+				}
+			}
+
+			// Third should be count of stored results
+			assertThat(results.get(2)).isInstanceOf(Number.class);
+			assertThat(((Number) results.get(2)).longValue()).isGreaterThan(0L);
+
+			// Verify stored results exist
+			List<Point> storedPos = connection.geoCommands().geoPos(destKey.getBytes(), "Palermo".getBytes());
+			assertThat(storedPos.get(0)).isNotNull();
+		}
+		finally {
+			cleanupKey(key);
+			cleanupKey(destKey);
+		}
+	}
+
+	@Test
+	void testTransactionWithWatchedGeoKeys() {
+		String watchedKey = "test:tx:geo:watched";
+		String valueKey = "test:tx:geo:value";
+
+		try {
+			// Set initial geo data
+			connection.geoCommands().geoAdd(watchedKey.getBytes(), PALERMO, "Palermo".getBytes());
+
+			// Watch the key
+			connection.watch(watchedKey.getBytes());
+
+			// Start transaction
+			connection.multi();
+			connection.geoCommands().geoAdd(valueKey.getBytes(), CATANIA, "Catania".getBytes());
+
+			// Execute transaction (should succeed since key wasn't modified)
+			List<Object> results = connection.exec();
+
+			assertThat(results).hasSize(1);
+			assertThat(results.get(0)).isEqualTo(1L);
+
+			// Verify the conditional add worked
+			List<Point> positions = connection.geoCommands().geoPos(valueKey.getBytes(), "Catania".getBytes());
+			assertThat(positions.get(0)).isNotNull();
+		}
+		finally {
+			cleanupKey(watchedKey);
+			cleanupKey(valueKey);
+		}
+	}
+
+	@Test
+	void testMixedGeoOperationsInTransaction() {
+		String baseKey = "test:tx:geo:mixed";
+
+		try {
+			connection.multi();
+
+			// Mix of different geo operations
+			connection.geoCommands().geoAdd((baseKey + ":1").getBytes(), PALERMO, "Palermo".getBytes());
+			connection.geoCommands().geoAdd((baseKey + ":1").getBytes(), CATANIA, "Catania".getBytes());
+			connection.geoCommands().geoAdd((baseKey + ":2").getBytes(), ROME, "Rome".getBytes());
+			connection.geoCommands().geoPos((baseKey + ":1").getBytes(), "Palermo".getBytes(), "Catania".getBytes());
+			connection.geoCommands().geoHash((baseKey + ":1").getBytes(), "Palermo".getBytes());
+			connection.geoCommands()
+				.geoDist((baseKey + ":1").getBytes(), "Palermo".getBytes(), "Catania".getBytes(),
+						DistanceUnit.KILOMETERS);
+			connection.geoCommands().geoRemove((baseKey + ":2").getBytes(), "Rome".getBytes());
+
+			List<Object> results = connection.exec();
+
+			assertThat(results).hasSize(7);
+			assertThat(results.get(0)).isEqualTo(1L); // GEOADD
+			assertThat(results.get(1)).isEqualTo(1L); // GEOADD
+			assertThat(results.get(2)).isEqualTo(1L); // GEOADD
+
+			@SuppressWarnings("unchecked")
+			List<Point> posResults = (List<Point>) results.get(3);
+			assertThat(posResults).hasSize(2);
+			assertThat(posResults.get(0)).isNotNull();
+			assertThat(posResults.get(1)).isNotNull();
+
+			@SuppressWarnings("unchecked")
+			List<String> hashResults = (List<String>) results.get(4);
+			assertThat(hashResults).hasSize(1);
+			assertThat(hashResults.get(0)).isNotNull();
+
+			assertThat(results.get(5)).isNotNull(); // GEODIST
+			assertThat(results.get(6)).isEqualTo(1L); // ZREM
+
+			// Verify final state
+			List<Point> finalPos1 = connection.geoCommands()
+				.geoPos((baseKey + ":1").getBytes(), "Palermo".getBytes(), "Catania".getBytes());
+			assertThat(finalPos1).hasSize(2);
+			assertThat(finalPos1.get(0)).isNotNull();
+			assertThat(finalPos1.get(1)).isNotNull();
+
+			// Verify removal worked
+			List<Point> finalPos2 = connection.geoCommands().geoPos((baseKey + ":2").getBytes(), "Rome".getBytes());
+			assertThat(finalPos2.get(0)).isNull(); // Should be removed
+		}
+		finally {
+			cleanupKey(baseKey + ":1");
+			cleanupKey(baseKey + ":2");
+		}
+	}
+
+	@Test
+	void testGeoOperationsWithComplexTransactionScenario() {
+		String sourceKey = "test:tx:geo:source";
+		String targetKey = "test:tx:geo:target";
+		String logKey = "test:tx:geo:log";
+
+		try {
+			connection.multi();
+
+			// Complex scenario: Add locations, perform searches, store results
+			Map<byte[], Point> locations = new HashMap<>();
+			locations.put("Milan".getBytes(), new Point(9.1900, 45.4642));
+			locations.put("Naples".getBytes(), new Point(14.2681, 40.8518));
+			locations.put("Venice".getBytes(), new Point(12.3155, 45.4408));
+			connection.geoCommands().geoAdd(sourceKey.getBytes(), locations);
+
+			// Search and store nearby locations
+			GeoReference<byte[]> milanRef = GeoReference.fromMember("Milan".getBytes());
+			GeoShape searchArea = GeoShape.byRadius(new Distance(500, DistanceUnit.KILOMETERS));
+			GeoSearchStoreCommandArgs storeArgs = GeoSearchStoreCommandArgs.newGeoSearchStoreArgs().limit(10);
+			connection.geoCommands()
+				.geoSearchStore(targetKey.getBytes(), sourceKey.getBytes(), milanRef, searchArea, storeArgs);
+
+			// Log the operation (using a simple key-value)
+			connection.stringCommands().set(logKey.getBytes(), "geo_search_completed".getBytes());
+
+			List<Object> results = connection.exec();
+
+			assertThat(results).hasSize(3);
+			assertThat(results.get(0)).isEqualTo(3L); // GEOADD count
+			assertThat(((Number) results.get(1)).longValue()).isGreaterThan(0L); // GEOSEARCHSTORE
+																					// count
+			assertThat(results.get(2)).isEqualTo(true); // SET result
+
+			// Verify all operations completed successfully
+			List<Point> sourcePositions = connection.geoCommands()
+				.geoPos(sourceKey.getBytes(), "Milan".getBytes(), "Naples".getBytes(), "Venice".getBytes());
+			assertThat(sourcePositions).hasSize(3);
+			assertThat(sourcePositions.get(0)).isNotNull();
+			assertThat(sourcePositions.get(1)).isNotNull();
+			assertThat(sourcePositions.get(2)).isNotNull();
+
+			List<Point> targetPositions = connection.geoCommands().geoPos(targetKey.getBytes(), "Milan".getBytes());
+			assertThat(targetPositions.get(0)).isNotNull();
+
+			assertThat(connection.stringCommands().get(logKey.getBytes())).isEqualTo("geo_search_completed".getBytes());
+		}
+		finally {
+			cleanupKey(sourceKey);
+			cleanupKey(targetKey);
+			cleanupKey(logKey);
+		}
+	}
+
 }

--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionHashCommandsIntegrationTests.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionHashCommandsIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,1937 +34,2012 @@ import io.valkey.springframework.data.valkey.core.Cursor;
 import io.valkey.springframework.data.valkey.core.ScanOptions;
 
 /**
- * Comprehensive low-level integration tests for {@link ValkeyGlideConnection} 
- * hash functionality using the ValkeyHashCommands interface directly.
- * 
- * These tests validate the implementation of all ValkeyHashCommands methods:
- * - Basic hash operations (hSet, hSetNX, hGet, hMGet, hMSet)
- * - Increment/decrement operations (hIncrBy for long and double)
- * - Existence and deletion operations (hExists, hDel)
- * - Structural operations (hLen, hKeys, hVals, hGetAll)
- * - Random field operations (hRandField variants)
- * - Scanning operations (hScan)
- * - Field length operations (hStrLen)
- * - Field expiration operations (hExpire, hpExpire, hExpireAt, hpExpireAt, hPersist, hTtl, hpTtl)
+ * Comprehensive low-level integration tests for {@link ValkeyGlideConnection} hash
+ * functionality using the ValkeyHashCommands interface directly.
+ *
+ * These tests validate the implementation of all ValkeyHashCommands methods: - Basic hash
+ * operations (hSet, hSetNX, hGet, hMGet, hMSet) - Increment/decrement operations (hIncrBy
+ * for long and double) - Existence and deletion operations (hExists, hDel) - Structural
+ * operations (hLen, hKeys, hVals, hGetAll) - Random field operations (hRandField
+ * variants) - Scanning operations (hScan) - Field length operations (hStrLen) - Field
+ * expiration operations (hExpire, hpExpire, hExpireAt, hpExpireAt, hPersist, hTtl, hpTtl)
  *
  * @author Ilia Kolominsky
  * @since 2.0
  */
 public class ValkeyGlideConnectionHashCommandsIntegrationTests extends AbstractValkeyGlideIntegrationTests {
 
-    @Override
-    protected String[] getTestKeyPatterns() {
-        return new String[]{
-            "test:hash:basic", "test:hash:setnx", "test:hash:multi", "test:hash:incr",
-            "test:hash:exists", "test:hash:structure", "test:hash:random", "test:hash:randomwithvals",
-            "test:hash:scan", "test:hash:strlen", "test:hash:expire", "test:hash:expireat",
-            "test:hash:persist", "test:hash:ttl", "test:hash:error:string", "test:hash:empty",
-            "test:hash:binary", "non:existent:key",
-            "test:hash:hgetdel", "test:hash:hgetex", "test:hash:hsetex",
-            "test:hash:hsetex:nx", "test:hash:hsetex:nxfail"
-        };
-    }
-
-    // ==================== Basic Hash Operations ====================
-
-    @Test
-    void testHSetAndHGet() {
-        String key = "test:hash:basic";
-        byte[] keyBytes = key.getBytes();
-        byte[] field1 = "field1".getBytes();
-        byte[] field2 = "field2".getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        
-        try {
-            // Test hSet on new field
-            Boolean setResult1 = connection.hashCommands().hSet(keyBytes, field1, value1);
-            assertThat(setResult1).isTrue();
-            
-            // Test hGet
-            byte[] retrievedValue1 = connection.hashCommands().hGet(keyBytes, field1);
-            assertThat(retrievedValue1).isEqualTo(value1);
-            
-            // Test hSet on existing field (should update)
-            Boolean setResult2 = connection.hashCommands().hSet(keyBytes, field1, value2);
-            assertThat(setResult2).isFalse(); // Field already existed
-            
-            // Verify updated value
-            byte[] retrievedValue2 = connection.hashCommands().hGet(keyBytes, field1);
-            assertThat(retrievedValue2).isEqualTo(value2);
-            
-            // Test hGet on non-existent field
-            byte[] nonExistentValue = connection.hashCommands().hGet(keyBytes, field2);
-            assertThat(nonExistentValue).isNull();
-            
-            // Test hGet on non-existent key
-            byte[] nonExistentKeyValue = connection.hashCommands().hGet("non:existent:key".getBytes(), field1);
-            assertThat(nonExistentKeyValue).isNull();
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    @Test
-    void testHSetNX() {
-        String key = "test:hash:setnx";
-        byte[] keyBytes = key.getBytes();
-        byte[] field = "field".getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        
-        try {
-            // Test hSetNX on new field
-            Boolean setNXResult1 = connection.hashCommands().hSetNX(keyBytes, field, value1);
-            assertThat(setNXResult1).isTrue();
-            
-            // Verify value was set
-            byte[] retrievedValue1 = connection.hashCommands().hGet(keyBytes, field);
-            assertThat(retrievedValue1).isEqualTo(value1);
-            
-            // Test hSetNX on existing field - should fail
-            Boolean setNXResult2 = connection.hashCommands().hSetNX(keyBytes, field, value2);
-            assertThat(setNXResult2).isFalse();
-            
-            // Verify value was not changed
-            byte[] retrievedValue2 = connection.hashCommands().hGet(keyBytes, field);
-            assertThat(retrievedValue2).isEqualTo(value1);
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    @Test
-    void testHMGetAndHMSet() {
-        String key = "test:hash:multi";
-        byte[] keyBytes = key.getBytes();
-        byte[] field1 = "field1".getBytes();
-        byte[] field2 = "field2".getBytes();
-        byte[] field3 = "field3".getBytes();
-        byte[] field4 = "nonexistent".getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        byte[] value3 = "value3".getBytes();
-        
-        try {
-            // Set up test data using hMSet
-            Map<byte[], byte[]> hashData = new HashMap<>();
-            hashData.put(field1, value1);
-            hashData.put(field2, value2);
-            hashData.put(field3, value3);
-            
-            connection.hashCommands().hMSet(keyBytes, hashData);
-            
-            // Test hMGet with existing and non-existing fields
-            List<byte[]> values = connection.hashCommands().hMGet(keyBytes, field1, field2, field3, field4);
-            
-            assertThat(values).hasSize(4);
-            assertThat(values.get(0)).isEqualTo(value1);
-            assertThat(values.get(1)).isEqualTo(value2);
-            assertThat(values.get(2)).isEqualTo(value3);
-            assertThat(values.get(3)).isNull(); // non-existent field
-            
-            // Test hMGet on non-existent key
-            List<byte[]> nonExistentValues = connection.hashCommands().hMGet("non:existent:key".getBytes(), field1);
-            assertThat(nonExistentValues).hasSize(1);
-            assertThat(nonExistentValues.get(0)).isNull();
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    // ==================== Increment Operations ====================
-
-    @Test
-    void testHIncrBy() {
-        String key = "test:hash:incr";
-        byte[] keyBytes = key.getBytes();
-        byte[] intField = "intField".getBytes();
-        byte[] floatField = "floatField".getBytes();
-        
-        try {
-            // Test hIncrBy with long on non-existent field (should start from 0)
-            Long incrResult1 = connection.hashCommands().hIncrBy(keyBytes, intField, 5L);
-            assertThat(incrResult1).isEqualTo(5L);
-            
-            // Test subsequent increment
-            Long incrResult2 = connection.hashCommands().hIncrBy(keyBytes, intField, 10L);
-            assertThat(incrResult2).isEqualTo(15L);
-            
-            // Test negative increment (decrement)
-            Long incrResult3 = connection.hashCommands().hIncrBy(keyBytes, intField, -7L);
-            assertThat(incrResult3).isEqualTo(8L);
-            
-            // Test hIncrBy with double on non-existent field
-            Double floatIncrResult1 = connection.hashCommands().hIncrBy(keyBytes, floatField, 3.14);
-            assertThat(floatIncrResult1).isEqualTo(3.14);
-            
-            // Test subsequent float increment
-            Double floatIncrResult2 = connection.hashCommands().hIncrBy(keyBytes, floatField, 2.86);
-            assertThat(floatIncrResult2).isEqualTo(6.0);
-            
-            // Test negative float increment
-            Double floatIncrResult3 = connection.hashCommands().hIncrBy(keyBytes, floatField, -1.5);
-            assertThat(floatIncrResult3).isEqualTo(4.5);
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    // ==================== Existence and Deletion Operations ====================
-
-    @Test
-    void testHExistsAndHDel() {
-        String key = "test:hash:exists";
-        byte[] keyBytes = key.getBytes();
-        byte[] field1 = "field1".getBytes();
-        byte[] field2 = "field2".getBytes();
-        byte[] field3 = "field3".getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        byte[] value3 = "value3".getBytes();
-        
-        try {
-            // Set up test data
-            connection.hashCommands().hSet(keyBytes, field1, value1);
-            connection.hashCommands().hSet(keyBytes, field2, value2);
-            connection.hashCommands().hSet(keyBytes, field3, value3);
-            
-            // Test hExists on existing fields
-            Boolean exists1 = connection.hashCommands().hExists(keyBytes, field1);
-            assertThat(exists1).isTrue();
-            
-            Boolean exists2 = connection.hashCommands().hExists(keyBytes, field2);
-            assertThat(exists2).isTrue();
-            
-            // Test hExists on non-existent field
-            Boolean existsNon = connection.hashCommands().hExists(keyBytes, "nonexistent".getBytes());
-            assertThat(existsNon).isFalse();
-            
-            // Test hExists on non-existent key
-            Boolean existsNonKey = connection.hashCommands().hExists("non:existent:key".getBytes(), field1);
-            assertThat(existsNonKey).isFalse();
-            
-            // Test hDel with single field
-            Long delResult1 = connection.hashCommands().hDel(keyBytes, field1);
-            assertThat(delResult1).isEqualTo(1L);
-            
-            // Verify field was deleted
-            Boolean existsAfterDel = connection.hashCommands().hExists(keyBytes, field1);
-            assertThat(existsAfterDel).isFalse();
-            
-            // Test hDel with multiple fields
-            Long delResult2 = connection.hashCommands().hDel(keyBytes, field2, field3);
-            assertThat(delResult2).isEqualTo(2L);
-            
-            // Test hDel on non-existent field
-            Long delResult3 = connection.hashCommands().hDel(keyBytes, "nonexistent".getBytes());
-            assertThat(delResult3).isEqualTo(0L);
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    // ==================== Structural Operations ====================
-
-    @Test
-    void testHLenHKeysHValsHGetAll() {
-        String key = "test:hash:structure";
-        byte[] keyBytes = key.getBytes();
-        byte[] field1 = "field1".getBytes();
-        byte[] field2 = "field2".getBytes();
-        byte[] field3 = "field3".getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        byte[] value3 = "value3".getBytes();
-        
-        try {
-            // Test on empty/non-existent hash
-            Long emptyLen = connection.hashCommands().hLen(keyBytes);
-            assertThat(emptyLen).isEqualTo(0L);
-            
-            Set<byte[]> emptyKeys = connection.hashCommands().hKeys(keyBytes);
-            assertThat(emptyKeys).isEmpty();
-            
-            List<byte[]> emptyVals = connection.hashCommands().hVals(keyBytes);
-            assertThat(emptyVals).isEmpty();
-            
-            Map<byte[], byte[]> emptyAll = connection.hashCommands().hGetAll(keyBytes);
-            assertThat(emptyAll).isEmpty();
-            
-            // Set up test data
-            Map<byte[], byte[]> hashData = new HashMap<>();
-            hashData.put(field1, value1);
-            hashData.put(field2, value2);
-            hashData.put(field3, value3);
-            connection.hashCommands().hMSet(keyBytes, hashData);
-            
-            // Test hLen
-            Long len = connection.hashCommands().hLen(keyBytes);
-            assertThat(len).isEqualTo(3L);
-            
-            // Test hKeys
-            Set<byte[]> keys = connection.hashCommands().hKeys(keyBytes);
-            assertThat(keys).hasSize(3);
-            assertThat(keys).containsExactlyInAnyOrder(field1, field2, field3);
-            
-            // Test hVals
-            List<byte[]> vals = connection.hashCommands().hVals(keyBytes);
-            assertThat(vals).hasSize(3);
-            assertThat(vals).containsExactlyInAnyOrder(value1, value2, value3);
-            
-            // Test hGetAll
-            Map<byte[], byte[]> all = connection.hashCommands().hGetAll(keyBytes);
-            assertThat(all).hasSize(3);
-
-            // Since byte arrays are compared by reference, not content, we need to check the content differently
-            boolean foundField1 = false, foundField2 = false, foundField3 = false;
-            for (Map.Entry<byte[], byte[]> entry : all.entrySet()) {
-                if (java.util.Arrays.equals(entry.getKey(), field1)) {
-                    assertThat(entry.getValue()).isEqualTo(value1);
-                    foundField1 = true;
-                } else if (java.util.Arrays.equals(entry.getKey(), field2)) {
-                    assertThat(entry.getValue()).isEqualTo(value2);
-                    foundField2 = true;
-                } else if (java.util.Arrays.equals(entry.getKey(), field3)) {
-                    assertThat(entry.getValue()).isEqualTo(value3);
-                    foundField3 = true;
-                }
-            }
-            assertThat(foundField1).as("field1 should be present in hGetAll result").isTrue();
-            assertThat(foundField2).as("field2 should be present in hGetAll result").isTrue();
-            assertThat(foundField3).as("field3 should be present in hGetAll result").isTrue();
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    // ==================== Random Field Operations ====================
-
-    @Test
-    void testHRandField() {
-        String key = "test:hash:random";
-        byte[] keyBytes = key.getBytes();
-        byte[] field1 = "field1".getBytes();
-        byte[] field2 = "field2".getBytes();
-        byte[] field3 = "field3".getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        byte[] value3 = "value3".getBytes();
-        
-        try {
-            // Test on non-existent key
-            byte[] nonExistentField = connection.hashCommands().hRandField("non:existent:key".getBytes());
-            assertThat(nonExistentField).isNull();
-            
-            // Set up test data
-            Map<byte[], byte[]> hashData = new HashMap<>();
-            hashData.put(field1, value1);
-            hashData.put(field2, value2);
-            hashData.put(field3, value3);
-            connection.hashCommands().hMSet(keyBytes, hashData);
-            
-            // Test hRandField (single field)
-            byte[] randomField = connection.hashCommands().hRandField(keyBytes);
-            assertThat(randomField).isIn(field1, field2, field3);
-            
-            // Test hRandField with count
-            List<byte[]> randomFields = connection.hashCommands().hRandField(keyBytes, 2);
-            assertThat(randomFields).hasSize(2);
-            
-            // Test hRandField with count larger than hash size
-            List<byte[]> allFields = connection.hashCommands().hRandField(keyBytes, 5);
-            assertThat(allFields).hasSize(3); // Should return all available fields
-            
-            // Test hRandField with negative count (allows repetitions)
-            List<byte[]> repeatedFields = connection.hashCommands().hRandField(keyBytes, -5);
-            assertThat(repeatedFields).hasSize(5); // Should return exactly 5 elements (may repeat)
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    @Test
-    void testHRandFieldWithValues() {
-        String key = "test:hash:randomwithvals";
-        byte[] keyBytes = key.getBytes();
-        byte[] field1 = "field1".getBytes();
-        byte[] field2 = "field2".getBytes();
-        byte[] field3 = "field3".getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        byte[] value3 = "value3".getBytes();
-        
-        try {
-            // Test on non-existent key
-            Map.Entry<byte[], byte[]> nonExistentEntry = connection.hashCommands().hRandFieldWithValues("non:existent:key".getBytes());
-            assertThat(nonExistentEntry).isNull();
-            
-            // Set up test data
-            Map<byte[], byte[]> hashData = new HashMap<>();
-            hashData.put(field1, value1);
-            hashData.put(field2, value2);
-            hashData.put(field3, value3);
-            connection.hashCommands().hMSet(keyBytes, hashData);
-            
-            // Test hRandFieldWithValues (single entry)
-            Map.Entry<byte[], byte[]> randomEntry = connection.hashCommands().hRandFieldWithValues(keyBytes);
-            assertThat(randomEntry).isNotNull();
-            assertThat(randomEntry.getKey()).isIn(field1, field2, field3);
-            // Verify the value matches the key
-            if (java.util.Arrays.equals(randomEntry.getKey(), field1)) {
-                assertThat(randomEntry.getValue()).isEqualTo(value1);
-            } else if (java.util.Arrays.equals(randomEntry.getKey(), field2)) {
-                assertThat(randomEntry.getValue()).isEqualTo(value2);
-            } else if (java.util.Arrays.equals(randomEntry.getKey(), field3)) {
-                assertThat(randomEntry.getValue()).isEqualTo(value3);
-            }
-            
-            // Test hRandFieldWithValues with count
-            List<Map.Entry<byte[], byte[]>> randomEntries = connection.hashCommands().hRandFieldWithValues(keyBytes, 2);
-            assertThat(randomEntries).hasSize(2);
-            
-            for (Map.Entry<byte[], byte[]> entry : randomEntries) {
-                assertThat(entry.getKey()).isIn(field1, field2, field3);
-                // Verify each value matches its key
-                if (java.util.Arrays.equals(entry.getKey(), field1)) {
-                    assertThat(entry.getValue()).isEqualTo(value1);
-                } else if (java.util.Arrays.equals(entry.getKey(), field2)) {
-                    assertThat(entry.getValue()).isEqualTo(value2);
-                } else if (java.util.Arrays.equals(entry.getKey(), field3)) {
-                    assertThat(entry.getValue()).isEqualTo(value3);
-                }
-            }
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    // ==================== Scanning Operations ====================
-
-    @Test
-    void testHScan() {
-        String key = "test:hash:scan";
-        byte[] keyBytes = key.getBytes();
-        
-        try {
-            // Set up test data with a pattern
-            Map<byte[], byte[]> hashData = new HashMap<>();
-            hashData.put("field1".getBytes(), "value1".getBytes());
-            hashData.put("field2".getBytes(), "value2".getBytes());
-            hashData.put("other1".getBytes(), "othervalue1".getBytes());
-            hashData.put("other2".getBytes(), "othervalue2".getBytes());
-            connection.hashCommands().hMSet(keyBytes, hashData);
-            
-            // Test basic scan
-            Cursor<Map.Entry<byte[], byte[]>> cursor = connection.hashCommands().hScan(keyBytes, ScanOptions.NONE);
-            
-            List<Map.Entry<byte[], byte[]>> scannedEntries = new ArrayList<>();
-            while (cursor.hasNext()) {
-                scannedEntries.add(cursor.next());
-            }
-            cursor.close();
-            
-            assertThat(scannedEntries).hasSize(4);
-            
-            // Test scan with pattern
-            ScanOptions patternOptions = ScanOptions.scanOptions().match("field*").build();
-            Cursor<Map.Entry<byte[], byte[]>> patternCursor = connection.hashCommands().hScan(keyBytes, patternOptions);
-            
-            List<Map.Entry<byte[], byte[]>> patternEntries = new ArrayList<>();
-            while (patternCursor.hasNext()) {
-                patternEntries.add(patternCursor.next());
-            }
-            patternCursor.close();
-            
-            // Should find only entries matching "field*" pattern
-            assertThat(patternEntries).hasSize(2);
-            for (Map.Entry<byte[], byte[]> entry : patternEntries) {
-                String fieldName = new String(entry.getKey());
-                assertThat(fieldName).startsWith("field");
-            }
-            
-            // Test scan with count
-            ScanOptions countOptions = ScanOptions.scanOptions().count(1).build();
-            Cursor<Map.Entry<byte[], byte[]>> countCursor = connection.hashCommands().hScan(keyBytes, countOptions);
-            
-            List<Map.Entry<byte[], byte[]>> countEntries = new ArrayList<>();
-            while (countCursor.hasNext()) {
-                countEntries.add(countCursor.next());
-            }
-            countCursor.close();
-            
-            assertThat(countEntries).hasSize(4); // Should still get all entries, just in smaller batches
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    // ==================== Field Length Operations ====================
-
-    @Test
-    void testHStrLen() {
-        String key = "test:hash:strlen";
-        byte[] keyBytes = key.getBytes();
-        byte[] field1 = "field1".getBytes();
-        byte[] field2 = "field2".getBytes();
-        byte[] shortValue = "short".getBytes(); // 5 characters
-        byte[] longValue = "this is a longer value".getBytes(); // 22 characters
-        
-        try {
-            // Test on non-existent key/field
-            Long nonExistentLen = connection.hashCommands().hStrLen("non:existent:key".getBytes(), field1);
-            assertThat(nonExistentLen).isEqualTo(0L);
-            
-            // Set up test data
-            connection.hashCommands().hSet(keyBytes, field1, shortValue);
-            connection.hashCommands().hSet(keyBytes, field2, longValue);
-            
-            // Test hStrLen
-            Long shortLen = connection.hashCommands().hStrLen(keyBytes, field1);
-            assertThat(shortLen).isEqualTo(5L);
-            
-            Long longLen = connection.hashCommands().hStrLen(keyBytes, field2);
-            assertThat(longLen).isEqualTo(22L);
-            
-            // Test on non-existent field in existing key
-            Long nonExistentFieldLen = connection.hashCommands().hStrLen(keyBytes, "nonexistent".getBytes());
-            assertThat(nonExistentFieldLen).isEqualTo(0L);
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    // ==================== Field Expiration Operations ====================
-
-    @Test
-    @EnabledOnCommand("HEXPIRE")
-    void testHExpire() {
-        String key = "test:hash:expire";
-        byte[] keyBytes = key.getBytes();
-        byte[] field1 = "field1".getBytes();
-        byte[] field2 = "field2".getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        
-        try {
-            // Set up test data
-            connection.hashCommands().hSet(keyBytes, field1, value1);
-            connection.hashCommands().hSet(keyBytes, field2, value2);
-            
-            // Test hExpire (seconds) - Basic happy path test to ensure command executes
-            List<Long> expireResults = connection.hashCommands().hExpire(keyBytes, 10L, 
-                ExpirationOptions.Condition.ALWAYS, field1);
-            assertThat(expireResults).hasSize(1);
-            assertThat(expireResults.get(0)).isEqualTo(1);
-
-            // Test hExpire (seconds) - Test non existing key
-            expireResults = connection.hashCommands().hExpire("non:existent:key".getBytes(), 10L, 
-                ExpirationOptions.Condition.ALWAYS, field1);
-            assertThat(expireResults).hasSize(1);
-            assertThat(expireResults.get(0)).isEqualTo(-2);
-
-            // Test hExpire (seconds) - 2 existing and 1 absent fields
-            expireResults = connection.hashCommands().hExpire(keyBytes, 10L, 
-                ExpirationOptions.Condition.ALWAYS, field1, field2, "nonexistent".getBytes());
-            assertThat(expireResults).hasSize(3);
-            assertThat(expireResults.get(0)).isEqualTo(1);
-            assertThat(expireResults.get(1)).isEqualTo(1);
-            assertThat(expireResults.get(2)).isEqualTo(-2);
-
-            // Test hExpire (seconds) - Test NX
-            expireResults = connection.hashCommands().hExpire(keyBytes, 10L, 
-                ExpirationOptions.Condition.NX, field1);
-            assertThat(expireResults).hasSize(1);
-            assertThat(expireResults.get(0)).isEqualTo(0);
-
-            // Test hExpire (seconds) - Test XX
-            expireResults = connection.hashCommands().hExpire(keyBytes, 10L, 
-                ExpirationOptions.Condition.XX, field1);
-            assertThat(expireResults).hasSize(1);
-            assertThat(expireResults.get(0)).isEqualTo(1);
-
-            // Test hExpire (seconds) - Test GT by setting a shorter expiry first
-            expireResults = connection.hashCommands().hExpire(keyBytes, 1L, 
-                ExpirationOptions.Condition.GT, field1);
-            assertThat(expireResults).hasSize(1);
-            assertThat(expireResults.get(0)).isEqualTo(0);
-
-            // Test hExpire (seconds) - Test LT by setting a longer expiry
-            expireResults = connection.hashCommands().hExpire(keyBytes, 11L, 
-                ExpirationOptions.Condition.LT, field1);
-            assertThat(expireResults).hasSize(1);
-            assertThat(expireResults.get(0)).isEqualTo(0);
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    @Test
-    @EnabledOnCommand("HPEXPIRE")
-    void testHpExpire() {
-        String key = "test:hash:expire";
-        byte[] keyBytes = key.getBytes();
-        byte[] field1 = "field1".getBytes();
-        byte[] field2 = "field2".getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        
-        try {
-            // Set up test data
-            connection.hashCommands().hSet(keyBytes, field1, value1);
-            connection.hashCommands().hSet(keyBytes, field2, value2);
-            
-            // Test hExpire (seconds) - Basic happy path test to ensure command executes
-            List<Long> expireResults = connection.hashCommands().hpExpire(keyBytes, 10000L, 
-                ExpirationOptions.Condition.ALWAYS, field1);
-            assertThat(expireResults).hasSize(1);
-            assertThat(expireResults.get(0)).isEqualTo(1);
-
-            // Test hExpire (seconds) - Test non existing key
-            expireResults = connection.hashCommands().hpExpire("non:existent:key".getBytes(), 10000L, 
-                ExpirationOptions.Condition.ALWAYS, field1);
-            assertThat(expireResults).hasSize(1);
-            assertThat(expireResults.get(0)).isEqualTo(-2);
-
-            // Test hExpire (seconds) - 2 existing and 1 absent fields
-            expireResults = connection.hashCommands().hpExpire(keyBytes, 10000L, 
-                ExpirationOptions.Condition.ALWAYS, field1, field2, "nonexistent".getBytes());
-            assertThat(expireResults).hasSize(3);
-            assertThat(expireResults.get(0)).isEqualTo(1);
-            assertThat(expireResults.get(1)).isEqualTo(1);
-            assertThat(expireResults.get(2)).isEqualTo(-2);
-
-            // Test hExpire (seconds) - Test NX
-            expireResults = connection.hashCommands().hpExpire(keyBytes, 10000L, 
-                ExpirationOptions.Condition.NX, field1);
-            assertThat(expireResults).hasSize(1);
-            assertThat(expireResults.get(0)).isEqualTo(0);
-
-            // Test hExpire (seconds) - Test XX
-            expireResults = connection.hashCommands().hpExpire(keyBytes, 10000L, 
-                ExpirationOptions.Condition.XX, field1);
-            assertThat(expireResults).hasSize(1);
-            assertThat(expireResults.get(0)).isEqualTo(1);
-
-            // Test hExpire (seconds) - Test GT by setting a shorter expiry first
-            expireResults = connection.hashCommands().hpExpire(keyBytes, 1000L, 
-                ExpirationOptions.Condition.GT, field1);
-            assertThat(expireResults).hasSize(1);
-            assertThat(expireResults.get(0)).isEqualTo(0);
-
-            // Test hExpire (seconds) - Test LT by setting a longer expiry
-            expireResults = connection.hashCommands().hpExpire(keyBytes, 11000L, 
-                ExpirationOptions.Condition.LT, field1);
-            assertThat(expireResults).hasSize(1);
-            assertThat(expireResults.get(0)).isEqualTo(0);
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    @Test
-    @EnabledOnCommand("HEXPIREAT")
-    void testHExpireAt() {
-        String key = "test:hash:expireat";
-        byte[] keyBytes = key.getBytes();
-        byte[] field1 = "field1".getBytes();
-        byte[] field2 = "field2".getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        
-        try {
-            // Set up test data
-            connection.hashCommands().hSet(keyBytes, field1, value1);
-            connection.hashCommands().hSet(keyBytes, field2, value2);
-            
-            long currentTimestamp = System.currentTimeMillis() / 1000;
-            long expirationTimestamp = currentTimestamp + 10; // 10 seconds in the future
-            long shorterTimestamp = currentTimestamp + 5; // 5 seconds in the future (shorter than 10)
-            long nextExpirationTimestampMillis = currentTimestamp + 20; // 20 seconds in the future
-
-            // Test hExpireAt (seconds) - Basic happy path test to ensure command executes
-            List<Long> expireResults = connection.hashCommands().hExpireAt(keyBytes, expirationTimestamp, 
-                ExpirationOptions.Condition.ALWAYS, field1);
-            assertThat(expireResults).hasSize(1);
-            assertThat(expireResults.get(0)).isEqualTo(1);
-
-            // Test hExpire (seconds) - Test non existing key
-            expireResults = connection.hashCommands().hExpireAt("non:existent:key".getBytes(), expirationTimestamp, 
-                ExpirationOptions.Condition.ALWAYS, field1);
-            assertThat(expireResults).hasSize(1);
-            assertThat(expireResults.get(0)).isEqualTo(-2);
-
-            // Test hExpire (seconds) - 2 existing and 1 absent fields
-            expireResults = connection.hashCommands().hExpireAt(keyBytes, expirationTimestamp, 
-                ExpirationOptions.Condition.ALWAYS, field1, field2, "nonexistent".getBytes());
-            assertThat(expireResults).hasSize(3);
-            assertThat(expireResults.get(0)).isEqualTo(1);
-            assertThat(expireResults.get(1)).isEqualTo(1);
-            assertThat(expireResults.get(2)).isEqualTo(-2);
-
-            // Test hExpire (seconds) - Test NX
-            expireResults = connection.hashCommands().hExpireAt(keyBytes, expirationTimestamp, 
-                ExpirationOptions.Condition.NX, field1);
-            assertThat(expireResults).hasSize(1);
-            assertThat(expireResults.get(0)).isEqualTo(0);
-
-            // Test hExpire (seconds) - Test XX
-            expireResults = connection.hashCommands().hExpireAt(keyBytes, expirationTimestamp, 
-                ExpirationOptions.Condition.XX, field1);
-            assertThat(expireResults).hasSize(1);
-            assertThat(expireResults.get(0)).isEqualTo(1);
-
-            // Test hExpire (seconds) - Test GT by setting a shorter expiry first
-            expireResults = connection.hashCommands().hExpireAt(keyBytes, shorterTimestamp,
-                ExpirationOptions.Condition.GT, field1);
-            assertThat(expireResults).hasSize(1);
-            assertThat(expireResults.get(0)).isEqualTo(0);
-
-            // Test hExpire (seconds) - Test LT by setting a longer expiry
-            expireResults = connection.hashCommands().hExpireAt(keyBytes, nextExpirationTimestampMillis, 
-                ExpirationOptions.Condition.LT, field1);
-            assertThat(expireResults).hasSize(1);
-            assertThat(expireResults.get(0)).isEqualTo(0);
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    @Test
-    @EnabledOnCommand("HPEXPIREAT")
-    void testHpExpireAt() {
-        String key = "test:hash:expireat";
-        byte[] keyBytes = key.getBytes();
-        byte[] field1 = "field1".getBytes();
-        byte[] field2 = "field2".getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        
-        try {
-            // Set up test data
-            connection.hashCommands().hSet(keyBytes, field1, value1);
-            connection.hashCommands().hSet(keyBytes, field2, value2);
-            
-            long currentTimestamp = System.currentTimeMillis();
-            long expirationTimestamp = currentTimestamp + 10000; // 10 seconds in the future
-            long shorterTimestamp = currentTimestamp + 5000; // 5 seconds in the future (shorter than 10)
-            long nextExpirationTimestampMillis = currentTimestamp + 20000; // 20 seconds in the future
-
-            // Test hExpireAt (seconds) - Basic happy path test to ensure command executes
-            List<Long> expireResults = connection.hashCommands().hpExpireAt(keyBytes, expirationTimestamp, 
-                ExpirationOptions.Condition.ALWAYS, field1);
-            assertThat(expireResults).hasSize(1);
-            assertThat(expireResults.get(0)).isEqualTo(1);
-
-            // Test hExpire (seconds) - Test non existing key
-            expireResults = connection.hashCommands().hpExpireAt("non:existent:key".getBytes(), expirationTimestamp, 
-                ExpirationOptions.Condition.ALWAYS, field1);
-            assertThat(expireResults).hasSize(1);
-            assertThat(expireResults.get(0)).isEqualTo(-2);
-
-            // Test hExpire (seconds) - 2 existing and 1 absent fields
-            expireResults = connection.hashCommands().hpExpireAt(keyBytes, expirationTimestamp, 
-                ExpirationOptions.Condition.ALWAYS, field1, field2, "nonexistent".getBytes());
-            assertThat(expireResults).hasSize(3);
-            assertThat(expireResults.get(0)).isEqualTo(1);
-            assertThat(expireResults.get(1)).isEqualTo(1);
-            assertThat(expireResults.get(2)).isEqualTo(-2);
-
-            // Test hExpire (seconds) - Test NX
-            expireResults = connection.hashCommands().hpExpireAt(keyBytes, expirationTimestamp, 
-                ExpirationOptions.Condition.NX, field1);
-            assertThat(expireResults).hasSize(1);
-            assertThat(expireResults.get(0)).isEqualTo(0);
-
-            // Test hExpire (seconds) - Test XX
-            expireResults = connection.hashCommands().hpExpireAt(keyBytes, expirationTimestamp, 
-                ExpirationOptions.Condition.XX, field1);
-            assertThat(expireResults).hasSize(1);
-            assertThat(expireResults.get(0)).isEqualTo(1);
-
-            // Test hExpire (seconds) - Test GT by setting a shorter expiry first
-            expireResults = connection.hashCommands().hpExpireAt(keyBytes, shorterTimestamp,
-                ExpirationOptions.Condition.GT, field1);
-            assertThat(expireResults).hasSize(1);
-            assertThat(expireResults.get(0)).isEqualTo(0);
-
-            // Test hExpire (seconds) - Test LT by setting a longer expiry
-            expireResults = connection.hashCommands().hpExpireAt(keyBytes, nextExpirationTimestampMillis, 
-                ExpirationOptions.Condition.LT, field1);
-            assertThat(expireResults).hasSize(1);
-            assertThat(expireResults.get(0)).isEqualTo(0);
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    @Test
-    @EnabledOnCommand("HPERSIST")
-    void testHPersist() {
-        String key = "test:hash:persist";
-        byte[] keyBytes = key.getBytes();
-        byte[] field1 = "field1".getBytes();
-        byte[] field2 = "field2".getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        
-        try {
-            // Set up test data
-            connection.hashCommands().hSet(keyBytes, field1, value1);
-            connection.hashCommands().hSet(keyBytes, field2, value2);
-            
-            // Test hPersist - Basic test to ensure command executes
-            List<Long> persistResults = connection.hashCommands().hPersist(keyBytes, field1, field2);
-            assertThat(persistResults).hasSize(2);
-            assertThat(persistResults.get(0)).isEqualTo(-1); // field1 had no expiration
-            assertThat(persistResults.get(1)).isEqualTo(-1); // field2 had no expiration
-
-            // Set expiration to test persistence removal (combined)
-            connection.hashCommands().hExpire(keyBytes, 10L, ExpirationOptions.Condition.ALWAYS, field1);
-            persistResults = connection.hashCommands().hPersist(keyBytes, field1, field2, "nonexistent".getBytes());
-            assertThat(persistResults).hasSize(3);
-            assertThat(persistResults.get(0)).isEqualTo(1); // field1 expiration removed
-            assertThat(persistResults.get(1)).isEqualTo(-1); // field2 had no expiration
-            assertThat(persistResults.get(2)).isEqualTo(-2); // nonexistent field
-            
-            // Test on non-existent field
-            List<Long> nonExistentResults = connection.hashCommands().hPersist(keyBytes, "nonexistent".getBytes());
-            assertThat(nonExistentResults).hasSize(1);
-            assertThat(nonExistentResults.get(0)).isEqualTo(-2);
-
-            // Test on non-existent key
-            List<Long> nonExistentKeyResults = connection.hashCommands().hPersist("non:existent:key".getBytes(), field1);
-            assertThat(nonExistentKeyResults).hasSize(1);
-            assertThat(nonExistentKeyResults.get(0)).isEqualTo(-2);
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    @Test
-    @EnabledOnCommand("HTTL")
-    void testHTtl() {
-        String key = "test:hash:ttl";
-        byte[] keyBytes = key.getBytes();
-        byte[] field1 = "field1".getBytes();
-        byte[] field2 = "field2".getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        
-        try {
-            // Set up test data
-            connection.hashCommands().hSet(keyBytes, field1, value1);
-            connection.hashCommands().hSet(keyBytes, field2, value2);
-            
-            // Test hTtl - Basic test to ensure command executes
-            List<Long> ttlResults = connection.hashCommands().hTtl(keyBytes, field1, field2);
-            assertThat(ttlResults).hasSize(2);
-            assertThat(ttlResults.get(0)).isEqualTo(-1); // No expiration
-            assertThat(ttlResults.get(1)).isEqualTo(-1); // No expiration
-
-            // Set expiration to test TTL retrieval (combined)
-            connection.hashCommands().hExpire(keyBytes, 10L, ExpirationOptions.Condition.ALWAYS, field1);
-            ttlResults = connection.hashCommands().hTtl(keyBytes, field1, field2, "nonexistent".getBytes());
-            assertThat(ttlResults).hasSize(3);
-            assertThat(ttlResults.get(0)).isGreaterThan(0); // field1 should have a TTL
-            assertThat(ttlResults.get(1)).isEqualTo(-1); // field2 has no expiration
-            assertThat(ttlResults.get(2)).isEqualTo(-2); // nonexistent field
-
-            // Test hTtl with TimeUnit
-            connection.hashCommands().hExpire(keyBytes, 10L, ExpirationOptions.Condition.ALWAYS, field2);
-            List<Long> ttlMillisResults = connection.hashCommands().hTtl(keyBytes, TimeUnit.MILLISECONDS, field1, field2);
-            assertThat(ttlMillisResults).hasSize(2);
-            assertThat(ttlMillisResults.get(0)).isGreaterThan(5000); // field1 should definitely have >5s left
-            assertThat(ttlMillisResults.get(1)).isGreaterThan(5000); // field2 should definitely have >5s left
-
-            // Test non existant key
-            ttlResults = connection.hashCommands().hTtl("non:existent:key".getBytes(), field1);
-            assertThat(ttlResults).hasSize(1);
-            assertThat(ttlResults.get(0)).isEqualTo(-2);
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    @Test
-    @EnabledOnCommand("HPTTL")
-    void testHpTtl() {
-        String key = "test:hash:ttl";
-        byte[] keyBytes = key.getBytes();
-        byte[] field1 = "field1".getBytes();
-        byte[] field2 = "field2".getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        
-        try {
-            // Set up test data
-            connection.hashCommands().hSet(keyBytes, field1, value1);
-            connection.hashCommands().hSet(keyBytes, field2, value2);
-            
-            // Test hpTtl - Basic test to ensure command executes
-            List<Long> ttlResults = connection.hashCommands().hpTtl(keyBytes, field1, field2);
-            assertThat(ttlResults).hasSize(2);
-            assertThat(ttlResults.get(0)).isEqualTo(-1); // No expiration
-            assertThat(ttlResults.get(1)).isEqualTo(-1); // No expiration
-
-            // Set expiration to test TTL retrieval (combined)
-            connection.hashCommands().hExpire(keyBytes, 10L, ExpirationOptions.Condition.ALWAYS, field1);
-            ttlResults = connection.hashCommands().hpTtl(keyBytes, field1, field2, "nonexistent".getBytes());
-            assertThat(ttlResults).hasSize(3);
-            assertThat(ttlResults.get(0)).isGreaterThan(1000); // field1 should have a TTL
-            assertThat(ttlResults.get(1)).isEqualTo(-1); // field2 has no expiration
-            assertThat(ttlResults.get(2)).isEqualTo(-2); // nonexistent field
-
-            // Test non existant key
-            ttlResults = connection.hashCommands().hpTtl("non:existent:key".getBytes(), field1);
-            assertThat(ttlResults).hasSize(1);
-            assertThat(ttlResults.get(0)).isEqualTo(-2);
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    // ==================== Error Handling and Edge Cases ====================
-
-    @Test
-    void testHashOperationsOnNonHashTypes() {
-        String stringKey = "test:hash:error:string";
-        
-        try {
-            // Create a string key
-            connection.stringCommands().set(stringKey.getBytes(), "stringvalue".getBytes());
-            
-            // Try hash operations on string key - should fail or return appropriate response
-            assertThatThrownBy(() -> connection.hashCommands().hSet(stringKey.getBytes(), "field".getBytes(), "value".getBytes()))
-                .isInstanceOf(Exception.class);
-        } finally {
-            cleanupKey(stringKey);
-        }
-    }
-
-    @Test
-    void testEmptyHashOperations() {
-        String key = "test:hash:empty";
-        byte[] keyBytes = key.getBytes();
-        byte[] field = "field".getBytes();
-        byte[] emptyValue = new byte[0];
-        
-        try {
-            // Set field with empty value
-            Boolean setResult = connection.hashCommands().hSet(keyBytes, field, emptyValue);
-            assertThat(setResult).isTrue();
-            
-            // Get empty value
-            byte[] retrievedValue = connection.hashCommands().hGet(keyBytes, field);
-            assertThat(retrievedValue).isEqualTo(emptyValue);
-            
-            // String length should be 0
-            Long strLen = connection.hashCommands().hStrLen(keyBytes, field);
-            assertThat(strLen).isEqualTo(0L);
-            
-            // Hash should have 1 field
-            Long hashLen = connection.hashCommands().hLen(keyBytes);
-            assertThat(hashLen).isEqualTo(1L);
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    @Test
-    void testHashOperationsWithBinaryData() {
-        String key = "test:hash:binary";
-        byte[] keyBytes = key.getBytes();
-        byte[] binaryField = new byte[]{0x00, 0x01, 0x02, (byte) 0xFF};
-        byte[] binaryValue = new byte[]{(byte) 0xFF, (byte) 0xFE, 0x00, 0x01, 0x7F};
-        
-        try {
-            // Test with binary field and value
-            Boolean setResult = connection.hashCommands().hSet(keyBytes, binaryField, binaryValue);
-            assertThat(setResult).isTrue();
-            
-            // Retrieve binary value
-            byte[] retrievedValue = connection.hashCommands().hGet(keyBytes, binaryField);
-            assertThat(retrievedValue).isEqualTo(binaryValue);
-            
-            // Test exists with binary field
-            Boolean exists = connection.hashCommands().hExists(keyBytes, binaryField);
-            assertThat(exists).isTrue();
-            
-        // Test hGetAll with binary data
-        Map<byte[], byte[]> all = connection.hashCommands().hGetAll(keyBytes);
-        assertThat(all).hasSize(1);
-        
-        // Since byte arrays are compared by reference, not content, we need to check the content differently
-        boolean foundBinaryField = false;
-        for (Map.Entry<byte[], byte[]> entry : all.entrySet()) {
-            if (java.util.Arrays.equals(entry.getKey(), binaryField)) {
-                assertThat(entry.getValue()).isEqualTo(binaryValue);
-                foundBinaryField = true;
-                break;
-            }
-        }
-        assertThat(foundBinaryField).as("binaryField should be present in hGetAll result").isTrue();
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    // ==================== Pipeline Mode Tests ====================
-
-    @Test
-    void testHashCommandsInPipelineMode() {
-        String key1 = "test:hash:pipeline:basic";
-        String key2 = "test:hash:pipeline:multi";
-        byte[] key1Bytes = key1.getBytes();
-        byte[] key2Bytes = key2.getBytes();
-        byte[] field1 = "field1".getBytes();
-        byte[] field2 = "field2".getBytes();
-        byte[] field3 = "field3".getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        byte[] value3 = "value3".getBytes();
-        
-        try {
-            // Start pipeline for main test logic
-            connection.openPipeline();
-            
-            // Queue multiple hash commands - assert they return null in pipeline mode
-            assertThat(connection.hashCommands().hSet(key1Bytes, field1, value1)).isNull();
-            assertThat(connection.hashCommands().hSet(key1Bytes, field2, value2)).isNull();
-            assertThat(connection.hashCommands().hGet(key1Bytes, field1)).isNull();
-            assertThat(connection.hashCommands().hExists(key1Bytes, field1)).isNull();
-            assertThat(connection.hashCommands().hLen(key1Bytes)).isNull();
-            
-            // Queue multi-operations - assert they return null in pipeline mode
-            Map<byte[], byte[]> hashData = new HashMap<>();
-            hashData.put(field1, value1);
-            hashData.put(field2, value2);
-            hashData.put(field3, value3);
-            connection.hashCommands().hMSet(key2Bytes, hashData); // void method, no assertion needed
-            assertThat(connection.hashCommands().hMGet(key2Bytes, field1, field2, field3)).isNull();
-            assertThat(connection.hashCommands().hGetAll(key2Bytes)).isNull();
-            
-            // Execute pipeline
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(8);
-            assertThat(results.get(0)).isEqualTo(true);  // hSet result
-            assertThat(results.get(1)).isEqualTo(true);  // hSet result  
-            assertThat(results.get(2)).isEqualTo(value1); // hGet result
-            assertThat(results.get(3)).isEqualTo(true);  // hExists result
-            assertThat(results.get(4)).isEqualTo(2L);    // hLen result
-            
-            // hMSet returns simple string reply "OK"
-            assertThat(results.get(5)).isEqualTo("OK");
-            
-            // hMGet results
-            @SuppressWarnings("unchecked")
-            List<byte[]> mgetResults = (List<byte[]>) results.get(6);
-            assertThat(mgetResults).hasSize(3);
-            assertThat(mgetResults.get(0)).isEqualTo(value1);
-            assertThat(mgetResults.get(1)).isEqualTo(value2);
-            assertThat(mgetResults.get(2)).isEqualTo(value3);
-            
-            // hGetAll results
-            @SuppressWarnings("unchecked")
-            Map<byte[], byte[]> getAllResults = (Map<byte[], byte[]>) results.get(7);
-            assertThat(getAllResults).hasSize(3);
-            
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-        }
-    }
-
-    @Test
-    void testHashIncrementCommandsInPipelineMode() {
-        String key = "test:hash:pipeline:incr";
-        byte[] keyBytes = key.getBytes();
-        byte[] intField = "intField".getBytes();
-        byte[] floatField = "floatField".getBytes();
-        
-        try {
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Queue increment commands - assert they return null in pipeline mode
-            assertThat(connection.hashCommands().hIncrBy(keyBytes, intField, 5L)).isNull();
-            assertThat(connection.hashCommands().hIncrBy(keyBytes, intField, 10L)).isNull();
-            assertThat(connection.hashCommands().hIncrBy(keyBytes, floatField, 3.14)).isNull();
-            assertThat(connection.hashCommands().hIncrBy(keyBytes, floatField, 2.86)).isNull();
-            assertThat(connection.hashCommands().hGet(keyBytes, intField)).isNull();
-            assertThat(connection.hashCommands().hGet(keyBytes, floatField)).isNull();
-            
-            // Execute pipeline
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(6);
-            assertThat(results.get(0)).isEqualTo(5L);    // First increment
-            assertThat(results.get(1)).isEqualTo(15L);   // Second increment
-            assertThat(results.get(2)).isEqualTo(3.14);  // First float increment
-            assertThat(results.get(3)).isEqualTo(6.0);   // Second float increment
-            assertThat(results.get(4)).isEqualTo("15".getBytes()); // Get int result
-            assertThat(results.get(5)).isEqualTo("6".getBytes());   // Get float result
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    @Test
-    void testHashStructuralCommandsInPipelineMode() {
-        String key = "test:hash:pipeline:structure";
-        byte[] keyBytes = key.getBytes();
-        byte[] field1 = "field1".getBytes();
-        byte[] field2 = "field2".getBytes();
-        byte[] field3 = "field3".getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        byte[] value3 = "value3".getBytes();
-        
-        try {
-            // Setup data first
-            Map<byte[], byte[]> hashData = new HashMap<>();
-            hashData.put(field1, value1);
-            hashData.put(field2, value2);
-            hashData.put(field3, value3);
-            connection.hashCommands().hMSet(keyBytes, hashData);
-            
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Queue structural commands - assert they return null in pipeline mode
-            assertThat(connection.hashCommands().hLen(keyBytes)).isNull();
-            assertThat(connection.hashCommands().hKeys(keyBytes)).isNull();
-            assertThat(connection.hashCommands().hVals(keyBytes)).isNull();
-            assertThat(connection.hashCommands().hGetAll(keyBytes)).isNull();
-            assertThat(connection.hashCommands().hDel(keyBytes, field1)).isNull();
-            assertThat(connection.hashCommands().hLen(keyBytes)).isNull();
-            
-            // Execute pipeline
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(6);
-            assertThat(results.get(0)).isEqualTo(3L); // Initial length
-            
-            @SuppressWarnings("unchecked")
-            Set<byte[]> keys = (Set<byte[]>) results.get(1);
-            assertThat(keys).hasSize(3);
-            
-            @SuppressWarnings("unchecked")
-            List<byte[]> vals = (List<byte[]>) results.get(2);
-            assertThat(vals).hasSize(3);
-            
-            @SuppressWarnings("unchecked")
-            Map<byte[], byte[]> all = (Map<byte[], byte[]>) results.get(3);
-            assertThat(all).hasSize(3);
-            
-            assertThat(results.get(4)).isEqualTo(1L); // Delete result
-            assertThat(results.get(5)).isEqualTo(2L); // Final length
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    @Test
-    void testHashRandomFieldCommandsInPipelineMode() {
-        String key = "test:hash:pipeline:random";
-        byte[] keyBytes = key.getBytes();
-        byte[] field1 = "field1".getBytes();
-        byte[] field2 = "field2".getBytes();
-        byte[] field3 = "field3".getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        byte[] value3 = "value3".getBytes();
-        
-        try {
-            // Setup data first
-            Map<byte[], byte[]> hashData = new HashMap<>();
-            hashData.put(field1, value1);
-            hashData.put(field2, value2);
-            hashData.put(field3, value3);
-            connection.hashCommands().hMSet(keyBytes, hashData);
-            
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Queue random field commands - assert they return null in pipeline mode
-            assertThat(connection.hashCommands().hRandField(keyBytes)).isNull();
-            assertThat(connection.hashCommands().hRandField(keyBytes, 2)).isNull();
-            assertThat(connection.hashCommands().hRandFieldWithValues(keyBytes)).isNull();
-            assertThat(connection.hashCommands().hRandFieldWithValues(keyBytes, 2)).isNull();
-            
-            // Execute pipeline
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(4);
-            
-            // Single random field
-            assertThat(results.get(0)).isInstanceOf(byte[].class);
-            
-            // Multiple random fields
-            @SuppressWarnings("unchecked")
-            List<byte[]> multipleFields = (List<byte[]>) results.get(1);
-            assertThat(multipleFields).hasSize(2);
-            
-            // Single random field with value
-            @SuppressWarnings("unchecked")
-            Map.Entry<byte[], byte[]> singleEntry = (Map.Entry<byte[], byte[]>) results.get(2);
-            assertThat(singleEntry).isNotNull();
-            
-            // Multiple random fields with values
-            @SuppressWarnings("unchecked")
-            List<Map.Entry<byte[], byte[]>> multipleEntries = (List<Map.Entry<byte[], byte[]>>) results.get(3);
-            assertThat(multipleEntries).hasSize(2);
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    @Test
-    @EnabledOnCommand("HEXPIRE")
-    void testHashExpirationCommandsInPipelineMode() {
-        String key = "test:hash:pipeline:expire";
-        byte[] keyBytes = key.getBytes();
-        byte[] field1 = "field1".getBytes();
-        byte[] field2 = "field2".getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        
-        try {
-            // Setup data first
-            connection.hashCommands().hSet(keyBytes, field1, value1);
-            connection.hashCommands().hSet(keyBytes, field2, value2);
-            
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Queue expiration commands - assert they return null in pipeline mode
-            assertThat(connection.hashCommands().hExpire(keyBytes, 10L, ExpirationOptions.Condition.ALWAYS, field1)).isNull();
-            assertThat(connection.hashCommands().hpExpire(keyBytes, 10000L, ExpirationOptions.Condition.ALWAYS, field2)).isNull();
-            assertThat(connection.hashCommands().hTtl(keyBytes, field1, field2)).isNull();
-            assertThat(connection.hashCommands().hpTtl(keyBytes, field1, field2)).isNull();
-            assertThat(connection.hashCommands().hPersist(keyBytes, field1, field2)).isNull();
-            
-            // Execute pipeline
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(5);
-            
-            @SuppressWarnings("unchecked")
-            List<Long> expireResults1 = (List<Long>) results.get(0);
-            assertThat(expireResults1).hasSize(1);
-            assertThat(expireResults1.get(0)).isEqualTo(1L);
-            
-            @SuppressWarnings("unchecked")
-            List<Long> expireResults2 = (List<Long>) results.get(1);
-            assertThat(expireResults2).hasSize(1);
-            assertThat(expireResults2.get(0)).isEqualTo(1L);
-            
-            @SuppressWarnings("unchecked")
-            List<Long> ttlResults = (List<Long>) results.get(2);
-            assertThat(ttlResults).hasSize(2);
-            assertThat(ttlResults.get(0)).isGreaterThan(0L);
-            assertThat(ttlResults.get(1)).isGreaterThan(0L);
-            
-            @SuppressWarnings("unchecked")
-            List<Long> pttlResults = (List<Long>) results.get(3);
-            assertThat(pttlResults).hasSize(2);
-            assertThat(pttlResults.get(0)).isGreaterThan(1000L);
-            assertThat(pttlResults.get(1)).isGreaterThan(1000L);
-            
-            @SuppressWarnings("unchecked")
-            List<Long> persistResults = (List<Long>) results.get(4);
-            assertThat(persistResults).hasSize(2);
-            assertThat(persistResults.get(0)).isEqualTo(1L);
-            assertThat(persistResults.get(1)).isEqualTo(1L);
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    // ==================== Transaction Mode Tests ====================
-
-    @Test
-    void testHashCommandsInTransactionMode() {
-        String key1 = "test:hash:transaction:basic";
-        String key2 = "test:hash:transaction:multi";
-        byte[] key1Bytes = key1.getBytes();
-        byte[] key2Bytes = key2.getBytes();
-        byte[] field1 = "field1".getBytes();
-        byte[] field2 = "field2".getBytes();
-        byte[] field3 = "field3".getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        byte[] value3 = "value3".getBytes();
-        
-        try {
-            // Start transaction for main test logic
-            connection.multi();
-            
-            // Queue multiple hash commands - assert they return null in transaction mode
-            assertThat(connection.hashCommands().hSet(key1Bytes, field1, value1)).isNull();
-            assertThat(connection.hashCommands().hSet(key1Bytes, field2, value2)).isNull();
-            assertThat(connection.hashCommands().hGet(key1Bytes, field1)).isNull();
-            assertThat(connection.hashCommands().hExists(key1Bytes, field1)).isNull();
-            assertThat(connection.hashCommands().hLen(key1Bytes)).isNull();
-            
-            // Queue multi-operations - assert they return null in transaction mode
-            Map<byte[], byte[]> hashData = new HashMap<>();
-            hashData.put(field1, value1);
-            hashData.put(field2, value2);
-            hashData.put(field3, value3);
-            connection.hashCommands().hMSet(key2Bytes, hashData); // void method, no assertion needed
-            assertThat(connection.hashCommands().hMGet(key2Bytes, field1, field2, field3)).isNull();
-            assertThat(connection.hashCommands().hGetAll(key2Bytes)).isNull();
-            
-            // Execute transaction
-            List<Object> results = connection.exec();
-            
-            // Verify results
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(8);
-            assertThat(results.get(0)).isEqualTo(true);  // hSet result
-            assertThat(results.get(1)).isEqualTo(true);  // hSet result  
-            assertThat(results.get(2)).isEqualTo(value1); // hGet result
-            assertThat(results.get(3)).isEqualTo(true);  // hExists result
-            assertThat(results.get(4)).isEqualTo(2L);    // hLen result
-            
-            // hMSet returns simple string reply "OK"
-            assertThat(results.get(5)).isEqualTo("OK");
-            
-            // hMGet results
-            @SuppressWarnings("unchecked")
-            List<byte[]> mgetResults = (List<byte[]>) results.get(6);
-            assertThat(mgetResults).hasSize(3);
-            assertThat(mgetResults.get(0)).isEqualTo(value1);
-            assertThat(mgetResults.get(1)).isEqualTo(value2);
-            assertThat(mgetResults.get(2)).isEqualTo(value3);
-            
-            // hGetAll results
-            @SuppressWarnings("unchecked")
-            Map<byte[], byte[]> getAllResults = (Map<byte[], byte[]>) results.get(7);
-            assertThat(getAllResults).hasSize(3);
-            
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-        }
-    }
-
-    @Test
-    void testHashIncrementCommandsInTransactionMode() {
-        String key = "test:hash:transaction:incr";
-        byte[] keyBytes = key.getBytes();
-        byte[] intField = "intField".getBytes();
-        byte[] floatField = "floatField".getBytes();
-        
-        try {
-            // Start transaction
-            connection.multi();
-            
-            // Queue increment commands - assert they return null in transaction mode
-            assertThat(connection.hashCommands().hIncrBy(keyBytes, intField, 5L)).isNull();
-            assertThat(connection.hashCommands().hIncrBy(keyBytes, intField, 10L)).isNull();
-            assertThat(connection.hashCommands().hIncrBy(keyBytes, floatField, 3.14)).isNull();
-            assertThat(connection.hashCommands().hIncrBy(keyBytes, floatField, 2.86)).isNull();
-            assertThat(connection.hashCommands().hGet(keyBytes, intField)).isNull();
-            assertThat(connection.hashCommands().hGet(keyBytes, floatField)).isNull();
-            
-            // Execute transaction
-            List<Object> results = connection.exec();
-            
-            // Verify results
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(6);
-            assertThat(results.get(0)).isEqualTo(5L);    // First increment
-            assertThat(results.get(1)).isEqualTo(15L);   // Second increment
-            assertThat(results.get(2)).isEqualTo(3.14);  // First float increment
-            assertThat(results.get(3)).isEqualTo(6.0);   // Second float increment
-            assertThat(results.get(4)).isEqualTo("15".getBytes()); // Get int result
-            assertThat(results.get(5)).isEqualTo("6".getBytes());   // Get float result
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    @Test
-    void testHashStructuralCommandsInTransactionMode() {
-        String key = "test:hash:transaction:structure";
-        byte[] keyBytes = key.getBytes();
-        byte[] field1 = "field1".getBytes();
-        byte[] field2 = "field2".getBytes();
-        byte[] field3 = "field3".getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        byte[] value3 = "value3".getBytes();
-        
-        try {
-            // Setup data first
-            Map<byte[], byte[]> hashData = new HashMap<>();
-            hashData.put(field1, value1);
-            hashData.put(field2, value2);
-            hashData.put(field3, value3);
-            connection.hashCommands().hMSet(keyBytes, hashData);
-            
-            // Start transaction
-            connection.multi();
-            
-            // Queue structural commands - assert they return null in transaction mode
-            assertThat(connection.hashCommands().hLen(keyBytes)).isNull();
-            assertThat(connection.hashCommands().hKeys(keyBytes)).isNull();
-            assertThat(connection.hashCommands().hVals(keyBytes)).isNull();
-            assertThat(connection.hashCommands().hGetAll(keyBytes)).isNull();
-            assertThat(connection.hashCommands().hDel(keyBytes, field1)).isNull();
-            assertThat(connection.hashCommands().hLen(keyBytes)).isNull();
-            
-            // Execute transaction
-            List<Object> results = connection.exec();
-            
-            // Verify results
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(6);
-            assertThat(results.get(0)).isEqualTo(3L); // Initial length
-            
-            @SuppressWarnings("unchecked")
-            Set<byte[]> keys = (Set<byte[]>) results.get(1);
-            assertThat(keys).hasSize(3);
-            
-            @SuppressWarnings("unchecked")
-            List<byte[]> vals = (List<byte[]>) results.get(2);
-            assertThat(vals).hasSize(3);
-            
-            @SuppressWarnings("unchecked")
-            Map<byte[], byte[]> all = (Map<byte[], byte[]>) results.get(3);
-            assertThat(all).hasSize(3);
-            
-            assertThat(results.get(4)).isEqualTo(1L); // Delete result
-            assertThat(results.get(5)).isEqualTo(2L); // Final length
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    @Test
-    void testHashRandomFieldCommandsInTransactionMode() {
-        String key = "test:hash:transaction:random";
-        byte[] keyBytes = key.getBytes();
-        byte[] field1 = "field1".getBytes();
-        byte[] field2 = "field2".getBytes();
-        byte[] field3 = "field3".getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        byte[] value3 = "value3".getBytes();
-        
-        try {
-            // Setup data first
-            Map<byte[], byte[]> hashData = new HashMap<>();
-            hashData.put(field1, value1);
-            hashData.put(field2, value2);
-            hashData.put(field3, value3);
-            connection.hashCommands().hMSet(keyBytes, hashData);
-            
-            // Start transaction
-            connection.multi();
-            
-            // Queue random field commands - assert they return null in transaction mode
-            assertThat(connection.hashCommands().hRandField(keyBytes)).isNull();
-            assertThat(connection.hashCommands().hRandField(keyBytes, 2)).isNull();
-            assertThat(connection.hashCommands().hRandFieldWithValues(keyBytes)).isNull();
-            assertThat(connection.hashCommands().hRandFieldWithValues(keyBytes, 2)).isNull();
-            
-            // Execute transaction
-            List<Object> results = connection.exec();
-            
-            // Verify results
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(4);
-            
-            // Single random field
-            assertThat(results.get(0)).isInstanceOf(byte[].class);
-            
-            // Multiple random fields
-            @SuppressWarnings("unchecked")
-            List<byte[]> multipleFields = (List<byte[]>) results.get(1);
-            assertThat(multipleFields).hasSize(2);
-            
-            // Single random field with value
-            @SuppressWarnings("unchecked")
-            Map.Entry<byte[], byte[]> singleEntry = (Map.Entry<byte[], byte[]>) results.get(2);
-            assertThat(singleEntry).isNotNull();
-            
-            // Multiple random fields with values
-            @SuppressWarnings("unchecked")
-            List<Map.Entry<byte[], byte[]>> multipleEntries = (List<Map.Entry<byte[], byte[]>>) results.get(3);
-            assertThat(multipleEntries).hasSize(2);
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    @Test
-    @EnabledOnCommand("HEXPIRE")
-    void testHashExpirationCommandsInTransactionMode() {
-        String key = "test:hash:transaction:expire";
-        byte[] keyBytes = key.getBytes();
-        byte[] field1 = "field1".getBytes();
-        byte[] field2 = "field2".getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        
-        try {
-            // Setup data first
-            connection.hashCommands().hSet(keyBytes, field1, value1);
-            connection.hashCommands().hSet(keyBytes, field2, value2);
-            
-            // Start transaction
-            connection.multi();
-            
-            // Queue expiration commands - assert they return null in transaction mode
-            assertThat(connection.hashCommands().hExpire(keyBytes, 10L, ExpirationOptions.Condition.ALWAYS, field1)).isNull();
-            assertThat(connection.hashCommands().hpExpire(keyBytes, 10000L, ExpirationOptions.Condition.ALWAYS, field2)).isNull();
-            assertThat(connection.hashCommands().hTtl(keyBytes, field1, field2)).isNull();
-            assertThat(connection.hashCommands().hpTtl(keyBytes, field1, field2)).isNull();
-            assertThat(connection.hashCommands().hPersist(keyBytes, field1, field2)).isNull();
-            
-            // Execute transaction
-            List<Object> results = connection.exec();
-            
-            // Verify results
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(5);
-            
-            @SuppressWarnings("unchecked")
-            List<Long> expireResults1 = (List<Long>) results.get(0);
-            assertThat(expireResults1).hasSize(1);
-            assertThat(expireResults1.get(0)).isEqualTo(1L);
-            
-            @SuppressWarnings("unchecked")
-            List<Long> expireResults2 = (List<Long>) results.get(1);
-            assertThat(expireResults2).hasSize(1);
-            assertThat(expireResults2.get(0)).isEqualTo(1L);
-            
-            @SuppressWarnings("unchecked")
-            List<Long> ttlResults = (List<Long>) results.get(2);
-            assertThat(ttlResults).hasSize(2);
-            assertThat(ttlResults.get(0)).isGreaterThan(0L);
-            assertThat(ttlResults.get(1)).isGreaterThan(0L);
-            
-            @SuppressWarnings("unchecked")
-            List<Long> pttlResults = (List<Long>) results.get(3);
-            assertThat(pttlResults).hasSize(2);
-            assertThat(pttlResults.get(0)).isGreaterThan(1000L);
-            assertThat(pttlResults.get(1)).isGreaterThan(1000L);
-            
-            @SuppressWarnings("unchecked")
-            List<Long> persistResults = (List<Long>) results.get(4);
-            assertThat(persistResults).hasSize(2);
-            assertThat(persistResults.get(0)).isEqualTo(1L);
-            assertThat(persistResults.get(1)).isEqualTo(1L);
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    @Test
-    void testTransactionDiscardWithHashCommands() {
-        String key = "test:hash:transaction:discard";
-        byte[] keyBytes = key.getBytes();
-        byte[] field = "field".getBytes();
-        byte[] value = "value".getBytes();
-        
-        try {
-            // Start transaction
-            connection.multi();
-            
-            // Queue hash commands
-            connection.hashCommands().hSet(keyBytes, field, value);
-            connection.hashCommands().hGet(keyBytes, field);
-            
-            // Discard transaction
-            connection.discard();
-            
-            // Verify key doesn't exist (transaction was discarded)
-            Boolean exists = connection.hashCommands().hExists(keyBytes, field);
-            assertThat(exists).isFalse();
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    @Test
-    void testWatchWithHashCommandsTransaction() throws InterruptedException {
-        String watchKey = "test:hash:transaction:watch";
-        String otherKey = "test:hash:transaction:other";
-        byte[] watchKeyBytes = watchKey.getBytes();
-        byte[] otherKeyBytes = otherKey.getBytes();
-        byte[] field = "field".getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        
-        try {
-            // Setup initial data
-            connection.hashCommands().hSet(watchKeyBytes, field, value1);
-            
-            // Watch the key
-            connection.watch(watchKeyBytes);
-            
-            // Modify the watched key from "outside" the transaction
-            // (simulating another client)
-            connection.hashCommands().hSet(watchKeyBytes, field, value2);
-            
-            // Start transaction
-            connection.multi();
-            
-            // Queue hash commands
-            connection.hashCommands().hSet(otherKeyBytes, field, value1);
-            connection.hashCommands().hGet(otherKeyBytes, field);
-            
-            // Execute transaction - should be aborted due to WATCH
-            List<Object> results = connection.exec();
-            
-            // Transaction should be aborted (results should be null)
-            assertThat(results).isNotNull().isEmpty();
-            
-            // Verify that the other key was not set
-            Boolean exists = connection.hashCommands().hExists(otherKeyBytes, field);
-            assertThat(exists).isFalse();
-            
-        } finally {
-            cleanupKey(watchKey);
-            cleanupKey(otherKey);
-        }
-    }
-
-    // ==================== Error Handling Tests for Pipeline/Transaction ====================
-
-    @Test
-    void testPipelineErrorHandling() {
-        String validKey = "test:hash:pipeline:error:valid";
-        String stringKey = "test:hash:pipeline:error:string";
-        byte[] validKeyBytes = validKey.getBytes();
-        byte[] stringKeyBytes = stringKey.getBytes();
-        byte[] field = "field".getBytes();
-        byte[] value = "value".getBytes();
-        
-        try {
-            // Set up a string key to cause type errors
-            connection.stringCommands().set(stringKeyBytes, "stringvalue".getBytes());
-            
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Queue valid command
-            connection.hashCommands().hSet(validKeyBytes, field, value);
-            
-            // Queue command that will cause error (wrong type)
-            connection.hashCommands().hSet(stringKeyBytes, field, value);
-            
-            // Queue another valid command
-            connection.hashCommands().hGet(validKeyBytes, field);
-            
-            // Execute pipeline
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results - valid commands should succeed, error command should return exception
-            assertThat(results).hasSize(3);
-            assertThat(results.get(0)).isEqualTo(true); // Valid hSet
-            assertThat(results.get(1)).isInstanceOf(DataAccessException.class); // Error result
-            assertThat(results.get(2)).isEqualTo(value); // Valid hGet
-            
-        } finally {
-            cleanupKey(validKey);
-            cleanupKey(stringKey);
-        }
-    }
-
-    @Test
-    void testTransactionErrorHandling() {
-        String validKey = "test:hash:transaction:error:valid";
-        String stringKey = "test:hash:transaction:error:string";
-        byte[] validKeyBytes = validKey.getBytes();
-        byte[] stringKeyBytes = stringKey.getBytes();
-        byte[] field = "field".getBytes();
-        byte[] value = "value".getBytes();
-        
-        try {
-            // Set up a string key to cause type errors
-            connection.stringCommands().set(stringKeyBytes, "stringvalue".getBytes());
-            
-            // Start transaction
-            connection.multi();
-            
-            // Queue valid command
-            connection.hashCommands().hSet(validKeyBytes, field, value);
-            
-            // Queue command that will cause error (wrong type)
-            connection.hashCommands().hSet(stringKeyBytes, field, value);
-            
-            // Queue another valid command
-            connection.hashCommands().hGet(validKeyBytes, field);
-            
-            // Execute transaction
-            List<Object> results = connection.exec();
-            
-            // Verify results - valid commands should succeed, error command should return exception
-            assertThat(results).isNotNull(); // Transaction should not be aborted
-            assertThat(results).hasSize(3);
-            assertThat(results.get(0)).isEqualTo(true); // Valid hSet
-            assertThat(results.get(1)).isInstanceOf(DataAccessException.class); // Error result
-            assertThat(results.get(2)).isEqualTo(value); // Valid hGet
-            
-        } finally {
-            cleanupKey(validKey);
-            cleanupKey(stringKey);
-        }
-    }
-
-    @Test
-    void testHScanNotAllowedInPipelineTransactionModes() {
-        String key = "test:hash:scan:error";
-        byte[] keyBytes = key.getBytes();
-        
-        try {
-            // Set up some data
-            Map<byte[], byte[]> hashData = new HashMap<>();
-            hashData.put("field1".getBytes(), "value1".getBytes());
-            connection.hashCommands().hMSet(keyBytes, hashData);
-            
-            // Test HSCAN not allowed in pipeline mode
-            connection.openPipeline();
-            assertThatThrownBy(() -> connection.hashCommands().hScan(keyBytes, ScanOptions.NONE))
-                .isInstanceOf(DataAccessException.class)
-                .hasMessageContaining("pipeline");
-            connection.closePipeline();
-            
-            // Test HSCAN not allowed in transaction mode
-            connection.multi();
-            assertThatThrownBy(() -> connection.hashCommands().hScan(keyBytes, ScanOptions.NONE))
-                .isInstanceOf(DataAccessException.class)
-                .hasMessageContaining("transaction");
-            connection.discard();
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    // ==================== HGETDEL / HGETEX / HSETEX Tests ====================
-
-    @Test
-    @EnabledOnCommand("HGETDEL")
-    void testHGetDel() {
-        String key = "test:hash:hgetdel";
-        byte[] keyBytes = key.getBytes();
-        byte[] field1 = "field1".getBytes();
-        byte[] field2 = "field2".getBytes();
-        byte[] field3 = "field3".getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        byte[] value3 = "value3".getBytes();
-
-        try {
-            // Set up test data
-            connection.hashCommands().hSet(keyBytes, field1, value1);
-            connection.hashCommands().hSet(keyBytes, field2, value2);
-            connection.hashCommands().hSet(keyBytes, field3, value3);
-
-            // Test hGetDel on non-existent field - should return list with null
-            List<byte[]> absentResult = connection.hashCommands().hGetDel(keyBytes, "absent".getBytes());
-            assertThat(absentResult).hasSize(1);
-            assertThat(absentResult.get(0)).isNull();
-
-            // Test hGetDel on existing fields - should return values and delete fields
-            List<byte[]> result = connection.hashCommands().hGetDel(keyBytes, field1, field2);
-            assertThat(result).hasSize(2);
-            assertThat(result.get(0)).isEqualTo(value1);
-            assertThat(result.get(1)).isEqualTo(value2);
-
-            // Verify fields were deleted
-            assertThat(connection.hashCommands().hExists(keyBytes, field1)).isFalse();
-            assertThat(connection.hashCommands().hExists(keyBytes, field2)).isFalse();
-            // field3 should still exist
-            assertThat(connection.hashCommands().hExists(keyBytes, field3)).isTrue();
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    @Test
-    @EnabledOnCommand("HGETEX")
-    void testHGetEx() {
-        String key = "test:hash:hgetex";
-        byte[] keyBytes = key.getBytes();
-        byte[] field1 = "field1".getBytes();
-        byte[] field2 = "field2".getBytes();
-        byte[] field3 = "field3".getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        byte[] value3 = "value3".getBytes();
-
-        try {
-            // Set up test data
-            connection.hashCommands().hSet(keyBytes, field1, value1);
-            connection.hashCommands().hSet(keyBytes, field2, value2);
-            connection.hashCommands().hSet(keyBytes, field3, value3);
-
-            // Test hGetEx with expiration - should return values and set TTL
-            List<byte[]> result = connection.hashCommands().hGetEx(keyBytes, Expiration.seconds(30), field1, field2);
-            assertThat(result).hasSize(2);
-            assertThat(result.get(0)).isEqualTo(value1);
-            assertThat(result.get(1)).isEqualTo(value2);
-
-            // Test hGetEx on non-existent field - should return list with null
-            List<byte[]> noFieldResult = connection.hashCommands().hGetEx(keyBytes, null, "no-such-field".getBytes());
-            assertThat(noFieldResult).hasSize(1);
-            assertThat(noFieldResult.get(0)).isNull();
-
-            // Test hGetEx on non-existent key - should return list with null
-            List<byte[]> noKeyResult = connection.hashCommands().hGetEx("no-such-key".getBytes(), null, field1);
-            assertThat(noKeyResult).hasSize(1);
-            assertThat(noKeyResult.get(0)).isNull();
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    @Test
-    @EnabledOnCommand("HSETEX")
-    void testHSetEx() {
-        String key = "test:hash:hsetex";
-        byte[] keyBytes = key.getBytes();
-        byte[] field1 = "field1".getBytes();
-        byte[] field2 = "field2".getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-
-        try {
-            // Test hSetEx with upsert and expiration
-            Map<byte[], byte[]> fieldMap = new HashMap<>();
-            fieldMap.put(field1, value1);
-            fieldMap.put(field2, value2);
-
-            Boolean result = connection.hashCommands().hSetEx(keyBytes, fieldMap,
-                    ValkeyHashCommands.HashFieldSetOption.upsert(), Expiration.seconds(30));
-            assertThat(result).isTrue();
-
-            // Verify values were set
-            assertThat(connection.hashCommands().hGet(keyBytes, field1)).isEqualTo(value1);
-            assertThat(connection.hashCommands().hGet(keyBytes, field2)).isEqualTo(value2);
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    @Test
-    @EnabledOnCommand("HSETEX")
-    void testHSetExIfNoneExistSucceeds() {
-        String key = "test:hash:hsetex:nx";
-        byte[] keyBytes = key.getBytes();
-        byte[] field1 = "field1".getBytes();
-        byte[] field2 = "field2".getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-
-        try {
-            // Test hSetEx with ifNoneExist when no fields exist - should succeed
-            Map<byte[], byte[]> fieldMap = new HashMap<>();
-            fieldMap.put(field1, value1);
-            fieldMap.put(field2, value2);
-
-            Boolean result = connection.hashCommands().hSetEx(keyBytes, fieldMap,
-                    ValkeyHashCommands.HashFieldSetOption.ifNoneExist(), Expiration.seconds(60));
-            assertThat(result).isTrue();
-
-            // Verify values were set
-            assertThat(connection.hashCommands().hGet(keyBytes, field1)).isEqualTo(value1);
-            assertThat(connection.hashCommands().hGet(keyBytes, field2)).isEqualTo(value2);
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    @Test
-    @EnabledOnCommand("HSETEX")
-    void testHSetExIfNoneExistFailsWhenFieldsExist() {
-        String key = "test:hash:hsetex:nxfail";
-        byte[] keyBytes = key.getBytes();
-        byte[] field1 = "field1".getBytes();
-        byte[] field2 = "field2".getBytes();
-        byte[] existingValue = "existing-value".getBytes();
-        byte[] newValue = "new-value".getBytes();
-        byte[] value2 = "value2".getBytes();
-
-        try {
-            // Pre-set field1
-            connection.hashCommands().hSet(keyBytes, field1, existingValue);
-
-            // Try hSetEx with ifNoneExist when field1 already exists
-            Map<byte[], byte[]> fieldMap = new HashMap<>();
-            fieldMap.put(field1, newValue);
-            fieldMap.put(field2, value2);
-
-            Boolean result = connection.hashCommands().hSetEx(keyBytes, fieldMap,
-                    ValkeyHashCommands.HashFieldSetOption.ifNoneExist(), Expiration.seconds(60));
-            // The operation should not overwrite existing field1
-            assertThat(connection.hashCommands().hGet(keyBytes, field1)).isEqualTo(existingValue);
-            // field2 should not exist either (all-or-nothing with FNX depends on server behavior)
-            // Server may or may not set field2 - just verify field1 was not overwritten
-        } finally {
-            cleanupKey(key);
-        }
-    }
-
-    @Test 
-    void testMixedCommandTypesInPipeline() {
-        String hashKey = "test:hash:pipeline:mixed:hash";
-        String stringKey = "test:hash:pipeline:mixed:string";
-        byte[] hashKeyBytes = hashKey.getBytes();
-        byte[] stringKeyBytes = stringKey.getBytes();
-        byte[] field = "field".getBytes();
-        byte[] hashValue = "hashvalue".getBytes();
-        byte[] stringValue = "stringvalue".getBytes();
-        
-        try {
-            // Start pipeline with mixed commands
-            connection.openPipeline();
-            
-            // Mix hash and string commands
-            connection.hashCommands().hSet(hashKeyBytes, field, hashValue);
-            connection.stringCommands().set(stringKeyBytes, stringValue);
-            connection.hashCommands().hGet(hashKeyBytes, field);
-            connection.stringCommands().get(stringKeyBytes);
-            connection.hashCommands().hExists(hashKeyBytes, field);
-            
-            // Execute pipeline
-            List<Object> results = connection.closePipeline();
-            
-            // Verify mixed results
-            assertThat(results).hasSize(5);
-            assertThat(results.get(0)).isEqualTo(true); // hSet result
-            assertThat(results.get(1)).isEqualTo(true); // string set result (converted to boolean)
-            assertThat(results.get(2)).isEqualTo(hashValue); // hGet result
-            assertThat(results.get(3)).isEqualTo(stringValue); // string get result  
-            assertThat(results.get(4)).isEqualTo(true); // hExists result
-            
-        } finally {
-            cleanupKey(hashKey);
-            cleanupKey(stringKey);
-        }
-    }
+	@Override
+	protected String[] getTestKeyPatterns() {
+		return new String[] { "test:hash:basic", "test:hash:setnx", "test:hash:multi", "test:hash:incr",
+				"test:hash:exists", "test:hash:structure", "test:hash:random", "test:hash:randomwithvals",
+				"test:hash:scan", "test:hash:strlen", "test:hash:expire", "test:hash:expireat", "test:hash:persist",
+				"test:hash:ttl", "test:hash:error:string", "test:hash:empty", "test:hash:binary", "non:existent:key",
+				"test:hash:hgetdel", "test:hash:hgetex", "test:hash:hsetex", "test:hash:hsetex:nx",
+				"test:hash:hsetex:nxfail" };
+	}
+
+	// ==================== Basic Hash Operations ====================
+
+	@Test
+	void testHSetAndHGet() {
+		String key = "test:hash:basic";
+		byte[] keyBytes = key.getBytes();
+		byte[] field1 = "field1".getBytes();
+		byte[] field2 = "field2".getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+
+		try {
+			// Test hSet on new field
+			Boolean setResult1 = connection.hashCommands().hSet(keyBytes, field1, value1);
+			assertThat(setResult1).isTrue();
+
+			// Test hGet
+			byte[] retrievedValue1 = connection.hashCommands().hGet(keyBytes, field1);
+			assertThat(retrievedValue1).isEqualTo(value1);
+
+			// Test hSet on existing field (should update)
+			Boolean setResult2 = connection.hashCommands().hSet(keyBytes, field1, value2);
+			assertThat(setResult2).isFalse(); // Field already existed
+
+			// Verify updated value
+			byte[] retrievedValue2 = connection.hashCommands().hGet(keyBytes, field1);
+			assertThat(retrievedValue2).isEqualTo(value2);
+
+			// Test hGet on non-existent field
+			byte[] nonExistentValue = connection.hashCommands().hGet(keyBytes, field2);
+			assertThat(nonExistentValue).isNull();
+
+			// Test hGet on non-existent key
+			byte[] nonExistentKeyValue = connection.hashCommands().hGet("non:existent:key".getBytes(), field1);
+			assertThat(nonExistentKeyValue).isNull();
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testHSetNX() {
+		String key = "test:hash:setnx";
+		byte[] keyBytes = key.getBytes();
+		byte[] field = "field".getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+
+		try {
+			// Test hSetNX on new field
+			Boolean setNXResult1 = connection.hashCommands().hSetNX(keyBytes, field, value1);
+			assertThat(setNXResult1).isTrue();
+
+			// Verify value was set
+			byte[] retrievedValue1 = connection.hashCommands().hGet(keyBytes, field);
+			assertThat(retrievedValue1).isEqualTo(value1);
+
+			// Test hSetNX on existing field - should fail
+			Boolean setNXResult2 = connection.hashCommands().hSetNX(keyBytes, field, value2);
+			assertThat(setNXResult2).isFalse();
+
+			// Verify value was not changed
+			byte[] retrievedValue2 = connection.hashCommands().hGet(keyBytes, field);
+			assertThat(retrievedValue2).isEqualTo(value1);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testHMGetAndHMSet() {
+		String key = "test:hash:multi";
+		byte[] keyBytes = key.getBytes();
+		byte[] field1 = "field1".getBytes();
+		byte[] field2 = "field2".getBytes();
+		byte[] field3 = "field3".getBytes();
+		byte[] field4 = "nonexistent".getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+		byte[] value3 = "value3".getBytes();
+
+		try {
+			// Set up test data using hMSet
+			Map<byte[], byte[]> hashData = new HashMap<>();
+			hashData.put(field1, value1);
+			hashData.put(field2, value2);
+			hashData.put(field3, value3);
+
+			connection.hashCommands().hMSet(keyBytes, hashData);
+
+			// Test hMGet with existing and non-existing fields
+			List<byte[]> values = connection.hashCommands().hMGet(keyBytes, field1, field2, field3, field4);
+
+			assertThat(values).hasSize(4);
+			assertThat(values.get(0)).isEqualTo(value1);
+			assertThat(values.get(1)).isEqualTo(value2);
+			assertThat(values.get(2)).isEqualTo(value3);
+			assertThat(values.get(3)).isNull(); // non-existent field
+
+			// Test hMGet on non-existent key
+			List<byte[]> nonExistentValues = connection.hashCommands().hMGet("non:existent:key".getBytes(), field1);
+			assertThat(nonExistentValues).hasSize(1);
+			assertThat(nonExistentValues.get(0)).isNull();
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== Increment Operations ====================
+
+	@Test
+	void testHIncrBy() {
+		String key = "test:hash:incr";
+		byte[] keyBytes = key.getBytes();
+		byte[] intField = "intField".getBytes();
+		byte[] floatField = "floatField".getBytes();
+
+		try {
+			// Test hIncrBy with long on non-existent field (should start from 0)
+			Long incrResult1 = connection.hashCommands().hIncrBy(keyBytes, intField, 5L);
+			assertThat(incrResult1).isEqualTo(5L);
+
+			// Test subsequent increment
+			Long incrResult2 = connection.hashCommands().hIncrBy(keyBytes, intField, 10L);
+			assertThat(incrResult2).isEqualTo(15L);
+
+			// Test negative increment (decrement)
+			Long incrResult3 = connection.hashCommands().hIncrBy(keyBytes, intField, -7L);
+			assertThat(incrResult3).isEqualTo(8L);
+
+			// Test hIncrBy with double on non-existent field
+			Double floatIncrResult1 = connection.hashCommands().hIncrBy(keyBytes, floatField, 3.14);
+			assertThat(floatIncrResult1).isEqualTo(3.14);
+
+			// Test subsequent float increment
+			Double floatIncrResult2 = connection.hashCommands().hIncrBy(keyBytes, floatField, 2.86);
+			assertThat(floatIncrResult2).isEqualTo(6.0);
+
+			// Test negative float increment
+			Double floatIncrResult3 = connection.hashCommands().hIncrBy(keyBytes, floatField, -1.5);
+			assertThat(floatIncrResult3).isEqualTo(4.5);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== Existence and Deletion Operations ====================
+
+	@Test
+	void testHExistsAndHDel() {
+		String key = "test:hash:exists";
+		byte[] keyBytes = key.getBytes();
+		byte[] field1 = "field1".getBytes();
+		byte[] field2 = "field2".getBytes();
+		byte[] field3 = "field3".getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+		byte[] value3 = "value3".getBytes();
+
+		try {
+			// Set up test data
+			connection.hashCommands().hSet(keyBytes, field1, value1);
+			connection.hashCommands().hSet(keyBytes, field2, value2);
+			connection.hashCommands().hSet(keyBytes, field3, value3);
+
+			// Test hExists on existing fields
+			Boolean exists1 = connection.hashCommands().hExists(keyBytes, field1);
+			assertThat(exists1).isTrue();
+
+			Boolean exists2 = connection.hashCommands().hExists(keyBytes, field2);
+			assertThat(exists2).isTrue();
+
+			// Test hExists on non-existent field
+			Boolean existsNon = connection.hashCommands().hExists(keyBytes, "nonexistent".getBytes());
+			assertThat(existsNon).isFalse();
+
+			// Test hExists on non-existent key
+			Boolean existsNonKey = connection.hashCommands().hExists("non:existent:key".getBytes(), field1);
+			assertThat(existsNonKey).isFalse();
+
+			// Test hDel with single field
+			Long delResult1 = connection.hashCommands().hDel(keyBytes, field1);
+			assertThat(delResult1).isEqualTo(1L);
+
+			// Verify field was deleted
+			Boolean existsAfterDel = connection.hashCommands().hExists(keyBytes, field1);
+			assertThat(existsAfterDel).isFalse();
+
+			// Test hDel with multiple fields
+			Long delResult2 = connection.hashCommands().hDel(keyBytes, field2, field3);
+			assertThat(delResult2).isEqualTo(2L);
+
+			// Test hDel on non-existent field
+			Long delResult3 = connection.hashCommands().hDel(keyBytes, "nonexistent".getBytes());
+			assertThat(delResult3).isEqualTo(0L);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== Structural Operations ====================
+
+	@Test
+	void testHLenHKeysHValsHGetAll() {
+		String key = "test:hash:structure";
+		byte[] keyBytes = key.getBytes();
+		byte[] field1 = "field1".getBytes();
+		byte[] field2 = "field2".getBytes();
+		byte[] field3 = "field3".getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+		byte[] value3 = "value3".getBytes();
+
+		try {
+			// Test on empty/non-existent hash
+			Long emptyLen = connection.hashCommands().hLen(keyBytes);
+			assertThat(emptyLen).isEqualTo(0L);
+
+			Set<byte[]> emptyKeys = connection.hashCommands().hKeys(keyBytes);
+			assertThat(emptyKeys).isEmpty();
+
+			List<byte[]> emptyVals = connection.hashCommands().hVals(keyBytes);
+			assertThat(emptyVals).isEmpty();
+
+			Map<byte[], byte[]> emptyAll = connection.hashCommands().hGetAll(keyBytes);
+			assertThat(emptyAll).isEmpty();
+
+			// Set up test data
+			Map<byte[], byte[]> hashData = new HashMap<>();
+			hashData.put(field1, value1);
+			hashData.put(field2, value2);
+			hashData.put(field3, value3);
+			connection.hashCommands().hMSet(keyBytes, hashData);
+
+			// Test hLen
+			Long len = connection.hashCommands().hLen(keyBytes);
+			assertThat(len).isEqualTo(3L);
+
+			// Test hKeys
+			Set<byte[]> keys = connection.hashCommands().hKeys(keyBytes);
+			assertThat(keys).hasSize(3);
+			assertThat(keys).containsExactlyInAnyOrder(field1, field2, field3);
+
+			// Test hVals
+			List<byte[]> vals = connection.hashCommands().hVals(keyBytes);
+			assertThat(vals).hasSize(3);
+			assertThat(vals).containsExactlyInAnyOrder(value1, value2, value3);
+
+			// Test hGetAll
+			Map<byte[], byte[]> all = connection.hashCommands().hGetAll(keyBytes);
+			assertThat(all).hasSize(3);
+
+			// Since byte arrays are compared by reference, not content, we need to check
+			// the content differently
+			boolean foundField1 = false, foundField2 = false, foundField3 = false;
+			for (Map.Entry<byte[], byte[]> entry : all.entrySet()) {
+				if (java.util.Arrays.equals(entry.getKey(), field1)) {
+					assertThat(entry.getValue()).isEqualTo(value1);
+					foundField1 = true;
+				}
+				else if (java.util.Arrays.equals(entry.getKey(), field2)) {
+					assertThat(entry.getValue()).isEqualTo(value2);
+					foundField2 = true;
+				}
+				else if (java.util.Arrays.equals(entry.getKey(), field3)) {
+					assertThat(entry.getValue()).isEqualTo(value3);
+					foundField3 = true;
+				}
+			}
+			assertThat(foundField1).as("field1 should be present in hGetAll result").isTrue();
+			assertThat(foundField2).as("field2 should be present in hGetAll result").isTrue();
+			assertThat(foundField3).as("field3 should be present in hGetAll result").isTrue();
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== Random Field Operations ====================
+
+	@Test
+	void testHRandField() {
+		String key = "test:hash:random";
+		byte[] keyBytes = key.getBytes();
+		byte[] field1 = "field1".getBytes();
+		byte[] field2 = "field2".getBytes();
+		byte[] field3 = "field3".getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+		byte[] value3 = "value3".getBytes();
+
+		try {
+			// Test on non-existent key
+			byte[] nonExistentField = connection.hashCommands().hRandField("non:existent:key".getBytes());
+			assertThat(nonExistentField).isNull();
+
+			// Set up test data
+			Map<byte[], byte[]> hashData = new HashMap<>();
+			hashData.put(field1, value1);
+			hashData.put(field2, value2);
+			hashData.put(field3, value3);
+			connection.hashCommands().hMSet(keyBytes, hashData);
+
+			// Test hRandField (single field)
+			byte[] randomField = connection.hashCommands().hRandField(keyBytes);
+			assertThat(randomField).isIn(field1, field2, field3);
+
+			// Test hRandField with count
+			List<byte[]> randomFields = connection.hashCommands().hRandField(keyBytes, 2);
+			assertThat(randomFields).hasSize(2);
+
+			// Test hRandField with count larger than hash size
+			List<byte[]> allFields = connection.hashCommands().hRandField(keyBytes, 5);
+			assertThat(allFields).hasSize(3); // Should return all available fields
+
+			// Test hRandField with negative count (allows repetitions)
+			List<byte[]> repeatedFields = connection.hashCommands().hRandField(keyBytes, -5);
+			assertThat(repeatedFields).hasSize(5); // Should return exactly 5 elements
+													// (may repeat)
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testHRandFieldWithValues() {
+		String key = "test:hash:randomwithvals";
+		byte[] keyBytes = key.getBytes();
+		byte[] field1 = "field1".getBytes();
+		byte[] field2 = "field2".getBytes();
+		byte[] field3 = "field3".getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+		byte[] value3 = "value3".getBytes();
+
+		try {
+			// Test on non-existent key
+			Map.Entry<byte[], byte[]> nonExistentEntry = connection.hashCommands()
+				.hRandFieldWithValues("non:existent:key".getBytes());
+			assertThat(nonExistentEntry).isNull();
+
+			// Set up test data
+			Map<byte[], byte[]> hashData = new HashMap<>();
+			hashData.put(field1, value1);
+			hashData.put(field2, value2);
+			hashData.put(field3, value3);
+			connection.hashCommands().hMSet(keyBytes, hashData);
+
+			// Test hRandFieldWithValues (single entry)
+			Map.Entry<byte[], byte[]> randomEntry = connection.hashCommands().hRandFieldWithValues(keyBytes);
+			assertThat(randomEntry).isNotNull();
+			assertThat(randomEntry.getKey()).isIn(field1, field2, field3);
+			// Verify the value matches the key
+			if (java.util.Arrays.equals(randomEntry.getKey(), field1)) {
+				assertThat(randomEntry.getValue()).isEqualTo(value1);
+			}
+			else if (java.util.Arrays.equals(randomEntry.getKey(), field2)) {
+				assertThat(randomEntry.getValue()).isEqualTo(value2);
+			}
+			else if (java.util.Arrays.equals(randomEntry.getKey(), field3)) {
+				assertThat(randomEntry.getValue()).isEqualTo(value3);
+			}
+
+			// Test hRandFieldWithValues with count
+			List<Map.Entry<byte[], byte[]>> randomEntries = connection.hashCommands().hRandFieldWithValues(keyBytes, 2);
+			assertThat(randomEntries).hasSize(2);
+
+			for (Map.Entry<byte[], byte[]> entry : randomEntries) {
+				assertThat(entry.getKey()).isIn(field1, field2, field3);
+				// Verify each value matches its key
+				if (java.util.Arrays.equals(entry.getKey(), field1)) {
+					assertThat(entry.getValue()).isEqualTo(value1);
+				}
+				else if (java.util.Arrays.equals(entry.getKey(), field2)) {
+					assertThat(entry.getValue()).isEqualTo(value2);
+				}
+				else if (java.util.Arrays.equals(entry.getKey(), field3)) {
+					assertThat(entry.getValue()).isEqualTo(value3);
+				}
+			}
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== Scanning Operations ====================
+
+	@Test
+	void testHScan() {
+		String key = "test:hash:scan";
+		byte[] keyBytes = key.getBytes();
+
+		try {
+			// Set up test data with a pattern
+			Map<byte[], byte[]> hashData = new HashMap<>();
+			hashData.put("field1".getBytes(), "value1".getBytes());
+			hashData.put("field2".getBytes(), "value2".getBytes());
+			hashData.put("other1".getBytes(), "othervalue1".getBytes());
+			hashData.put("other2".getBytes(), "othervalue2".getBytes());
+			connection.hashCommands().hMSet(keyBytes, hashData);
+
+			// Test basic scan
+			Cursor<Map.Entry<byte[], byte[]>> cursor = connection.hashCommands().hScan(keyBytes, ScanOptions.NONE);
+
+			List<Map.Entry<byte[], byte[]>> scannedEntries = new ArrayList<>();
+			while (cursor.hasNext()) {
+				scannedEntries.add(cursor.next());
+			}
+			cursor.close();
+
+			assertThat(scannedEntries).hasSize(4);
+
+			// Test scan with pattern
+			ScanOptions patternOptions = ScanOptions.scanOptions().match("field*").build();
+			Cursor<Map.Entry<byte[], byte[]>> patternCursor = connection.hashCommands().hScan(keyBytes, patternOptions);
+
+			List<Map.Entry<byte[], byte[]>> patternEntries = new ArrayList<>();
+			while (patternCursor.hasNext()) {
+				patternEntries.add(patternCursor.next());
+			}
+			patternCursor.close();
+
+			// Should find only entries matching "field*" pattern
+			assertThat(patternEntries).hasSize(2);
+			for (Map.Entry<byte[], byte[]> entry : patternEntries) {
+				String fieldName = new String(entry.getKey());
+				assertThat(fieldName).startsWith("field");
+			}
+
+			// Test scan with count
+			ScanOptions countOptions = ScanOptions.scanOptions().count(1).build();
+			Cursor<Map.Entry<byte[], byte[]>> countCursor = connection.hashCommands().hScan(keyBytes, countOptions);
+
+			List<Map.Entry<byte[], byte[]>> countEntries = new ArrayList<>();
+			while (countCursor.hasNext()) {
+				countEntries.add(countCursor.next());
+			}
+			countCursor.close();
+
+			assertThat(countEntries).hasSize(4); // Should still get all entries, just in
+													// smaller batches
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== Field Length Operations ====================
+
+	@Test
+	void testHStrLen() {
+		String key = "test:hash:strlen";
+		byte[] keyBytes = key.getBytes();
+		byte[] field1 = "field1".getBytes();
+		byte[] field2 = "field2".getBytes();
+		byte[] shortValue = "short".getBytes(); // 5 characters
+		byte[] longValue = "this is a longer value".getBytes(); // 22 characters
+
+		try {
+			// Test on non-existent key/field
+			Long nonExistentLen = connection.hashCommands().hStrLen("non:existent:key".getBytes(), field1);
+			assertThat(nonExistentLen).isEqualTo(0L);
+
+			// Set up test data
+			connection.hashCommands().hSet(keyBytes, field1, shortValue);
+			connection.hashCommands().hSet(keyBytes, field2, longValue);
+
+			// Test hStrLen
+			Long shortLen = connection.hashCommands().hStrLen(keyBytes, field1);
+			assertThat(shortLen).isEqualTo(5L);
+
+			Long longLen = connection.hashCommands().hStrLen(keyBytes, field2);
+			assertThat(longLen).isEqualTo(22L);
+
+			// Test on non-existent field in existing key
+			Long nonExistentFieldLen = connection.hashCommands().hStrLen(keyBytes, "nonexistent".getBytes());
+			assertThat(nonExistentFieldLen).isEqualTo(0L);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== Field Expiration Operations ====================
+
+	@Test
+	@EnabledOnCommand("HEXPIRE")
+	void testHExpire() {
+		String key = "test:hash:expire";
+		byte[] keyBytes = key.getBytes();
+		byte[] field1 = "field1".getBytes();
+		byte[] field2 = "field2".getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+
+		try {
+			// Set up test data
+			connection.hashCommands().hSet(keyBytes, field1, value1);
+			connection.hashCommands().hSet(keyBytes, field2, value2);
+
+			// Test hExpire (seconds) - Basic happy path test to ensure command executes
+			List<Long> expireResults = connection.hashCommands()
+				.hExpire(keyBytes, 10L, ExpirationOptions.Condition.ALWAYS, field1);
+			assertThat(expireResults).hasSize(1);
+			assertThat(expireResults.get(0)).isEqualTo(1);
+
+			// Test hExpire (seconds) - Test non existing key
+			expireResults = connection.hashCommands()
+				.hExpire("non:existent:key".getBytes(), 10L, ExpirationOptions.Condition.ALWAYS, field1);
+			assertThat(expireResults).hasSize(1);
+			assertThat(expireResults.get(0)).isEqualTo(-2);
+
+			// Test hExpire (seconds) - 2 existing and 1 absent fields
+			expireResults = connection.hashCommands()
+				.hExpire(keyBytes, 10L, ExpirationOptions.Condition.ALWAYS, field1, field2, "nonexistent".getBytes());
+			assertThat(expireResults).hasSize(3);
+			assertThat(expireResults.get(0)).isEqualTo(1);
+			assertThat(expireResults.get(1)).isEqualTo(1);
+			assertThat(expireResults.get(2)).isEqualTo(-2);
+
+			// Test hExpire (seconds) - Test NX
+			expireResults = connection.hashCommands().hExpire(keyBytes, 10L, ExpirationOptions.Condition.NX, field1);
+			assertThat(expireResults).hasSize(1);
+			assertThat(expireResults.get(0)).isEqualTo(0);
+
+			// Test hExpire (seconds) - Test XX
+			expireResults = connection.hashCommands().hExpire(keyBytes, 10L, ExpirationOptions.Condition.XX, field1);
+			assertThat(expireResults).hasSize(1);
+			assertThat(expireResults.get(0)).isEqualTo(1);
+
+			// Test hExpire (seconds) - Test GT by setting a shorter expiry first
+			expireResults = connection.hashCommands().hExpire(keyBytes, 1L, ExpirationOptions.Condition.GT, field1);
+			assertThat(expireResults).hasSize(1);
+			assertThat(expireResults.get(0)).isEqualTo(0);
+
+			// Test hExpire (seconds) - Test LT by setting a longer expiry
+			expireResults = connection.hashCommands().hExpire(keyBytes, 11L, ExpirationOptions.Condition.LT, field1);
+			assertThat(expireResults).hasSize(1);
+			assertThat(expireResults.get(0)).isEqualTo(0);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	@EnabledOnCommand("HPEXPIRE")
+	void testHpExpire() {
+		String key = "test:hash:expire";
+		byte[] keyBytes = key.getBytes();
+		byte[] field1 = "field1".getBytes();
+		byte[] field2 = "field2".getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+
+		try {
+			// Set up test data
+			connection.hashCommands().hSet(keyBytes, field1, value1);
+			connection.hashCommands().hSet(keyBytes, field2, value2);
+
+			// Test hExpire (seconds) - Basic happy path test to ensure command executes
+			List<Long> expireResults = connection.hashCommands()
+				.hpExpire(keyBytes, 10000L, ExpirationOptions.Condition.ALWAYS, field1);
+			assertThat(expireResults).hasSize(1);
+			assertThat(expireResults.get(0)).isEqualTo(1);
+
+			// Test hExpire (seconds) - Test non existing key
+			expireResults = connection.hashCommands()
+				.hpExpire("non:existent:key".getBytes(), 10000L, ExpirationOptions.Condition.ALWAYS, field1);
+			assertThat(expireResults).hasSize(1);
+			assertThat(expireResults.get(0)).isEqualTo(-2);
+
+			// Test hExpire (seconds) - 2 existing and 1 absent fields
+			expireResults = connection.hashCommands()
+				.hpExpire(keyBytes, 10000L, ExpirationOptions.Condition.ALWAYS, field1, field2,
+						"nonexistent".getBytes());
+			assertThat(expireResults).hasSize(3);
+			assertThat(expireResults.get(0)).isEqualTo(1);
+			assertThat(expireResults.get(1)).isEqualTo(1);
+			assertThat(expireResults.get(2)).isEqualTo(-2);
+
+			// Test hExpire (seconds) - Test NX
+			expireResults = connection.hashCommands()
+				.hpExpire(keyBytes, 10000L, ExpirationOptions.Condition.NX, field1);
+			assertThat(expireResults).hasSize(1);
+			assertThat(expireResults.get(0)).isEqualTo(0);
+
+			// Test hExpire (seconds) - Test XX
+			expireResults = connection.hashCommands()
+				.hpExpire(keyBytes, 10000L, ExpirationOptions.Condition.XX, field1);
+			assertThat(expireResults).hasSize(1);
+			assertThat(expireResults.get(0)).isEqualTo(1);
+
+			// Test hExpire (seconds) - Test GT by setting a shorter expiry first
+			expireResults = connection.hashCommands().hpExpire(keyBytes, 1000L, ExpirationOptions.Condition.GT, field1);
+			assertThat(expireResults).hasSize(1);
+			assertThat(expireResults.get(0)).isEqualTo(0);
+
+			// Test hExpire (seconds) - Test LT by setting a longer expiry
+			expireResults = connection.hashCommands()
+				.hpExpire(keyBytes, 11000L, ExpirationOptions.Condition.LT, field1);
+			assertThat(expireResults).hasSize(1);
+			assertThat(expireResults.get(0)).isEqualTo(0);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	@EnabledOnCommand("HEXPIREAT")
+	void testHExpireAt() {
+		String key = "test:hash:expireat";
+		byte[] keyBytes = key.getBytes();
+		byte[] field1 = "field1".getBytes();
+		byte[] field2 = "field2".getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+
+		try {
+			// Set up test data
+			connection.hashCommands().hSet(keyBytes, field1, value1);
+			connection.hashCommands().hSet(keyBytes, field2, value2);
+
+			long currentTimestamp = System.currentTimeMillis() / 1000;
+			long expirationTimestamp = currentTimestamp + 10; // 10 seconds in the future
+			long shorterTimestamp = currentTimestamp + 5; // 5 seconds in the future
+															// (shorter than 10)
+			long nextExpirationTimestampMillis = currentTimestamp + 20; // 20 seconds in
+																		// the future
+
+			// Test hExpireAt (seconds) - Basic happy path test to ensure command executes
+			List<Long> expireResults = connection.hashCommands()
+				.hExpireAt(keyBytes, expirationTimestamp, ExpirationOptions.Condition.ALWAYS, field1);
+			assertThat(expireResults).hasSize(1);
+			assertThat(expireResults.get(0)).isEqualTo(1);
+
+			// Test hExpire (seconds) - Test non existing key
+			expireResults = connection.hashCommands()
+				.hExpireAt("non:existent:key".getBytes(), expirationTimestamp, ExpirationOptions.Condition.ALWAYS,
+						field1);
+			assertThat(expireResults).hasSize(1);
+			assertThat(expireResults.get(0)).isEqualTo(-2);
+
+			// Test hExpire (seconds) - 2 existing and 1 absent fields
+			expireResults = connection.hashCommands()
+				.hExpireAt(keyBytes, expirationTimestamp, ExpirationOptions.Condition.ALWAYS, field1, field2,
+						"nonexistent".getBytes());
+			assertThat(expireResults).hasSize(3);
+			assertThat(expireResults.get(0)).isEqualTo(1);
+			assertThat(expireResults.get(1)).isEqualTo(1);
+			assertThat(expireResults.get(2)).isEqualTo(-2);
+
+			// Test hExpire (seconds) - Test NX
+			expireResults = connection.hashCommands()
+				.hExpireAt(keyBytes, expirationTimestamp, ExpirationOptions.Condition.NX, field1);
+			assertThat(expireResults).hasSize(1);
+			assertThat(expireResults.get(0)).isEqualTo(0);
+
+			// Test hExpire (seconds) - Test XX
+			expireResults = connection.hashCommands()
+				.hExpireAt(keyBytes, expirationTimestamp, ExpirationOptions.Condition.XX, field1);
+			assertThat(expireResults).hasSize(1);
+			assertThat(expireResults.get(0)).isEqualTo(1);
+
+			// Test hExpire (seconds) - Test GT by setting a shorter expiry first
+			expireResults = connection.hashCommands()
+				.hExpireAt(keyBytes, shorterTimestamp, ExpirationOptions.Condition.GT, field1);
+			assertThat(expireResults).hasSize(1);
+			assertThat(expireResults.get(0)).isEqualTo(0);
+
+			// Test hExpire (seconds) - Test LT by setting a longer expiry
+			expireResults = connection.hashCommands()
+				.hExpireAt(keyBytes, nextExpirationTimestampMillis, ExpirationOptions.Condition.LT, field1);
+			assertThat(expireResults).hasSize(1);
+			assertThat(expireResults.get(0)).isEqualTo(0);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	@EnabledOnCommand("HPEXPIREAT")
+	void testHpExpireAt() {
+		String key = "test:hash:expireat";
+		byte[] keyBytes = key.getBytes();
+		byte[] field1 = "field1".getBytes();
+		byte[] field2 = "field2".getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+
+		try {
+			// Set up test data
+			connection.hashCommands().hSet(keyBytes, field1, value1);
+			connection.hashCommands().hSet(keyBytes, field2, value2);
+
+			long currentTimestamp = System.currentTimeMillis();
+			long expirationTimestamp = currentTimestamp + 10000; // 10 seconds in the
+																	// future
+			long shorterTimestamp = currentTimestamp + 5000; // 5 seconds in the future
+																// (shorter than 10)
+			long nextExpirationTimestampMillis = currentTimestamp + 20000; // 20 seconds
+																			// in the
+																			// future
+
+			// Test hExpireAt (seconds) - Basic happy path test to ensure command executes
+			List<Long> expireResults = connection.hashCommands()
+				.hpExpireAt(keyBytes, expirationTimestamp, ExpirationOptions.Condition.ALWAYS, field1);
+			assertThat(expireResults).hasSize(1);
+			assertThat(expireResults.get(0)).isEqualTo(1);
+
+			// Test hExpire (seconds) - Test non existing key
+			expireResults = connection.hashCommands()
+				.hpExpireAt("non:existent:key".getBytes(), expirationTimestamp, ExpirationOptions.Condition.ALWAYS,
+						field1);
+			assertThat(expireResults).hasSize(1);
+			assertThat(expireResults.get(0)).isEqualTo(-2);
+
+			// Test hExpire (seconds) - 2 existing and 1 absent fields
+			expireResults = connection.hashCommands()
+				.hpExpireAt(keyBytes, expirationTimestamp, ExpirationOptions.Condition.ALWAYS, field1, field2,
+						"nonexistent".getBytes());
+			assertThat(expireResults).hasSize(3);
+			assertThat(expireResults.get(0)).isEqualTo(1);
+			assertThat(expireResults.get(1)).isEqualTo(1);
+			assertThat(expireResults.get(2)).isEqualTo(-2);
+
+			// Test hExpire (seconds) - Test NX
+			expireResults = connection.hashCommands()
+				.hpExpireAt(keyBytes, expirationTimestamp, ExpirationOptions.Condition.NX, field1);
+			assertThat(expireResults).hasSize(1);
+			assertThat(expireResults.get(0)).isEqualTo(0);
+
+			// Test hExpire (seconds) - Test XX
+			expireResults = connection.hashCommands()
+				.hpExpireAt(keyBytes, expirationTimestamp, ExpirationOptions.Condition.XX, field1);
+			assertThat(expireResults).hasSize(1);
+			assertThat(expireResults.get(0)).isEqualTo(1);
+
+			// Test hExpire (seconds) - Test GT by setting a shorter expiry first
+			expireResults = connection.hashCommands()
+				.hpExpireAt(keyBytes, shorterTimestamp, ExpirationOptions.Condition.GT, field1);
+			assertThat(expireResults).hasSize(1);
+			assertThat(expireResults.get(0)).isEqualTo(0);
+
+			// Test hExpire (seconds) - Test LT by setting a longer expiry
+			expireResults = connection.hashCommands()
+				.hpExpireAt(keyBytes, nextExpirationTimestampMillis, ExpirationOptions.Condition.LT, field1);
+			assertThat(expireResults).hasSize(1);
+			assertThat(expireResults.get(0)).isEqualTo(0);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	@EnabledOnCommand("HPERSIST")
+	void testHPersist() {
+		String key = "test:hash:persist";
+		byte[] keyBytes = key.getBytes();
+		byte[] field1 = "field1".getBytes();
+		byte[] field2 = "field2".getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+
+		try {
+			// Set up test data
+			connection.hashCommands().hSet(keyBytes, field1, value1);
+			connection.hashCommands().hSet(keyBytes, field2, value2);
+
+			// Test hPersist - Basic test to ensure command executes
+			List<Long> persistResults = connection.hashCommands().hPersist(keyBytes, field1, field2);
+			assertThat(persistResults).hasSize(2);
+			assertThat(persistResults.get(0)).isEqualTo(-1); // field1 had no expiration
+			assertThat(persistResults.get(1)).isEqualTo(-1); // field2 had no expiration
+
+			// Set expiration to test persistence removal (combined)
+			connection.hashCommands().hExpire(keyBytes, 10L, ExpirationOptions.Condition.ALWAYS, field1);
+			persistResults = connection.hashCommands().hPersist(keyBytes, field1, field2, "nonexistent".getBytes());
+			assertThat(persistResults).hasSize(3);
+			assertThat(persistResults.get(0)).isEqualTo(1); // field1 expiration removed
+			assertThat(persistResults.get(1)).isEqualTo(-1); // field2 had no expiration
+			assertThat(persistResults.get(2)).isEqualTo(-2); // nonexistent field
+
+			// Test on non-existent field
+			List<Long> nonExistentResults = connection.hashCommands().hPersist(keyBytes, "nonexistent".getBytes());
+			assertThat(nonExistentResults).hasSize(1);
+			assertThat(nonExistentResults.get(0)).isEqualTo(-2);
+
+			// Test on non-existent key
+			List<Long> nonExistentKeyResults = connection.hashCommands()
+				.hPersist("non:existent:key".getBytes(), field1);
+			assertThat(nonExistentKeyResults).hasSize(1);
+			assertThat(nonExistentKeyResults.get(0)).isEqualTo(-2);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	@EnabledOnCommand("HTTL")
+	void testHTtl() {
+		String key = "test:hash:ttl";
+		byte[] keyBytes = key.getBytes();
+		byte[] field1 = "field1".getBytes();
+		byte[] field2 = "field2".getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+
+		try {
+			// Set up test data
+			connection.hashCommands().hSet(keyBytes, field1, value1);
+			connection.hashCommands().hSet(keyBytes, field2, value2);
+
+			// Test hTtl - Basic test to ensure command executes
+			List<Long> ttlResults = connection.hashCommands().hTtl(keyBytes, field1, field2);
+			assertThat(ttlResults).hasSize(2);
+			assertThat(ttlResults.get(0)).isEqualTo(-1); // No expiration
+			assertThat(ttlResults.get(1)).isEqualTo(-1); // No expiration
+
+			// Set expiration to test TTL retrieval (combined)
+			connection.hashCommands().hExpire(keyBytes, 10L, ExpirationOptions.Condition.ALWAYS, field1);
+			ttlResults = connection.hashCommands().hTtl(keyBytes, field1, field2, "nonexistent".getBytes());
+			assertThat(ttlResults).hasSize(3);
+			assertThat(ttlResults.get(0)).isGreaterThan(0); // field1 should have a TTL
+			assertThat(ttlResults.get(1)).isEqualTo(-1); // field2 has no expiration
+			assertThat(ttlResults.get(2)).isEqualTo(-2); // nonexistent field
+
+			// Test hTtl with TimeUnit
+			connection.hashCommands().hExpire(keyBytes, 10L, ExpirationOptions.Condition.ALWAYS, field2);
+			List<Long> ttlMillisResults = connection.hashCommands()
+				.hTtl(keyBytes, TimeUnit.MILLISECONDS, field1, field2);
+			assertThat(ttlMillisResults).hasSize(2);
+			assertThat(ttlMillisResults.get(0)).isGreaterThan(5000); // field1 should
+																		// definitely have
+																		// >5s left
+			assertThat(ttlMillisResults.get(1)).isGreaterThan(5000); // field2 should
+																		// definitely have
+																		// >5s left
+
+			// Test non existant key
+			ttlResults = connection.hashCommands().hTtl("non:existent:key".getBytes(), field1);
+			assertThat(ttlResults).hasSize(1);
+			assertThat(ttlResults.get(0)).isEqualTo(-2);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	@EnabledOnCommand("HPTTL")
+	void testHpTtl() {
+		String key = "test:hash:ttl";
+		byte[] keyBytes = key.getBytes();
+		byte[] field1 = "field1".getBytes();
+		byte[] field2 = "field2".getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+
+		try {
+			// Set up test data
+			connection.hashCommands().hSet(keyBytes, field1, value1);
+			connection.hashCommands().hSet(keyBytes, field2, value2);
+
+			// Test hpTtl - Basic test to ensure command executes
+			List<Long> ttlResults = connection.hashCommands().hpTtl(keyBytes, field1, field2);
+			assertThat(ttlResults).hasSize(2);
+			assertThat(ttlResults.get(0)).isEqualTo(-1); // No expiration
+			assertThat(ttlResults.get(1)).isEqualTo(-1); // No expiration
+
+			// Set expiration to test TTL retrieval (combined)
+			connection.hashCommands().hExpire(keyBytes, 10L, ExpirationOptions.Condition.ALWAYS, field1);
+			ttlResults = connection.hashCommands().hpTtl(keyBytes, field1, field2, "nonexistent".getBytes());
+			assertThat(ttlResults).hasSize(3);
+			assertThat(ttlResults.get(0)).isGreaterThan(1000); // field1 should have a TTL
+			assertThat(ttlResults.get(1)).isEqualTo(-1); // field2 has no expiration
+			assertThat(ttlResults.get(2)).isEqualTo(-2); // nonexistent field
+
+			// Test non existant key
+			ttlResults = connection.hashCommands().hpTtl("non:existent:key".getBytes(), field1);
+			assertThat(ttlResults).hasSize(1);
+			assertThat(ttlResults.get(0)).isEqualTo(-2);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== Error Handling and Edge Cases ====================
+
+	@Test
+	void testHashOperationsOnNonHashTypes() {
+		String stringKey = "test:hash:error:string";
+
+		try {
+			// Create a string key
+			connection.stringCommands().set(stringKey.getBytes(), "stringvalue".getBytes());
+
+			// Try hash operations on string key - should fail or return appropriate
+			// response
+			assertThatThrownBy(
+					() -> connection.hashCommands().hSet(stringKey.getBytes(), "field".getBytes(), "value".getBytes()))
+				.isInstanceOf(Exception.class);
+		}
+		finally {
+			cleanupKey(stringKey);
+		}
+	}
+
+	@Test
+	void testEmptyHashOperations() {
+		String key = "test:hash:empty";
+		byte[] keyBytes = key.getBytes();
+		byte[] field = "field".getBytes();
+		byte[] emptyValue = new byte[0];
+
+		try {
+			// Set field with empty value
+			Boolean setResult = connection.hashCommands().hSet(keyBytes, field, emptyValue);
+			assertThat(setResult).isTrue();
+
+			// Get empty value
+			byte[] retrievedValue = connection.hashCommands().hGet(keyBytes, field);
+			assertThat(retrievedValue).isEqualTo(emptyValue);
+
+			// String length should be 0
+			Long strLen = connection.hashCommands().hStrLen(keyBytes, field);
+			assertThat(strLen).isEqualTo(0L);
+
+			// Hash should have 1 field
+			Long hashLen = connection.hashCommands().hLen(keyBytes);
+			assertThat(hashLen).isEqualTo(1L);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testHashOperationsWithBinaryData() {
+		String key = "test:hash:binary";
+		byte[] keyBytes = key.getBytes();
+		byte[] binaryField = new byte[] { 0x00, 0x01, 0x02, (byte) 0xFF };
+		byte[] binaryValue = new byte[] { (byte) 0xFF, (byte) 0xFE, 0x00, 0x01, 0x7F };
+
+		try {
+			// Test with binary field and value
+			Boolean setResult = connection.hashCommands().hSet(keyBytes, binaryField, binaryValue);
+			assertThat(setResult).isTrue();
+
+			// Retrieve binary value
+			byte[] retrievedValue = connection.hashCommands().hGet(keyBytes, binaryField);
+			assertThat(retrievedValue).isEqualTo(binaryValue);
+
+			// Test exists with binary field
+			Boolean exists = connection.hashCommands().hExists(keyBytes, binaryField);
+			assertThat(exists).isTrue();
+
+			// Test hGetAll with binary data
+			Map<byte[], byte[]> all = connection.hashCommands().hGetAll(keyBytes);
+			assertThat(all).hasSize(1);
+
+			// Since byte arrays are compared by reference, not content, we need to check
+			// the content differently
+			boolean foundBinaryField = false;
+			for (Map.Entry<byte[], byte[]> entry : all.entrySet()) {
+				if (java.util.Arrays.equals(entry.getKey(), binaryField)) {
+					assertThat(entry.getValue()).isEqualTo(binaryValue);
+					foundBinaryField = true;
+					break;
+				}
+			}
+			assertThat(foundBinaryField).as("binaryField should be present in hGetAll result").isTrue();
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== Pipeline Mode Tests ====================
+
+	@Test
+	void testHashCommandsInPipelineMode() {
+		String key1 = "test:hash:pipeline:basic";
+		String key2 = "test:hash:pipeline:multi";
+		byte[] key1Bytes = key1.getBytes();
+		byte[] key2Bytes = key2.getBytes();
+		byte[] field1 = "field1".getBytes();
+		byte[] field2 = "field2".getBytes();
+		byte[] field3 = "field3".getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+		byte[] value3 = "value3".getBytes();
+
+		try {
+			// Start pipeline for main test logic
+			connection.openPipeline();
+
+			// Queue multiple hash commands - assert they return null in pipeline mode
+			assertThat(connection.hashCommands().hSet(key1Bytes, field1, value1)).isNull();
+			assertThat(connection.hashCommands().hSet(key1Bytes, field2, value2)).isNull();
+			assertThat(connection.hashCommands().hGet(key1Bytes, field1)).isNull();
+			assertThat(connection.hashCommands().hExists(key1Bytes, field1)).isNull();
+			assertThat(connection.hashCommands().hLen(key1Bytes)).isNull();
+
+			// Queue multi-operations - assert they return null in pipeline mode
+			Map<byte[], byte[]> hashData = new HashMap<>();
+			hashData.put(field1, value1);
+			hashData.put(field2, value2);
+			hashData.put(field3, value3);
+			connection.hashCommands().hMSet(key2Bytes, hashData); // void method, no
+																	// assertion needed
+			assertThat(connection.hashCommands().hMGet(key2Bytes, field1, field2, field3)).isNull();
+			assertThat(connection.hashCommands().hGetAll(key2Bytes)).isNull();
+
+			// Execute pipeline
+			List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(8);
+			assertThat(results.get(0)).isEqualTo(true); // hSet result
+			assertThat(results.get(1)).isEqualTo(true); // hSet result
+			assertThat(results.get(2)).isEqualTo(value1); // hGet result
+			assertThat(results.get(3)).isEqualTo(true); // hExists result
+			assertThat(results.get(4)).isEqualTo(2L); // hLen result
+
+			// hMSet returns simple string reply "OK"
+			assertThat(results.get(5)).isEqualTo("OK");
+
+			// hMGet results
+			@SuppressWarnings("unchecked")
+			List<byte[]> mgetResults = (List<byte[]>) results.get(6);
+			assertThat(mgetResults).hasSize(3);
+			assertThat(mgetResults.get(0)).isEqualTo(value1);
+			assertThat(mgetResults.get(1)).isEqualTo(value2);
+			assertThat(mgetResults.get(2)).isEqualTo(value3);
+
+			// hGetAll results
+			@SuppressWarnings("unchecked")
+			Map<byte[], byte[]> getAllResults = (Map<byte[], byte[]>) results.get(7);
+			assertThat(getAllResults).hasSize(3);
+
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+		}
+	}
+
+	@Test
+	void testHashIncrementCommandsInPipelineMode() {
+		String key = "test:hash:pipeline:incr";
+		byte[] keyBytes = key.getBytes();
+		byte[] intField = "intField".getBytes();
+		byte[] floatField = "floatField".getBytes();
+
+		try {
+			// Start pipeline
+			connection.openPipeline();
+
+			// Queue increment commands - assert they return null in pipeline mode
+			assertThat(connection.hashCommands().hIncrBy(keyBytes, intField, 5L)).isNull();
+			assertThat(connection.hashCommands().hIncrBy(keyBytes, intField, 10L)).isNull();
+			assertThat(connection.hashCommands().hIncrBy(keyBytes, floatField, 3.14)).isNull();
+			assertThat(connection.hashCommands().hIncrBy(keyBytes, floatField, 2.86)).isNull();
+			assertThat(connection.hashCommands().hGet(keyBytes, intField)).isNull();
+			assertThat(connection.hashCommands().hGet(keyBytes, floatField)).isNull();
+
+			// Execute pipeline
+			List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(6);
+			assertThat(results.get(0)).isEqualTo(5L); // First increment
+			assertThat(results.get(1)).isEqualTo(15L); // Second increment
+			assertThat(results.get(2)).isEqualTo(3.14); // First float increment
+			assertThat(results.get(3)).isEqualTo(6.0); // Second float increment
+			assertThat(results.get(4)).isEqualTo("15".getBytes()); // Get int result
+			assertThat(results.get(5)).isEqualTo("6".getBytes()); // Get float result
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testHashStructuralCommandsInPipelineMode() {
+		String key = "test:hash:pipeline:structure";
+		byte[] keyBytes = key.getBytes();
+		byte[] field1 = "field1".getBytes();
+		byte[] field2 = "field2".getBytes();
+		byte[] field3 = "field3".getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+		byte[] value3 = "value3".getBytes();
+
+		try {
+			// Setup data first
+			Map<byte[], byte[]> hashData = new HashMap<>();
+			hashData.put(field1, value1);
+			hashData.put(field2, value2);
+			hashData.put(field3, value3);
+			connection.hashCommands().hMSet(keyBytes, hashData);
+
+			// Start pipeline
+			connection.openPipeline();
+
+			// Queue structural commands - assert they return null in pipeline mode
+			assertThat(connection.hashCommands().hLen(keyBytes)).isNull();
+			assertThat(connection.hashCommands().hKeys(keyBytes)).isNull();
+			assertThat(connection.hashCommands().hVals(keyBytes)).isNull();
+			assertThat(connection.hashCommands().hGetAll(keyBytes)).isNull();
+			assertThat(connection.hashCommands().hDel(keyBytes, field1)).isNull();
+			assertThat(connection.hashCommands().hLen(keyBytes)).isNull();
+
+			// Execute pipeline
+			List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(6);
+			assertThat(results.get(0)).isEqualTo(3L); // Initial length
+
+			@SuppressWarnings("unchecked")
+			Set<byte[]> keys = (Set<byte[]>) results.get(1);
+			assertThat(keys).hasSize(3);
+
+			@SuppressWarnings("unchecked")
+			List<byte[]> vals = (List<byte[]>) results.get(2);
+			assertThat(vals).hasSize(3);
+
+			@SuppressWarnings("unchecked")
+			Map<byte[], byte[]> all = (Map<byte[], byte[]>) results.get(3);
+			assertThat(all).hasSize(3);
+
+			assertThat(results.get(4)).isEqualTo(1L); // Delete result
+			assertThat(results.get(5)).isEqualTo(2L); // Final length
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testHashRandomFieldCommandsInPipelineMode() {
+		String key = "test:hash:pipeline:random";
+		byte[] keyBytes = key.getBytes();
+		byte[] field1 = "field1".getBytes();
+		byte[] field2 = "field2".getBytes();
+		byte[] field3 = "field3".getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+		byte[] value3 = "value3".getBytes();
+
+		try {
+			// Setup data first
+			Map<byte[], byte[]> hashData = new HashMap<>();
+			hashData.put(field1, value1);
+			hashData.put(field2, value2);
+			hashData.put(field3, value3);
+			connection.hashCommands().hMSet(keyBytes, hashData);
+
+			// Start pipeline
+			connection.openPipeline();
+
+			// Queue random field commands - assert they return null in pipeline mode
+			assertThat(connection.hashCommands().hRandField(keyBytes)).isNull();
+			assertThat(connection.hashCommands().hRandField(keyBytes, 2)).isNull();
+			assertThat(connection.hashCommands().hRandFieldWithValues(keyBytes)).isNull();
+			assertThat(connection.hashCommands().hRandFieldWithValues(keyBytes, 2)).isNull();
+
+			// Execute pipeline
+			List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(4);
+
+			// Single random field
+			assertThat(results.get(0)).isInstanceOf(byte[].class);
+
+			// Multiple random fields
+			@SuppressWarnings("unchecked")
+			List<byte[]> multipleFields = (List<byte[]>) results.get(1);
+			assertThat(multipleFields).hasSize(2);
+
+			// Single random field with value
+			@SuppressWarnings("unchecked")
+			Map.Entry<byte[], byte[]> singleEntry = (Map.Entry<byte[], byte[]>) results.get(2);
+			assertThat(singleEntry).isNotNull();
+
+			// Multiple random fields with values
+			@SuppressWarnings("unchecked")
+			List<Map.Entry<byte[], byte[]>> multipleEntries = (List<Map.Entry<byte[], byte[]>>) results.get(3);
+			assertThat(multipleEntries).hasSize(2);
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	@EnabledOnCommand("HEXPIRE")
+	void testHashExpirationCommandsInPipelineMode() {
+		String key = "test:hash:pipeline:expire";
+		byte[] keyBytes = key.getBytes();
+		byte[] field1 = "field1".getBytes();
+		byte[] field2 = "field2".getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+
+		try {
+			// Setup data first
+			connection.hashCommands().hSet(keyBytes, field1, value1);
+			connection.hashCommands().hSet(keyBytes, field2, value2);
+
+			// Start pipeline
+			connection.openPipeline();
+
+			// Queue expiration commands - assert they return null in pipeline mode
+			assertThat(connection.hashCommands().hExpire(keyBytes, 10L, ExpirationOptions.Condition.ALWAYS, field1))
+				.isNull();
+			assertThat(connection.hashCommands().hpExpire(keyBytes, 10000L, ExpirationOptions.Condition.ALWAYS, field2))
+				.isNull();
+			assertThat(connection.hashCommands().hTtl(keyBytes, field1, field2)).isNull();
+			assertThat(connection.hashCommands().hpTtl(keyBytes, field1, field2)).isNull();
+			assertThat(connection.hashCommands().hPersist(keyBytes, field1, field2)).isNull();
+
+			// Execute pipeline
+			List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(5);
+
+			@SuppressWarnings("unchecked")
+			List<Long> expireResults1 = (List<Long>) results.get(0);
+			assertThat(expireResults1).hasSize(1);
+			assertThat(expireResults1.get(0)).isEqualTo(1L);
+
+			@SuppressWarnings("unchecked")
+			List<Long> expireResults2 = (List<Long>) results.get(1);
+			assertThat(expireResults2).hasSize(1);
+			assertThat(expireResults2.get(0)).isEqualTo(1L);
+
+			@SuppressWarnings("unchecked")
+			List<Long> ttlResults = (List<Long>) results.get(2);
+			assertThat(ttlResults).hasSize(2);
+			assertThat(ttlResults.get(0)).isGreaterThan(0L);
+			assertThat(ttlResults.get(1)).isGreaterThan(0L);
+
+			@SuppressWarnings("unchecked")
+			List<Long> pttlResults = (List<Long>) results.get(3);
+			assertThat(pttlResults).hasSize(2);
+			assertThat(pttlResults.get(0)).isGreaterThan(1000L);
+			assertThat(pttlResults.get(1)).isGreaterThan(1000L);
+
+			@SuppressWarnings("unchecked")
+			List<Long> persistResults = (List<Long>) results.get(4);
+			assertThat(persistResults).hasSize(2);
+			assertThat(persistResults.get(0)).isEqualTo(1L);
+			assertThat(persistResults.get(1)).isEqualTo(1L);
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== Transaction Mode Tests ====================
+
+	@Test
+	void testHashCommandsInTransactionMode() {
+		String key1 = "test:hash:transaction:basic";
+		String key2 = "test:hash:transaction:multi";
+		byte[] key1Bytes = key1.getBytes();
+		byte[] key2Bytes = key2.getBytes();
+		byte[] field1 = "field1".getBytes();
+		byte[] field2 = "field2".getBytes();
+		byte[] field3 = "field3".getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+		byte[] value3 = "value3".getBytes();
+
+		try {
+			// Start transaction for main test logic
+			connection.multi();
+
+			// Queue multiple hash commands - assert they return null in transaction mode
+			assertThat(connection.hashCommands().hSet(key1Bytes, field1, value1)).isNull();
+			assertThat(connection.hashCommands().hSet(key1Bytes, field2, value2)).isNull();
+			assertThat(connection.hashCommands().hGet(key1Bytes, field1)).isNull();
+			assertThat(connection.hashCommands().hExists(key1Bytes, field1)).isNull();
+			assertThat(connection.hashCommands().hLen(key1Bytes)).isNull();
+
+			// Queue multi-operations - assert they return null in transaction mode
+			Map<byte[], byte[]> hashData = new HashMap<>();
+			hashData.put(field1, value1);
+			hashData.put(field2, value2);
+			hashData.put(field3, value3);
+			connection.hashCommands().hMSet(key2Bytes, hashData); // void method, no
+																	// assertion needed
+			assertThat(connection.hashCommands().hMGet(key2Bytes, field1, field2, field3)).isNull();
+			assertThat(connection.hashCommands().hGetAll(key2Bytes)).isNull();
+
+			// Execute transaction
+			List<Object> results = connection.exec();
+
+			// Verify results
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(8);
+			assertThat(results.get(0)).isEqualTo(true); // hSet result
+			assertThat(results.get(1)).isEqualTo(true); // hSet result
+			assertThat(results.get(2)).isEqualTo(value1); // hGet result
+			assertThat(results.get(3)).isEqualTo(true); // hExists result
+			assertThat(results.get(4)).isEqualTo(2L); // hLen result
+
+			// hMSet returns simple string reply "OK"
+			assertThat(results.get(5)).isEqualTo("OK");
+
+			// hMGet results
+			@SuppressWarnings("unchecked")
+			List<byte[]> mgetResults = (List<byte[]>) results.get(6);
+			assertThat(mgetResults).hasSize(3);
+			assertThat(mgetResults.get(0)).isEqualTo(value1);
+			assertThat(mgetResults.get(1)).isEqualTo(value2);
+			assertThat(mgetResults.get(2)).isEqualTo(value3);
+
+			// hGetAll results
+			@SuppressWarnings("unchecked")
+			Map<byte[], byte[]> getAllResults = (Map<byte[], byte[]>) results.get(7);
+			assertThat(getAllResults).hasSize(3);
+
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+		}
+	}
+
+	@Test
+	void testHashIncrementCommandsInTransactionMode() {
+		String key = "test:hash:transaction:incr";
+		byte[] keyBytes = key.getBytes();
+		byte[] intField = "intField".getBytes();
+		byte[] floatField = "floatField".getBytes();
+
+		try {
+			// Start transaction
+			connection.multi();
+
+			// Queue increment commands - assert they return null in transaction mode
+			assertThat(connection.hashCommands().hIncrBy(keyBytes, intField, 5L)).isNull();
+			assertThat(connection.hashCommands().hIncrBy(keyBytes, intField, 10L)).isNull();
+			assertThat(connection.hashCommands().hIncrBy(keyBytes, floatField, 3.14)).isNull();
+			assertThat(connection.hashCommands().hIncrBy(keyBytes, floatField, 2.86)).isNull();
+			assertThat(connection.hashCommands().hGet(keyBytes, intField)).isNull();
+			assertThat(connection.hashCommands().hGet(keyBytes, floatField)).isNull();
+
+			// Execute transaction
+			List<Object> results = connection.exec();
+
+			// Verify results
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(6);
+			assertThat(results.get(0)).isEqualTo(5L); // First increment
+			assertThat(results.get(1)).isEqualTo(15L); // Second increment
+			assertThat(results.get(2)).isEqualTo(3.14); // First float increment
+			assertThat(results.get(3)).isEqualTo(6.0); // Second float increment
+			assertThat(results.get(4)).isEqualTo("15".getBytes()); // Get int result
+			assertThat(results.get(5)).isEqualTo("6".getBytes()); // Get float result
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testHashStructuralCommandsInTransactionMode() {
+		String key = "test:hash:transaction:structure";
+		byte[] keyBytes = key.getBytes();
+		byte[] field1 = "field1".getBytes();
+		byte[] field2 = "field2".getBytes();
+		byte[] field3 = "field3".getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+		byte[] value3 = "value3".getBytes();
+
+		try {
+			// Setup data first
+			Map<byte[], byte[]> hashData = new HashMap<>();
+			hashData.put(field1, value1);
+			hashData.put(field2, value2);
+			hashData.put(field3, value3);
+			connection.hashCommands().hMSet(keyBytes, hashData);
+
+			// Start transaction
+			connection.multi();
+
+			// Queue structural commands - assert they return null in transaction mode
+			assertThat(connection.hashCommands().hLen(keyBytes)).isNull();
+			assertThat(connection.hashCommands().hKeys(keyBytes)).isNull();
+			assertThat(connection.hashCommands().hVals(keyBytes)).isNull();
+			assertThat(connection.hashCommands().hGetAll(keyBytes)).isNull();
+			assertThat(connection.hashCommands().hDel(keyBytes, field1)).isNull();
+			assertThat(connection.hashCommands().hLen(keyBytes)).isNull();
+
+			// Execute transaction
+			List<Object> results = connection.exec();
+
+			// Verify results
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(6);
+			assertThat(results.get(0)).isEqualTo(3L); // Initial length
+
+			@SuppressWarnings("unchecked")
+			Set<byte[]> keys = (Set<byte[]>) results.get(1);
+			assertThat(keys).hasSize(3);
+
+			@SuppressWarnings("unchecked")
+			List<byte[]> vals = (List<byte[]>) results.get(2);
+			assertThat(vals).hasSize(3);
+
+			@SuppressWarnings("unchecked")
+			Map<byte[], byte[]> all = (Map<byte[], byte[]>) results.get(3);
+			assertThat(all).hasSize(3);
+
+			assertThat(results.get(4)).isEqualTo(1L); // Delete result
+			assertThat(results.get(5)).isEqualTo(2L); // Final length
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testHashRandomFieldCommandsInTransactionMode() {
+		String key = "test:hash:transaction:random";
+		byte[] keyBytes = key.getBytes();
+		byte[] field1 = "field1".getBytes();
+		byte[] field2 = "field2".getBytes();
+		byte[] field3 = "field3".getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+		byte[] value3 = "value3".getBytes();
+
+		try {
+			// Setup data first
+			Map<byte[], byte[]> hashData = new HashMap<>();
+			hashData.put(field1, value1);
+			hashData.put(field2, value2);
+			hashData.put(field3, value3);
+			connection.hashCommands().hMSet(keyBytes, hashData);
+
+			// Start transaction
+			connection.multi();
+
+			// Queue random field commands - assert they return null in transaction mode
+			assertThat(connection.hashCommands().hRandField(keyBytes)).isNull();
+			assertThat(connection.hashCommands().hRandField(keyBytes, 2)).isNull();
+			assertThat(connection.hashCommands().hRandFieldWithValues(keyBytes)).isNull();
+			assertThat(connection.hashCommands().hRandFieldWithValues(keyBytes, 2)).isNull();
+
+			// Execute transaction
+			List<Object> results = connection.exec();
+
+			// Verify results
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(4);
+
+			// Single random field
+			assertThat(results.get(0)).isInstanceOf(byte[].class);
+
+			// Multiple random fields
+			@SuppressWarnings("unchecked")
+			List<byte[]> multipleFields = (List<byte[]>) results.get(1);
+			assertThat(multipleFields).hasSize(2);
+
+			// Single random field with value
+			@SuppressWarnings("unchecked")
+			Map.Entry<byte[], byte[]> singleEntry = (Map.Entry<byte[], byte[]>) results.get(2);
+			assertThat(singleEntry).isNotNull();
+
+			// Multiple random fields with values
+			@SuppressWarnings("unchecked")
+			List<Map.Entry<byte[], byte[]>> multipleEntries = (List<Map.Entry<byte[], byte[]>>) results.get(3);
+			assertThat(multipleEntries).hasSize(2);
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	@EnabledOnCommand("HEXPIRE")
+	void testHashExpirationCommandsInTransactionMode() {
+		String key = "test:hash:transaction:expire";
+		byte[] keyBytes = key.getBytes();
+		byte[] field1 = "field1".getBytes();
+		byte[] field2 = "field2".getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+
+		try {
+			// Setup data first
+			connection.hashCommands().hSet(keyBytes, field1, value1);
+			connection.hashCommands().hSet(keyBytes, field2, value2);
+
+			// Start transaction
+			connection.multi();
+
+			// Queue expiration commands - assert they return null in transaction mode
+			assertThat(connection.hashCommands().hExpire(keyBytes, 10L, ExpirationOptions.Condition.ALWAYS, field1))
+				.isNull();
+			assertThat(connection.hashCommands().hpExpire(keyBytes, 10000L, ExpirationOptions.Condition.ALWAYS, field2))
+				.isNull();
+			assertThat(connection.hashCommands().hTtl(keyBytes, field1, field2)).isNull();
+			assertThat(connection.hashCommands().hpTtl(keyBytes, field1, field2)).isNull();
+			assertThat(connection.hashCommands().hPersist(keyBytes, field1, field2)).isNull();
+
+			// Execute transaction
+			List<Object> results = connection.exec();
+
+			// Verify results
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(5);
+
+			@SuppressWarnings("unchecked")
+			List<Long> expireResults1 = (List<Long>) results.get(0);
+			assertThat(expireResults1).hasSize(1);
+			assertThat(expireResults1.get(0)).isEqualTo(1L);
+
+			@SuppressWarnings("unchecked")
+			List<Long> expireResults2 = (List<Long>) results.get(1);
+			assertThat(expireResults2).hasSize(1);
+			assertThat(expireResults2.get(0)).isEqualTo(1L);
+
+			@SuppressWarnings("unchecked")
+			List<Long> ttlResults = (List<Long>) results.get(2);
+			assertThat(ttlResults).hasSize(2);
+			assertThat(ttlResults.get(0)).isGreaterThan(0L);
+			assertThat(ttlResults.get(1)).isGreaterThan(0L);
+
+			@SuppressWarnings("unchecked")
+			List<Long> pttlResults = (List<Long>) results.get(3);
+			assertThat(pttlResults).hasSize(2);
+			assertThat(pttlResults.get(0)).isGreaterThan(1000L);
+			assertThat(pttlResults.get(1)).isGreaterThan(1000L);
+
+			@SuppressWarnings("unchecked")
+			List<Long> persistResults = (List<Long>) results.get(4);
+			assertThat(persistResults).hasSize(2);
+			assertThat(persistResults.get(0)).isEqualTo(1L);
+			assertThat(persistResults.get(1)).isEqualTo(1L);
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testTransactionDiscardWithHashCommands() {
+		String key = "test:hash:transaction:discard";
+		byte[] keyBytes = key.getBytes();
+		byte[] field = "field".getBytes();
+		byte[] value = "value".getBytes();
+
+		try {
+			// Start transaction
+			connection.multi();
+
+			// Queue hash commands
+			connection.hashCommands().hSet(keyBytes, field, value);
+			connection.hashCommands().hGet(keyBytes, field);
+
+			// Discard transaction
+			connection.discard();
+
+			// Verify key doesn't exist (transaction was discarded)
+			Boolean exists = connection.hashCommands().hExists(keyBytes, field);
+			assertThat(exists).isFalse();
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testWatchWithHashCommandsTransaction() throws InterruptedException {
+		String watchKey = "test:hash:transaction:watch";
+		String otherKey = "test:hash:transaction:other";
+		byte[] watchKeyBytes = watchKey.getBytes();
+		byte[] otherKeyBytes = otherKey.getBytes();
+		byte[] field = "field".getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+
+		try {
+			// Setup initial data
+			connection.hashCommands().hSet(watchKeyBytes, field, value1);
+
+			// Watch the key
+			connection.watch(watchKeyBytes);
+
+			// Modify the watched key from "outside" the transaction
+			// (simulating another client)
+			connection.hashCommands().hSet(watchKeyBytes, field, value2);
+
+			// Start transaction
+			connection.multi();
+
+			// Queue hash commands
+			connection.hashCommands().hSet(otherKeyBytes, field, value1);
+			connection.hashCommands().hGet(otherKeyBytes, field);
+
+			// Execute transaction - should be aborted due to WATCH
+			List<Object> results = connection.exec();
+
+			// Transaction should be aborted (results should be null)
+			assertThat(results).isNotNull().isEmpty();
+
+			// Verify that the other key was not set
+			Boolean exists = connection.hashCommands().hExists(otherKeyBytes, field);
+			assertThat(exists).isFalse();
+
+		}
+		finally {
+			cleanupKey(watchKey);
+			cleanupKey(otherKey);
+		}
+	}
+
+	// ==================== Error Handling Tests for Pipeline/Transaction
+	// ====================
+
+	@Test
+	void testPipelineErrorHandling() {
+		String validKey = "test:hash:pipeline:error:valid";
+		String stringKey = "test:hash:pipeline:error:string";
+		byte[] validKeyBytes = validKey.getBytes();
+		byte[] stringKeyBytes = stringKey.getBytes();
+		byte[] field = "field".getBytes();
+		byte[] value = "value".getBytes();
+
+		try {
+			// Set up a string key to cause type errors
+			connection.stringCommands().set(stringKeyBytes, "stringvalue".getBytes());
+
+			// Start pipeline
+			connection.openPipeline();
+
+			// Queue valid command
+			connection.hashCommands().hSet(validKeyBytes, field, value);
+
+			// Queue command that will cause error (wrong type)
+			connection.hashCommands().hSet(stringKeyBytes, field, value);
+
+			// Queue another valid command
+			connection.hashCommands().hGet(validKeyBytes, field);
+
+			// Execute pipeline
+			List<Object> results = connection.closePipeline();
+
+			// Verify results - valid commands should succeed, error command should return
+			// exception
+			assertThat(results).hasSize(3);
+			assertThat(results.get(0)).isEqualTo(true); // Valid hSet
+			assertThat(results.get(1)).isInstanceOf(DataAccessException.class); // Error
+																				// result
+			assertThat(results.get(2)).isEqualTo(value); // Valid hGet
+
+		}
+		finally {
+			cleanupKey(validKey);
+			cleanupKey(stringKey);
+		}
+	}
+
+	@Test
+	void testTransactionErrorHandling() {
+		String validKey = "test:hash:transaction:error:valid";
+		String stringKey = "test:hash:transaction:error:string";
+		byte[] validKeyBytes = validKey.getBytes();
+		byte[] stringKeyBytes = stringKey.getBytes();
+		byte[] field = "field".getBytes();
+		byte[] value = "value".getBytes();
+
+		try {
+			// Set up a string key to cause type errors
+			connection.stringCommands().set(stringKeyBytes, "stringvalue".getBytes());
+
+			// Start transaction
+			connection.multi();
+
+			// Queue valid command
+			connection.hashCommands().hSet(validKeyBytes, field, value);
+
+			// Queue command that will cause error (wrong type)
+			connection.hashCommands().hSet(stringKeyBytes, field, value);
+
+			// Queue another valid command
+			connection.hashCommands().hGet(validKeyBytes, field);
+
+			// Execute transaction
+			List<Object> results = connection.exec();
+
+			// Verify results - valid commands should succeed, error command should return
+			// exception
+			assertThat(results).isNotNull(); // Transaction should not be aborted
+			assertThat(results).hasSize(3);
+			assertThat(results.get(0)).isEqualTo(true); // Valid hSet
+			assertThat(results.get(1)).isInstanceOf(DataAccessException.class); // Error
+																				// result
+			assertThat(results.get(2)).isEqualTo(value); // Valid hGet
+
+		}
+		finally {
+			cleanupKey(validKey);
+			cleanupKey(stringKey);
+		}
+	}
+
+	@Test
+	void testHScanNotAllowedInPipelineTransactionModes() {
+		String key = "test:hash:scan:error";
+		byte[] keyBytes = key.getBytes();
+
+		try {
+			// Set up some data
+			Map<byte[], byte[]> hashData = new HashMap<>();
+			hashData.put("field1".getBytes(), "value1".getBytes());
+			connection.hashCommands().hMSet(keyBytes, hashData);
+
+			// Test HSCAN not allowed in pipeline mode
+			connection.openPipeline();
+			assertThatThrownBy(() -> connection.hashCommands().hScan(keyBytes, ScanOptions.NONE))
+				.isInstanceOf(DataAccessException.class)
+				.hasMessageContaining("pipeline");
+			connection.closePipeline();
+
+			// Test HSCAN not allowed in transaction mode
+			connection.multi();
+			assertThatThrownBy(() -> connection.hashCommands().hScan(keyBytes, ScanOptions.NONE))
+				.isInstanceOf(DataAccessException.class)
+				.hasMessageContaining("transaction");
+			connection.discard();
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== HGETDEL / HGETEX / HSETEX Tests ====================
+
+	@Test
+	@EnabledOnCommand("HGETDEL")
+	void testHGetDel() {
+		String key = "test:hash:hgetdel";
+		byte[] keyBytes = key.getBytes();
+		byte[] field1 = "field1".getBytes();
+		byte[] field2 = "field2".getBytes();
+		byte[] field3 = "field3".getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+		byte[] value3 = "value3".getBytes();
+
+		try {
+			// Set up test data
+			connection.hashCommands().hSet(keyBytes, field1, value1);
+			connection.hashCommands().hSet(keyBytes, field2, value2);
+			connection.hashCommands().hSet(keyBytes, field3, value3);
+
+			// Test hGetDel on non-existent field - should return list with null
+			List<byte[]> absentResult = connection.hashCommands().hGetDel(keyBytes, "absent".getBytes());
+			assertThat(absentResult).hasSize(1);
+			assertThat(absentResult.get(0)).isNull();
+
+			// Test hGetDel on existing fields - should return values and delete fields
+			List<byte[]> result = connection.hashCommands().hGetDel(keyBytes, field1, field2);
+			assertThat(result).hasSize(2);
+			assertThat(result.get(0)).isEqualTo(value1);
+			assertThat(result.get(1)).isEqualTo(value2);
+
+			// Verify fields were deleted
+			assertThat(connection.hashCommands().hExists(keyBytes, field1)).isFalse();
+			assertThat(connection.hashCommands().hExists(keyBytes, field2)).isFalse();
+			// field3 should still exist
+			assertThat(connection.hashCommands().hExists(keyBytes, field3)).isTrue();
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	@EnabledOnCommand("HGETEX")
+	void testHGetEx() {
+		String key = "test:hash:hgetex";
+		byte[] keyBytes = key.getBytes();
+		byte[] field1 = "field1".getBytes();
+		byte[] field2 = "field2".getBytes();
+		byte[] field3 = "field3".getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+		byte[] value3 = "value3".getBytes();
+
+		try {
+			// Set up test data
+			connection.hashCommands().hSet(keyBytes, field1, value1);
+			connection.hashCommands().hSet(keyBytes, field2, value2);
+			connection.hashCommands().hSet(keyBytes, field3, value3);
+
+			// Test hGetEx with expiration - should return values and set TTL
+			List<byte[]> result = connection.hashCommands().hGetEx(keyBytes, Expiration.seconds(30), field1, field2);
+			assertThat(result).hasSize(2);
+			assertThat(result.get(0)).isEqualTo(value1);
+			assertThat(result.get(1)).isEqualTo(value2);
+
+			// Test hGetEx on non-existent field - should return list with null
+			List<byte[]> noFieldResult = connection.hashCommands().hGetEx(keyBytes, null, "no-such-field".getBytes());
+			assertThat(noFieldResult).hasSize(1);
+			assertThat(noFieldResult.get(0)).isNull();
+
+			// Test hGetEx on non-existent key - should return list with null
+			List<byte[]> noKeyResult = connection.hashCommands().hGetEx("no-such-key".getBytes(), null, field1);
+			assertThat(noKeyResult).hasSize(1);
+			assertThat(noKeyResult.get(0)).isNull();
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	@EnabledOnCommand("HSETEX")
+	void testHSetEx() {
+		String key = "test:hash:hsetex";
+		byte[] keyBytes = key.getBytes();
+		byte[] field1 = "field1".getBytes();
+		byte[] field2 = "field2".getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+
+		try {
+			// Test hSetEx with upsert and expiration
+			Map<byte[], byte[]> fieldMap = new HashMap<>();
+			fieldMap.put(field1, value1);
+			fieldMap.put(field2, value2);
+
+			Boolean result = connection.hashCommands()
+				.hSetEx(keyBytes, fieldMap, ValkeyHashCommands.HashFieldSetOption.upsert(), Expiration.seconds(30));
+			assertThat(result).isTrue();
+
+			// Verify values were set
+			assertThat(connection.hashCommands().hGet(keyBytes, field1)).isEqualTo(value1);
+			assertThat(connection.hashCommands().hGet(keyBytes, field2)).isEqualTo(value2);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	@EnabledOnCommand("HSETEX")
+	void testHSetExIfNoneExistSucceeds() {
+		String key = "test:hash:hsetex:nx";
+		byte[] keyBytes = key.getBytes();
+		byte[] field1 = "field1".getBytes();
+		byte[] field2 = "field2".getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+
+		try {
+			// Test hSetEx with ifNoneExist when no fields exist - should succeed
+			Map<byte[], byte[]> fieldMap = new HashMap<>();
+			fieldMap.put(field1, value1);
+			fieldMap.put(field2, value2);
+
+			Boolean result = connection.hashCommands()
+				.hSetEx(keyBytes, fieldMap, ValkeyHashCommands.HashFieldSetOption.ifNoneExist(),
+						Expiration.seconds(60));
+			assertThat(result).isTrue();
+
+			// Verify values were set
+			assertThat(connection.hashCommands().hGet(keyBytes, field1)).isEqualTo(value1);
+			assertThat(connection.hashCommands().hGet(keyBytes, field2)).isEqualTo(value2);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	@EnabledOnCommand("HSETEX")
+	void testHSetExIfNoneExistFailsWhenFieldsExist() {
+		String key = "test:hash:hsetex:nxfail";
+		byte[] keyBytes = key.getBytes();
+		byte[] field1 = "field1".getBytes();
+		byte[] field2 = "field2".getBytes();
+		byte[] existingValue = "existing-value".getBytes();
+		byte[] newValue = "new-value".getBytes();
+		byte[] value2 = "value2".getBytes();
+
+		try {
+			// Pre-set field1
+			connection.hashCommands().hSet(keyBytes, field1, existingValue);
+
+			// Try hSetEx with ifNoneExist when field1 already exists
+			Map<byte[], byte[]> fieldMap = new HashMap<>();
+			fieldMap.put(field1, newValue);
+			fieldMap.put(field2, value2);
+
+			Boolean result = connection.hashCommands()
+				.hSetEx(keyBytes, fieldMap, ValkeyHashCommands.HashFieldSetOption.ifNoneExist(),
+						Expiration.seconds(60));
+			// The operation should not overwrite existing field1
+			assertThat(connection.hashCommands().hGet(keyBytes, field1)).isEqualTo(existingValue);
+			// field2 should not exist either (all-or-nothing with FNX depends on server
+			// behavior)
+			// Server may or may not set field2 - just verify field1 was not overwritten
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testMixedCommandTypesInPipeline() {
+		String hashKey = "test:hash:pipeline:mixed:hash";
+		String stringKey = "test:hash:pipeline:mixed:string";
+		byte[] hashKeyBytes = hashKey.getBytes();
+		byte[] stringKeyBytes = stringKey.getBytes();
+		byte[] field = "field".getBytes();
+		byte[] hashValue = "hashvalue".getBytes();
+		byte[] stringValue = "stringvalue".getBytes();
+
+		try {
+			// Start pipeline with mixed commands
+			connection.openPipeline();
+
+			// Mix hash and string commands
+			connection.hashCommands().hSet(hashKeyBytes, field, hashValue);
+			connection.stringCommands().set(stringKeyBytes, stringValue);
+			connection.hashCommands().hGet(hashKeyBytes, field);
+			connection.stringCommands().get(stringKeyBytes);
+			connection.hashCommands().hExists(hashKeyBytes, field);
+
+			// Execute pipeline
+			List<Object> results = connection.closePipeline();
+
+			// Verify mixed results
+			assertThat(results).hasSize(5);
+			assertThat(results.get(0)).isEqualTo(true); // hSet result
+			assertThat(results.get(1)).isEqualTo(true); // string set result (converted to
+														// boolean)
+			assertThat(results.get(2)).isEqualTo(hashValue); // hGet result
+			assertThat(results.get(3)).isEqualTo(stringValue); // string get result
+			assertThat(results.get(4)).isEqualTo(true); // hExists result
+
+		}
+		finally {
+			cleanupKey(hashKey);
+			cleanupKey(stringKey);
+		}
+	}
 
 }

--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionHyperLogLogCommandsIntegrationTests.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionHyperLogLogCommandsIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,677 +23,778 @@ import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataAccessException;
 
 /**
- * Comprehensive low-level integration tests for {@link ValkeyGlideConnection} 
- * HyperLogLog functionality using the ValkeyHyperLogLogCommands interface directly.
- * 
- * These tests validate the implementation of all ValkeyHyperLogLogCommands methods:
- * - pfAdd: Add elements to HyperLogLog
- * - pfCount: Get cardinality estimate of HyperLogLog(s)
- * - pfMerge: Merge multiple HyperLogLogs into one
+ * Comprehensive low-level integration tests for {@link ValkeyGlideConnection} HyperLogLog
+ * functionality using the ValkeyHyperLogLogCommands interface directly.
  *
- * Tests cover all three invocation modes:
- * - Immediate mode: Direct execution with results
- * - Pipeline mode: Commands return null, results collected in closePipeline()
- * - Transaction mode: Commands return null, results collected in exec()
+ * These tests validate the implementation of all ValkeyHyperLogLogCommands methods: -
+ * pfAdd: Add elements to HyperLogLog - pfCount: Get cardinality estimate of
+ * HyperLogLog(s) - pfMerge: Merge multiple HyperLogLogs into one
+ *
+ * Tests cover all three invocation modes: - Immediate mode: Direct execution with results
+ * - Pipeline mode: Commands return null, results collected in closePipeline() -
+ * Transaction mode: Commands return null, results collected in exec()
  *
  * @author Ilia Kolominsky
  * @since 2.0
  */
 public class ValkeyGlideConnectionHyperLogLogCommandsIntegrationTests extends AbstractValkeyGlideIntegrationTests {
 
-    @Override
-    protected String[] getTestKeyPatterns() {
-        return new String[]{
-            "test:hll:basic", "test:hll:count:single", "test:hll:count:multiple1", 
-            "test:hll:count:multiple2", "test:hll:merge:source1", "test:hll:merge:source2",
-            "test:hll:merge:dest", "test:hll:empty", "test:hll:binary", "test:hll:duplicate",
-            "test:hll:large", "test:hll:pipeline:basic", "test:hll:pipeline:count1",
-            "test:hll:pipeline:count2", "test:hll:pipeline:merge:src1", "test:hll:pipeline:merge:src2",
-            "test:hll:pipeline:merge:dst", "test:hll:transaction:basic", "test:hll:transaction:count1",
-            "test:hll:transaction:count2", "test:hll:transaction:merge:src1", "test:hll:transaction:merge:src2",
-            "test:hll:transaction:merge:dst", "test:hll:error:string", "non:existent:key"
-        };
-    }
+	@Override
+	protected String[] getTestKeyPatterns() {
+		return new String[] { "test:hll:basic", "test:hll:count:single", "test:hll:count:multiple1",
+				"test:hll:count:multiple2", "test:hll:merge:source1", "test:hll:merge:source2", "test:hll:merge:dest",
+				"test:hll:empty", "test:hll:binary", "test:hll:duplicate", "test:hll:large", "test:hll:pipeline:basic",
+				"test:hll:pipeline:count1", "test:hll:pipeline:count2", "test:hll:pipeline:merge:src1",
+				"test:hll:pipeline:merge:src2", "test:hll:pipeline:merge:dst", "test:hll:transaction:basic",
+				"test:hll:transaction:count1", "test:hll:transaction:count2", "test:hll:transaction:merge:src1",
+				"test:hll:transaction:merge:src2", "test:hll:transaction:merge:dst", "test:hll:error:string",
+				"non:existent:key" };
+	}
 
-    // ==================== Basic HyperLogLog Operations (Immediate Mode) ====================
+	// ==================== Basic HyperLogLog Operations (Immediate Mode)
+	// ====================
 
-    @Test
-    void testPfAddBasic() {
-        String key = "test:hll:basic";
-        byte[] keyBytes = key.getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        byte[] value3 = "value3".getBytes();
-        
-        try {
-            // Test pfAdd with single value
-            Long addResult1 = connection.hyperLogLogCommands().pfAdd(keyBytes, value1);
-            assertThat(addResult1).isEqualTo(1L); // First element added
-            
-            // Test pfAdd with multiple values
-            Long addResult2 = connection.hyperLogLogCommands().pfAdd(keyBytes, value2, value3);
-            assertThat(addResult2).isEqualTo(1L); // HLL was modified
-            
-            // Test pfAdd with duplicate value
-            Long addResult3 = connection.hyperLogLogCommands().pfAdd(keyBytes, value1);
-            assertThat(addResult3).isEqualTo(0L); // HLL was not modified (duplicate)
-            
-            // Test pfAdd with mix of new and duplicate values
-            Long addResult4 = connection.hyperLogLogCommands().pfAdd(keyBytes, value1, "value4".getBytes());
-            assertThat(addResult4).isEqualTo(1L); // HLL was modified (new value added)
-            
-            // Verify cardinality is approximately correct (HLL is probabilistic)
-            Long count = connection.hyperLogLogCommands().pfCount(keyBytes);
-            assertThat(count).isGreaterThanOrEqualTo(3L).isLessThanOrEqualTo(5L); // Should be around 4
-        } finally {
-            cleanupKey(key);
-        }
-    }
+	@Test
+	void testPfAddBasic() {
+		String key = "test:hll:basic";
+		byte[] keyBytes = key.getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+		byte[] value3 = "value3".getBytes();
 
-    @Test
-    void testPfCountSingle() {
-        String key = "test:hll:count:single";
-        byte[] keyBytes = key.getBytes();
-        
-        try {
-            // Test pfCount on non-existent key
-            Long emptyCount = connection.hyperLogLogCommands().pfCount(keyBytes);
-            assertThat(emptyCount).isEqualTo(0L);
-            
-            // Add some elements
-            connection.hyperLogLogCommands().pfAdd(keyBytes, "elem1".getBytes(), "elem2".getBytes(), "elem3".getBytes());
-            
-            // Test pfCount on existing HLL
-            Long count = connection.hyperLogLogCommands().pfCount(keyBytes);
-            assertThat(count).isGreaterThanOrEqualTo(2L).isLessThanOrEqualTo(4L); // Should be around 3
-            
-            // Add more elements to test accuracy
-            for (int i = 4; i <= 100; i++) {
-                connection.hyperLogLogCommands().pfAdd(keyBytes, ("elem" + i).getBytes());
-            }
-            
-            Long largeCount = connection.hyperLogLogCommands().pfCount(keyBytes);
-            assertThat(largeCount).isGreaterThanOrEqualTo(90L).isLessThanOrEqualTo(110L); // Should be around 100
-        } finally {
-            cleanupKey(key);
-        }
-    }
+		try {
+			// Test pfAdd with single value
+			Long addResult1 = connection.hyperLogLogCommands().pfAdd(keyBytes, value1);
+			assertThat(addResult1).isEqualTo(1L); // First element added
 
-    @Test
-    void testPfCountMultiple() {
-        String key1 = "test:hll:count:multiple1";
-        String key2 = "test:hll:count:multiple2";
-        byte[] key1Bytes = key1.getBytes();
-        byte[] key2Bytes = key2.getBytes();
-        
-        try {
-            // Test pfCount on non-existent keys
-            Long emptyCount = connection.hyperLogLogCommands().pfCount(key1Bytes, key2Bytes);
-            assertThat(emptyCount).isEqualTo(0L);
-            
-            // Add different elements to each HLL
-            connection.hyperLogLogCommands().pfAdd(key1Bytes, "elem1".getBytes(), "elem2".getBytes(), "elem3".getBytes());
-            connection.hyperLogLogCommands().pfAdd(key2Bytes, "elem3".getBytes(), "elem4".getBytes(), "elem5".getBytes());
-            
-            // Test individual counts
-            Long count1 = connection.hyperLogLogCommands().pfCount(key1Bytes);
-            Long count2 = connection.hyperLogLogCommands().pfCount(key2Bytes);
-            assertThat(count1).isGreaterThanOrEqualTo(2L).isLessThanOrEqualTo(4L); // Should be around 3
-            assertThat(count2).isGreaterThanOrEqualTo(2L).isLessThanOrEqualTo(4L); // Should be around 3
-            
-            // Test union count (elem3 is in both, so total unique should be around 5)
-            Long unionCount = connection.hyperLogLogCommands().pfCount(key1Bytes, key2Bytes);
-            assertThat(unionCount).isGreaterThanOrEqualTo(4L).isLessThanOrEqualTo(6L); // Should be around 5
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-        }
-    }
+			// Test pfAdd with multiple values
+			Long addResult2 = connection.hyperLogLogCommands().pfAdd(keyBytes, value2, value3);
+			assertThat(addResult2).isEqualTo(1L); // HLL was modified
 
-    @Test
-    void testPfMerge() {
-        String source1 = "test:hll:merge:source1";
-        String source2 = "test:hll:merge:source2";
-        String dest = "test:hll:merge:dest";
-        byte[] source1Bytes = source1.getBytes();
-        byte[] source2Bytes = source2.getBytes();
-        byte[] destBytes = dest.getBytes();
-        
-        try {
-            // Add elements to source HLLs
-            connection.hyperLogLogCommands().pfAdd(source1Bytes, "elem1".getBytes(), "elem2".getBytes(), "elem3".getBytes());
-            connection.hyperLogLogCommands().pfAdd(source2Bytes, "elem3".getBytes(), "elem4".getBytes(), "elem5".getBytes());
-            
-            // Get individual counts before merge
-            Long count1 = connection.hyperLogLogCommands().pfCount(source1Bytes);
-            Long count2 = connection.hyperLogLogCommands().pfCount(source2Bytes);
-            
-            // Test pfMerge
-            connection.hyperLogLogCommands().pfMerge(destBytes, source1Bytes, source2Bytes);
-            
-            // Verify merge result
-            Long mergedCount = connection.hyperLogLogCommands().pfCount(destBytes);
-            assertThat(mergedCount).isGreaterThanOrEqualTo(4L).isLessThanOrEqualTo(6L); // Should be around 5 (elem3 overlaps)
-            
-            // Verify original HLLs are unchanged
-            Long count1After = connection.hyperLogLogCommands().pfCount(source1Bytes);
-            Long count2After = connection.hyperLogLogCommands().pfCount(source2Bytes);
-            assertThat(count1After).isEqualTo(count1);
-            assertThat(count2After).isEqualTo(count2);
-            
-            // Test merging into existing HLL
-            connection.hyperLogLogCommands().pfAdd(destBytes, "elem6".getBytes());
-            connection.hyperLogLogCommands().pfMerge(destBytes, source1Bytes);
-            
-            Long finalCount = connection.hyperLogLogCommands().pfCount(destBytes);
-            assertThat(finalCount).isGreaterThanOrEqualTo(5L).isLessThanOrEqualTo(7L); // Should be around 6
-        } finally {
-            cleanupKey(source1);
-            cleanupKey(source2);
-            cleanupKey(dest);
-        }
-    }
+			// Test pfAdd with duplicate value
+			Long addResult3 = connection.hyperLogLogCommands().pfAdd(keyBytes, value1);
+			assertThat(addResult3).isEqualTo(0L); // HLL was not modified (duplicate)
 
-    // ==================== Edge Cases and Error Handling ====================
+			// Test pfAdd with mix of new and duplicate values
+			Long addResult4 = connection.hyperLogLogCommands().pfAdd(keyBytes, value1, "value4".getBytes());
+			assertThat(addResult4).isEqualTo(1L); // HLL was modified (new value added)
 
-    @Test
-    void testHyperLogLogWithEmptyValues() {
-        String key = "test:hll:empty";
-        byte[] keyBytes = key.getBytes();
-        byte[] emptyValue = new byte[0];
-        
-        try {
-            // Add empty value
-            Long addResult = connection.hyperLogLogCommands().pfAdd(keyBytes, emptyValue);
-            assertThat(addResult).isEqualTo(1L);
-            
-            // Count should include empty value
-            Long count = connection.hyperLogLogCommands().pfCount(keyBytes);
-            assertThat(count).isEqualTo(1L);
-            
-            // Add empty value again (duplicate)
-            Long addResult2 = connection.hyperLogLogCommands().pfAdd(keyBytes, emptyValue);
-            assertThat(addResult2).isEqualTo(0L); // No change
-            
-            // Count should still be 1
-            Long count2 = connection.hyperLogLogCommands().pfCount(keyBytes);
-            assertThat(count2).isEqualTo(1L);
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Verify cardinality is approximately correct (HLL is probabilistic)
+			Long count = connection.hyperLogLogCommands().pfCount(keyBytes);
+			assertThat(count).isGreaterThanOrEqualTo(3L).isLessThanOrEqualTo(5L); // Should
+																					// be
+																					// around
+																					// 4
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
 
-    @Test
-    void testHyperLogLogWithBinaryData() {
-        String key = "test:hll:binary";
-        byte[] keyBytes = key.getBytes();
-        byte[] binaryValue1 = new byte[]{0x00, 0x01, 0x02, (byte) 0xFF};
-        byte[] binaryValue2 = new byte[]{(byte) 0xFF, (byte) 0xFE, 0x00, 0x01, 0x7F};
-        byte[] binaryValue3 = new byte[]{0x00, 0x01, 0x02, (byte) 0xFF}; // duplicate of value1
-        
-        try {
-            // Add binary values
-            Long addResult1 = connection.hyperLogLogCommands().pfAdd(keyBytes, binaryValue1, binaryValue2);
-            assertThat(addResult1).isEqualTo(1L);
-            
-            // Add duplicate binary value
-            Long addResult2 = connection.hyperLogLogCommands().pfAdd(keyBytes, binaryValue3);
-            assertThat(addResult2).isEqualTo(0L); // Should be duplicate
-            
-            // Count should be around 2
-            Long count = connection.hyperLogLogCommands().pfCount(keyBytes);
-            assertThat(count).isGreaterThanOrEqualTo(1L).isLessThanOrEqualTo(3L);
-        } finally {
-            cleanupKey(key);
-        }
-    }
+	@Test
+	void testPfCountSingle() {
+		String key = "test:hll:count:single";
+		byte[] keyBytes = key.getBytes();
 
-    @Test
-    void testHyperLogLogDuplicateHandling() {
-        String key = "test:hll:duplicate";
-        byte[] keyBytes = key.getBytes();
-        byte[] value = "testvalue".getBytes();
-        
-        try {
-            // Add same value multiple times
-            Long addResult1 = connection.hyperLogLogCommands().pfAdd(keyBytes, value);
-            assertThat(addResult1).isEqualTo(1L); // First time
-            
-            Long addResult2 = connection.hyperLogLogCommands().pfAdd(keyBytes, value);
-            assertThat(addResult2).isEqualTo(0L); // Duplicate
-            
-            Long addResult3 = connection.hyperLogLogCommands().pfAdd(keyBytes, value);
-            assertThat(addResult3).isEqualTo(0L); // Duplicate
-            
-            // Count should be 1
-            Long count = connection.hyperLogLogCommands().pfCount(keyBytes);
-            assertThat(count).isEqualTo(1L);
-        } finally {
-            cleanupKey(key);
-        }
-    }
+		try {
+			// Test pfCount on non-existent key
+			Long emptyCount = connection.hyperLogLogCommands().pfCount(keyBytes);
+			assertThat(emptyCount).isEqualTo(0L);
 
-    @Test
-    void testHyperLogLogLargeDataSet() {
-        String key = "test:hll:large";
-        byte[] keyBytes = key.getBytes();
-        
-        try {
-            // Add many unique elements
-            for (int i = 0; i < 10000; i++) {
-                connection.hyperLogLogCommands().pfAdd(keyBytes, ("element" + i).getBytes());
-            }
-            
-            // Count should be close to 10000 (within acceptable HLL error range)
-            Long count = connection.hyperLogLogCommands().pfCount(keyBytes);
-            assertThat(count).isGreaterThan(9500L).isLessThan(10500L); // ~5% error tolerance
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Add some elements
+			connection.hyperLogLogCommands()
+				.pfAdd(keyBytes, "elem1".getBytes(), "elem2".getBytes(), "elem3".getBytes());
 
-    @Test
-    void testHyperLogLogOperationsOnNonHLLTypes() {
-        String stringKey = "test:hll:error:string";
-        
-        try {
-            // Create a string key
-            connection.stringCommands().set(stringKey.getBytes(), "stringvalue".getBytes());
-            
-            // Try HLL operations on string key - should fail
-            assertThatThrownBy(() -> connection.hyperLogLogCommands().pfAdd(stringKey.getBytes(), "value".getBytes()))
-                .isInstanceOf(DataAccessException.class);
-                
-            assertThatThrownBy(() -> connection.hyperLogLogCommands().pfCount(stringKey.getBytes()))
-                .isInstanceOf(DataAccessException.class);
-        } finally {
-            cleanupKey(stringKey);
-        }
-    }
+			// Test pfCount on existing HLL
+			Long count = connection.hyperLogLogCommands().pfCount(keyBytes);
+			assertThat(count).isGreaterThanOrEqualTo(2L).isLessThanOrEqualTo(4L); // Should
+																					// be
+																					// around
+																					// 3
 
-    // ==================== Pipeline Mode Tests ====================
+			// Add more elements to test accuracy
+			for (int i = 4; i <= 100; i++) {
+				connection.hyperLogLogCommands().pfAdd(keyBytes, ("elem" + i).getBytes());
+			}
 
-    @Test
-    void testBasicHyperLogLogCommandsInPipelineMode() {
-        String key = "test:hll:pipeline:basic";
-        byte[] keyBytes = key.getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        byte[] value3 = "value3".getBytes();
-        
-        try {
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Queue HLL commands - assert they return null in pipeline mode
-            assertThat(connection.hyperLogLogCommands().pfAdd(keyBytes, value1, value2)).isNull();
-            assertThat(connection.hyperLogLogCommands().pfAdd(keyBytes, value3)).isNull();
-            assertThat(connection.hyperLogLogCommands().pfCount(keyBytes)).isNull();
-            assertThat(connection.hyperLogLogCommands().pfAdd(keyBytes, value1)).isNull(); // duplicate
-            assertThat(connection.hyperLogLogCommands().pfCount(keyBytes)).isNull();
-            
-            // Execute pipeline
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(5);
-            assertThat(results.get(0)).isEqualTo(1L); // pfAdd with new values
-            assertThat(results.get(1)).isEqualTo(1L); // pfAdd with new value
-            assertThat((Long) results.get(2)).isGreaterThanOrEqualTo(2L).isLessThanOrEqualTo(4L); // pfCount result
-            assertThat(results.get(3)).isEqualTo(0L); // pfAdd with duplicate
-            assertThat((Long) results.get(4)).isGreaterThanOrEqualTo(2L).isLessThanOrEqualTo(4L); // pfCount result
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			Long largeCount = connection.hyperLogLogCommands().pfCount(keyBytes);
+			assertThat(largeCount).isGreaterThanOrEqualTo(90L).isLessThanOrEqualTo(110L); // Should
+																							// be
+																							// around
+																							// 100
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
 
-    @Test
-    void testPfCountMultipleInPipelineMode() {
-        String key1 = "test:hll:pipeline:count1";
-        String key2 = "test:hll:pipeline:count2";
-        byte[] key1Bytes = key1.getBytes();
-        byte[] key2Bytes = key2.getBytes();
-        
-        try {
-            // Set up test data
-            connection.hyperLogLogCommands().pfAdd(key1Bytes, "elem1".getBytes(), "elem2".getBytes());
-            connection.hyperLogLogCommands().pfAdd(key2Bytes, "elem2".getBytes(), "elem3".getBytes());
-            
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Queue count commands - assert they return null in pipeline mode
-            assertThat(connection.hyperLogLogCommands().pfCount(key1Bytes)).isNull();
-            assertThat(connection.hyperLogLogCommands().pfCount(key2Bytes)).isNull();
-            assertThat(connection.hyperLogLogCommands().pfCount(key1Bytes, key2Bytes)).isNull(); // union count
-            assertThat(connection.hyperLogLogCommands().pfCount("non:existent:key".getBytes())).isNull();
-            
-            // Execute pipeline
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(4);
-            assertThat((Long) results.get(0)).isGreaterThanOrEqualTo(1L).isLessThanOrEqualTo(3L); // key1 count
-            assertThat((Long) results.get(1)).isGreaterThanOrEqualTo(1L).isLessThanOrEqualTo(3L); // key2 count
-            assertThat((Long) results.get(2)).isGreaterThanOrEqualTo(2L).isLessThanOrEqualTo(4L); // union count
-            assertThat(results.get(3)).isEqualTo(0L); // non-existent key count
-            
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-        }
-    }
+	@Test
+	void testPfCountMultiple() {
+		String key1 = "test:hll:count:multiple1";
+		String key2 = "test:hll:count:multiple2";
+		byte[] key1Bytes = key1.getBytes();
+		byte[] key2Bytes = key2.getBytes();
 
-    @Test
-    void testPfMergeInPipelineMode() {
-        String source1 = "test:hll:pipeline:merge:src1";
-        String source2 = "test:hll:pipeline:merge:src2";
-        String dest = "test:hll:pipeline:merge:dst";
-        byte[] source1Bytes = source1.getBytes();
-        byte[] source2Bytes = source2.getBytes();
-        byte[] destBytes = dest.getBytes();
-        
-        try {
-            // Set up source HLLs
-            connection.hyperLogLogCommands().pfAdd(source1Bytes, "elem1".getBytes(), "elem2".getBytes());
-            connection.hyperLogLogCommands().pfAdd(source2Bytes, "elem2".getBytes(), "elem3".getBytes());
-            
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Queue merge and verification commands
-            connection.hyperLogLogCommands().pfMerge(destBytes, source1Bytes, source2Bytes); // void method, no assertion
-            assertThat(connection.hyperLogLogCommands().pfCount(destBytes)).isNull();
-            assertThat(connection.hyperLogLogCommands().pfCount(source1Bytes)).isNull(); // verify unchanged
-            assertThat(connection.hyperLogLogCommands().pfCount(source2Bytes)).isNull(); // verify unchanged
-            
-            // Execute pipeline
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(4);
-            assertThat(results.get(0)).isEqualTo("OK"); // pfMerge result
-            assertThat((Long) results.get(1)).isGreaterThanOrEqualTo(2L).isLessThanOrEqualTo(4L); // merged count
-            assertThat((Long) results.get(2)).isGreaterThanOrEqualTo(1L).isLessThanOrEqualTo(3L); // source1 unchanged
-            assertThat((Long) results.get(3)).isGreaterThanOrEqualTo(1L).isLessThanOrEqualTo(3L); // source2 unchanged
-            
-        } finally {
-            cleanupKey(source1);
-            cleanupKey(source2);
-            cleanupKey(dest);
-        }
-    }
+		try {
+			// Test pfCount on non-existent keys
+			Long emptyCount = connection.hyperLogLogCommands().pfCount(key1Bytes, key2Bytes);
+			assertThat(emptyCount).isEqualTo(0L);
 
-    @Test
-    void testEmptyHyperLogLogOperationsInPipelineMode() {
-        String key = "test:hll:pipeline:empty";
-        byte[] keyBytes = key.getBytes();
-        byte[] emptyValue = new byte[0];
-        
-        try {
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Queue operations with empty values - assert they return null in pipeline mode
-            assertThat(connection.hyperLogLogCommands().pfAdd(keyBytes, emptyValue)).isNull();
-            assertThat(connection.hyperLogLogCommands().pfCount(keyBytes)).isNull();
-            assertThat(connection.hyperLogLogCommands().pfAdd(keyBytes, emptyValue)).isNull(); // duplicate
-            assertThat(connection.hyperLogLogCommands().pfCount(keyBytes)).isNull();
-            
-            // Execute pipeline
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(4);
-            assertThat(results.get(0)).isEqualTo(1L); // pfAdd with new empty value
-            assertThat(results.get(1)).isEqualTo(1L); // pfCount result
-            assertThat(results.get(2)).isEqualTo(0L); // pfAdd with duplicate empty value
-            assertThat(results.get(3)).isEqualTo(1L); // pfCount result (unchanged)
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Add different elements to each HLL
+			connection.hyperLogLogCommands()
+				.pfAdd(key1Bytes, "elem1".getBytes(), "elem2".getBytes(), "elem3".getBytes());
+			connection.hyperLogLogCommands()
+				.pfAdd(key2Bytes, "elem3".getBytes(), "elem4".getBytes(), "elem5".getBytes());
 
-    // ==================== Transaction Mode Tests ====================
+			// Test individual counts
+			Long count1 = connection.hyperLogLogCommands().pfCount(key1Bytes);
+			Long count2 = connection.hyperLogLogCommands().pfCount(key2Bytes);
+			assertThat(count1).isGreaterThanOrEqualTo(2L).isLessThanOrEqualTo(4L); // Should
+																					// be
+																					// around
+																					// 3
+			assertThat(count2).isGreaterThanOrEqualTo(2L).isLessThanOrEqualTo(4L); // Should
+																					// be
+																					// around
+																					// 3
 
-    @Test
-    void testBasicHyperLogLogCommandsInTransactionMode() {
-        String key = "test:hll:transaction:basic";
-        byte[] keyBytes = key.getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        byte[] value3 = "value3".getBytes();
-        
-        try {
-            // Start transaction
-            connection.multi();
-            
-            // Queue HLL commands - assert they return null in transaction mode
-            assertThat(connection.hyperLogLogCommands().pfAdd(keyBytes, value1, value2)).isNull();
-            assertThat(connection.hyperLogLogCommands().pfAdd(keyBytes, value3)).isNull();
-            assertThat(connection.hyperLogLogCommands().pfCount(keyBytes)).isNull();
-            assertThat(connection.hyperLogLogCommands().pfAdd(keyBytes, value1)).isNull(); // duplicate
-            assertThat(connection.hyperLogLogCommands().pfCount(keyBytes)).isNull();
-            
-            // Execute transaction
-            List<Object> results = connection.exec();
-            
-            // Verify results
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(5);
-            assertThat(results.get(0)).isEqualTo(1L); // pfAdd with new values
-            assertThat(results.get(1)).isEqualTo(1L); // pfAdd with new value
-            assertThat((Long) results.get(2)).isGreaterThanOrEqualTo(2L).isLessThanOrEqualTo(4L); // pfCount result
-            assertThat(results.get(3)).isEqualTo(0L); // pfAdd with duplicate
-            assertThat((Long) results.get(4)).isGreaterThanOrEqualTo(2L).isLessThanOrEqualTo(4L); // pfCount result
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test union count (elem3 is in both, so total unique should be around 5)
+			Long unionCount = connection.hyperLogLogCommands().pfCount(key1Bytes, key2Bytes);
+			assertThat(unionCount).isGreaterThanOrEqualTo(4L).isLessThanOrEqualTo(6L); // Should
+																						// be
+																						// around
+																						// 5
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+		}
+	}
 
-    @Test
-    void testPfCountMultipleInTransactionMode() {
-        String key1 = "test:hll:transaction:count1";
-        String key2 = "test:hll:transaction:count2";
-        byte[] key1Bytes = key1.getBytes();
-        byte[] key2Bytes = key2.getBytes();
-        
-        try {
-            // Set up test data
-            connection.hyperLogLogCommands().pfAdd(key1Bytes, "elem1".getBytes(), "elem2".getBytes());
-            connection.hyperLogLogCommands().pfAdd(key2Bytes, "elem2".getBytes(), "elem3".getBytes());
-            
-            // Start transaction
-            connection.multi();
-            
-            // Queue count commands - assert they return null in transaction mode
-            assertThat(connection.hyperLogLogCommands().pfCount(key1Bytes)).isNull();
-            assertThat(connection.hyperLogLogCommands().pfCount(key2Bytes)).isNull();
-            assertThat(connection.hyperLogLogCommands().pfCount(key1Bytes, key2Bytes)).isNull(); // union count
-            assertThat(connection.hyperLogLogCommands().pfCount("non:existent:key".getBytes())).isNull();
-            
-            // Execute transaction
-            List<Object> results = connection.exec();
-            
-            // Verify results
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(4);
-            assertThat((Long) results.get(0)).isGreaterThanOrEqualTo(1L).isLessThanOrEqualTo(3L); // key1 count
-            assertThat((Long) results.get(1)).isGreaterThanOrEqualTo(1L).isLessThanOrEqualTo(3L); // key2 count
-            assertThat((Long) results.get(2)).isGreaterThanOrEqualTo(2L).isLessThanOrEqualTo(4L); // union count
-            assertThat(results.get(3)).isEqualTo(0L); // non-existent key count
-            
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-        }
-    }
+	@Test
+	void testPfMerge() {
+		String source1 = "test:hll:merge:source1";
+		String source2 = "test:hll:merge:source2";
+		String dest = "test:hll:merge:dest";
+		byte[] source1Bytes = source1.getBytes();
+		byte[] source2Bytes = source2.getBytes();
+		byte[] destBytes = dest.getBytes();
 
-    @Test
-    void testPfMergeInTransactionMode() {
-        String source1 = "test:hll:transaction:merge:src1";
-        String source2 = "test:hll:transaction:merge:src2";
-        String dest = "test:hll:transaction:merge:dst";
-        byte[] source1Bytes = source1.getBytes();
-        byte[] source2Bytes = source2.getBytes();
-        byte[] destBytes = dest.getBytes();
-        
-        try {
-            // Set up source HLLs
-            connection.hyperLogLogCommands().pfAdd(source1Bytes, "elem1".getBytes(), "elem2".getBytes());
-            connection.hyperLogLogCommands().pfAdd(source2Bytes, "elem2".getBytes(), "elem3".getBytes());
-            
-            // Start transaction
-            connection.multi();
-            
-            // Queue merge and verification commands
-            connection.hyperLogLogCommands().pfMerge(destBytes, source1Bytes, source2Bytes); // void method, no assertion
-            assertThat(connection.hyperLogLogCommands().pfCount(destBytes)).isNull();
-            assertThat(connection.hyperLogLogCommands().pfCount(source1Bytes)).isNull(); // verify unchanged
-            assertThat(connection.hyperLogLogCommands().pfCount(source2Bytes)).isNull(); // verify unchanged
-            
-            // Execute transaction
-            List<Object> results = connection.exec();
-            
-            // Verify results
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(4);
-            assertThat(results.get(0)).isEqualTo("OK"); // pfMerge result
-            assertThat((Long) results.get(1)).isGreaterThanOrEqualTo(2L).isLessThanOrEqualTo(4L); // merged count
-            assertThat((Long) results.get(2)).isGreaterThanOrEqualTo(1L).isLessThanOrEqualTo(3L); // source1 unchanged
-            assertThat((Long) results.get(3)).isGreaterThanOrEqualTo(1L).isLessThanOrEqualTo(3L); // source2 unchanged
-            
-        } finally {
-            cleanupKey(source1);
-            cleanupKey(source2);
-            cleanupKey(dest);
-        }
-    }
+		try {
+			// Add elements to source HLLs
+			connection.hyperLogLogCommands()
+				.pfAdd(source1Bytes, "elem1".getBytes(), "elem2".getBytes(), "elem3".getBytes());
+			connection.hyperLogLogCommands()
+				.pfAdd(source2Bytes, "elem3".getBytes(), "elem4".getBytes(), "elem5".getBytes());
 
-    @Test
-    void testTransactionDiscardWithHyperLogLogCommands() {
-        String key = "test:hll:transaction:discard";
-        byte[] keyBytes = key.getBytes();
-        byte[] value = "value".getBytes();
-        
-        try {
-            // Start transaction
-            connection.multi();
-            
-            // Queue HLL commands
-            connection.hyperLogLogCommands().pfAdd(keyBytes, value);
-            connection.hyperLogLogCommands().pfCount(keyBytes);
-            
-            // Discard transaction
-            connection.discard();
-            
-            // Verify key doesn't exist (transaction was discarded)
-            Long count = connection.hyperLogLogCommands().pfCount(keyBytes);
-            assertThat(count).isEqualTo(0L);
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Get individual counts before merge
+			Long count1 = connection.hyperLogLogCommands().pfCount(source1Bytes);
+			Long count2 = connection.hyperLogLogCommands().pfCount(source2Bytes);
 
-    @Test
-    void testWatchWithHyperLogLogCommandsTransaction() throws InterruptedException {
-        String watchKey = "test:hll:transaction:watch";
-        String otherKey = "test:hll:transaction:other";
-        byte[] watchKeyBytes = watchKey.getBytes();
-        byte[] otherKeyBytes = otherKey.getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        
-        try {
-            // Setup initial data
-            connection.hyperLogLogCommands().pfAdd(watchKeyBytes, value1);
-            
-            // Watch the key
-            connection.watch(watchKeyBytes);
-            
-            // Modify the watched key from "outside" the transaction
-            // (simulating another client)
-            connection.hyperLogLogCommands().pfAdd(watchKeyBytes, value2);
-            
-            // Start transaction
-            connection.multi();
-            
-            // Queue HLL commands
-            connection.hyperLogLogCommands().pfAdd(otherKeyBytes, value1);
-            connection.hyperLogLogCommands().pfCount(otherKeyBytes);
-            
-            // Execute transaction - should be aborted due to WATCH
-            List<Object> results = connection.exec();
-            
-            // Transaction should be aborted (results should be null)
-            assertThat(results).isNotNull().isEmpty();
-            
-            // Verify that the other key was not set
-            Long count = connection.hyperLogLogCommands().pfCount(otherKeyBytes);
-            assertThat(count).isEqualTo(0L);
-            
-        } finally {
-            cleanupKey(watchKey);
-            cleanupKey(otherKey);
-        }
-    }
+			// Test pfMerge
+			connection.hyperLogLogCommands().pfMerge(destBytes, source1Bytes, source2Bytes);
 
-    // ==================== Comprehensive HyperLogLog Workflow Tests ====================
+			// Verify merge result
+			Long mergedCount = connection.hyperLogLogCommands().pfCount(destBytes);
+			assertThat(mergedCount).isGreaterThanOrEqualTo(4L).isLessThanOrEqualTo(6L); // Should
+																						// be
+																						// around
+																						// 5
+																						// (elem3
+																						// overlaps)
 
-    @Test
-    void testHyperLogLogComprehensiveWorkflow() {
-        String hll1 = "test:hll:workflow:hll1";
-        String hll2 = "test:hll:workflow:hll2";
-        String hll3 = "test:hll:workflow:hll3";
-        String merged = "test:hll:workflow:merged";
-        
-        try {
-            // Create multiple HLLs with overlapping and unique data
-            connection.hyperLogLogCommands().pfAdd(hll1.getBytes(), "common1".getBytes(), "unique1a".getBytes(), "unique1b".getBytes());
-            connection.hyperLogLogCommands().pfAdd(hll2.getBytes(), "common1".getBytes(), "common2".getBytes(), "unique2a".getBytes());
-            connection.hyperLogLogCommands().pfAdd(hll3.getBytes(), "common2".getBytes(), "unique3a".getBytes(), "unique3b".getBytes());
-            
-            // Verify individual counts
-            Long count1 = connection.hyperLogLogCommands().pfCount(hll1.getBytes());
-            Long count2 = connection.hyperLogLogCommands().pfCount(hll2.getBytes());
-            Long count3 = connection.hyperLogLogCommands().pfCount(hll3.getBytes());
-            
-            assertThat(count1).isGreaterThanOrEqualTo(2L).isLessThanOrEqualTo(4L); // Should be around 3
-            assertThat(count2).isGreaterThanOrEqualTo(2L).isLessThanOrEqualTo(4L); // Should be around 3
-            assertThat(count3).isGreaterThanOrEqualTo(2L).isLessThanOrEqualTo(4L); // Should be around 3
-            
-            // Test union counts
-            Long union12 = connection.hyperLogLogCommands().pfCount(hll1.getBytes(), hll2.getBytes());
-            Long union23 = connection.hyperLogLogCommands().pfCount(hll2.getBytes(), hll3.getBytes());
-            Long unionAll = connection.hyperLogLogCommands().pfCount(hll1.getBytes(), hll2.getBytes(), hll3.getBytes());
-            
-            assertThat(union12).isGreaterThanOrEqualTo(4L).isLessThanOrEqualTo(6L); // Should be around 5
-            assertThat(union23).isGreaterThanOrEqualTo(3L).isLessThanOrEqualTo(5L); // Should be around 4
-            assertThat(unionAll).isGreaterThanOrEqualTo(6L).isLessThanOrEqualTo(8L); // Should be around 7
-            
-            // Merge all into one HLL
-            connection.hyperLogLogCommands().pfMerge(merged.getBytes(), hll1.getBytes(), hll2.getBytes(), hll3.getBytes());
-            
-            // Verify merged count matches union count
-            Long mergedCount = connection.hyperLogLogCommands().pfCount(merged.getBytes());
-            assertThat(mergedCount).isEqualTo(unionAll);
-            
-            // Add more elements to merged HLL
-            connection.hyperLogLogCommands().pfAdd(merged.getBytes(), "additional1".getBytes(), "additional2".getBytes());
-            
-            Long finalCount = connection.hyperLogLogCommands().pfCount(merged.getBytes());
-            assertThat(finalCount).isGreaterThan(mergedCount);
-            
-        } finally {
-            cleanupKey(hll1);
-            cleanupKey(hll2);
-            cleanupKey(hll3);
-            cleanupKey(merged);
-        }
-    }
+			// Verify original HLLs are unchanged
+			Long count1After = connection.hyperLogLogCommands().pfCount(source1Bytes);
+			Long count2After = connection.hyperLogLogCommands().pfCount(source2Bytes);
+			assertThat(count1After).isEqualTo(count1);
+			assertThat(count2After).isEqualTo(count2);
+
+			// Test merging into existing HLL
+			connection.hyperLogLogCommands().pfAdd(destBytes, "elem6".getBytes());
+			connection.hyperLogLogCommands().pfMerge(destBytes, source1Bytes);
+
+			Long finalCount = connection.hyperLogLogCommands().pfCount(destBytes);
+			assertThat(finalCount).isGreaterThanOrEqualTo(5L).isLessThanOrEqualTo(7L); // Should
+																						// be
+																						// around
+																						// 6
+		}
+		finally {
+			cleanupKey(source1);
+			cleanupKey(source2);
+			cleanupKey(dest);
+		}
+	}
+
+	// ==================== Edge Cases and Error Handling ====================
+
+	@Test
+	void testHyperLogLogWithEmptyValues() {
+		String key = "test:hll:empty";
+		byte[] keyBytes = key.getBytes();
+		byte[] emptyValue = new byte[0];
+
+		try {
+			// Add empty value
+			Long addResult = connection.hyperLogLogCommands().pfAdd(keyBytes, emptyValue);
+			assertThat(addResult).isEqualTo(1L);
+
+			// Count should include empty value
+			Long count = connection.hyperLogLogCommands().pfCount(keyBytes);
+			assertThat(count).isEqualTo(1L);
+
+			// Add empty value again (duplicate)
+			Long addResult2 = connection.hyperLogLogCommands().pfAdd(keyBytes, emptyValue);
+			assertThat(addResult2).isEqualTo(0L); // No change
+
+			// Count should still be 1
+			Long count2 = connection.hyperLogLogCommands().pfCount(keyBytes);
+			assertThat(count2).isEqualTo(1L);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testHyperLogLogWithBinaryData() {
+		String key = "test:hll:binary";
+		byte[] keyBytes = key.getBytes();
+		byte[] binaryValue1 = new byte[] { 0x00, 0x01, 0x02, (byte) 0xFF };
+		byte[] binaryValue2 = new byte[] { (byte) 0xFF, (byte) 0xFE, 0x00, 0x01, 0x7F };
+		byte[] binaryValue3 = new byte[] { 0x00, 0x01, 0x02, (byte) 0xFF }; // duplicate
+																			// of value1
+
+		try {
+			// Add binary values
+			Long addResult1 = connection.hyperLogLogCommands().pfAdd(keyBytes, binaryValue1, binaryValue2);
+			assertThat(addResult1).isEqualTo(1L);
+
+			// Add duplicate binary value
+			Long addResult2 = connection.hyperLogLogCommands().pfAdd(keyBytes, binaryValue3);
+			assertThat(addResult2).isEqualTo(0L); // Should be duplicate
+
+			// Count should be around 2
+			Long count = connection.hyperLogLogCommands().pfCount(keyBytes);
+			assertThat(count).isGreaterThanOrEqualTo(1L).isLessThanOrEqualTo(3L);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testHyperLogLogDuplicateHandling() {
+		String key = "test:hll:duplicate";
+		byte[] keyBytes = key.getBytes();
+		byte[] value = "testvalue".getBytes();
+
+		try {
+			// Add same value multiple times
+			Long addResult1 = connection.hyperLogLogCommands().pfAdd(keyBytes, value);
+			assertThat(addResult1).isEqualTo(1L); // First time
+
+			Long addResult2 = connection.hyperLogLogCommands().pfAdd(keyBytes, value);
+			assertThat(addResult2).isEqualTo(0L); // Duplicate
+
+			Long addResult3 = connection.hyperLogLogCommands().pfAdd(keyBytes, value);
+			assertThat(addResult3).isEqualTo(0L); // Duplicate
+
+			// Count should be 1
+			Long count = connection.hyperLogLogCommands().pfCount(keyBytes);
+			assertThat(count).isEqualTo(1L);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testHyperLogLogLargeDataSet() {
+		String key = "test:hll:large";
+		byte[] keyBytes = key.getBytes();
+
+		try {
+			// Add many unique elements
+			for (int i = 0; i < 10000; i++) {
+				connection.hyperLogLogCommands().pfAdd(keyBytes, ("element" + i).getBytes());
+			}
+
+			// Count should be close to 10000 (within acceptable HLL error range)
+			Long count = connection.hyperLogLogCommands().pfCount(keyBytes);
+			assertThat(count).isGreaterThan(9500L).isLessThan(10500L); // ~5% error
+																		// tolerance
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testHyperLogLogOperationsOnNonHLLTypes() {
+		String stringKey = "test:hll:error:string";
+
+		try {
+			// Create a string key
+			connection.stringCommands().set(stringKey.getBytes(), "stringvalue".getBytes());
+
+			// Try HLL operations on string key - should fail
+			assertThatThrownBy(() -> connection.hyperLogLogCommands().pfAdd(stringKey.getBytes(), "value".getBytes()))
+				.isInstanceOf(DataAccessException.class);
+
+			assertThatThrownBy(() -> connection.hyperLogLogCommands().pfCount(stringKey.getBytes()))
+				.isInstanceOf(DataAccessException.class);
+		}
+		finally {
+			cleanupKey(stringKey);
+		}
+	}
+
+	// ==================== Pipeline Mode Tests ====================
+
+	@Test
+	void testBasicHyperLogLogCommandsInPipelineMode() {
+		String key = "test:hll:pipeline:basic";
+		byte[] keyBytes = key.getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+		byte[] value3 = "value3".getBytes();
+
+		try {
+			// Start pipeline
+			connection.openPipeline();
+
+			// Queue HLL commands - assert they return null in pipeline mode
+			assertThat(connection.hyperLogLogCommands().pfAdd(keyBytes, value1, value2)).isNull();
+			assertThat(connection.hyperLogLogCommands().pfAdd(keyBytes, value3)).isNull();
+			assertThat(connection.hyperLogLogCommands().pfCount(keyBytes)).isNull();
+			assertThat(connection.hyperLogLogCommands().pfAdd(keyBytes, value1)).isNull(); // duplicate
+			assertThat(connection.hyperLogLogCommands().pfCount(keyBytes)).isNull();
+
+			// Execute pipeline
+			List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(5);
+			assertThat(results.get(0)).isEqualTo(1L); // pfAdd with new values
+			assertThat(results.get(1)).isEqualTo(1L); // pfAdd with new value
+			assertThat((Long) results.get(2)).isGreaterThanOrEqualTo(2L).isLessThanOrEqualTo(4L); // pfCount
+																									// result
+			assertThat(results.get(3)).isEqualTo(0L); // pfAdd with duplicate
+			assertThat((Long) results.get(4)).isGreaterThanOrEqualTo(2L).isLessThanOrEqualTo(4L); // pfCount
+																									// result
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testPfCountMultipleInPipelineMode() {
+		String key1 = "test:hll:pipeline:count1";
+		String key2 = "test:hll:pipeline:count2";
+		byte[] key1Bytes = key1.getBytes();
+		byte[] key2Bytes = key2.getBytes();
+
+		try {
+			// Set up test data
+			connection.hyperLogLogCommands().pfAdd(key1Bytes, "elem1".getBytes(), "elem2".getBytes());
+			connection.hyperLogLogCommands().pfAdd(key2Bytes, "elem2".getBytes(), "elem3".getBytes());
+
+			// Start pipeline
+			connection.openPipeline();
+
+			// Queue count commands - assert they return null in pipeline mode
+			assertThat(connection.hyperLogLogCommands().pfCount(key1Bytes)).isNull();
+			assertThat(connection.hyperLogLogCommands().pfCount(key2Bytes)).isNull();
+			assertThat(connection.hyperLogLogCommands().pfCount(key1Bytes, key2Bytes)).isNull(); // union
+																									// count
+			assertThat(connection.hyperLogLogCommands().pfCount("non:existent:key".getBytes())).isNull();
+
+			// Execute pipeline
+			List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(4);
+			assertThat((Long) results.get(0)).isGreaterThanOrEqualTo(1L).isLessThanOrEqualTo(3L); // key1
+																									// count
+			assertThat((Long) results.get(1)).isGreaterThanOrEqualTo(1L).isLessThanOrEqualTo(3L); // key2
+																									// count
+			assertThat((Long) results.get(2)).isGreaterThanOrEqualTo(2L).isLessThanOrEqualTo(4L); // union
+																									// count
+			assertThat(results.get(3)).isEqualTo(0L); // non-existent key count
+
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+		}
+	}
+
+	@Test
+	void testPfMergeInPipelineMode() {
+		String source1 = "test:hll:pipeline:merge:src1";
+		String source2 = "test:hll:pipeline:merge:src2";
+		String dest = "test:hll:pipeline:merge:dst";
+		byte[] source1Bytes = source1.getBytes();
+		byte[] source2Bytes = source2.getBytes();
+		byte[] destBytes = dest.getBytes();
+
+		try {
+			// Set up source HLLs
+			connection.hyperLogLogCommands().pfAdd(source1Bytes, "elem1".getBytes(), "elem2".getBytes());
+			connection.hyperLogLogCommands().pfAdd(source2Bytes, "elem2".getBytes(), "elem3".getBytes());
+
+			// Start pipeline
+			connection.openPipeline();
+
+			// Queue merge and verification commands
+			connection.hyperLogLogCommands().pfMerge(destBytes, source1Bytes, source2Bytes); // void
+																								// method,
+																								// no
+																								// assertion
+			assertThat(connection.hyperLogLogCommands().pfCount(destBytes)).isNull();
+			assertThat(connection.hyperLogLogCommands().pfCount(source1Bytes)).isNull(); // verify
+																							// unchanged
+			assertThat(connection.hyperLogLogCommands().pfCount(source2Bytes)).isNull(); // verify
+																							// unchanged
+
+			// Execute pipeline
+			List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(4);
+			assertThat(results.get(0)).isEqualTo("OK"); // pfMerge result
+			assertThat((Long) results.get(1)).isGreaterThanOrEqualTo(2L).isLessThanOrEqualTo(4L); // merged
+																									// count
+			assertThat((Long) results.get(2)).isGreaterThanOrEqualTo(1L).isLessThanOrEqualTo(3L); // source1
+																									// unchanged
+			assertThat((Long) results.get(3)).isGreaterThanOrEqualTo(1L).isLessThanOrEqualTo(3L); // source2
+																									// unchanged
+
+		}
+		finally {
+			cleanupKey(source1);
+			cleanupKey(source2);
+			cleanupKey(dest);
+		}
+	}
+
+	@Test
+	void testEmptyHyperLogLogOperationsInPipelineMode() {
+		String key = "test:hll:pipeline:empty";
+		byte[] keyBytes = key.getBytes();
+		byte[] emptyValue = new byte[0];
+
+		try {
+			// Start pipeline
+			connection.openPipeline();
+
+			// Queue operations with empty values - assert they return null in pipeline
+			// mode
+			assertThat(connection.hyperLogLogCommands().pfAdd(keyBytes, emptyValue)).isNull();
+			assertThat(connection.hyperLogLogCommands().pfCount(keyBytes)).isNull();
+			assertThat(connection.hyperLogLogCommands().pfAdd(keyBytes, emptyValue)).isNull(); // duplicate
+			assertThat(connection.hyperLogLogCommands().pfCount(keyBytes)).isNull();
+
+			// Execute pipeline
+			List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(4);
+			assertThat(results.get(0)).isEqualTo(1L); // pfAdd with new empty value
+			assertThat(results.get(1)).isEqualTo(1L); // pfCount result
+			assertThat(results.get(2)).isEqualTo(0L); // pfAdd with duplicate empty value
+			assertThat(results.get(3)).isEqualTo(1L); // pfCount result (unchanged)
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== Transaction Mode Tests ====================
+
+	@Test
+	void testBasicHyperLogLogCommandsInTransactionMode() {
+		String key = "test:hll:transaction:basic";
+		byte[] keyBytes = key.getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+		byte[] value3 = "value3".getBytes();
+
+		try {
+			// Start transaction
+			connection.multi();
+
+			// Queue HLL commands - assert they return null in transaction mode
+			assertThat(connection.hyperLogLogCommands().pfAdd(keyBytes, value1, value2)).isNull();
+			assertThat(connection.hyperLogLogCommands().pfAdd(keyBytes, value3)).isNull();
+			assertThat(connection.hyperLogLogCommands().pfCount(keyBytes)).isNull();
+			assertThat(connection.hyperLogLogCommands().pfAdd(keyBytes, value1)).isNull(); // duplicate
+			assertThat(connection.hyperLogLogCommands().pfCount(keyBytes)).isNull();
+
+			// Execute transaction
+			List<Object> results = connection.exec();
+
+			// Verify results
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(5);
+			assertThat(results.get(0)).isEqualTo(1L); // pfAdd with new values
+			assertThat(results.get(1)).isEqualTo(1L); // pfAdd with new value
+			assertThat((Long) results.get(2)).isGreaterThanOrEqualTo(2L).isLessThanOrEqualTo(4L); // pfCount
+																									// result
+			assertThat(results.get(3)).isEqualTo(0L); // pfAdd with duplicate
+			assertThat((Long) results.get(4)).isGreaterThanOrEqualTo(2L).isLessThanOrEqualTo(4L); // pfCount
+																									// result
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testPfCountMultipleInTransactionMode() {
+		String key1 = "test:hll:transaction:count1";
+		String key2 = "test:hll:transaction:count2";
+		byte[] key1Bytes = key1.getBytes();
+		byte[] key2Bytes = key2.getBytes();
+
+		try {
+			// Set up test data
+			connection.hyperLogLogCommands().pfAdd(key1Bytes, "elem1".getBytes(), "elem2".getBytes());
+			connection.hyperLogLogCommands().pfAdd(key2Bytes, "elem2".getBytes(), "elem3".getBytes());
+
+			// Start transaction
+			connection.multi();
+
+			// Queue count commands - assert they return null in transaction mode
+			assertThat(connection.hyperLogLogCommands().pfCount(key1Bytes)).isNull();
+			assertThat(connection.hyperLogLogCommands().pfCount(key2Bytes)).isNull();
+			assertThat(connection.hyperLogLogCommands().pfCount(key1Bytes, key2Bytes)).isNull(); // union
+																									// count
+			assertThat(connection.hyperLogLogCommands().pfCount("non:existent:key".getBytes())).isNull();
+
+			// Execute transaction
+			List<Object> results = connection.exec();
+
+			// Verify results
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(4);
+			assertThat((Long) results.get(0)).isGreaterThanOrEqualTo(1L).isLessThanOrEqualTo(3L); // key1
+																									// count
+			assertThat((Long) results.get(1)).isGreaterThanOrEqualTo(1L).isLessThanOrEqualTo(3L); // key2
+																									// count
+			assertThat((Long) results.get(2)).isGreaterThanOrEqualTo(2L).isLessThanOrEqualTo(4L); // union
+																									// count
+			assertThat(results.get(3)).isEqualTo(0L); // non-existent key count
+
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+		}
+	}
+
+	@Test
+	void testPfMergeInTransactionMode() {
+		String source1 = "test:hll:transaction:merge:src1";
+		String source2 = "test:hll:transaction:merge:src2";
+		String dest = "test:hll:transaction:merge:dst";
+		byte[] source1Bytes = source1.getBytes();
+		byte[] source2Bytes = source2.getBytes();
+		byte[] destBytes = dest.getBytes();
+
+		try {
+			// Set up source HLLs
+			connection.hyperLogLogCommands().pfAdd(source1Bytes, "elem1".getBytes(), "elem2".getBytes());
+			connection.hyperLogLogCommands().pfAdd(source2Bytes, "elem2".getBytes(), "elem3".getBytes());
+
+			// Start transaction
+			connection.multi();
+
+			// Queue merge and verification commands
+			connection.hyperLogLogCommands().pfMerge(destBytes, source1Bytes, source2Bytes); // void
+																								// method,
+																								// no
+																								// assertion
+			assertThat(connection.hyperLogLogCommands().pfCount(destBytes)).isNull();
+			assertThat(connection.hyperLogLogCommands().pfCount(source1Bytes)).isNull(); // verify
+																							// unchanged
+			assertThat(connection.hyperLogLogCommands().pfCount(source2Bytes)).isNull(); // verify
+																							// unchanged
+
+			// Execute transaction
+			List<Object> results = connection.exec();
+
+			// Verify results
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(4);
+			assertThat(results.get(0)).isEqualTo("OK"); // pfMerge result
+			assertThat((Long) results.get(1)).isGreaterThanOrEqualTo(2L).isLessThanOrEqualTo(4L); // merged
+																									// count
+			assertThat((Long) results.get(2)).isGreaterThanOrEqualTo(1L).isLessThanOrEqualTo(3L); // source1
+																									// unchanged
+			assertThat((Long) results.get(3)).isGreaterThanOrEqualTo(1L).isLessThanOrEqualTo(3L); // source2
+																									// unchanged
+
+		}
+		finally {
+			cleanupKey(source1);
+			cleanupKey(source2);
+			cleanupKey(dest);
+		}
+	}
+
+	@Test
+	void testTransactionDiscardWithHyperLogLogCommands() {
+		String key = "test:hll:transaction:discard";
+		byte[] keyBytes = key.getBytes();
+		byte[] value = "value".getBytes();
+
+		try {
+			// Start transaction
+			connection.multi();
+
+			// Queue HLL commands
+			connection.hyperLogLogCommands().pfAdd(keyBytes, value);
+			connection.hyperLogLogCommands().pfCount(keyBytes);
+
+			// Discard transaction
+			connection.discard();
+
+			// Verify key doesn't exist (transaction was discarded)
+			Long count = connection.hyperLogLogCommands().pfCount(keyBytes);
+			assertThat(count).isEqualTo(0L);
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testWatchWithHyperLogLogCommandsTransaction() throws InterruptedException {
+		String watchKey = "test:hll:transaction:watch";
+		String otherKey = "test:hll:transaction:other";
+		byte[] watchKeyBytes = watchKey.getBytes();
+		byte[] otherKeyBytes = otherKey.getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+
+		try {
+			// Setup initial data
+			connection.hyperLogLogCommands().pfAdd(watchKeyBytes, value1);
+
+			// Watch the key
+			connection.watch(watchKeyBytes);
+
+			// Modify the watched key from "outside" the transaction
+			// (simulating another client)
+			connection.hyperLogLogCommands().pfAdd(watchKeyBytes, value2);
+
+			// Start transaction
+			connection.multi();
+
+			// Queue HLL commands
+			connection.hyperLogLogCommands().pfAdd(otherKeyBytes, value1);
+			connection.hyperLogLogCommands().pfCount(otherKeyBytes);
+
+			// Execute transaction - should be aborted due to WATCH
+			List<Object> results = connection.exec();
+
+			// Transaction should be aborted (results should be null)
+			assertThat(results).isNotNull().isEmpty();
+
+			// Verify that the other key was not set
+			Long count = connection.hyperLogLogCommands().pfCount(otherKeyBytes);
+			assertThat(count).isEqualTo(0L);
+
+		}
+		finally {
+			cleanupKey(watchKey);
+			cleanupKey(otherKey);
+		}
+	}
+
+	// ==================== Comprehensive HyperLogLog Workflow Tests ====================
+
+	@Test
+	void testHyperLogLogComprehensiveWorkflow() {
+		String hll1 = "test:hll:workflow:hll1";
+		String hll2 = "test:hll:workflow:hll2";
+		String hll3 = "test:hll:workflow:hll3";
+		String merged = "test:hll:workflow:merged";
+
+		try {
+			// Create multiple HLLs with overlapping and unique data
+			connection.hyperLogLogCommands()
+				.pfAdd(hll1.getBytes(), "common1".getBytes(), "unique1a".getBytes(), "unique1b".getBytes());
+			connection.hyperLogLogCommands()
+				.pfAdd(hll2.getBytes(), "common1".getBytes(), "common2".getBytes(), "unique2a".getBytes());
+			connection.hyperLogLogCommands()
+				.pfAdd(hll3.getBytes(), "common2".getBytes(), "unique3a".getBytes(), "unique3b".getBytes());
+
+			// Verify individual counts
+			Long count1 = connection.hyperLogLogCommands().pfCount(hll1.getBytes());
+			Long count2 = connection.hyperLogLogCommands().pfCount(hll2.getBytes());
+			Long count3 = connection.hyperLogLogCommands().pfCount(hll3.getBytes());
+
+			assertThat(count1).isGreaterThanOrEqualTo(2L).isLessThanOrEqualTo(4L); // Should
+																					// be
+																					// around
+																					// 3
+			assertThat(count2).isGreaterThanOrEqualTo(2L).isLessThanOrEqualTo(4L); // Should
+																					// be
+																					// around
+																					// 3
+			assertThat(count3).isGreaterThanOrEqualTo(2L).isLessThanOrEqualTo(4L); // Should
+																					// be
+																					// around
+																					// 3
+
+			// Test union counts
+			Long union12 = connection.hyperLogLogCommands().pfCount(hll1.getBytes(), hll2.getBytes());
+			Long union23 = connection.hyperLogLogCommands().pfCount(hll2.getBytes(), hll3.getBytes());
+			Long unionAll = connection.hyperLogLogCommands().pfCount(hll1.getBytes(), hll2.getBytes(), hll3.getBytes());
+
+			assertThat(union12).isGreaterThanOrEqualTo(4L).isLessThanOrEqualTo(6L); // Should
+																					// be
+																					// around
+																					// 5
+			assertThat(union23).isGreaterThanOrEqualTo(3L).isLessThanOrEqualTo(5L); // Should
+																					// be
+																					// around
+																					// 4
+			assertThat(unionAll).isGreaterThanOrEqualTo(6L).isLessThanOrEqualTo(8L); // Should
+																						// be
+																						// around
+																						// 7
+
+			// Merge all into one HLL
+			connection.hyperLogLogCommands()
+				.pfMerge(merged.getBytes(), hll1.getBytes(), hll2.getBytes(), hll3.getBytes());
+
+			// Verify merged count matches union count
+			Long mergedCount = connection.hyperLogLogCommands().pfCount(merged.getBytes());
+			assertThat(mergedCount).isEqualTo(unionAll);
+
+			// Add more elements to merged HLL
+			connection.hyperLogLogCommands()
+				.pfAdd(merged.getBytes(), "additional1".getBytes(), "additional2".getBytes());
+
+			Long finalCount = connection.hyperLogLogCommands().pfCount(merged.getBytes());
+			assertThat(finalCount).isGreaterThan(mergedCount);
+
+		}
+		finally {
+			cleanupKey(hll1);
+			cleanupKey(hll2);
+			cleanupKey(hll3);
+			cleanupKey(merged);
+		}
+	}
 
 }

--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionIntegrationTests.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,708 +32,737 @@ import io.valkey.springframework.data.valkey.connection.ValkeyNode;
 import io.valkey.springframework.data.valkey.connection.ValkeyPipelineException;
 
 /**
- * Comprehensive integration tests for {@link ValkeyGlideConnection} covering
- * the ValkeyConnection interface methods directly.
- * 
- * <p>These tests validate the implementation of ValkeyConnection interface methods and ensure
- * standard behavior for basic and edge cases including:
+ * Comprehensive integration tests for {@link ValkeyGlideConnection} covering the
+ * ValkeyConnection interface methods directly.
+ *
+ * <p>
+ * These tests validate the implementation of ValkeyConnection interface methods and
+ * ensure standard behavior for basic and edge cases including:
  * <ul>
- *   <li>Connection lifecycle: close(), isClosed(), getNativeConnection()</li>
- *   <li>Pipeline functionality: openPipeline() → commands → closePipeline()</li>
- *   <li>State management: isPipelined(), isQueueing() interactions</li>
- *   <li>Empty pipeline should return an empty list</li>
- *   <li>getSentinelConnection() - not implemented, should throw exception</li>
- *   <li>Pipeline vs transaction mode isolation</li>
- *   <li>Error conditions and edge cases</li>
- *   <li>Complex scenarios: large pipelines, concurrent access</li>
+ * <li>Connection lifecycle: close(), isClosed(), getNativeConnection()</li>
+ * <li>Pipeline functionality: openPipeline() → commands → closePipeline()</li>
+ * <li>State management: isPipelined(), isQueueing() interactions</li>
+ * <li>Empty pipeline should return an empty list</li>
+ * <li>getSentinelConnection() - not implemented, should throw exception</li>
+ * <li>Pipeline vs transaction mode isolation</li>
+ * <li>Error conditions and edge cases</li>
+ * <li>Complex scenarios: large pipelines, concurrent access</li>
  * </ul>
  *
- * <p>This test class focuses on validating the core ValkeyConnection interface
- * compliance, with particular emphasis on pipeline functionality which mirrors
- * the comprehensive transaction testing approach used in ValkeyGlideConnectionTxCommandsIntegrationTests.
+ * <p>
+ * This test class focuses on validating the core ValkeyConnection interface compliance,
+ * with particular emphasis on pipeline functionality which mirrors the comprehensive
+ * transaction testing approach used in ValkeyGlideConnectionTxCommandsIntegrationTests.
  *
  * @author Ilia Kolominsky
  * @since 2.0
  */
 public class ValkeyGlideConnectionIntegrationTests extends AbstractValkeyGlideIntegrationTests {
 
-    @Override
-    protected String[] getTestKeyPatterns() {
-        return new String[]{
-            // Connection lifecycle test keys
-            "test:conn:lifecycle:key", "test:conn:native:key",
-            
-            // Basic pipeline test keys
-            "test:pipe:basic:key1", "test:pipe:basic:key2", "test:pipe:basic:string", "test:pipe:basic:hash",
-            
-            // Consecutive pipeline test keys
-            "test:pipe:consecutive:key1", "test:pipe:consecutive:key2", "test:pipe:consecutive:key3",
-            
-            // Mixed command type test keys
-            "test:pipe:mixed:string", "test:pipe:mixed:hash", "test:pipe:mixed:list", "test:pipe:mixed:set",
-            "test:pipe:mixed:zset", "test:pipe:mixed:geo",
-            
-            // State management test keys
-            "test:pipe:state:key", "test:pipe:state:isolation:key",
-            
-            // Error handling test keys
-            "test:pipe:error:key", "test:pipe:error:nested", "test:pipe:error:exception",
-            
-            // Large pipeline test keys
-            "test:pipe:large:key", "test:pipe:performance:key",
-            
-            // Concurrent test keys (with thread ID suffix pattern)
-            "test:pipe:concurrent:shared", "test:pipe:concurrent:key",
-            
-            // Result conversion test keys
-            "test:pipe:conversion:key", "test:pipe:conversion:counter",
-            
-            // Edge case test keys
-            "test:pipe:edge:nonexistent", "test:pipe:edge:empty"
-        };
-    }
+	@Override
+	protected String[] getTestKeyPatterns() {
+		return new String[] {
+				// Connection lifecycle test keys
+				"test:conn:lifecycle:key", "test:conn:native:key",
 
-    // ==================== Connection Lifecycle Tests ====================
+				// Basic pipeline test keys
+				"test:pipe:basic:key1", "test:pipe:basic:key2", "test:pipe:basic:string", "test:pipe:basic:hash",
 
-    @Test
-    void testConnectionLifecycle() {
-        String key = "test:conn:lifecycle:key";
-        
-        try {
-            // Test initial state
-            assertThat(connection.isClosed()).isFalse();
-            
-            // Test basic operation works
-            connection.stringCommands().set(key.getBytes(), "test_value".getBytes());
-            assertThat(connection.stringCommands().get(key.getBytes())).isEqualTo("test_value".getBytes());
-            
-            // Test connection is still open
-            assertThat(connection.isClosed()).isFalse();
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+				// Consecutive pipeline test keys
+				"test:pipe:consecutive:key1", "test:pipe:consecutive:key2", "test:pipe:consecutive:key3",
 
-    @Test
-    void testGetNativeConnection() {
-        String key = "test:conn:native:key";
-        
-        try {
-            // Verify native connection exists and is not null
-            Object nativeConnection = connection.getNativeConnection();
-            assertThat(nativeConnection).isNotNull();
-            assertThat(nativeConnection.getClass().getName()).contains("GlideClient");
-            
-            // Verify connection is functional
-            connection.stringCommands().set(key.getBytes(), "native_test".getBytes());
-            assertThat(connection.stringCommands().get(key.getBytes())).isEqualTo("native_test".getBytes());
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+				// Mixed command type test keys
+				"test:pipe:mixed:string", "test:pipe:mixed:hash", "test:pipe:mixed:list", "test:pipe:mixed:set",
+				"test:pipe:mixed:zset", "test:pipe:mixed:geo",
 
-    @Test
-    @Disabled("⚠️  WARNING: getSentinelConnection() not implemented, rework the test when it is")
-    void testGetSentinelConnection() {
-        // getSentinelConnection is not implemented yet
-        assertThatThrownBy(() -> connection.getSentinelConnection())
-            .isInstanceOf(InvalidDataAccessResourceUsageException.class)
-            .hasMessageContaining("No sentinels configured");
-    }
+				// State management test keys
+				"test:pipe:state:key", "test:pipe:state:isolation:key",
 
-    // ==================== Basic Pipeline Tests ====================
+				// Error handling test keys
+				"test:pipe:error:key", "test:pipe:error:nested", "test:pipe:error:exception",
 
-    @Test
-    void testBasicPipelineFlow() {
-        String key1 = "test:pipe:basic:key1";
-        String key2 = "test:pipe:basic:key2";
-        
-        try {
-            // Verify initial state
-            assertThat(connection.isPipelined()).isFalse();
-            
-            // Start pipeline
-            connection.openPipeline();
-            assertThat(connection.isPipelined()).isTrue();
-            
-            // Queue commands - should return null in pipeline mode
-            Object setResult1 = connection.stringCommands().set(key1.getBytes(), "value1".getBytes());
-            Object setResult2 = connection.stringCommands().set(key2.getBytes(), "value2".getBytes());
-            Object getResult1 = connection.stringCommands().get(key1.getBytes());
-            Object getResult2 = connection.stringCommands().get(key2.getBytes());
-            
-            // All commands in pipeline should return null (queued)
-            assertThat(setResult1).isNull();
-            assertThat(setResult2).isNull();
-            assertThat(getResult1).isNull();
-            assertThat(getResult2).isNull();
-            
-            // Still in pipeline state
-            assertThat(connection.isPipelined()).isTrue();
-            
-            // Execute pipeline
-            List<Object> results = connection.closePipeline();
-            
-            // Pipeline should complete
-            assertThat(connection.isPipelined()).isFalse();
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(4); // 2 SETs + 2 GETs
-            
-            // Verify results - SET commands typically return boolean true
-            assertThat(results.get(0)).isEqualTo(true); // SET result
-            assertThat(results.get(1)).isEqualTo(true); // SET result
-            assertThat(results.get(2)).isEqualTo("value1".getBytes()); // GET result
-            assertThat(results.get(3)).isEqualTo("value2".getBytes()); // GET result
-            
-            // Verify values were actually set
-            byte[] actualValue1 = connection.stringCommands().get(key1.getBytes());
-            byte[] actualValue2 = connection.stringCommands().get(key2.getBytes());
-            assertThat(actualValue1).isEqualTo("value1".getBytes());
-            assertThat(actualValue2).isEqualTo("value2".getBytes());
-            
-        } finally {
-            cleanupKeys(key1, key2);
-        }
-    }
+				// Large pipeline test keys
+				"test:pipe:large:key", "test:pipe:performance:key",
 
-    @Test
-    void testEmptyPipeline() {
-        // Start and immediately execute empty pipeline
-        assertThat(connection.isPipelined()).isFalse();
-        
-        connection.openPipeline();
-        assertThat(connection.isPipelined()).isTrue();
-        
-        List<Object> results = connection.closePipeline();
-        
-        // Empty pipeline should return empty list, not null
-        assertThat(connection.isPipelined()).isFalse();
-        assertThat(results).isNotNull();
-        assertThat(results).isEmpty();
-    }
+				// Concurrent test keys (with thread ID suffix pattern)
+				"test:pipe:concurrent:shared", "test:pipe:concurrent:key",
 
-    @Test
-    void testMultipleConsecutivePipelines() {
-        String key1 = "test:pipe:consecutive:key1";
-        String key2 = "test:pipe:consecutive:key2";
-        String key3 = "test:pipe:consecutive:key3";
-        
-        try {
-            // First pipeline
-            connection.openPipeline();
-            connection.stringCommands().set(key1.getBytes(), "pipe1_value".getBytes());
-            List<Object> results1 = connection.closePipeline();
-            
-            assertThat(connection.isPipelined()).isFalse();
-            assertThat(results1).hasSize(1);
-            assertThat(results1.get(0)).isEqualTo(true);
-            
-            // Second pipeline
-            connection.openPipeline();
-            connection.stringCommands().set(key2.getBytes(), "pipe2_value".getBytes());
-            connection.stringCommands().get(key1.getBytes()); // Read from first pipeline
-            List<Object> results2 = connection.closePipeline();
-            
-            assertThat(connection.isPipelined()).isFalse();
-            assertThat(results2).hasSize(2);
-            assertThat(results2.get(0)).isEqualTo(true);
-            assertThat(results2.get(1)).isEqualTo("pipe1_value".getBytes());
-            
-            // Third empty pipeline
-            connection.openPipeline();
-            List<Object> results3 = connection.closePipeline();
-            
-            assertThat(connection.isPipelined()).isFalse();
-            assertThat(results3).isEmpty();
-            
-            // Verify final state
-            assertThat(connection.stringCommands().get(key1.getBytes())).isEqualTo("pipe1_value".getBytes());
-            assertThat(connection.stringCommands().get(key2.getBytes())).isEqualTo("pipe2_value".getBytes());
-            assertThat(connection.stringCommands().get(key3.getBytes())).isNull();
-            
-        } finally {
-            cleanupKeys(key1, key2, key3);
-        }
-    }
+				// Result conversion test keys
+				"test:pipe:conversion:key", "test:pipe:conversion:counter",
 
-    // ==================== Mixed Command Type Pipeline Tests ====================
+				// Edge case test keys
+				"test:pipe:edge:nonexistent", "test:pipe:edge:empty" };
+	}
 
-    @Test
-    void testPipelineWithMixedCommandTypes() {
-        String stringKey = "test:pipe:mixed:string";
-        String hashKey = "test:pipe:mixed:hash";
-        String listKey = "test:pipe:mixed:list";
-        String setKey = "test:pipe:mixed:set";
-        String zsetKey = "test:pipe:mixed:zset";
-        
-        try {
-            connection.openPipeline();
-            
-            // String commands
-            connection.stringCommands().set(stringKey.getBytes(), "string_value".getBytes());
-            connection.stringCommands().get(stringKey.getBytes());
-            
-            // Hash commands
-            connection.hashCommands().hSet(hashKey.getBytes(), "field1".getBytes(), "hash_value".getBytes());
-            connection.hashCommands().hGet(hashKey.getBytes(), "field1".getBytes());
-            
-            // List commands
-            connection.listCommands().lPush(listKey.getBytes(), "list_item".getBytes());
-            connection.listCommands().lLen(listKey.getBytes());
-            
-            // Set commands
-            connection.setCommands().sAdd(setKey.getBytes(), "set_member".getBytes());
-            connection.setCommands().sCard(setKey.getBytes());
-            
-            // ZSet commands
-            connection.zSetCommands().zAdd(zsetKey.getBytes(), 1.0, "zset_member".getBytes());
-            connection.zSetCommands().zCard(zsetKey.getBytes());
-            
-            List<Object> results = connection.closePipeline();
-            
-            assertThat(results).hasSize(10);
-            
-            // Verify write results
-            assertThat(results.get(0)).isEqualTo(true); // SET
-            assertThat(results.get(2)).isEqualTo(true); // HSET
-            assertThat(results.get(4)).isEqualTo(1L);   // LPUSH (returns length)
-            assertThat(results.get(6)).isEqualTo(1L);   // SADD (returns count added)
-            assertThat(results.get(8)).isEqualTo(true); // ZADD
-            
-            // Verify read results
-            assertThat(results.get(1)).isEqualTo("string_value".getBytes()); // GET
-            assertThat(results.get(3)).isEqualTo("hash_value".getBytes());   // HGET
-            assertThat(results.get(5)).isEqualTo(1L);                        // LLEN
-            assertThat(results.get(7)).isEqualTo(1L);                        // SCARD
-            assertThat(results.get(9)).isEqualTo(1L);                        // ZCARD
-            
-            // Verify values exist outside pipeline
-            assertThat(connection.stringCommands().get(stringKey.getBytes())).isEqualTo("string_value".getBytes());
-            assertThat(connection.hashCommands().hGet(hashKey.getBytes(), "field1".getBytes())).isEqualTo("hash_value".getBytes());
-            assertThat(connection.listCommands().lLen(listKey.getBytes())).isEqualTo(1L);
-            assertThat(connection.setCommands().sCard(setKey.getBytes())).isEqualTo(1L);
-            assertThat(connection.zSetCommands().zCard(zsetKey.getBytes())).isEqualTo(1L);
-            
-        } finally {
-            cleanupKeys(stringKey, hashKey, listKey, setKey, zsetKey);
-        }
-    }
+	// ==================== Connection Lifecycle Tests ====================
 
-    @Test
-    void testPipelineWithGeoCommands() {
-        String geoKey = "test:pipe:mixed:geo";
-        
-        try {
-            connection.openPipeline();
-            
-            // Add geo location
-            connection.geoCommands().geoAdd(geoKey.getBytes(),
-                new org.springframework.data.geo.Point(13.361389, 38.115556), "Palermo".getBytes());
-            
-            // Get geo position
-            connection.geoCommands().geoPos(geoKey.getBytes(), "Palermo".getBytes());
-            
-            List<Object> results = connection.closePipeline();
-            
-            assertThat(results).hasSize(2);
-            assertThat(results.get(0)).isEqualTo(1L); // GEOADD result
-            
-            // Verify geo data exists outside pipeline
-            List<org.springframework.data.geo.Point> positions = connection.geoCommands().geoPos(geoKey.getBytes(), "Palermo".getBytes());
-            assertThat(positions).hasSize(1);
-            assertThat(positions.get(0)).isNotNull();
-            
-        } finally {
-            cleanupKey(geoKey);
-        }
-    }
+	@Test
+	void testConnectionLifecycle() {
+		String key = "test:conn:lifecycle:key";
 
-    // ==================== State Management Tests ====================
+		try {
+			// Test initial state
+			assertThat(connection.isClosed()).isFalse();
 
-    @Test
-    void testIsPipelinedState() {
-        assertThat(connection.isPipelined()).isFalse();
-        
-        connection.openPipeline();
-        assertThat(connection.isPipelined()).isTrue();
-        
-        connection.closePipeline();
-        assertThat(connection.isPipelined()).isFalse();
-    }
+			// Test basic operation works
+			connection.stringCommands().set(key.getBytes(), "test_value".getBytes());
+			assertThat(connection.stringCommands().get(key.getBytes())).isEqualTo("test_value".getBytes());
 
-    @Test
-    void testPipelineTransactionIsolation() {
-        String key = "test:pipe:state:isolation:key";
-        
-        try {
-            // Cannot start transaction while pipeline is active
-            connection.openPipeline();
-            
-            assertThatThrownBy(() -> connection.multi())
-                .isInstanceOf(InvalidDataAccessApiUsageException.class)
-                .hasMessageContaining("Cannot use transaction while a pipeline is open");
-            
-            connection.closePipeline();
-            
-            // Cannot start pipeline while transaction is active  
-            connection.multi();
-            
-            assertThatThrownBy(() -> connection.openPipeline())
-                .isInstanceOf(InvalidDataAccessApiUsageException.class)
-                .hasMessageContaining("Cannot use pipelining while a transaction is active");
-            
-            connection.discard();
-            
-        } finally {
-            // Ensure clean state
-            if (connection.isPipelined()) {
-                connection.closePipeline();
-            }
-            if (connection.isQueueing()) {
-                connection.discard();
-            }
-            cleanupKey(key);
-        }
-    }
+			// Test connection is still open
+			assertThat(connection.isClosed()).isFalse();
 
-    @Test
-    void testStateManagementAfterException() {
-        String key = "test:pipe:state:key";
-        
-        try {
-            connection.openPipeline();
-            assertThat(connection.isPipelined()).isTrue();
-            
-            // Queue some commands including potentially problematic ones
-            connection.stringCommands().set(key.getBytes(), "test_value".getBytes());
-            
-            // Pipeline state should remain active even if there are potential command issues
-            assertThat(connection.isPipelined()).isTrue();
-            
-            // Should be able to close pipeline normally
-            List<Object> results = connection.closePipeline();
-            assertThat(connection.isPipelined()).isFalse();
-            assertThat(results).hasSize(1);
-            
-            // Verify command was executed
-            assertThat(connection.stringCommands().get(key.getBytes())).isEqualTo("test_value".getBytes());
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
 
-    // ==================== Edge Cases and Error Handling ====================
+	@Test
+	void testGetNativeConnection() {
+		String key = "test:conn:native:key";
 
-    @Test
-    void testClosePipelineWithoutOpen() {
-        // closePipeline() without openPipeline() should return empty list safely
-        assertThat(connection.isPipelined()).isFalse();
-        
-        List<Object> results = connection.closePipeline();
-        
-        assertThat(results).isNotNull();
-        assertThat(results).isEmpty();
-        assertThat(connection.isPipelined()).isFalse();
-    }
+		try {
+			// Verify native connection exists and is not null
+			Object nativeConnection = connection.getNativeConnection();
+			assertThat(nativeConnection).isNotNull();
+			assertThat(nativeConnection.getClass().getName()).contains("GlideClient");
 
-    @Test
-    void testNestedOpenPipelineCalls() {
-        String key = "test:pipe:error:nested";
-        
-        try {
-            // First openPipeline() call
-            connection.openPipeline();
-            assertThat(connection.isPipelined()).isTrue();
-            
-            // Second openPipeline() call - should be idempotent
-            connection.openPipeline();
-            assertThat(connection.isPipelined()).isTrue();
-            
-            // Queue a command
-            connection.stringCommands().set(key.getBytes(), "nested_value".getBytes());
-            
-            // Execute pipeline
-            List<Object> results = connection.closePipeline();
-            
-            assertThat(connection.isPipelined()).isFalse();
-            assertThat(results).hasSize(1);
-            assertThat(results.get(0)).isEqualTo(true);
-            
-            // Verify command was executed
-            assertThat(connection.stringCommands().get(key.getBytes())).isEqualTo("nested_value".getBytes());
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Verify connection is functional
+			connection.stringCommands().set(key.getBytes(), "native_test".getBytes());
+			assertThat(connection.stringCommands().get(key.getBytes())).isEqualTo("native_test".getBytes());
 
-    @Test
-    void testPipelineWithNonExistentKeys() {
-        String nonExistentKey1 = "test:pipe:edge:nonexistent1";
-        String nonExistentKey2 = "test:pipe:edge:nonexistent2";
-        
-        try {
-            connection.openPipeline();
-            
-            // Operations on non-existent keys
-            connection.stringCommands().get(nonExistentKey1.getBytes());
-            connection.stringCommands().get(nonExistentKey2.getBytes());
-            connection.listCommands().lLen("non:existent:list".getBytes());
-            connection.setCommands().sCard("non:existent:set".getBytes());
-            
-            List<Object> results = connection.closePipeline();
-            
-            assertThat(results).hasSize(4);
-            // Results for non-existent keys should be null or 0 depending on command
-            assertThat(results.get(0)).isNull(); // GET returns null
-            assertThat(results.get(1)).isNull(); // GET returns null
-            assertThat(results.get(2)).isEqualTo(0L); // LLEN returns 0
-            assertThat(results.get(3)).isEqualTo(0L); // SCARD returns 0
-            
-        } finally {
-            // No cleanup needed for non-existent keys
-        }
-    }
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
 
-    // ==================== Large Pipeline Tests ====================
+	@Test
+	@Disabled("⚠️  WARNING: getSentinelConnection() not implemented, rework the test when it is")
+	void testGetSentinelConnection() {
+		// getSentinelConnection is not implemented yet
+		assertThatThrownBy(() -> connection.getSentinelConnection())
+			.isInstanceOf(InvalidDataAccessResourceUsageException.class)
+			.hasMessageContaining("No sentinels configured");
+	}
 
-    @Test
-    void testLargePipeline() {
-        String keyPrefix = "test:pipe:large:key";
-        int commandCount = 100;
-        
-        try {
-            connection.openPipeline();
-            
-            // Queue many commands
-            for (int i = 0; i < commandCount; i++) {
-                String key = keyPrefix + ":" + i;
-                String value = "value" + i;
-                Object result = connection.stringCommands().set(key.getBytes(), value.getBytes());
-                assertThat(result).isNull(); // Should be null in pipeline mode
-            }
-            
-            List<Object> results = connection.closePipeline();
-            
-            assertThat(results).hasSize(commandCount);
-            
-            // All SET operations should succeed
-            for (int i = 0; i < commandCount; i++) {
-                assertThat(results.get(i)).isEqualTo(true);
-            }
-            
-            // Verify a few random values were actually set
-            assertThat(connection.stringCommands().get((keyPrefix + ":0").getBytes())).isEqualTo("value0".getBytes());
-            assertThat(connection.stringCommands().get((keyPrefix + ":50").getBytes())).isEqualTo("value50".getBytes());
-            assertThat(connection.stringCommands().get((keyPrefix + ":99").getBytes())).isEqualTo("value99".getBytes());
-            
-        } finally {
-            // Clean up all generated keys
-            for (int i = 0; i < commandCount; i++) {
-                cleanupKey(keyPrefix + ":" + i);
-            }
-        }
-    }
+	// ==================== Basic Pipeline Tests ====================
 
-    @Test
-    void testPipelinePerformance() {
-        String keyPrefix = "test:pipe:performance:key";
-        int commandCount = 200;
-        
-        try {
-            long startTime = System.currentTimeMillis();
-            
-            connection.openPipeline();
-            
-            // Mix of SET and GET commands
-            for (int i = 0; i < commandCount; i++) {
-                String key = keyPrefix + ":" + i;
-                connection.stringCommands().set(key.getBytes(), ("value" + i).getBytes());
-                connection.stringCommands().get(key.getBytes());
-            }
-            
-            List<Object> results = connection.closePipeline();
-            
-            long endTime = System.currentTimeMillis();
-            long duration = endTime - startTime;
-            
-            assertThat(results).hasSize(commandCount * 2);
-            
-            // Pipeline should complete within reasonable time
-            assertThat(duration).isLessThan(10000); // Should complete within 10 seconds
-            
-            // Verify some results
-            for (int i = 0; i < commandCount; i += 10) {
-                assertThat(results.get(i * 2)).isEqualTo(true); // SET result
-                assertThat(results.get(i * 2 + 1)).isEqualTo(("value" + i).getBytes()); // GET result
-            }
-            
-        } finally {
-            // Clean up performance test keys
-            for (int i = 0; i < commandCount; i++) {
-                cleanupKey(keyPrefix + ":" + i);
-            }
-        }
-    }
+	@Test
+	void testBasicPipelineFlow() {
+		String key1 = "test:pipe:basic:key1";
+		String key2 = "test:pipe:basic:key2";
 
-    // ==================== Concurrent Pipeline Tests ====================
+		try {
+			// Verify initial state
+			assertThat(connection.isPipelined()).isFalse();
 
-    @Test
-    void testConcurrentPipelines() throws Exception {
-        String sharedKey = "test:pipe:concurrent:shared";
-        String keyPrefix = "test:pipe:concurrent:key";
-        ExecutorService executor = Executors.newFixedThreadPool(5);
-        
-        try {
-            // Set initial shared value
-            connection.stringCommands().set(sharedKey.getBytes(), "shared_value".getBytes());
-            
-            CompletableFuture<?>[] futures = new CompletableFuture[5];
-            
-            for (int i = 0; i < 5; i++) {
-                final int threadId = i;
-                futures[i] = CompletableFuture.runAsync(() -> {
-                    try (ValkeyConnection conn = connectionFactory.getConnection()) {
-                        // Each thread runs its own pipeline
-                        conn.openPipeline();
-                        conn.stringCommands().set((keyPrefix + ":" + threadId).getBytes(), ("thread" + threadId).getBytes());
-                        conn.stringCommands().get(sharedKey.getBytes()); // Read shared value
-                        List<Object> results = conn.closePipeline();
-                        
-                        assertThat(results).hasSize(2);
-                        assertThat(results.get(0)).isEqualTo(true); // SET result
-                        assertThat(results.get(1)).isEqualTo("shared_value".getBytes()); // GET result
-                    }
-                }, executor);
-            }
-            
-            CompletableFuture.allOf(futures).get(10, TimeUnit.SECONDS);
-            
-            // Verify all threads succeeded
-            for (int i = 0; i < 5; i++) {
-                assertThat(connection.stringCommands().get((keyPrefix + ":" + i).getBytes()))
-                    .isEqualTo(("thread" + i).getBytes());
-            }
-            
-        } finally {
-            executor.shutdown();
-            cleanupKey(sharedKey);
-            for (int i = 0; i < 5; i++) {
-                cleanupKey(keyPrefix + ":" + i);
-            }
-        }
-    }
+			// Start pipeline
+			connection.openPipeline();
+			assertThat(connection.isPipelined()).isTrue();
 
-    // ==================== Result Conversion Tests ====================
+			// Queue commands - should return null in pipeline mode
+			Object setResult1 = connection.stringCommands().set(key1.getBytes(), "value1".getBytes());
+			Object setResult2 = connection.stringCommands().set(key2.getBytes(), "value2".getBytes());
+			Object getResult1 = connection.stringCommands().get(key1.getBytes());
+			Object getResult2 = connection.stringCommands().get(key2.getBytes());
 
-    @Test
-    void testPipelineResultConversion() {
-        String key = "test:pipe:conversion:key";
-        String counterKey = "test:pipe:conversion:counter";
-        
-        try {
-            connection.openPipeline();
-            
-            // Commands that return different types
-            connection.stringCommands().set(key.getBytes(), "42".getBytes()); // Boolean result
-            connection.stringCommands().get(key.getBytes()); // byte[] result
-            connection.stringCommands().set(counterKey.getBytes(), "10".getBytes()); // Boolean result
-            connection.stringCommands().incr(counterKey.getBytes()); // Long result
-            connection.stringCommands().strLen(counterKey.getBytes()); // Long result
-            
-            List<Object> results = connection.closePipeline();
-            
-            assertThat(results).hasSize(5);
-            
-            // Verify result types and values are properly converted
-            assertThat(results.get(0)).isEqualTo(true); // SET result
-            assertThat(results.get(1)).isEqualTo("42".getBytes()); // GET result  
-            assertThat(results.get(2)).isEqualTo(true); // SET result
-            assertThat(results.get(3)).isEqualTo(11L); // INCR result
-            assertThat(results.get(4)).isEqualTo(2L); // STRLEN result ("11" has length 2)
-        } finally {
-            cleanupKeys(key, counterKey);
-        }
-    }
+			// All commands in pipeline should return null (queued)
+			assertThat(setResult1).isNull();
+			assertThat(setResult2).isNull();
+			assertThat(getResult1).isNull();
+			assertThat(getResult2).isNull();
 
-    // ==================== Error Recovery Tests ====================
+			// Still in pipeline state
+			assertThat(connection.isPipelined()).isTrue();
 
-    @Test
-    void testPipelineErrorRecovery() {
-        String validKey = "test:pipe:error:valid";
-        String errorKey = "test:pipe:error:exception";
-        
-        try {
-            connection.openPipeline();
-            
-            // Queue valid command
-            connection.stringCommands().set(validKey.getBytes(), "valid_value".getBytes());
-            
-            // Queue potentially problematic command (this behavior may depend on implementation)
-            connection.stringCommands().get(errorKey.getBytes()); // Non-existent key returns null
-            
-            // Queue another valid command
-            connection.stringCommands().get(validKey.getBytes());
-            
-            List<Object> results = connection.closePipeline();
-            
-            // Pipeline should complete even with null results
-            assertThat(results).hasSize(3);
-            assertThat(results.get(0)).isEqualTo(true); // Valid SET
-            assertThat(results.get(1)).isNull(); // GET non-existent key
-            assertThat(results.get(2)).isEqualTo("valid_value".getBytes()); // Valid GET
-            
-        } finally {
-            cleanupKeys(validKey, errorKey);
-        }
-    }
+			// Execute pipeline
+			List<Object> results = connection.closePipeline();
 
-    // ==================== Edge Case Tests ====================
+			// Pipeline should complete
+			assertThat(connection.isPipelined()).isFalse();
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(4); // 2 SETs + 2 GETs
 
-    @Test
-    void testPipelineWithEmptyValues() {
-        String key = "test:pipe:edge:empty";
-        
-        try {
-            connection.openPipeline();
-            
-            // Set field with empty value
-            connection.stringCommands().set(key.getBytes(), new byte[0]);
-            connection.stringCommands().get(key.getBytes());
-            connection.stringCommands().strLen(key.getBytes());
-            
-            List<Object> results = connection.closePipeline();
-            
-            assertThat(results).hasSize(3);
-            assertThat(results.get(0)).isEqualTo(true); // SET result
-            assertThat(results.get(1)).isEqualTo(new byte[0]); // GET result (empty byte array)
-            assertThat(results.get(2)).isEqualTo(0L); // STRLEN result
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Verify results - SET commands typically return boolean true
+			assertThat(results.get(0)).isEqualTo(true); // SET result
+			assertThat(results.get(1)).isEqualTo(true); // SET result
+			assertThat(results.get(2)).isEqualTo("value1".getBytes()); // GET result
+			assertThat(results.get(3)).isEqualTo("value2".getBytes()); // GET result
 
-    @Test
-    void testPipelineStateConsistency() {
-        // Test that pipeline state is properly maintained across various operations
-        assertThat(connection.isPipelined()).isFalse();
-        
-        // Multiple openPipeline/closePipeline cycles
-        for (int i = 0; i < 3; i++) {
-            connection.openPipeline();
-            assertThat(connection.isPipelined()).isTrue();
-            
-            List<Object> results = connection.closePipeline();
-            assertThat(connection.isPipelined()).isFalse();
-            assertThat(results).isEmpty();
-        }
-        
-        // Final state should be clean
-        assertThat(connection.isPipelined()).isFalse();
-        assertThat(connection.isQueueing()).isFalse();
-    }
+			// Verify values were actually set
+			byte[] actualValue1 = connection.stringCommands().get(key1.getBytes());
+			byte[] actualValue2 = connection.stringCommands().get(key2.getBytes());
+			assertThat(actualValue1).isEqualTo("value1".getBytes());
+			assertThat(actualValue2).isEqualTo("value2".getBytes());
+
+		}
+		finally {
+			cleanupKeys(key1, key2);
+		}
+	}
+
+	@Test
+	void testEmptyPipeline() {
+		// Start and immediately execute empty pipeline
+		assertThat(connection.isPipelined()).isFalse();
+
+		connection.openPipeline();
+		assertThat(connection.isPipelined()).isTrue();
+
+		List<Object> results = connection.closePipeline();
+
+		// Empty pipeline should return empty list, not null
+		assertThat(connection.isPipelined()).isFalse();
+		assertThat(results).isNotNull();
+		assertThat(results).isEmpty();
+	}
+
+	@Test
+	void testMultipleConsecutivePipelines() {
+		String key1 = "test:pipe:consecutive:key1";
+		String key2 = "test:pipe:consecutive:key2";
+		String key3 = "test:pipe:consecutive:key3";
+
+		try {
+			// First pipeline
+			connection.openPipeline();
+			connection.stringCommands().set(key1.getBytes(), "pipe1_value".getBytes());
+			List<Object> results1 = connection.closePipeline();
+
+			assertThat(connection.isPipelined()).isFalse();
+			assertThat(results1).hasSize(1);
+			assertThat(results1.get(0)).isEqualTo(true);
+
+			// Second pipeline
+			connection.openPipeline();
+			connection.stringCommands().set(key2.getBytes(), "pipe2_value".getBytes());
+			connection.stringCommands().get(key1.getBytes()); // Read from first pipeline
+			List<Object> results2 = connection.closePipeline();
+
+			assertThat(connection.isPipelined()).isFalse();
+			assertThat(results2).hasSize(2);
+			assertThat(results2.get(0)).isEqualTo(true);
+			assertThat(results2.get(1)).isEqualTo("pipe1_value".getBytes());
+
+			// Third empty pipeline
+			connection.openPipeline();
+			List<Object> results3 = connection.closePipeline();
+
+			assertThat(connection.isPipelined()).isFalse();
+			assertThat(results3).isEmpty();
+
+			// Verify final state
+			assertThat(connection.stringCommands().get(key1.getBytes())).isEqualTo("pipe1_value".getBytes());
+			assertThat(connection.stringCommands().get(key2.getBytes())).isEqualTo("pipe2_value".getBytes());
+			assertThat(connection.stringCommands().get(key3.getBytes())).isNull();
+
+		}
+		finally {
+			cleanupKeys(key1, key2, key3);
+		}
+	}
+
+	// ==================== Mixed Command Type Pipeline Tests ====================
+
+	@Test
+	void testPipelineWithMixedCommandTypes() {
+		String stringKey = "test:pipe:mixed:string";
+		String hashKey = "test:pipe:mixed:hash";
+		String listKey = "test:pipe:mixed:list";
+		String setKey = "test:pipe:mixed:set";
+		String zsetKey = "test:pipe:mixed:zset";
+
+		try {
+			connection.openPipeline();
+
+			// String commands
+			connection.stringCommands().set(stringKey.getBytes(), "string_value".getBytes());
+			connection.stringCommands().get(stringKey.getBytes());
+
+			// Hash commands
+			connection.hashCommands().hSet(hashKey.getBytes(), "field1".getBytes(), "hash_value".getBytes());
+			connection.hashCommands().hGet(hashKey.getBytes(), "field1".getBytes());
+
+			// List commands
+			connection.listCommands().lPush(listKey.getBytes(), "list_item".getBytes());
+			connection.listCommands().lLen(listKey.getBytes());
+
+			// Set commands
+			connection.setCommands().sAdd(setKey.getBytes(), "set_member".getBytes());
+			connection.setCommands().sCard(setKey.getBytes());
+
+			// ZSet commands
+			connection.zSetCommands().zAdd(zsetKey.getBytes(), 1.0, "zset_member".getBytes());
+			connection.zSetCommands().zCard(zsetKey.getBytes());
+
+			List<Object> results = connection.closePipeline();
+
+			assertThat(results).hasSize(10);
+
+			// Verify write results
+			assertThat(results.get(0)).isEqualTo(true); // SET
+			assertThat(results.get(2)).isEqualTo(true); // HSET
+			assertThat(results.get(4)).isEqualTo(1L); // LPUSH (returns length)
+			assertThat(results.get(6)).isEqualTo(1L); // SADD (returns count added)
+			assertThat(results.get(8)).isEqualTo(true); // ZADD
+
+			// Verify read results
+			assertThat(results.get(1)).isEqualTo("string_value".getBytes()); // GET
+			assertThat(results.get(3)).isEqualTo("hash_value".getBytes()); // HGET
+			assertThat(results.get(5)).isEqualTo(1L); // LLEN
+			assertThat(results.get(7)).isEqualTo(1L); // SCARD
+			assertThat(results.get(9)).isEqualTo(1L); // ZCARD
+
+			// Verify values exist outside pipeline
+			assertThat(connection.stringCommands().get(stringKey.getBytes())).isEqualTo("string_value".getBytes());
+			assertThat(connection.hashCommands().hGet(hashKey.getBytes(), "field1".getBytes()))
+				.isEqualTo("hash_value".getBytes());
+			assertThat(connection.listCommands().lLen(listKey.getBytes())).isEqualTo(1L);
+			assertThat(connection.setCommands().sCard(setKey.getBytes())).isEqualTo(1L);
+			assertThat(connection.zSetCommands().zCard(zsetKey.getBytes())).isEqualTo(1L);
+
+		}
+		finally {
+			cleanupKeys(stringKey, hashKey, listKey, setKey, zsetKey);
+		}
+	}
+
+	@Test
+	void testPipelineWithGeoCommands() {
+		String geoKey = "test:pipe:mixed:geo";
+
+		try {
+			connection.openPipeline();
+
+			// Add geo location
+			connection.geoCommands()
+				.geoAdd(geoKey.getBytes(), new org.springframework.data.geo.Point(13.361389, 38.115556),
+						"Palermo".getBytes());
+
+			// Get geo position
+			connection.geoCommands().geoPos(geoKey.getBytes(), "Palermo".getBytes());
+
+			List<Object> results = connection.closePipeline();
+
+			assertThat(results).hasSize(2);
+			assertThat(results.get(0)).isEqualTo(1L); // GEOADD result
+
+			// Verify geo data exists outside pipeline
+			List<org.springframework.data.geo.Point> positions = connection.geoCommands()
+				.geoPos(geoKey.getBytes(), "Palermo".getBytes());
+			assertThat(positions).hasSize(1);
+			assertThat(positions.get(0)).isNotNull();
+
+		}
+		finally {
+			cleanupKey(geoKey);
+		}
+	}
+
+	// ==================== State Management Tests ====================
+
+	@Test
+	void testIsPipelinedState() {
+		assertThat(connection.isPipelined()).isFalse();
+
+		connection.openPipeline();
+		assertThat(connection.isPipelined()).isTrue();
+
+		connection.closePipeline();
+		assertThat(connection.isPipelined()).isFalse();
+	}
+
+	@Test
+	void testPipelineTransactionIsolation() {
+		String key = "test:pipe:state:isolation:key";
+
+		try {
+			// Cannot start transaction while pipeline is active
+			connection.openPipeline();
+
+			assertThatThrownBy(() -> connection.multi()).isInstanceOf(InvalidDataAccessApiUsageException.class)
+				.hasMessageContaining("Cannot use transaction while a pipeline is open");
+
+			connection.closePipeline();
+
+			// Cannot start pipeline while transaction is active
+			connection.multi();
+
+			assertThatThrownBy(() -> connection.openPipeline()).isInstanceOf(InvalidDataAccessApiUsageException.class)
+				.hasMessageContaining("Cannot use pipelining while a transaction is active");
+
+			connection.discard();
+
+		}
+		finally {
+			// Ensure clean state
+			if (connection.isPipelined()) {
+				connection.closePipeline();
+			}
+			if (connection.isQueueing()) {
+				connection.discard();
+			}
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testStateManagementAfterException() {
+		String key = "test:pipe:state:key";
+
+		try {
+			connection.openPipeline();
+			assertThat(connection.isPipelined()).isTrue();
+
+			// Queue some commands including potentially problematic ones
+			connection.stringCommands().set(key.getBytes(), "test_value".getBytes());
+
+			// Pipeline state should remain active even if there are potential command
+			// issues
+			assertThat(connection.isPipelined()).isTrue();
+
+			// Should be able to close pipeline normally
+			List<Object> results = connection.closePipeline();
+			assertThat(connection.isPipelined()).isFalse();
+			assertThat(results).hasSize(1);
+
+			// Verify command was executed
+			assertThat(connection.stringCommands().get(key.getBytes())).isEqualTo("test_value".getBytes());
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== Edge Cases and Error Handling ====================
+
+	@Test
+	void testClosePipelineWithoutOpen() {
+		// closePipeline() without openPipeline() should return empty list safely
+		assertThat(connection.isPipelined()).isFalse();
+
+		List<Object> results = connection.closePipeline();
+
+		assertThat(results).isNotNull();
+		assertThat(results).isEmpty();
+		assertThat(connection.isPipelined()).isFalse();
+	}
+
+	@Test
+	void testNestedOpenPipelineCalls() {
+		String key = "test:pipe:error:nested";
+
+		try {
+			// First openPipeline() call
+			connection.openPipeline();
+			assertThat(connection.isPipelined()).isTrue();
+
+			// Second openPipeline() call - should be idempotent
+			connection.openPipeline();
+			assertThat(connection.isPipelined()).isTrue();
+
+			// Queue a command
+			connection.stringCommands().set(key.getBytes(), "nested_value".getBytes());
+
+			// Execute pipeline
+			List<Object> results = connection.closePipeline();
+
+			assertThat(connection.isPipelined()).isFalse();
+			assertThat(results).hasSize(1);
+			assertThat(results.get(0)).isEqualTo(true);
+
+			// Verify command was executed
+			assertThat(connection.stringCommands().get(key.getBytes())).isEqualTo("nested_value".getBytes());
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testPipelineWithNonExistentKeys() {
+		String nonExistentKey1 = "test:pipe:edge:nonexistent1";
+		String nonExistentKey2 = "test:pipe:edge:nonexistent2";
+
+		try {
+			connection.openPipeline();
+
+			// Operations on non-existent keys
+			connection.stringCommands().get(nonExistentKey1.getBytes());
+			connection.stringCommands().get(nonExistentKey2.getBytes());
+			connection.listCommands().lLen("non:existent:list".getBytes());
+			connection.setCommands().sCard("non:existent:set".getBytes());
+
+			List<Object> results = connection.closePipeline();
+
+			assertThat(results).hasSize(4);
+			// Results for non-existent keys should be null or 0 depending on command
+			assertThat(results.get(0)).isNull(); // GET returns null
+			assertThat(results.get(1)).isNull(); // GET returns null
+			assertThat(results.get(2)).isEqualTo(0L); // LLEN returns 0
+			assertThat(results.get(3)).isEqualTo(0L); // SCARD returns 0
+
+		}
+		finally {
+			// No cleanup needed for non-existent keys
+		}
+	}
+
+	// ==================== Large Pipeline Tests ====================
+
+	@Test
+	void testLargePipeline() {
+		String keyPrefix = "test:pipe:large:key";
+		int commandCount = 100;
+
+		try {
+			connection.openPipeline();
+
+			// Queue many commands
+			for (int i = 0; i < commandCount; i++) {
+				String key = keyPrefix + ":" + i;
+				String value = "value" + i;
+				Object result = connection.stringCommands().set(key.getBytes(), value.getBytes());
+				assertThat(result).isNull(); // Should be null in pipeline mode
+			}
+
+			List<Object> results = connection.closePipeline();
+
+			assertThat(results).hasSize(commandCount);
+
+			// All SET operations should succeed
+			for (int i = 0; i < commandCount; i++) {
+				assertThat(results.get(i)).isEqualTo(true);
+			}
+
+			// Verify a few random values were actually set
+			assertThat(connection.stringCommands().get((keyPrefix + ":0").getBytes())).isEqualTo("value0".getBytes());
+			assertThat(connection.stringCommands().get((keyPrefix + ":50").getBytes())).isEqualTo("value50".getBytes());
+			assertThat(connection.stringCommands().get((keyPrefix + ":99").getBytes())).isEqualTo("value99".getBytes());
+
+		}
+		finally {
+			// Clean up all generated keys
+			for (int i = 0; i < commandCount; i++) {
+				cleanupKey(keyPrefix + ":" + i);
+			}
+		}
+	}
+
+	@Test
+	void testPipelinePerformance() {
+		String keyPrefix = "test:pipe:performance:key";
+		int commandCount = 200;
+
+		try {
+			long startTime = System.currentTimeMillis();
+
+			connection.openPipeline();
+
+			// Mix of SET and GET commands
+			for (int i = 0; i < commandCount; i++) {
+				String key = keyPrefix + ":" + i;
+				connection.stringCommands().set(key.getBytes(), ("value" + i).getBytes());
+				connection.stringCommands().get(key.getBytes());
+			}
+
+			List<Object> results = connection.closePipeline();
+
+			long endTime = System.currentTimeMillis();
+			long duration = endTime - startTime;
+
+			assertThat(results).hasSize(commandCount * 2);
+
+			// Pipeline should complete within reasonable time
+			assertThat(duration).isLessThan(10000); // Should complete within 10 seconds
+
+			// Verify some results
+			for (int i = 0; i < commandCount; i += 10) {
+				assertThat(results.get(i * 2)).isEqualTo(true); // SET result
+				assertThat(results.get(i * 2 + 1)).isEqualTo(("value" + i).getBytes()); // GET
+																						// result
+			}
+
+		}
+		finally {
+			// Clean up performance test keys
+			for (int i = 0; i < commandCount; i++) {
+				cleanupKey(keyPrefix + ":" + i);
+			}
+		}
+	}
+
+	// ==================== Concurrent Pipeline Tests ====================
+
+	@Test
+	void testConcurrentPipelines() throws Exception {
+		String sharedKey = "test:pipe:concurrent:shared";
+		String keyPrefix = "test:pipe:concurrent:key";
+		ExecutorService executor = Executors.newFixedThreadPool(5);
+
+		try {
+			// Set initial shared value
+			connection.stringCommands().set(sharedKey.getBytes(), "shared_value".getBytes());
+
+			CompletableFuture<?>[] futures = new CompletableFuture[5];
+
+			for (int i = 0; i < 5; i++) {
+				final int threadId = i;
+				futures[i] = CompletableFuture.runAsync(() -> {
+					try (ValkeyConnection conn = connectionFactory.getConnection()) {
+						// Each thread runs its own pipeline
+						conn.openPipeline();
+						conn.stringCommands()
+							.set((keyPrefix + ":" + threadId).getBytes(), ("thread" + threadId).getBytes());
+						conn.stringCommands().get(sharedKey.getBytes()); // Read shared
+																			// value
+						List<Object> results = conn.closePipeline();
+
+						assertThat(results).hasSize(2);
+						assertThat(results.get(0)).isEqualTo(true); // SET result
+						assertThat(results.get(1)).isEqualTo("shared_value".getBytes()); // GET
+																							// result
+					}
+				}, executor);
+			}
+
+			CompletableFuture.allOf(futures).get(10, TimeUnit.SECONDS);
+
+			// Verify all threads succeeded
+			for (int i = 0; i < 5; i++) {
+				assertThat(connection.stringCommands().get((keyPrefix + ":" + i).getBytes()))
+					.isEqualTo(("thread" + i).getBytes());
+			}
+
+		}
+		finally {
+			executor.shutdown();
+			cleanupKey(sharedKey);
+			for (int i = 0; i < 5; i++) {
+				cleanupKey(keyPrefix + ":" + i);
+			}
+		}
+	}
+
+	// ==================== Result Conversion Tests ====================
+
+	@Test
+	void testPipelineResultConversion() {
+		String key = "test:pipe:conversion:key";
+		String counterKey = "test:pipe:conversion:counter";
+
+		try {
+			connection.openPipeline();
+
+			// Commands that return different types
+			connection.stringCommands().set(key.getBytes(), "42".getBytes()); // Boolean
+																				// result
+			connection.stringCommands().get(key.getBytes()); // byte[] result
+			connection.stringCommands().set(counterKey.getBytes(), "10".getBytes()); // Boolean
+																						// result
+			connection.stringCommands().incr(counterKey.getBytes()); // Long result
+			connection.stringCommands().strLen(counterKey.getBytes()); // Long result
+
+			List<Object> results = connection.closePipeline();
+
+			assertThat(results).hasSize(5);
+
+			// Verify result types and values are properly converted
+			assertThat(results.get(0)).isEqualTo(true); // SET result
+			assertThat(results.get(1)).isEqualTo("42".getBytes()); // GET result
+			assertThat(results.get(2)).isEqualTo(true); // SET result
+			assertThat(results.get(3)).isEqualTo(11L); // INCR result
+			assertThat(results.get(4)).isEqualTo(2L); // STRLEN result ("11" has length 2)
+		}
+		finally {
+			cleanupKeys(key, counterKey);
+		}
+	}
+
+	// ==================== Error Recovery Tests ====================
+
+	@Test
+	void testPipelineErrorRecovery() {
+		String validKey = "test:pipe:error:valid";
+		String errorKey = "test:pipe:error:exception";
+
+		try {
+			connection.openPipeline();
+
+			// Queue valid command
+			connection.stringCommands().set(validKey.getBytes(), "valid_value".getBytes());
+
+			// Queue potentially problematic command (this behavior may depend on
+			// implementation)
+			connection.stringCommands().get(errorKey.getBytes()); // Non-existent key
+																	// returns null
+
+			// Queue another valid command
+			connection.stringCommands().get(validKey.getBytes());
+
+			List<Object> results = connection.closePipeline();
+
+			// Pipeline should complete even with null results
+			assertThat(results).hasSize(3);
+			assertThat(results.get(0)).isEqualTo(true); // Valid SET
+			assertThat(results.get(1)).isNull(); // GET non-existent key
+			assertThat(results.get(2)).isEqualTo("valid_value".getBytes()); // Valid GET
+
+		}
+		finally {
+			cleanupKeys(validKey, errorKey);
+		}
+	}
+
+	// ==================== Edge Case Tests ====================
+
+	@Test
+	void testPipelineWithEmptyValues() {
+		String key = "test:pipe:edge:empty";
+
+		try {
+			connection.openPipeline();
+
+			// Set field with empty value
+			connection.stringCommands().set(key.getBytes(), new byte[0]);
+			connection.stringCommands().get(key.getBytes());
+			connection.stringCommands().strLen(key.getBytes());
+
+			List<Object> results = connection.closePipeline();
+
+			assertThat(results).hasSize(3);
+			assertThat(results.get(0)).isEqualTo(true); // SET result
+			assertThat(results.get(1)).isEqualTo(new byte[0]); // GET result (empty byte
+																// array)
+			assertThat(results.get(2)).isEqualTo(0L); // STRLEN result
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testPipelineStateConsistency() {
+		// Test that pipeline state is properly maintained across various operations
+		assertThat(connection.isPipelined()).isFalse();
+
+		// Multiple openPipeline/closePipeline cycles
+		for (int i = 0; i < 3; i++) {
+			connection.openPipeline();
+			assertThat(connection.isPipelined()).isTrue();
+
+			List<Object> results = connection.closePipeline();
+			assertThat(connection.isPipelined()).isFalse();
+			assertThat(results).isEmpty();
+		}
+
+		// Final state should be clean
+		assertThat(connection.isPipelined()).isFalse();
+		assertThat(connection.isQueueing()).isFalse();
+	}
+
 }

--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionKeyCommandsIntegrationTests.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionKeyCommandsIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,1894 +36,1990 @@ import io.valkey.springframework.data.valkey.test.condition.EnabledOnCommand;
 import io.valkey.springframework.data.valkey.test.condition.EnabledOnValkeyVersion;
 
 /**
- * Comprehensive low-level integration tests for {@link ValkeyGlideConnection} 
- * key functionality using the ValkeyKeyCommands interface directly.
- * 
- * These tests validate the implementation of all ValkeyKeyCommands methods in all 3 invocation modes:
- * - Immediate mode: Direct command execution with results
- * - Pipeline mode: Commands return null, results collected in closePipeline() 
- * - Transaction mode: Commands return null, results collected in exec()
+ * Comprehensive low-level integration tests for {@link ValkeyGlideConnection} key
+ * functionality using the ValkeyKeyCommands interface directly.
+ *
+ * These tests validate the implementation of all ValkeyKeyCommands methods in all 3
+ * invocation modes: - Immediate mode: Direct command execution with results - Pipeline
+ * mode: Commands return null, results collected in closePipeline() - Transaction mode:
+ * Commands return null, results collected in exec()
  *
  * @author Ilia Kolominsky
  * @since 2.0
  */
 public class ValkeyGlideConnectionKeyCommandsIntegrationTests extends AbstractValkeyGlideIntegrationTests {
 
-    @Override
-    protected String[] getTestKeyPatterns() {
-        return new String[]{
-            "test:key:exists:key1", "test:key:exists:key2", "test:key:exists:key3",
-            "test:key:copy:source", "test:key:copy:target", "test:key:copy:existing",
-            "test:key:type:string", "test:key:type:list", "test:key:type:hash", 
-            "test:key:touch:key1", "test:key:touch:key2", "test:key:touch:key3",
-            "test:key:keys:abc", "test:key:keys:def", "test:key:keys:xyz", "test:other:pattern",
-            "test:key:random:key1", "test:key:random:key2",
-            "test:key:scan:item1", "test:key:scan:item2", "test:key:scan:other1",
-            "test:key:rename:old", "test:key:rename:new",
-            "test:key:renamenx:old", "test:key:renamenx:new", "test:key:renamenx:existing",
-            "test:key:expire", "test:key:pexpire", "test:key:expireat", "test:key:pexpireat",
-            "test:key:persist", "test:key:ttl", "test:key:pttl",
-            "test:key:sort:list", "test:key:sort:store", "test:key:dump", "test:key:restore",
-            "test:key:move", "test:key:unlink:key1", "test:key:unlink:key2",
-            "test:key:encoding", "test:key:idletime", "test:key:refcount",
-            "test:key:pipeline:key1", "test:key:pipeline:key2", "test:key:pipeline:key3",
-            "test:key:transaction:key1", "test:key:transaction:key2", "test:key:transaction:key3",
-            "non:existent:key", "new:key"
-        };
-    }
+	@Override
+	protected String[] getTestKeyPatterns() {
+		return new String[] { "test:key:exists:key1", "test:key:exists:key2", "test:key:exists:key3",
+				"test:key:copy:source", "test:key:copy:target", "test:key:copy:existing", "test:key:type:string",
+				"test:key:type:list", "test:key:type:hash", "test:key:touch:key1", "test:key:touch:key2",
+				"test:key:touch:key3", "test:key:keys:abc", "test:key:keys:def", "test:key:keys:xyz",
+				"test:other:pattern", "test:key:random:key1", "test:key:random:key2", "test:key:scan:item1",
+				"test:key:scan:item2", "test:key:scan:other1", "test:key:rename:old", "test:key:rename:new",
+				"test:key:renamenx:old", "test:key:renamenx:new", "test:key:renamenx:existing", "test:key:expire",
+				"test:key:pexpire", "test:key:expireat", "test:key:pexpireat", "test:key:persist", "test:key:ttl",
+				"test:key:pttl", "test:key:sort:list", "test:key:sort:store", "test:key:dump", "test:key:restore",
+				"test:key:move", "test:key:unlink:key1", "test:key:unlink:key2", "test:key:encoding",
+				"test:key:idletime", "test:key:refcount", "test:key:pipeline:key1", "test:key:pipeline:key2",
+				"test:key:pipeline:key3", "test:key:transaction:key1", "test:key:transaction:key2",
+				"test:key:transaction:key3", "non:existent:key", "new:key" };
+	}
 
-    // ==================== Basic Key Operations ====================
+	// ==================== Basic Key Operations ====================
 
-    @Test
-    void testExistsAndDel() {
-        String key1 = "test:key:exists:key1";
-        String key2 = "test:key:exists:key2";
-        String key3 = "test:key:exists:key3";
-        byte[] value = "test_value".getBytes();
-        
-        try {
-            // Test exists on non-existent keys
-            Boolean exists1 = connection.keyCommands().exists(key1.getBytes());
-            assertThat(exists1).isFalse();
-            
-            Long existsMultiple1 = connection.keyCommands().exists(key1.getBytes(), key2.getBytes(), key3.getBytes());
-            assertThat(existsMultiple1).isEqualTo(0L);
-            
-            // Set up test data
-            connection.stringCommands().set(key1.getBytes(), value);
-            connection.stringCommands().set(key2.getBytes(), value);
-            
-            // Test exists on existing keys
-            Boolean exists2 = connection.keyCommands().exists(key1.getBytes());
-            assertThat(exists2).isTrue();
-            
-            Long existsMultiple2 = connection.keyCommands().exists(key1.getBytes(), key2.getBytes(), key3.getBytes());
-            assertThat(existsMultiple2).isEqualTo(2L); // 2 keys exist
-            
-            // Test with duplicate keys
-            Long existsDuplicate = connection.keyCommands().exists(key1.getBytes(), key1.getBytes(), key2.getBytes());
-            assertThat(existsDuplicate).isEqualTo(3L); // Counts duplicates
-            
-            // Test del single key
-            Long delResult1 = connection.keyCommands().del(key1.getBytes());
-            assertThat(delResult1).isEqualTo(1L);
-            
-            // Verify key was deleted
-            Boolean existsAfterDel = connection.keyCommands().exists(key1.getBytes());
-            assertThat(existsAfterDel).isFalse();
-            
-            // Test del multiple keys
-            connection.stringCommands().set(key3.getBytes(), value); // Add key3
-            Long delResult2 = connection.keyCommands().del(key2.getBytes(), key3.getBytes());
-            assertThat(delResult2).isEqualTo(2L);
-            
-            // Test del non-existent key
-            Long delResult3 = connection.keyCommands().del("non:existent:key".getBytes());
-            assertThat(delResult3).isEqualTo(0L);
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-            cleanupKey(key3);
-        }
-    }
+	@Test
+	void testExistsAndDel() {
+		String key1 = "test:key:exists:key1";
+		String key2 = "test:key:exists:key2";
+		String key3 = "test:key:exists:key3";
+		byte[] value = "test_value".getBytes();
 
-    @Test
-    void testUnlink() {
-        String key1 = "test:key:unlink:key1";
-        String key2 = "test:key:unlink:key2";
-        byte[] value = "test_value".getBytes();
-        
-        try {
-            // Set up test data
-            connection.stringCommands().set(key1.getBytes(), value);
-            connection.stringCommands().set(key2.getBytes(), value);
-            
-            // Test unlink single key
-            Long unlinkResult1 = connection.keyCommands().unlink(key1.getBytes());
-            assertThat(unlinkResult1).isEqualTo(1L);
-            
-            // Verify key was unlinked
-            Boolean existsAfterUnlink = connection.keyCommands().exists(key1.getBytes());
-            assertThat(existsAfterUnlink).isFalse();
-            
-            // Test unlink multiple keys
-            Long unlinkResult2 = connection.keyCommands().unlink(key2.getBytes(), "non:existent:key".getBytes());
-            assertThat(unlinkResult2).isEqualTo(1L); // Only one key existed
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-        }
-    }
+		try {
+			// Test exists on non-existent keys
+			Boolean exists1 = connection.keyCommands().exists(key1.getBytes());
+			assertThat(exists1).isFalse();
 
-    @Test
-    void testCopy() {
-        String sourceKey = "test:key:copy:source";
-        String targetKey = "test:key:copy:target";
-        String existingTargetKey = "test:key:copy:existing";
-        byte[] value = "test_value".getBytes();
-        byte[] existingValue = "existing_value".getBytes();
-        
-        try {
-            // Test copy on non-existent source key
-            Boolean copyNonExistent = connection.keyCommands().copy(sourceKey.getBytes(), targetKey.getBytes(), false);
-            assertThat(copyNonExistent).isFalse();
-            
-            // Set up test data
-            connection.stringCommands().set(sourceKey.getBytes(), value);
-            connection.stringCommands().set(existingTargetKey.getBytes(), existingValue);
-            
-            // Test successful copy
-            Boolean copyResult1 = connection.keyCommands().copy(sourceKey.getBytes(), targetKey.getBytes(), false);
-            assertThat(copyResult1).isTrue();
-            
-            // Verify copy was successful
-            byte[] copiedValue = connection.stringCommands().get(targetKey.getBytes());
-            assertThat(copiedValue).isEqualTo(value);
-            
-            // Verify source still exists
-            byte[] sourceValue = connection.stringCommands().get(sourceKey.getBytes());
-            assertThat(sourceValue).isEqualTo(value);
-            
-            // Test copy without replace (should fail)
-            Boolean copyResult2 = connection.keyCommands().copy(sourceKey.getBytes(), existingTargetKey.getBytes(), false);
-            assertThat(copyResult2).isFalse();
-            
-            // Verify existing target was not overwritten
-            byte[] existingTargetValue = connection.stringCommands().get(existingTargetKey.getBytes());
-            assertThat(existingTargetValue).isEqualTo(existingValue);
-            
-            // Test copy with replace (should succeed)
-            Boolean copyResult3 = connection.keyCommands().copy(sourceKey.getBytes(), existingTargetKey.getBytes(), true);
-            assertThat(copyResult3).isTrue();
-            
-            // Verify existing target was overwritten
-            byte[] replacedValue = connection.stringCommands().get(existingTargetKey.getBytes());
-            assertThat(replacedValue).isEqualTo(value);
-        } finally {
-            cleanupKey(sourceKey);
-            cleanupKey(targetKey);
-            cleanupKey(existingTargetKey);
-        }
-    }
+			Long existsMultiple1 = connection.keyCommands().exists(key1.getBytes(), key2.getBytes(), key3.getBytes());
+			assertThat(existsMultiple1).isEqualTo(0L);
 
-    @Test
-    void testType() {
-        String stringKey = "test:key:type:string";
-        String listKey = "test:key:type:list";
-        String hashKey = "test:key:type:hash";
-        
-        try {
-            // Test type on non-existent key
-            DataType nonExistentType = connection.keyCommands().type("non:existent:key".getBytes());
-            assertThat(nonExistentType).isEqualTo(DataType.NONE);
-            
-            // Set up different data types
-            connection.stringCommands().set(stringKey.getBytes(), "value".getBytes());
-            connection.listCommands().lPush(listKey.getBytes(), "item".getBytes());
-            connection.hashCommands().hSet(hashKey.getBytes(), "field".getBytes(), "value".getBytes());
-            
-            // Test different types
-            DataType stringType = connection.keyCommands().type(stringKey.getBytes());
-            assertThat(stringType).isEqualTo(DataType.STRING);
-            
-            DataType listType = connection.keyCommands().type(listKey.getBytes());
-            assertThat(listType).isEqualTo(DataType.LIST);
-            
-            DataType hashType = connection.keyCommands().type(hashKey.getBytes());
-            assertThat(hashType).isEqualTo(DataType.HASH);
-        } finally {
-            cleanupKey(stringKey);
-            cleanupKey(listKey);
-            cleanupKey(hashKey);
-        }
-    }
+			// Set up test data
+			connection.stringCommands().set(key1.getBytes(), value);
+			connection.stringCommands().set(key2.getBytes(), value);
 
-    @Test
-    void testTouch() {
-        String key1 = "test:key:touch:key1";
-        String key2 = "test:key:touch:key2";
-        String key3 = "test:key:touch:key3";
-        byte[] value = "test_value".getBytes();
-        
-        try {
-            // Test touch on non-existent keys
-            Long touchResult1 = connection.keyCommands().touch(key1.getBytes(), key2.getBytes());
-            assertThat(touchResult1).isEqualTo(0L);
-            
-            // Set up test data
-            connection.stringCommands().set(key1.getBytes(), value);
-            connection.stringCommands().set(key2.getBytes(), value);
-            
-            // Test touch on existing keys
-            Long touchResult2 = connection.keyCommands().touch(key1.getBytes(), key2.getBytes(), key3.getBytes());
-            assertThat(touchResult2).isEqualTo(2L); // Only 2 keys exist
-            
-            // Test single key touch
-            Long touchResult3 = connection.keyCommands().touch(key1.getBytes());
-            assertThat(touchResult3).isEqualTo(1L);
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-            cleanupKey(key3);
-        }
-    }
+			// Test exists on existing keys
+			Boolean exists2 = connection.keyCommands().exists(key1.getBytes());
+			assertThat(exists2).isTrue();
 
-    @Test
-    void testKeys() {
-        String basePattern = "test:key:keys:";
-        String key1 = basePattern + "abc";
-        String key2 = basePattern + "def";
-        String key3 = basePattern + "xyz";
-        String otherKey = "test:other:pattern";
-        byte[] value = "test_value".getBytes();
-        
-        try {
-            // Set up test data
-            connection.stringCommands().set(key1.getBytes(), value);
-            connection.stringCommands().set(key2.getBytes(), value);
-            connection.stringCommands().set(key3.getBytes(), value);
-            connection.stringCommands().set(otherKey.getBytes(), value);
-            
-            // Test pattern matching
-            Set<byte[]> matchedKeys = connection.keyCommands().keys((basePattern + "*").getBytes());
-            assertThat(matchedKeys).hasSize(3);
-            
-            // Convert to strings for easier comparison
-            Set<String> matchedKeyStrings = matchedKeys.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toSet());
-            
-            assertThat(matchedKeyStrings).containsExactlyInAnyOrder(key1, key2, key3);
-            
-            // Test specific pattern
-            Set<byte[]> specificMatch = connection.keyCommands().keys((basePattern + "a*").getBytes());
-            assertThat(specificMatch).hasSize(1);
-            assertThat(new String(specificMatch.iterator().next())).isEqualTo(key1);
-            
-            // Test non-matching pattern
-            Set<byte[]> noMatch = connection.keyCommands().keys("no:match:*".getBytes());
-            assertThat(noMatch).isEmpty();
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-            cleanupKey(key3);
-            cleanupKey(otherKey);
-        }
-    }
+			Long existsMultiple2 = connection.keyCommands().exists(key1.getBytes(), key2.getBytes(), key3.getBytes());
+			assertThat(existsMultiple2).isEqualTo(2L); // 2 keys exist
 
-    @Test
-    void testRandomKey() {
-        String key1 = "test:key:random:key1";
-        String key2 = "test:key:random:key2";
-        byte[] value = "test_value".getBytes();
-        
-        try {
-            // Set up test data
-            connection.stringCommands().set(key1.getBytes(), value);
-            connection.stringCommands().set(key2.getBytes(), value);
-            
-            // Test randomKey when keys exist
-            byte[] randomKey = connection.keyCommands().randomKey();
-            assertThat(randomKey).isNotNull();
-            
-            // Should be one of our keys or some other key in the database
-            String randomKeyStr = new String(randomKey);
-            assertThat(randomKeyStr).isNotEmpty();
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-        }
-    }
+			// Test with duplicate keys
+			Long existsDuplicate = connection.keyCommands().exists(key1.getBytes(), key1.getBytes(), key2.getBytes());
+			assertThat(existsDuplicate).isEqualTo(3L); // Counts duplicates
 
-    @Test
-    void testScan() {
-        String basePattern = "test:key:scan:";
-        String key1 = basePattern + "item1";
-        String key2 = basePattern + "item2";
-        String key3 = basePattern + "other1";
-        byte[] value = "test_value".getBytes();
-        
-        try {
-            // Set up test data
-            connection.stringCommands().set(key1.getBytes(), value);
-            connection.stringCommands().set(key2.getBytes(), value);
-            connection.stringCommands().set(key3.getBytes(), value);
-            
-            // Test basic scan
-            ScanOptions options = ScanOptions.scanOptions().match(basePattern + "*").build();
-            Cursor<byte[]> cursor = connection.keyCommands().scan(options);
-            
-            java.util.List<String> scannedKeys = new java.util.ArrayList<>();
-            while (cursor.hasNext()) {
-                scannedKeys.add(new String(cursor.next()));
-            }
-            cursor.close();
-            
-            // Should find our test keys
-            assertThat(scannedKeys).containsAll(java.util.Arrays.asList(key1, key2, key3));
-            
-            // Test scan with count
-            ScanOptions countOptions = ScanOptions.scanOptions().count(1).build();
-            Cursor<byte[]> countCursor = connection.keyCommands().scan(countOptions);
-            
-            java.util.List<String> countScannedKeys = new java.util.ArrayList<>();
-            while (countCursor.hasNext()) {
-                countScannedKeys.add(new String(countCursor.next()));
-            }
-            countCursor.close();
-            
-            // Should get results, but in smaller batches
-            assertThat(countScannedKeys).isNotEmpty();
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-            cleanupKey(key3);
-        }
-    }
+			// Test del single key
+			Long delResult1 = connection.keyCommands().del(key1.getBytes());
+			assertThat(delResult1).isEqualTo(1L);
 
-    @Test
-    void testRename() {
-        String oldKey = "test:key:rename:old";
-        String newKey = "test:key:rename:new";
-        byte[] value = "test_value".getBytes();
-        
-        try {
-            // Set up test data
-            connection.stringCommands().set(oldKey.getBytes(), value);
-            
-            // Test rename
-            connection.keyCommands().rename(oldKey.getBytes(), newKey.getBytes());
-            
-            // Verify old key no longer exists
-            Boolean oldExists = connection.keyCommands().exists(oldKey.getBytes());
-            assertThat(oldExists).isFalse();
-            
-            // Verify new key exists with correct value
-            Boolean newExists = connection.keyCommands().exists(newKey.getBytes());
-            assertThat(newExists).isTrue();
-            
-            byte[] newValue = connection.stringCommands().get(newKey.getBytes());
-            assertThat(newValue).isEqualTo(value);
-        } finally {
-            cleanupKey(oldKey);
-            cleanupKey(newKey);
-        }
-    }
+			// Verify key was deleted
+			Boolean existsAfterDel = connection.keyCommands().exists(key1.getBytes());
+			assertThat(existsAfterDel).isFalse();
 
-    @Test
-    void testRenameNX() {
-        String oldKey = "test:key:renamenx:old";
-        String newKey = "test:key:renamenx:new";
-        String existingKey = "test:key:renamenx:existing";
-        byte[] value = "test_value".getBytes();
-        byte[] existingValue = "existing_value".getBytes();
-        
-        try {
-            // Set up test data
-            connection.stringCommands().set(oldKey.getBytes(), value);
-            connection.stringCommands().set(existingKey.getBytes(), existingValue);
-            
-            // Test renameNX to non-existing key (should succeed)
-            Boolean renameResult1 = connection.keyCommands().renameNX(oldKey.getBytes(), newKey.getBytes());
-            assertThat(renameResult1).isTrue();
-            
-            // Verify rename was successful
-            Boolean oldExists = connection.keyCommands().exists(oldKey.getBytes());
-            assertThat(oldExists).isFalse();
-            
-            Boolean newExists = connection.keyCommands().exists(newKey.getBytes());
-            assertThat(newExists).isTrue();
-            
-            // Test renameNX to existing key (should fail)
-            Boolean renameResult2 = connection.keyCommands().renameNX(newKey.getBytes(), existingKey.getBytes());
-            assertThat(renameResult2).isFalse();
-            
-            // Verify keys remain unchanged
-            Boolean newStillExists = connection.keyCommands().exists(newKey.getBytes());
-            assertThat(newStillExists).isTrue();
-            
-            byte[] existingStillValue = connection.stringCommands().get(existingKey.getBytes());
-            assertThat(existingStillValue).isEqualTo(existingValue);
-        } finally {
-            cleanupKey(oldKey);
-            cleanupKey(newKey);
-            cleanupKey(existingKey);
-        }
-    }
+			// Test del multiple keys
+			connection.stringCommands().set(key3.getBytes(), value); // Add key3
+			Long delResult2 = connection.keyCommands().del(key2.getBytes(), key3.getBytes());
+			assertThat(delResult2).isEqualTo(2L);
 
-    @Test
-    void testExpire() {
-        String key = "test:key:expire";
-        byte[] value = "test_value".getBytes();
-        
-        try {
-            // Test expire
-            connection.stringCommands().set(key.getBytes(), value);
-            Boolean expireResult = connection.keyCommands().expire(key.getBytes(), 1);
-            assertThat(expireResult).isTrue();
-            
-            // Verify key still exists initially
-            Boolean exists1 = connection.keyCommands().exists(key.getBytes());
-            assertThat(exists1).isTrue();
-            
-            // Wait for expiration
-            Thread.sleep(2000);
-            Boolean exists2 = connection.keyCommands().exists(key.getBytes());
-            assertThat(exists2).isFalse();
-            
-            // Test expire on non-existent key
-            Boolean expireNonExistent = connection.keyCommands().expire("non:existent:key".getBytes(), 1);
-            assertThat(expireNonExistent).isFalse();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test del non-existent key
+			Long delResult3 = connection.keyCommands().del("non:existent:key".getBytes());
+			assertThat(delResult3).isEqualTo(0L);
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+			cleanupKey(key3);
+		}
+	}
 
-    @Test
-    @EnabledOnValkeyVersion("7.0") // ExpirationOptions conditions (NX, XX, GT, LT) added in Redis 7.0
-    void testExpirationConditions() {
-        String key = "test:key:expire";
-        byte[] value = "test_value".getBytes();
-        
-        try {
-            // Test expire with NX condition (key must not have expiration)
-            connection.stringCommands().set(key.getBytes(), value);
-            Boolean expireNX1 = connection.keyCommands().expire(key.getBytes(), 10, ExpirationOptions.Condition.NX);
-            assertThat(expireNX1).isTrue(); // Should succeed, key had no expiration
-            
-            Boolean expireNX2 = connection.keyCommands().expire(key.getBytes(), 20, ExpirationOptions.Condition.NX);
-            assertThat(expireNX2).isFalse(); // Should fail, key already has expiration
-            
-            // Test expire with XX condition (key must have expiration)
-            Boolean expireXX1 = connection.keyCommands().expire(key.getBytes(), 30, ExpirationOptions.Condition.XX);
-            assertThat(expireXX1).isTrue(); // Should succeed, key has expiration
-            
-            // Test expire with GT condition (new expiration must be greater than current)
-            Boolean expireGT1 = connection.keyCommands().expire(key.getBytes(), 20, ExpirationOptions.Condition.GT);
-            assertThat(expireGT1).isFalse(); // Should fail, 20s < 30s (current)
-            
-            Boolean expireGT2 = connection.keyCommands().expire(key.getBytes(), 40, ExpirationOptions.Condition.GT);
-            assertThat(expireGT2).isTrue(); // Should succeed, 40s > 30s (current)
-            
-            // Test expire with LT condition (new expiration must be less than current)
-            Boolean expireLT1 = connection.keyCommands().expire(key.getBytes(), 50, ExpirationOptions.Condition.LT);
-            assertThat(expireLT1).isFalse(); // Should fail, 50s > 40s (current)
-            
-            Boolean expireLT2 = connection.keyCommands().expire(key.getBytes(), 35, ExpirationOptions.Condition.LT);
-            assertThat(expireLT2).isTrue(); // Should succeed, 35s < 40s (current)
-            
-            // Remove expiration
-            connection.keyCommands().persist(key.getBytes());
-            
-            Boolean expireXX2 = connection.keyCommands().expire(key.getBytes(), 40, ExpirationOptions.Condition.XX);
-            assertThat(expireXX2).isFalse(); // Should fail, key has no expiration
-        } finally {
-            cleanupKey(key);
-        }
-    }
+	@Test
+	void testUnlink() {
+		String key1 = "test:key:unlink:key1";
+		String key2 = "test:key:unlink:key2";
+		byte[] value = "test_value".getBytes();
 
-    @Test
-    void testPExpire() {
-        String key = "test:key:pexpire";
-        byte[] value = "test_value".getBytes();
-        
-        try {
-            // Test pExpire (milliseconds)
-            connection.stringCommands().set(key.getBytes(), value);
-            Boolean pExpireResult = connection.keyCommands().pExpire(key.getBytes(), 1000);
-            assertThat(pExpireResult).isTrue();
-            
-            // Verify key still exists initially
-            Boolean exists1 = connection.keyCommands().exists(key.getBytes());
-            assertThat(exists1).isTrue();
-            
-            // Wait for expiration
-            Thread.sleep(2000);
-            Boolean exists2 = connection.keyCommands().exists(key.getBytes());
-            assertThat(exists2).isFalse();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        } finally {
-            cleanupKey(key);
-        }
-    }
+		try {
+			// Set up test data
+			connection.stringCommands().set(key1.getBytes(), value);
+			connection.stringCommands().set(key2.getBytes(), value);
 
-    @Test
-    void testExpireAt() {
-        String key = "test:key:expireat";
-        byte[] value = "test_value".getBytes();
-        
-        try {
-            // Test expireAt
-            connection.stringCommands().set(key.getBytes(), value);
-            long futureTimestamp = System.currentTimeMillis() / 1000 + 1;
-            
-            Boolean expireAtResult = connection.keyCommands().expireAt(key.getBytes(), futureTimestamp);
-            assertThat(expireAtResult).isTrue();
-            
-            // Verify key still exists initially
-            Boolean exists1 = connection.keyCommands().exists(key.getBytes());
-            assertThat(exists1).isTrue();
-            
-            // Wait for expiration
-            Thread.sleep(2000);
-            Boolean exists2 = connection.keyCommands().exists(key.getBytes());
-            assertThat(exists2).isFalse();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test unlink single key
+			Long unlinkResult1 = connection.keyCommands().unlink(key1.getBytes());
+			assertThat(unlinkResult1).isEqualTo(1L);
 
-    @Test
-    void testPExpireAt() {
-        String key = "test:key:pexpireat";
-        byte[] value = "test_value".getBytes();
-        
-        try {
-            // Test pExpireAt
-            connection.stringCommands().set(key.getBytes(), value);
-            long futureTimestampMillis = System.currentTimeMillis() + 1000;
-            
-            Boolean pExpireAtResult = connection.keyCommands().pExpireAt(key.getBytes(), futureTimestampMillis);
-            assertThat(pExpireAtResult).isTrue();
-            
-            // Verify key still exists initially
-            Boolean exists1 = connection.keyCommands().exists(key.getBytes());
-            assertThat(exists1).isTrue();
-            
-            // Wait for expiration
-            Thread.sleep(2000);
-            Boolean exists2 = connection.keyCommands().exists(key.getBytes());
-            assertThat(exists2).isFalse();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Verify key was unlinked
+			Boolean existsAfterUnlink = connection.keyCommands().exists(key1.getBytes());
+			assertThat(existsAfterUnlink).isFalse();
 
-    @Test
-    void testPersist() {
-        String key = "test:key:persist";
-        byte[] value = "test_value".getBytes();
-        
-        try {
-            // Set up test data with expiration
-            connection.stringCommands().set(key.getBytes(), value);
-            connection.keyCommands().expire(key.getBytes(), 10); // 10 seconds
-            
-            // Test persist
-            Boolean persistResult = connection.keyCommands().persist(key.getBytes());
-            assertThat(persistResult).isTrue();
-            
-            // Verify TTL is now -1 (no expiration)
-            Long ttl = connection.keyCommands().ttl(key.getBytes());
-            assertThat(ttl).isEqualTo(-1L);
-            
-            // Test persist on key without expiration
-            Boolean persistResult2 = connection.keyCommands().persist(key.getBytes());
-            assertThat(persistResult2).isFalse();
-            
-            // Test persist on non-existent key
-            Boolean persistNonExistent = connection.keyCommands().persist("non:existent:key".getBytes());
-            assertThat(persistNonExistent).isFalse();
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test unlink multiple keys
+			Long unlinkResult2 = connection.keyCommands().unlink(key2.getBytes(), "non:existent:key".getBytes());
+			assertThat(unlinkResult2).isEqualTo(1L); // Only one key existed
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+		}
+	}
 
-    @Test
-    void testMove() {
-        String key = "test:key:move";
-        byte[] value = "test_value".getBytes();
-        
-        try {
-            // Set up test data
-            connection.stringCommands().set(key.getBytes(), value);
-            
-            // Test move to different database (assuming database 1 exists)
-            Boolean moveResult = connection.keyCommands().move(key.getBytes(), 1);
-            // Note: Move behavior depends on Valkey configuration and available databases
-            // In many test setups, only database 0 is available, so move might fail
-            // We'll just verify the method executes without throwing an exception
-            assertThat(moveResult).isNotNull();
-            
-            // Test move non-existent key
-            Boolean moveNonExistent = connection.keyCommands().move("non:existent:key".getBytes(), 1);
-            assertThat(moveNonExistent).isFalse();
-        } finally {
-            cleanupKey(key);
-            // Also cleanup from database 1 if move succeeded
-            try {
-                connection.select(1);
-                connection.keyCommands().del(key.getBytes());
-                connection.select(0);
-            } catch (Exception e) {
-                // Ignore errors when switching databases in test environment
-            }
-        }
-    }
+	@Test
+	void testCopy() {
+		String sourceKey = "test:key:copy:source";
+		String targetKey = "test:key:copy:target";
+		String existingTargetKey = "test:key:copy:existing";
+		byte[] value = "test_value".getBytes();
+		byte[] existingValue = "existing_value".getBytes();
 
-    @Test
-    void testTtl() {
-        String key = "test:key:ttl";
-        byte[] value = "test_value".getBytes();
-        
-        try {
-            // Test TTL on non-existent key
-            Long nonExistentTtl = connection.keyCommands().ttl("non:existent:key".getBytes());
-            assertThat(nonExistentTtl).isEqualTo(-2L); // Key doesn't exist
-            
-            // Set up test data without expiration
-            connection.stringCommands().set(key.getBytes(), value);
-            Long noExpirationTtl = connection.keyCommands().ttl(key.getBytes());
-            assertThat(noExpirationTtl).isEqualTo(-1L); // No expiration set
-            
-            // Set expiration and test TTL
-            connection.keyCommands().expire(key.getBytes(), 10);
-            Long ttl = connection.keyCommands().ttl(key.getBytes());
-            assertThat(ttl).isGreaterThan(0L).isLessThanOrEqualTo(10L);
-            
-            // Test TTL with time unit conversion
-            Long ttlInMillis = connection.keyCommands().ttl(key.getBytes(), TimeUnit.MILLISECONDS);
-            assertThat(ttlInMillis).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
-        } finally {
-            cleanupKey(key);
-        }
-    }
+		try {
+			// Test copy on non-existent source key
+			Boolean copyNonExistent = connection.keyCommands().copy(sourceKey.getBytes(), targetKey.getBytes(), false);
+			assertThat(copyNonExistent).isFalse();
 
-    @Test
-    void testPTtl() {
-        String key = "test:key:pttl";
-        byte[] value = "test_value".getBytes();
-        
-        try {
-            // Set up test data with expiration
-            connection.stringCommands().set(key.getBytes(), value);
-            connection.keyCommands().pExpire(key.getBytes(), 10000); // 10 seconds in milliseconds
-            
-            // Test pTtl
-            Long pTtl = connection.keyCommands().pTtl(key.getBytes());
-            assertThat(pTtl).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
-            
-            // Test pTtl with time unit conversion
-            Long pTtlInSeconds = connection.keyCommands().pTtl(key.getBytes(), TimeUnit.SECONDS);
-            assertThat(pTtlInSeconds).isGreaterThan(0L).isLessThanOrEqualTo(10L);
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Set up test data
+			connection.stringCommands().set(sourceKey.getBytes(), value);
+			connection.stringCommands().set(existingTargetKey.getBytes(), existingValue);
 
-    @Test
-    void testTtlTimeUnitSpecialValues() {
-        String key = "test:key:ttl:special";
-        byte[] value = "test_value".getBytes();
-        
-        try {
-            // Test TTL on non-existent key with TimeUnit conversion
-            // Should return -2 (key doesn't exist) without conversion
-            Long ttlNonExistentSeconds = connection.keyCommands().ttl("non:existent:key".getBytes(), TimeUnit.SECONDS);
-            assertThat(ttlNonExistentSeconds).isEqualTo(-2L);
-            
-            Long ttlNonExistentMillis = connection.keyCommands().ttl("non:existent:key".getBytes(), TimeUnit.MILLISECONDS);
-            assertThat(ttlNonExistentMillis).isEqualTo(-2L);
-            
-            Long ttlNonExistentMinutes = connection.keyCommands().ttl("non:existent:key".getBytes(), TimeUnit.MINUTES);
-            assertThat(ttlNonExistentMinutes).isEqualTo(-2L);
-            
-            // Test TTL on key without expiration with TimeUnit conversion
-            // Should return -1 (no expiration) without conversion
-            connection.stringCommands().set(key.getBytes(), value);
-            
-            Long ttlNoExpirationSeconds = connection.keyCommands().ttl(key.getBytes(), TimeUnit.SECONDS);
-            assertThat(ttlNoExpirationSeconds).isEqualTo(-1L);
-            
-            Long ttlNoExpirationMillis = connection.keyCommands().ttl(key.getBytes(), TimeUnit.MILLISECONDS);
-            assertThat(ttlNoExpirationMillis).isEqualTo(-1L);
-            
-            Long ttlNoExpirationMinutes = connection.keyCommands().ttl(key.getBytes(), TimeUnit.MINUTES);
-            assertThat(ttlNoExpirationMinutes).isEqualTo(-1L);
-            
-            // Test TTL on key with expiration - should convert properly
-            connection.keyCommands().expire(key.getBytes(), 60); // 60 seconds
-            
-            Long ttlWithExpirationSeconds = connection.keyCommands().ttl(key.getBytes(), TimeUnit.SECONDS);
-            assertThat(ttlWithExpirationSeconds).isGreaterThan(0L).isLessThanOrEqualTo(60L);
-            
-            Long ttlWithExpirationMillis = connection.keyCommands().ttl(key.getBytes(), TimeUnit.MILLISECONDS);
-            assertThat(ttlWithExpirationMillis).isGreaterThan(0L).isLessThanOrEqualTo(60000L);
-            
-            // Verify conversion is correct: milliseconds should be roughly 1000x seconds
-            if (ttlWithExpirationSeconds != null && ttlWithExpirationSeconds > 0) {
-                double ratio = (double) ttlWithExpirationMillis / ttlWithExpirationSeconds;
-                assertThat(ratio).isBetween(900.0, 1100.0); // Allow some timing variance
-            }
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test successful copy
+			Boolean copyResult1 = connection.keyCommands().copy(sourceKey.getBytes(), targetKey.getBytes(), false);
+			assertThat(copyResult1).isTrue();
 
-    @Test
-    void testPTtlTimeUnitSpecialValues() {
-        String key = "test:key:pttl:special";
-        byte[] value = "test_value".getBytes();
-        
-        try {
-            // Test PTTL on non-existent key with TimeUnit conversion
-            // Should return -2 (key doesn't exist) without conversion
-            Long pTtlNonExistentSeconds = connection.keyCommands().pTtl("non:existent:key".getBytes(), TimeUnit.SECONDS);
-            assertThat(pTtlNonExistentSeconds).isEqualTo(-2L);
-            
-            Long pTtlNonExistentMillis = connection.keyCommands().pTtl("non:existent:key".getBytes(), TimeUnit.MILLISECONDS);
-            assertThat(pTtlNonExistentMillis).isEqualTo(-2L);
-            
-            Long pTtlNonExistentMinutes = connection.keyCommands().pTtl("non:existent:key".getBytes(), TimeUnit.MINUTES);
-            assertThat(pTtlNonExistentMinutes).isEqualTo(-2L);
-            
-            // Test PTTL on key without expiration with TimeUnit conversion
-            // Should return -1 (no expiration) without conversion
-            connection.stringCommands().set(key.getBytes(), value);
-            
-            Long pTtlNoExpirationSeconds = connection.keyCommands().pTtl(key.getBytes(), TimeUnit.SECONDS);
-            assertThat(pTtlNoExpirationSeconds).isEqualTo(-1L);
-            
-            Long pTtlNoExpirationMillis = connection.keyCommands().pTtl(key.getBytes(), TimeUnit.MILLISECONDS);
-            assertThat(pTtlNoExpirationMillis).isEqualTo(-1L);
-            
-            Long pTtlNoExpirationMinutes = connection.keyCommands().pTtl(key.getBytes(), TimeUnit.MINUTES);
-            assertThat(pTtlNoExpirationMinutes).isEqualTo(-1L);
-            
-            // Test PTTL on key with expiration - should convert properly
-            connection.keyCommands().pExpire(key.getBytes(), 60000); // 60 seconds in milliseconds
-            
-            Long pTtlWithExpirationMillis = connection.keyCommands().pTtl(key.getBytes(), TimeUnit.MILLISECONDS);
-            assertThat(pTtlWithExpirationMillis).isGreaterThan(0L).isLessThanOrEqualTo(60000L);
-            
-            Long pTtlWithExpirationSeconds = connection.keyCommands().pTtl(key.getBytes(), TimeUnit.SECONDS);
-            assertThat(pTtlWithExpirationSeconds).isGreaterThan(0L).isLessThanOrEqualTo(60L);
-            
-            // Verify conversion is correct: milliseconds should be roughly 1000x seconds
-            if (pTtlWithExpirationSeconds != null && pTtlWithExpirationSeconds > 0) {
-                double ratio = (double) pTtlWithExpirationMillis / pTtlWithExpirationSeconds;
-                assertThat(ratio).isBetween(900.0, 1100.0); // Allow some timing variance
-            }
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Verify copy was successful
+			byte[] copiedValue = connection.stringCommands().get(targetKey.getBytes());
+			assertThat(copiedValue).isEqualTo(value);
 
-    @Test
-    void testSortComprehensive() {
-        String listKey = "test:key:sort:list";
-        String storeKey = "test:key:sort:store";
-        
-        try {
-            // Set up test data - add some sortable values
-            connection.listCommands().lPush(listKey.getBytes(), "3".getBytes());
-            connection.listCommands().lPush(listKey.getBytes(), "1".getBytes());
-            connection.listCommands().lPush(listKey.getBytes(), "2".getBytes());
-            
-            // Test sort without parameters
-            List<byte[]> sortedResult1 = connection.keyCommands().sort(listKey.getBytes(), null);
-            assertThat(sortedResult1).hasSize(3);
-            // Should be sorted as strings: "1", "2", "3"
-            assertThat(new String(sortedResult1.get(0))).isEqualTo("1");
-            assertThat(new String(sortedResult1.get(1))).isEqualTo("2");
-            assertThat(new String(sortedResult1.get(2))).isEqualTo("3");
-            
-            // Test sort with LIMIT parameters
-            SortParameters params1 = new DefaultSortParameters().limit(0, 2);
-            List<byte[]> sortedResult2 = connection.keyCommands().sort(listKey.getBytes(), params1);
-            assertThat(sortedResult2).hasSize(2); // Limited by count
-            assertThat(new String(sortedResult2.get(0))).isEqualTo("1");
-            assertThat(new String(sortedResult2.get(1))).isEqualTo("2");
-            
-            // Test sort with DESC order
-            SortParameters params2 = new DefaultSortParameters().desc();
-            List<byte[]> sortedResult3 = connection.keyCommands().sort(listKey.getBytes(), params2);
-            assertThat(sortedResult3).hasSize(3);
-            assertThat(new String(sortedResult3.get(0))).isEqualTo("3");
-            assertThat(new String(sortedResult3.get(1))).isEqualTo("2");
-            assertThat(new String(sortedResult3.get(2))).isEqualTo("1");
-            
-            // Test sort with ASC order (explicit)
-            SortParameters params3 = new DefaultSortParameters().asc();
-            List<byte[]> sortedResult4 = connection.keyCommands().sort(listKey.getBytes(), params3);
-            assertThat(sortedResult4).hasSize(3);
-            assertThat(new String(sortedResult4.get(0))).isEqualTo("1");
-            assertThat(new String(sortedResult4.get(1))).isEqualTo("2");
-            assertThat(new String(sortedResult4.get(2))).isEqualTo("3");
-            
-            // Test sort with alphabetic ordering
-            connection.keyCommands().del(listKey.getBytes());
-            connection.listCommands().lPush(listKey.getBytes(), "b".getBytes());
-            connection.listCommands().lPush(listKey.getBytes(), "a".getBytes());
-            connection.listCommands().lPush(listKey.getBytes(), "c".getBytes());
-            
-            SortParameters params4 = new DefaultSortParameters().alpha();
-            List<byte[]> sortedResult5 = connection.keyCommands().sort(listKey.getBytes(), params4);
-            assertThat(sortedResult5).hasSize(3);
-            assertThat(new String(sortedResult5.get(0))).isEqualTo("a");
-            assertThat(new String(sortedResult5.get(1))).isEqualTo("b");
-            assertThat(new String(sortedResult5.get(2))).isEqualTo("c");
-            
-            // Test sort with multiple parameters combined
-            SortParameters params5 = new DefaultSortParameters().alpha().desc().limit(0, 2);
-            List<byte[]> sortedResult6 = connection.keyCommands().sort(listKey.getBytes(), params5);
-            assertThat(sortedResult6).hasSize(2);
-            assertThat(new String(sortedResult6.get(0))).isEqualTo("c");
-            assertThat(new String(sortedResult6.get(1))).isEqualTo("b");
-            
-            // Test sort with store (use alphabetic sort since list contains "a", "b", "c")
-            Long storeResult = connection.keyCommands().sort(listKey.getBytes(), params4, storeKey.getBytes());
-            assertThat(storeResult).isEqualTo(3L); // 3 elements stored
-            
-            // Verify stored results
-            List<byte[]> storedList = connection.listCommands().lRange(storeKey.getBytes(), 0, -1);
-            assertThat(storedList).hasSize(3);
-            
-            // Test sort with store and parameters
-            Long storeResult2 = connection.keyCommands().sort(listKey.getBytes(), params4, storeKey.getBytes());
-            assertThat(storeResult2).isEqualTo(3L);
-            
-        } finally {
-            cleanupKey(listKey);
-            cleanupKey(storeKey);
-        }
-    }
+			// Verify source still exists
+			byte[] sourceValue = connection.stringCommands().get(sourceKey.getBytes());
+			assertThat(sourceValue).isEqualTo(value);
 
-    @Test
-    void testDumpRestore() {
-        String sourceKey = "test:key:dump";
-        String restoreKey = "test:key:restore";
-        byte[] value = "test_value".getBytes();
-        
-        try {
-            // Set up test data
-            connection.stringCommands().set(sourceKey.getBytes(), value);
-            
-            // Test dump
-            byte[] serialized = connection.keyCommands().dump(sourceKey.getBytes());
-            assertThat(serialized).isNotNull();
-            
-            // Test dump on non-existent key
-            byte[] nonExistentDump = connection.keyCommands().dump("non:existent:key".getBytes());
-            assertThat(nonExistentDump).isNull();
-            
-            // Test restore
-            connection.keyCommands().restore(restoreKey.getBytes(), 0, serialized, false);
-            
-            // Verify restore was successful
-            byte[] restoredValue = connection.stringCommands().get(restoreKey.getBytes());
-            assertThat(restoredValue).isEqualTo(value);
-            
-            // Test restore with replace
-            byte[] newValue = "new_value".getBytes();
-            connection.stringCommands().set(sourceKey.getBytes(), newValue);
-            byte[] newSerialized = connection.keyCommands().dump(sourceKey.getBytes());
-            
-            connection.keyCommands().restore(restoreKey.getBytes(), 0, newSerialized, true);
-            byte[] replacedValue = connection.stringCommands().get(restoreKey.getBytes());
-            assertThat(replacedValue).isEqualTo(newValue);
-        } finally {
-            cleanupKey(sourceKey);
-            cleanupKey(restoreKey);
-        }
-    }
+			// Test copy without replace (should fail)
+			Boolean copyResult2 = connection.keyCommands()
+				.copy(sourceKey.getBytes(), existingTargetKey.getBytes(), false);
+			assertThat(copyResult2).isFalse();
 
-    @Test
-    void testObjectIntrospection() {
-        String key = "test:key:encoding";
-        byte[] value = "test_value".getBytes();
-        
-        try {
-            // Set up test data
-            connection.stringCommands().set(key.getBytes(), value);
-            
-            // Test encodingOf
-            ValueEncoding encoding = connection.keyCommands().encodingOf(key.getBytes());
-            assertThat(encoding).isNotNull();
-            // The exact encoding depends on Valkey/Valkey version and configuration
-            
-            // Test encodingOf on non-existent key
-            ValueEncoding nonExistentEncoding = connection.keyCommands().encodingOf("non:existent:key".getBytes());
-            assertThat(nonExistentEncoding).isEqualTo(ValueEncoding.ValkeyValueEncoding.VACANT);
-            
-            // Test idletime
-            Duration idletime = connection.keyCommands().idletime(key.getBytes());
-            assertThat(idletime).isNotNull();
-            assertThat(idletime.getSeconds()).isGreaterThanOrEqualTo(0);
-            
-            // Test idletime on non-existent key
-            Duration nonExistentIdletime = connection.keyCommands().idletime("non:existent:key".getBytes());
-            assertThat(nonExistentIdletime).isNull();
-            
-            // Test refcount
-            Long refcount = connection.keyCommands().refcount(key.getBytes());
-            assertThat(refcount).isNotNull();
-            assertThat(refcount).isGreaterThan(0);
-            
-            // Test refcount on non-existent key
-            Long nonExistentRefcount = connection.keyCommands().refcount("non:existent:key".getBytes());
-            assertThat(nonExistentRefcount).isNull();
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Verify existing target was not overwritten
+			byte[] existingTargetValue = connection.stringCommands().get(existingTargetKey.getBytes());
+			assertThat(existingTargetValue).isEqualTo(existingValue);
 
-    // ==================== PIPELINE MODE TESTS ====================
+			// Test copy with replace (should succeed)
+			Boolean copyResult3 = connection.keyCommands()
+				.copy(sourceKey.getBytes(), existingTargetKey.getBytes(), true);
+			assertThat(copyResult3).isTrue();
 
-    @Test
-    void testKeyOperationsPipeline() {
-        String key1 = "test:key:pipeline:key1";
-        String key2 = "test:key:pipeline:key2";
-        String key3 = "test:key:pipeline:key3";
-        byte[] value = "test_value".getBytes();
-        
-        try {
-            // Set up test data
-            connection.stringCommands().set(key1.getBytes(), value);
-            connection.stringCommands().set(key2.getBytes(), value);
-            
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Pipeline commands should return null
-            Boolean existsResult = connection.keyCommands().exists(key1.getBytes());
-            assertThat(existsResult).isNull();
-            
-            Long existsMultipleResult = connection.keyCommands().exists(key1.getBytes(), key2.getBytes(), key3.getBytes());
-            assertThat(existsMultipleResult).isNull();
-            
-            DataType typeResult = connection.keyCommands().type(key1.getBytes());
-            assertThat(typeResult).isNull();
-            
-            Long touchResult = connection.keyCommands().touch(key1.getBytes(), key2.getBytes());
-            assertThat(touchResult).isNull();
-            
-            Boolean copyResult = connection.keyCommands().copy(key1.getBytes(), key3.getBytes(), false);
-            assertThat(copyResult).isNull();
-            
-            Long delResult = connection.keyCommands().del(key2.getBytes());
-            assertThat(delResult).isNull();
-            
-            // Execute pipeline and collect results
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results in order
-            assertThat(results).hasSize(6);
-            assertThat((Boolean) results.get(0)).isTrue(); // exists(key1)
-            assertThat((Long) results.get(1)).isEqualTo(2L); // exists multiple (key1, key2 existed)
-            assertThat((DataType) results.get(2)).isEqualTo(DataType.STRING); // type(key1)
-            assertThat((Long) results.get(3)).isEqualTo(2L); // touch(key1, key2)
-            assertThat((Boolean) results.get(4)).isTrue(); // copy(key1 -> key3)
-            assertThat((Long) results.get(5)).isEqualTo(1L); // del(key2)
-            
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-            cleanupKey(key3);
-        }
-    }
+			// Verify existing target was overwritten
+			byte[] replacedValue = connection.stringCommands().get(existingTargetKey.getBytes());
+			assertThat(replacedValue).isEqualTo(value);
+		}
+		finally {
+			cleanupKey(sourceKey);
+			cleanupKey(targetKey);
+			cleanupKey(existingTargetKey);
+		}
+	}
 
-    @Test
-    void testExpirationOperationsPipeline() {
-        String key1 = "test:key:pipeline:expire1";
-        String key2 = "test:key:pipeline:expire2";
-        byte[] value = "test_value".getBytes();
-        
-        try {
-            // Set up test data
-            connection.stringCommands().set(key1.getBytes(), value);
-            connection.stringCommands().set(key2.getBytes(), value);
-            
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Pipeline commands should return null
-            Boolean expireResult = connection.keyCommands().expire(key1.getBytes(), 10);
-            assertThat(expireResult).isNull();
-            
-            Boolean pExpireResult = connection.keyCommands().pExpire(key2.getBytes(), 20000);
-            assertThat(pExpireResult).isNull();
-            
-            Long ttlResult = connection.keyCommands().ttl(key1.getBytes());
-            assertThat(ttlResult).isNull();
-            
-            Long pTtlResult = connection.keyCommands().pTtl(key2.getBytes());
-            assertThat(pTtlResult).isNull();
-            
-            Boolean persistResult = connection.keyCommands().persist(key1.getBytes());
-            assertThat(persistResult).isNull();
-            
-            // Execute pipeline and collect results
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results in order
-            assertThat(results).hasSize(5);
-            assertThat((Boolean) results.get(0)).isTrue(); // expire
-            assertThat((Boolean) results.get(1)).isTrue(); // pExpire
-            assertThat((Long) results.get(2)).isGreaterThan(0L).isLessThanOrEqualTo(10L); // ttl
-            assertThat((Long) results.get(3)).isGreaterThan(0L).isLessThanOrEqualTo(20000L); // pTtl
-            assertThat((Boolean) results.get(4)).isTrue(); // persist
-            
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-        }
-    }
+	@Test
+	void testType() {
+		String stringKey = "test:key:type:string";
+		String listKey = "test:key:type:list";
+		String hashKey = "test:key:type:hash";
 
-    @Test
-    void testVoidMethodsPipeline() {
-        String oldKey = "test:key:pipeline:rename:old";
-        String newKey = "test:key:pipeline:rename:new";
-        String restoreKey = "test:key:pipeline:restore";
-        byte[] value = "test_value".getBytes();
-        
-        try {
-            // Set up test data
-            connection.stringCommands().set(oldKey.getBytes(), value);
-            byte[] serialized = connection.keyCommands().dump(oldKey.getBytes());
-            
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Void methods should return null in pipeline mode but still queue the command
-            connection.keyCommands().rename(oldKey.getBytes(), newKey.getBytes());
-            connection.keyCommands().restore(restoreKey.getBytes(), 0, serialized, false);
-            
-            // Execute pipeline and collect results
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results - void methods should return "OK" responses
-            assertThat(results).hasSize(2);
-            assertThat(results.get(0)).isEqualTo("OK"); // rename
-            assertThat(results.get(1)).isEqualTo("OK"); // restore
-            
-            // Verify operations actually succeeded
-            Boolean newExists = connection.keyCommands().exists(newKey.getBytes());
-            assertThat(newExists).isTrue();
-            
-            Boolean restoreExists = connection.keyCommands().exists(restoreKey.getBytes());
-            assertThat(restoreExists).isTrue();
-            
-        } finally {
-            cleanupKey(oldKey);
-            cleanupKey(newKey);
-            cleanupKey(restoreKey);
-        }
-    }
+		try {
+			// Test type on non-existent key
+			DataType nonExistentType = connection.keyCommands().type("non:existent:key".getBytes());
+			assertThat(nonExistentType).isEqualTo(DataType.NONE);
 
-    @Test
-    void testAdvancedKeyOperationsPipeline() {
-        String key1 = "test:key:pipeline:advanced:key1";
-        String key2 = "test:key:pipeline:advanced:key2";
-        String key3 = "test:key:pipeline:advanced:key3";
-        String listKey = "test:key:pipeline:advanced:list";
-        String storeKey = "test:key:pipeline:advanced:store";
-        String renameKey = "test:key:pipeline:advanced:rename";
-        String newRenameKey = "test:key:pipeline:advanced:newrename";
-        String basePattern = "test:key:pipeline:advanced:";
-        byte[] value = "test_value".getBytes();
-        
-        try {
-            // Set up test data
-            connection.stringCommands().set(key1.getBytes(), value);
-            connection.stringCommands().set(key2.getBytes(), value);
-            connection.stringCommands().set(key3.getBytes(), value);
-            connection.stringCommands().set(renameKey.getBytes(), value);
-            connection.listCommands().lPush(listKey.getBytes(), "c".getBytes());
-            connection.listCommands().lPush(listKey.getBytes(), "a".getBytes());
-            connection.listCommands().lPush(listKey.getBytes(), "b".getBytes());
-            
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Test all missing operations - pipeline commands should return null
-            Long unlinkResult = connection.keyCommands().unlink(key1.getBytes(), key2.getBytes());
-            assertThat(unlinkResult).isNull();
-            
-            Set<byte[]> keysResult = connection.keyCommands().keys((basePattern + "*").getBytes());
-            assertThat(keysResult).isNull();
-            
-            byte[] randomKeyResult = connection.keyCommands().randomKey();
-            assertThat(randomKeyResult).isNull();
-            
-            Boolean renameNXResult = connection.keyCommands().renameNX(renameKey.getBytes(), newRenameKey.getBytes());
-            assertThat(renameNXResult).isNull();
-            
-            Boolean moveResult = connection.keyCommands().move(key3.getBytes(), 1);
-            assertThat(moveResult).isNull();
-            
-            long futureTimestamp = System.currentTimeMillis() / 1000 + 30;
-            Boolean expireAtResult = connection.keyCommands().expireAt(newRenameKey.getBytes(), futureTimestamp);
-            assertThat(expireAtResult).isNull();
-            
-            long futureTimestampMillis = System.currentTimeMillis() + 30000;
-            Boolean pExpireAtResult = connection.keyCommands().pExpireAt(newRenameKey.getBytes(), futureTimestampMillis);
-            assertThat(pExpireAtResult).isNull();
-            
-            Long ttlTimeUnitResult = connection.keyCommands().ttl(newRenameKey.getBytes(), TimeUnit.MILLISECONDS);
-            assertThat(ttlTimeUnitResult).isNull();
-            
-            SortParameters sortParams = new DefaultSortParameters().alpha();
-            List<byte[]> sortResult = connection.keyCommands().sort(listKey.getBytes(), sortParams);
-            assertThat(sortResult).isNull();
-            
-            Long sortStoreResult = connection.keyCommands().sort(listKey.getBytes(), sortParams, storeKey.getBytes());
-            assertThat(sortStoreResult).isNull();
-            
-            byte[] dumpResult = connection.keyCommands().dump(newRenameKey.getBytes());
-            assertThat(dumpResult).isNull();
-            
-            ValueEncoding encodingResult = connection.keyCommands().encodingOf(newRenameKey.getBytes());
-            assertThat(encodingResult).isNull();
-            
-            Duration idletimeResult = connection.keyCommands().idletime(newRenameKey.getBytes());
-            assertThat(idletimeResult).isNull();
-            
-            Long refcountResult = connection.keyCommands().refcount(newRenameKey.getBytes());
-            assertThat(refcountResult).isNull();
-            
-            // Execute pipeline and collect results
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results in order
-            assertThat(results).hasSize(14);
-            assertThat((Long) results.get(0)).isEqualTo(2L); // unlink(key1, key2)
-            assertThat((Set<?>) results.get(1)).isNotNull(); // keys(pattern)
-            assertThat(results.get(2)).isNotNull(); // randomKey() - should return some key
-            assertThat((Boolean) results.get(3)).isTrue(); // renameNX succeeded
-            assertThat(results.get(4)).isNotNull(); // move result (depends on DB config)
-            assertThat((Boolean) results.get(5)).isTrue(); // expireAt
-            assertThat((Boolean) results.get(6)).isTrue(); // pExpireAt  
-            assertThat(results.get(7)).isNotNull(); // ttl with TimeUnit
-            assertThat((List<?>) results.get(8)).hasSize(3); // sort result
-            assertThat((Long) results.get(9)).isEqualTo(3L); // sort store result
-            assertThat(results.get(10)).isNotNull(); // dump result
-            assertThat(results.get(11)).isNotNull(); // encodingOf result
-            assertThat(results.get(12)).isNotNull(); // idletime result
-            assertThat(results.get(13)).isNotNull(); // refcount result
-            
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-            cleanupKey(key3);
-            cleanupKey(listKey);
-            cleanupKey(storeKey);
-            cleanupKey(renameKey);
-            cleanupKey(newRenameKey);
-        }
-    }
+			// Set up different data types
+			connection.stringCommands().set(stringKey.getBytes(), "value".getBytes());
+			connection.listCommands().lPush(listKey.getBytes(), "item".getBytes());
+			connection.hashCommands().hSet(hashKey.getBytes(), "field".getBytes(), "value".getBytes());
 
-    // ==================== TRANSACTION MODE TESTS ====================
+			// Test different types
+			DataType stringType = connection.keyCommands().type(stringKey.getBytes());
+			assertThat(stringType).isEqualTo(DataType.STRING);
 
-    @Test
-    void testKeyOperationsTransaction() {
-        String key1 = "test:key:transaction:key1";
-        String key2 = "test:key:transaction:key2";
-        String key3 = "test:key:transaction:key3";
-        byte[] value = "test_value".getBytes();
-        
-        try {
-            // Set up test data
-            connection.stringCommands().set(key1.getBytes(), value);
-            connection.stringCommands().set(key2.getBytes(), value);
-            
-            // Start transaction
-            connection.multi();
-            
-            // Transaction commands should return null
-            Boolean existsResult = connection.keyCommands().exists(key1.getBytes());
-            assertThat(existsResult).isNull();
-            
-            Long existsMultipleResult = connection.keyCommands().exists(key1.getBytes(), key2.getBytes(), key3.getBytes());
-            assertThat(existsMultipleResult).isNull();
-            
-            DataType typeResult = connection.keyCommands().type(key1.getBytes());
-            assertThat(typeResult).isNull();
-            
-            Long touchResult = connection.keyCommands().touch(key1.getBytes(), key2.getBytes());
-            assertThat(touchResult).isNull();
-            
-            Boolean copyResult = connection.keyCommands().copy(key1.getBytes(), key3.getBytes(), false);
-            assertThat(copyResult).isNull();
-            
-            Long delResult = connection.keyCommands().del(key2.getBytes());
-            assertThat(delResult).isNull();
-            
-            // Execute transaction and collect results
-            List<Object> results = connection.exec();
-            
-            // Verify results in order
-            assertThat(results).hasSize(6);
-            assertThat((Boolean) results.get(0)).isTrue(); // exists(key1)
-            assertThat((Long) results.get(1)).isEqualTo(2L); // exists multiple (key1, key2 existed)
-            assertThat((DataType) results.get(2)).isEqualTo(DataType.STRING); // type(key1)
-            assertThat((Long) results.get(3)).isEqualTo(2L); // touch(key1, key2)
-            assertThat((Boolean) results.get(4)).isTrue(); // copy(key1 -> key3)
-            assertThat((Long) results.get(5)).isEqualTo(1L); // del(key2)
-            
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-            cleanupKey(key3);
-        }
-    }
+			DataType listType = connection.keyCommands().type(listKey.getBytes());
+			assertThat(listType).isEqualTo(DataType.LIST);
 
-    @Test
-    void testExpirationOperationsTransaction() {
-        String key1 = "test:key:transaction:expire1";
-        String key2 = "test:key:transaction:expire2";
-        byte[] value = "test_value".getBytes();
-        
-        try {
-            // Set up test data
-            connection.stringCommands().set(key1.getBytes(), value);
-            connection.stringCommands().set(key2.getBytes(), value);
-            
-            // Start transaction
-            connection.multi();
-            
-            // Transaction commands should return null
-            Boolean expireResult = connection.keyCommands().expire(key1.getBytes(), 10);
-            assertThat(expireResult).isNull();
-            
-            Boolean pExpireResult = connection.keyCommands().pExpire(key2.getBytes(), 20000);
-            assertThat(pExpireResult).isNull();
-            
-            Long ttlResult = connection.keyCommands().ttl(key1.getBytes());
-            assertThat(ttlResult).isNull();
-            
-            Long pTtlResult = connection.keyCommands().pTtl(key2.getBytes());
-            assertThat(pTtlResult).isNull();
-            
-            Boolean persistResult = connection.keyCommands().persist(key1.getBytes());
-            assertThat(persistResult).isNull();
-            
-            // Execute transaction and collect results
-            List<Object> results = connection.exec();
-            
-            // Verify results in order
-            assertThat(results).hasSize(5);
-            assertThat((Boolean) results.get(0)).isTrue(); // expire
-            assertThat((Boolean) results.get(1)).isTrue(); // pExpire
-            assertThat((Long) results.get(2)).isGreaterThan(0L).isLessThanOrEqualTo(10L); // ttl
-            assertThat((Long) results.get(3)).isGreaterThan(0L).isLessThanOrEqualTo(20000L); // pTtl
-            assertThat((Boolean) results.get(4)).isTrue(); // persist
-            
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-        }
-    }
+			DataType hashType = connection.keyCommands().type(hashKey.getBytes());
+			assertThat(hashType).isEqualTo(DataType.HASH);
+		}
+		finally {
+			cleanupKey(stringKey);
+			cleanupKey(listKey);
+			cleanupKey(hashKey);
+		}
+	}
 
-    @Test
-    void testVoidMethodsTransaction() {
-        String oldKey = "test:key:transaction:rename:old";
-        String newKey = "test:key:transaction:rename:new";
-        String restoreKey = "test:key:transaction:restore";
-        byte[] value = "test_value".getBytes();
-        
-        try {
-            // Set up test data
-            connection.stringCommands().set(oldKey.getBytes(), value);
-            byte[] serialized = connection.keyCommands().dump(oldKey.getBytes());
-            
-            // Start transaction
-            connection.multi();
-            
-            // Void methods should return null in transaction mode but still queue the command
-            connection.keyCommands().rename(oldKey.getBytes(), newKey.getBytes());
-            connection.keyCommands().restore(restoreKey.getBytes(), 0, serialized, false);
-            
-            // Execute transaction and collect results
-            List<Object> results = connection.exec();
-            
-            // Verify results - void methods should return "OK" responses
-            assertThat(results).hasSize(2);
-            assertThat(results.get(0)).isEqualTo("OK"); // rename
-            assertThat(results.get(1)).isEqualTo("OK"); // restore
-            
-            // Verify operations actually succeeded
-            Boolean newExists = connection.keyCommands().exists(newKey.getBytes());
-            assertThat(newExists).isTrue();
-            
-            Boolean restoreExists = connection.keyCommands().exists(restoreKey.getBytes());
-            assertThat(restoreExists).isTrue();
-            
-        } finally {
-            cleanupKey(oldKey);
-            cleanupKey(newKey);
-            cleanupKey(restoreKey);
-        }
-    }
+	@Test
+	void testTouch() {
+		String key1 = "test:key:touch:key1";
+		String key2 = "test:key:touch:key2";
+		String key3 = "test:key:touch:key3";
+		byte[] value = "test_value".getBytes();
 
-    @Test
-    void testAdvancedKeyOperationsTransaction() {
-        String key1 = "test:key:transaction:advanced:key1";
-        String key2 = "test:key:transaction:advanced:key2";
-        String key3 = "test:key:transaction:advanced:key3";
-        String listKey = "test:key:transaction:advanced:list";
-        String storeKey = "test:key:transaction:advanced:store";
-        String renameKey = "test:key:transaction:advanced:rename";
-        String newRenameKey = "test:key:transaction:advanced:newrename";
-        String basePattern = "test:key:transaction:advanced:";
-        byte[] value = "test_value".getBytes();
-        
-        try {
-            // Set up test data
-            connection.stringCommands().set(key1.getBytes(), value);
-            connection.stringCommands().set(key2.getBytes(), value);
-            connection.stringCommands().set(key3.getBytes(), value);
-            connection.stringCommands().set(renameKey.getBytes(), value);
-            connection.listCommands().lPush(listKey.getBytes(), "c".getBytes());
-            connection.listCommands().lPush(listKey.getBytes(), "a".getBytes());
-            connection.listCommands().lPush(listKey.getBytes(), "b".getBytes());
-            
-            // Start transaction
-            connection.multi();
-            
-            // Test all missing operations - transaction commands should return null
-            Long unlinkResult = connection.keyCommands().unlink(key1.getBytes(), key2.getBytes());
-            assertThat(unlinkResult).isNull();
-            
-            Set<byte[]> keysResult = connection.keyCommands().keys((basePattern + "*").getBytes());
-            assertThat(keysResult).isNull();
-            
-            byte[] randomKeyResult = connection.keyCommands().randomKey();
-            assertThat(randomKeyResult).isNull();
-            
-            Boolean renameNXResult = connection.keyCommands().renameNX(renameKey.getBytes(), newRenameKey.getBytes());
-            assertThat(renameNXResult).isNull();
-            
-            Boolean moveResult = connection.keyCommands().move(key3.getBytes(), 1);
-            assertThat(moveResult).isNull();
-            
-            long futureTimestamp = System.currentTimeMillis() / 1000 + 30;
-            Boolean expireAtResult = connection.keyCommands().expireAt(newRenameKey.getBytes(), futureTimestamp);
-            assertThat(expireAtResult).isNull();
-            
-            long futureTimestampMillis = System.currentTimeMillis() + 30000;
-            Boolean pExpireAtResult = connection.keyCommands().pExpireAt(newRenameKey.getBytes(), futureTimestampMillis);
-            assertThat(pExpireAtResult).isNull();
-            
-            Long ttlTimeUnitResult = connection.keyCommands().ttl(newRenameKey.getBytes(), TimeUnit.MILLISECONDS);
-            assertThat(ttlTimeUnitResult).isNull();
-            
-            SortParameters sortParams = new DefaultSortParameters().alpha();
-            List<byte[]> sortResult = connection.keyCommands().sort(listKey.getBytes(), sortParams);
-            assertThat(sortResult).isNull();
-            
-            Long sortStoreResult = connection.keyCommands().sort(listKey.getBytes(), sortParams, storeKey.getBytes());
-            assertThat(sortStoreResult).isNull();
-            
-            byte[] dumpResult = connection.keyCommands().dump(newRenameKey.getBytes());
-            assertThat(dumpResult).isNull();
-            
-            ValueEncoding encodingResult = connection.keyCommands().encodingOf(newRenameKey.getBytes());
-            assertThat(encodingResult).isNull();
-            
-            Duration idletimeResult = connection.keyCommands().idletime(newRenameKey.getBytes());
-            assertThat(idletimeResult).isNull();
-            
-            Long refcountResult = connection.keyCommands().refcount(newRenameKey.getBytes());
-            assertThat(refcountResult).isNull();
-            
-            // Execute transaction and collect results
-            List<Object> results = connection.exec();
-            
-            // Verify results in order
-            assertThat(results).hasSize(14);
-            assertThat((Long) results.get(0)).isEqualTo(2L); // unlink(key1, key2)
-            assertThat((Set<?>) results.get(1)).isNotNull(); // keys(pattern)
-            assertThat(results.get(2)).isNotNull(); // randomKey() - should return some key
-            assertThat((Boolean) results.get(3)).isTrue(); // renameNX succeeded
-            assertThat(results.get(4)).isNotNull(); // move result (depends on DB config)
-            assertThat((Boolean) results.get(5)).isTrue(); // expireAt
-            assertThat((Boolean) results.get(6)).isTrue(); // pExpireAt  
-            assertThat(results.get(7)).isNotNull(); // ttl with TimeUnit
-            assertThat((List<?>) results.get(8)).hasSize(3); // sort result
-            assertThat((Long) results.get(9)).isEqualTo(3L); // sort store result
-            assertThat(results.get(10)).isNotNull(); // dump result
-            assertThat(results.get(11)).isNotNull(); // encodingOf result
-            assertThat(results.get(12)).isNotNull(); // idletime result
-            assertThat(results.get(13)).isNotNull(); // refcount result
-            
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-            cleanupKey(key3);
-            cleanupKey(listKey);
-            cleanupKey(storeKey);
-            cleanupKey(renameKey);
-            cleanupKey(newRenameKey);
-        }
-    }
+		try {
+			// Test touch on non-existent keys
+			Long touchResult1 = connection.keyCommands().touch(key1.getBytes(), key2.getBytes());
+			assertThat(touchResult1).isEqualTo(0L);
 
-    // ==================== PIPELINE MODE TTL TIMEUNIT CONVERSION TESTS ====================
+			// Set up test data
+			connection.stringCommands().set(key1.getBytes(), value);
+			connection.stringCommands().set(key2.getBytes(), value);
 
-    @Test
-    void testTtlTimeUnitConversionPipeline() {
-        String key = "test:key:pipeline:ttl:conversion";
-        byte[] value = "test_value".getBytes();
-        
-        try {
-            // Set up test data
-            connection.stringCommands().set(key.getBytes(), value);
-            
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Set 1 day expiration (86400 seconds)
-            Boolean expireResult = connection.keyCommands().expire(key.getBytes(), 86400);
-            assertThat(expireResult).isNull(); // Should be null in pipeline mode
-            
-            // Get TTL in various time units - all should return null in pipeline mode
-            Long ttlSeconds = connection.keyCommands().ttl(key.getBytes());
-            assertThat(ttlSeconds).isNull();
-            
-            Long ttlMinutes = connection.keyCommands().ttl(key.getBytes(), TimeUnit.MINUTES);
-            assertThat(ttlMinutes).isNull();
-            
-            Long ttlHours = connection.keyCommands().ttl(key.getBytes(), TimeUnit.HOURS);
-            assertThat(ttlHours).isNull();
-            
-            Long ttlMilliseconds = connection.keyCommands().ttl(key.getBytes(), TimeUnit.MILLISECONDS);
-            assertThat(ttlMilliseconds).isNull();
-            
-            // Execute pipeline and collect results
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results - this is the critical test case that was failing
-            assertThat(results).hasSize(5);
-            assertThat((Boolean) results.get(0)).isTrue(); // expire succeeded
-            
-            // TTL in seconds should be around 86400 (1 day)
-            Long actualTtlSeconds = (Long) results.get(1);
-            assertThat(actualTtlSeconds).isGreaterThanOrEqualTo(86390L).isLessThanOrEqualTo(86400L);
-            
-            // TTL in minutes should be around 1440 (24 hours * 60 minutes)
-            Long actualTtlMinutes = (Long) results.get(2);
-            assertThat(actualTtlMinutes).isGreaterThanOrEqualTo(1439L).isLessThanOrEqualTo(1440L);
-            
-            // TTL in hours should be around 24 - THIS WAS THE FAILING CASE
-            Long actualTtlHours = (Long) results.get(3);
-            assertThat(actualTtlHours).isGreaterThanOrEqualTo(23L).isLessThanOrEqualTo(24L);
-            
-            // TTL in milliseconds should be around 86400000 (1 day in ms)
-            Long actualTtlMilliseconds = (Long) results.get(4);
-            assertThat(actualTtlMilliseconds).isGreaterThanOrEqualTo(86390000L).isLessThanOrEqualTo(86400000L);
-            
-            // Verify conversion relationships
-            if (actualTtlHours != null && actualTtlHours > 0) {
-                double hoursToSecondsRatio = (double) actualTtlSeconds / actualTtlHours;
-                assertThat(hoursToSecondsRatio).isBetween(3500.0, 3700.0); // ~3600 seconds per hour
-                
-                double hoursToMillisecondsRatio = (double) actualTtlMilliseconds / actualTtlHours;
-                assertThat(hoursToMillisecondsRatio).isBetween(3500000.0, 3800000.0); // ~3600000 ms per hour
-            }
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test touch on existing keys
+			Long touchResult2 = connection.keyCommands().touch(key1.getBytes(), key2.getBytes(), key3.getBytes());
+			assertThat(touchResult2).isEqualTo(2L); // Only 2 keys exist
 
-    @Test
-    void testPTtlTimeUnitConversionPipeline() {
-        String key = "test:key:pipeline:pttl:conversion";
-        byte[] value = "test_value".getBytes();
-        
-        try {
-            // Set up test data
-            connection.stringCommands().set(key.getBytes(), value);
-            
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Set 1 day expiration in milliseconds (86400000 ms)
-            Boolean pExpireResult = connection.keyCommands().pExpire(key.getBytes(), 86400000L);
-            assertThat(pExpireResult).isNull(); // Should be null in pipeline mode
-            
-            // Get PTTL in various time units - all should return null in pipeline mode
-            Long pTtlMilliseconds = connection.keyCommands().pTtl(key.getBytes());
-            assertThat(pTtlMilliseconds).isNull();
-            
-            Long pTtlSeconds = connection.keyCommands().pTtl(key.getBytes(), TimeUnit.SECONDS);
-            assertThat(pTtlSeconds).isNull();
-            
-            Long pTtlMinutes = connection.keyCommands().pTtl(key.getBytes(), TimeUnit.MINUTES);
-            assertThat(pTtlMinutes).isNull();
-            
-            Long pTtlHours = connection.keyCommands().pTtl(key.getBytes(), TimeUnit.HOURS);
-            assertThat(pTtlHours).isNull();
-            
-            // Execute pipeline and collect results
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(5);
-            assertThat((Boolean) results.get(0)).isTrue(); // pExpire succeeded
-            
-            // PTTL in milliseconds should be around 86400000 (1 day)
-            Long actualPTtlMilliseconds = (Long) results.get(1);
-            assertThat(actualPTtlMilliseconds).isGreaterThanOrEqualTo(86390000L).isLessThanOrEqualTo(86400000L);
-            
-            // PTTL in seconds should be around 86400 (1 day in seconds)
-            Long actualPTtlSeconds = (Long) results.get(2);
-            assertThat(actualPTtlSeconds).isGreaterThanOrEqualTo(86390L).isLessThanOrEqualTo(86400L);
-            
-            // PTTL in minutes should be around 1440 (24 hours * 60 minutes)
-            Long actualPTtlMinutes = (Long) results.get(3);
-            assertThat(actualPTtlMinutes).isGreaterThanOrEqualTo(1439L).isLessThanOrEqualTo(1440L);
-            
-            // PTTL in hours should be around 24
-            Long actualPTtlHours = (Long) results.get(4);
-            assertThat(actualPTtlHours).isGreaterThanOrEqualTo(23L).isLessThanOrEqualTo(24L);
-            
-            // Verify conversion relationships
-            if (actualPTtlHours != null && actualPTtlHours > 0) {
-                double hoursToMillisecondsRatio = (double) actualPTtlMilliseconds / actualPTtlHours;
-                assertThat(hoursToMillisecondsRatio).isBetween(3500000.0, 3800000.0); // ~3600000 ms per hour
-            }
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test single key touch
+			Long touchResult3 = connection.keyCommands().touch(key1.getBytes());
+			assertThat(touchResult3).isEqualTo(1L);
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+			cleanupKey(key3);
+		}
+	}
 
-    // ==================== TRANSACTION MODE TTL TIMEUNIT CONVERSION TESTS ====================
+	@Test
+	void testKeys() {
+		String basePattern = "test:key:keys:";
+		String key1 = basePattern + "abc";
+		String key2 = basePattern + "def";
+		String key3 = basePattern + "xyz";
+		String otherKey = "test:other:pattern";
+		byte[] value = "test_value".getBytes();
 
-    @Test
-    void testTtlTimeUnitConversionTransaction() {
-        String key = "test:key:transaction:ttl:conversion";
-        byte[] value = "test_value".getBytes();
-        
-        try {
-            // Set up test data
-            connection.stringCommands().set(key.getBytes(), value);
-            
-            // Start transaction
-            connection.multi();
-            
-            // Set 1 day expiration (86400 seconds)
-            Boolean expireResult = connection.keyCommands().expire(key.getBytes(), 86400);
-            assertThat(expireResult).isNull(); // Should be null in transaction mode
-            
-            // Get TTL in various time units - all should return null in transaction mode
-            Long ttlSeconds = connection.keyCommands().ttl(key.getBytes());
-            assertThat(ttlSeconds).isNull();
-            
-            Long ttlMinutes = connection.keyCommands().ttl(key.getBytes(), TimeUnit.MINUTES);
-            assertThat(ttlMinutes).isNull();
-            
-            Long ttlHours = connection.keyCommands().ttl(key.getBytes(), TimeUnit.HOURS);
-            assertThat(ttlHours).isNull();
-            
-            Long ttlMilliseconds = connection.keyCommands().ttl(key.getBytes(), TimeUnit.MILLISECONDS);
-            assertThat(ttlMilliseconds).isNull();
-            
-            // Execute transaction and collect results
-            List<Object> results = connection.exec();
-            
-            // Verify results - this is the critical test case that was failing
-            assertThat(results).hasSize(5);
-            assertThat((Boolean) results.get(0)).isTrue(); // expire succeeded
-            
-            // TTL in seconds should be around 86400 (1 day)
-            Long actualTtlSeconds = (Long) results.get(1);
-            assertThat(actualTtlSeconds).isGreaterThanOrEqualTo(86390L).isLessThanOrEqualTo(86400L);
-            
-            // TTL in minutes should be around 1440 (24 hours * 60 minutes)
-            Long actualTtlMinutes = (Long) results.get(2);
-            assertThat(actualTtlMinutes).isGreaterThanOrEqualTo(1439L).isLessThanOrEqualTo(1440L);
-            
-            // TTL in hours should be around 24 - THIS WAS THE FAILING CASE
-            Long actualTtlHours = (Long) results.get(3);
-            assertThat(actualTtlHours).isGreaterThanOrEqualTo(23L).isLessThanOrEqualTo(24L);
-            
-            // TTL in milliseconds should be around 86400000 (1 day in ms)
-            Long actualTtlMilliseconds = (Long) results.get(4);
-            assertThat(actualTtlMilliseconds).isGreaterThanOrEqualTo(86390000L).isLessThanOrEqualTo(86400000L);
-            
-            // Verify conversion relationships
-            if (actualTtlHours != null && actualTtlHours > 0) {
-                double hoursToSecondsRatio = (double) actualTtlSeconds / actualTtlHours;
-                assertThat(hoursToSecondsRatio).isBetween(3500.0, 3700.0); // ~3600 seconds per hour
-                
-                double hoursToMillisecondsRatio = (double) actualTtlMilliseconds / actualTtlHours;
-                assertThat(hoursToMillisecondsRatio).isBetween(3500000.0, 3800000.0); // ~3600000 ms per hour
-            }
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+		try {
+			// Set up test data
+			connection.stringCommands().set(key1.getBytes(), value);
+			connection.stringCommands().set(key2.getBytes(), value);
+			connection.stringCommands().set(key3.getBytes(), value);
+			connection.stringCommands().set(otherKey.getBytes(), value);
 
-    @Test
-    void testPTtlTimeUnitConversionTransaction() {
-        String key = "test:key:transaction:pttl:conversion";
-        byte[] value = "test_value".getBytes();
-        
-        try {
-            // Set up test data
-            connection.stringCommands().set(key.getBytes(), value);
-            
-            // Start transaction
-            connection.multi();
-            
-            // Set 1 day expiration in milliseconds (86400000 ms)
-            Boolean pExpireResult = connection.keyCommands().pExpire(key.getBytes(), 86400000L);
-            assertThat(pExpireResult).isNull(); // Should be null in transaction mode
-            
-            // Get PTTL in various time units - all should return null in transaction mode
-            Long pTtlMilliseconds = connection.keyCommands().pTtl(key.getBytes());
-            assertThat(pTtlMilliseconds).isNull();
-            
-            Long pTtlSeconds = connection.keyCommands().pTtl(key.getBytes(), TimeUnit.SECONDS);
-            assertThat(pTtlSeconds).isNull();
-            
-            Long pTtlMinutes = connection.keyCommands().pTtl(key.getBytes(), TimeUnit.MINUTES);
-            assertThat(pTtlMinutes).isNull();
-            
-            Long pTtlHours = connection.keyCommands().pTtl(key.getBytes(), TimeUnit.HOURS);
-            assertThat(pTtlHours).isNull();
-            
-            // Execute transaction and collect results
-            List<Object> results = connection.exec();
-            
-            // Verify results
-            assertThat(results).hasSize(5);
-            assertThat((Boolean) results.get(0)).isTrue(); // pExpire succeeded
-            
-            // PTTL in milliseconds should be around 86400000 (1 day)
-            Long actualPTtlMilliseconds = (Long) results.get(1);
-            assertThat(actualPTtlMilliseconds).isGreaterThanOrEqualTo(86390000L).isLessThanOrEqualTo(86400000L);
-            
-            // PTTL in seconds should be around 86400 (1 day in seconds)
-            Long actualPTtlSeconds = (Long) results.get(2);
-            assertThat(actualPTtlSeconds).isGreaterThanOrEqualTo(86390L).isLessThanOrEqualTo(86400L);
-            
-            // PTTL in minutes should be around 1440 (24 hours * 60 minutes)
-            Long actualPTtlMinutes = (Long) results.get(3);
-            assertThat(actualPTtlMinutes).isGreaterThanOrEqualTo(1439L).isLessThanOrEqualTo(1440L);
-            
-            // PTTL in hours should be around 24
-            Long actualPTtlHours = (Long) results.get(4);
-            assertThat(actualPTtlHours).isGreaterThanOrEqualTo(23L).isLessThanOrEqualTo(24L);
-            
-            // Verify conversion relationships
-            if (actualPTtlHours != null && actualPTtlHours > 0) {
-                double hoursToMillisecondsRatio = (double) actualPTtlMilliseconds / actualPTtlHours;
-                assertThat(hoursToMillisecondsRatio).isBetween(3500000.0, 3800000.0); // ~3600000 ms per hour
-            }
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test pattern matching
+			Set<byte[]> matchedKeys = connection.keyCommands().keys((basePattern + "*").getBytes());
+			assertThat(matchedKeys).hasSize(3);
 
-    // ==================== ERROR HANDLING AND EDGE CASES ====================
+			// Convert to strings for easier comparison
+			Set<String> matchedKeyStrings = matchedKeys.stream()
+				.map(String::new)
+				.collect(java.util.stream.Collectors.toSet());
 
-    @Test
-    void testKeyOperationsErrorHandling() {
-        // Test operations on null keys (should throw IllegalArgumentException)
-        assertThatThrownBy(() -> connection.keyCommands().exists((byte[]) null))
-            .isInstanceOf(IllegalArgumentException.class);
-        
-        assertThatThrownBy(() -> connection.keyCommands().del((byte[]) null))
-            .isInstanceOf(IllegalArgumentException.class);
-        
-        // Test rename with non-existent key (should throw an exception)
-        assertThatThrownBy(() -> connection.keyCommands().rename("non:existent:key".getBytes(), "new:key".getBytes()))
-            .isInstanceOf(Exception.class);
-    }
+			assertThat(matchedKeyStrings).containsExactlyInAnyOrder(key1, key2, key3);
 
-    @Test
-    @EnabledOnValkeyVersion("7.0") // ExpirationOptions conditions (NX, XX, GT, LT) added in Redis 7.0
-    void testAdvancedExpirationConditions() {
-        String key = "test:key:advanced:expiration";
-        byte[] value = "test_value".getBytes();
-        
-        try {
-            // ========== expireAt with conditions ==========
-            connection.stringCommands().set(key.getBytes(), value);
-            long futureTimestamp = System.currentTimeMillis() / 1000 + 30;
-            
-            // Test expireAt with NX condition (key must not have expiration)
-            Boolean expireAtNX1 = connection.keyCommands().expireAt(key.getBytes(), futureTimestamp, ExpirationOptions.Condition.NX);
-            assertThat(expireAtNX1).isTrue(); // Should succeed, key had no expiration
-            
-            Boolean expireAtNX2 = connection.keyCommands().expireAt(key.getBytes(), futureTimestamp + 10, ExpirationOptions.Condition.NX);
-            assertThat(expireAtNX2).isFalse(); // Should fail, key already has expiration
-            
-            // Test expireAt with XX condition (key must have expiration)
-            Boolean expireAtXX1 = connection.keyCommands().expireAt(key.getBytes(), futureTimestamp + 20, ExpirationOptions.Condition.XX);
-            assertThat(expireAtXX1).isTrue(); // Should succeed, key has expiration
-            
-            // Remove expiration
-            connection.keyCommands().persist(key.getBytes());
-            
-            Boolean expireAtXX2 = connection.keyCommands().expireAt(key.getBytes(), futureTimestamp + 30, ExpirationOptions.Condition.XX);
-            assertThat(expireAtXX2).isFalse(); // Should fail, key has no expiration
-            
-            // ========== pExpireAt with conditions ==========
-            long futureTimestampMillis = System.currentTimeMillis() + 30000;
-            
-            // Test pExpireAt with NX condition (key must not have expiration)
-            Boolean pExpireAtNX1 = connection.keyCommands().pExpireAt(key.getBytes(), futureTimestampMillis, ExpirationOptions.Condition.NX);
-            assertThat(pExpireAtNX1).isTrue(); // Should succeed, key had no expiration
-            
-            Boolean pExpireAtNX2 = connection.keyCommands().pExpireAt(key.getBytes(), futureTimestampMillis + 10000, ExpirationOptions.Condition.NX);
-            assertThat(pExpireAtNX2).isFalse(); // Should fail, key already has expiration
-            
-            // Test pExpireAt with XX condition (key must have expiration)
-            Boolean pExpireAtXX1 = connection.keyCommands().pExpireAt(key.getBytes(), futureTimestampMillis + 20000, ExpirationOptions.Condition.XX);
-            assertThat(pExpireAtXX1).isTrue(); // Should succeed, key has expiration
-            
-            // Remove expiration
-            connection.keyCommands().persist(key.getBytes());
-            
-            Boolean pExpireAtXX2 = connection.keyCommands().pExpireAt(key.getBytes(), futureTimestampMillis + 30000, ExpirationOptions.Condition.XX);
-            assertThat(pExpireAtXX2).isFalse(); // Should fail, key has no expiration
-            
-            // ========== Test cross-validation between methods ==========
-            // Set expiration with expire, then test with expireAt XX condition
-            connection.keyCommands().expire(key.getBytes(), 60); // 60 seconds
-            Boolean expireAtXXAfterExpire = connection.keyCommands().expireAt(key.getBytes(), futureTimestamp + 60, ExpirationOptions.Condition.XX);
-            assertThat(expireAtXXAfterExpire).isTrue(); // Should succeed, key has expiration from expire()
-            
-            // Set expiration with pExpire, then test with pExpireAt XX condition
-            connection.keyCommands().pExpire(key.getBytes(), 120000); // 120 seconds in milliseconds
-            Boolean pExpireAtXXAfterPExpire = connection.keyCommands().pExpireAt(key.getBytes(), futureTimestampMillis + 120000, ExpirationOptions.Condition.XX);
-            assertThat(pExpireAtXXAfterPExpire).isTrue(); // Should succeed, key has expiration from pExpire()
-            
-            // ========== Test conditions on non-existent key ==========
-            Boolean expireAtNonExistent = connection.keyCommands().expireAt("non:existent:key".getBytes(), futureTimestamp, ExpirationOptions.Condition.NX);
-            assertThat(expireAtNonExistent).isFalse(); // Should fail, key doesn't exist
-            
-            Boolean pExpireAtNonExistent = connection.keyCommands().pExpireAt("non:existent:key".getBytes(), futureTimestampMillis, ExpirationOptions.Condition.XX);
-            assertThat(pExpireAtNonExistent).isFalse(); // Should fail, key doesn't exist
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test specific pattern
+			Set<byte[]> specificMatch = connection.keyCommands().keys((basePattern + "a*").getBytes());
+			assertThat(specificMatch).hasSize(1);
+			assertThat(new String(specificMatch.iterator().next())).isEqualTo(key1);
 
-    @Test
-    void testExpirationOperationsEdgeCases() {
-        String key = "test:key:expiration:edge";
-        byte[] value = "test_value".getBytes();
-        
-        try {
-            // Test expiration operations on non-existent key (should return false)
-            Boolean expireNonExistent = connection.keyCommands().expire("non:existent:key".getBytes(), 10);
-            assertThat(expireNonExistent).isFalse();
-            
-            // Test with zero expiration (should delete the key immediately)
-            connection.stringCommands().set(key.getBytes(), value);
-            Boolean expireZero = connection.keyCommands().expire(key.getBytes(), 0);
-            assertThat(expireZero).isTrue(); // Should return true since key existed
-            Boolean keyExistsAfterZero = connection.keyCommands().exists(key.getBytes());
-            assertThat(keyExistsAfterZero).isFalse(); // Key should be deleted
-            
-            // Test with negative expiration (should delete the key immediately)
-            connection.stringCommands().set(key.getBytes(), value);
-            Boolean expireNegative = connection.keyCommands().expire(key.getBytes(), -1);
-            assertThat(expireNegative).isTrue(); // Should return true since key existed
-            Boolean keyExistsAfterNegative = connection.keyCommands().exists(key.getBytes());
-            assertThat(keyExistsAfterNegative).isFalse(); // Key should be deleted
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test non-matching pattern
+			Set<byte[]> noMatch = connection.keyCommands().keys("no:match:*".getBytes());
+			assertThat(noMatch).isEmpty();
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+			cleanupKey(key3);
+			cleanupKey(otherKey);
+		}
+	}
 
-    // ==================== DELEX / DIGEST Tests ====================
+	@Test
+	void testRandomKey() {
+		String key1 = "test:key:random:key1";
+		String key2 = "test:key:random:key2";
+		byte[] value = "test_value".getBytes();
 
-    @Test
-    @EnabledOnCommand("DELEX")
-    void testDelexShouldDeleteKeyWhenValueEqual() {
-        String key = "test:key:delex";
-        byte[] keyBytes = key.getBytes();
-        byte[] value = "bar".getBytes();
+		try {
+			// Set up test data
+			connection.stringCommands().set(key1.getBytes(), value);
+			connection.stringCommands().set(key2.getBytes(), value);
 
-        try {
-            // Set a key
-            connection.stringCommands().set(keyBytes, value);
+			// Test randomKey when keys exist
+			byte[] randomKey = connection.keyCommands().randomKey();
+			assertThat(randomKey).isNotNull();
 
-            // Test delex with condition that does NOT match - should not delete
-            Boolean result1 = connection.keyCommands().delex(keyBytes, CompareCondition.ifNotEquals(value));
-            assertThat(result1).isFalse();
+			// Should be one of our keys or some other key in the database
+			String randomKeyStr = new String(randomKey);
+			assertThat(randomKeyStr).isNotEmpty();
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+		}
+	}
 
-            // Key should still exist
-            assertThat(connection.keyCommands().exists(keyBytes)).isTrue();
+	@Test
+	void testScan() {
+		String basePattern = "test:key:scan:";
+		String key1 = basePattern + "item1";
+		String key2 = basePattern + "item2";
+		String key3 = basePattern + "other1";
+		byte[] value = "test_value".getBytes();
 
-            // Test delex with condition that DOES match - should delete
-            Boolean result2 = connection.keyCommands().delex(keyBytes, CompareCondition.ifEquals(value));
-            assertThat(result2).isTrue();
+		try {
+			// Set up test data
+			connection.stringCommands().set(key1.getBytes(), value);
+			connection.stringCommands().set(key2.getBytes(), value);
+			connection.stringCommands().set(key3.getBytes(), value);
 
-            // Key should no longer exist
-            assertThat(connection.keyCommands().exists(keyBytes)).isFalse();
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test basic scan
+			ScanOptions options = ScanOptions.scanOptions().match(basePattern + "*").build();
+			Cursor<byte[]> cursor = connection.keyCommands().scan(options);
 
-    @Test
-    @EnabledOnCommand("DELEX")
-    void testDelexShouldDeleteKeyWhenDigestEqual() {
-        String key = "test:key:delex:digest";
-        byte[] keyBytes = key.getBytes();
-        byte[] value = "bar".getBytes();
+			java.util.List<String> scannedKeys = new java.util.ArrayList<>();
+			while (cursor.hasNext()) {
+				scannedKeys.add(new String(cursor.next()));
+			}
+			cursor.close();
 
-        try {
-            // Set a key
-            connection.stringCommands().set(keyBytes, value);
+			// Should find our test keys
+			assertThat(scannedKeys).containsAll(java.util.Arrays.asList(key1, key2, key3));
 
-            // Get the actual digest for the value
-            String actualDigest = connection.keyCommands().digest(keyBytes);
+			// Test scan with count
+			ScanOptions countOptions = ScanOptions.scanOptions().count(1).build();
+			Cursor<byte[]> countCursor = connection.keyCommands().scan(countOptions);
 
-            // Test delex with wrong digest - should not delete
-            Boolean result1 = connection.keyCommands().delex(keyBytes, CompareCondition.ifDigestEquals("aabbccddeeff0000"));
-            assertThat(result1).isFalse();
+			java.util.List<String> countScannedKeys = new java.util.ArrayList<>();
+			while (countCursor.hasNext()) {
+				countScannedKeys.add(new String(countCursor.next()));
+			}
+			countCursor.close();
 
-            // Key should still exist
-            assertThat(connection.keyCommands().exists(keyBytes)).isTrue();
+			// Should get results, but in smaller batches
+			assertThat(countScannedKeys).isNotEmpty();
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+			cleanupKey(key3);
+		}
+	}
 
-            // Test delex with correct digest - should delete
-            Boolean result2 = connection.keyCommands().delex(keyBytes, CompareCondition.ifDigestEquals(actualDigest));
-            assertThat(result2).isTrue();
+	@Test
+	void testRename() {
+		String oldKey = "test:key:rename:old";
+		String newKey = "test:key:rename:new";
+		byte[] value = "test_value".getBytes();
 
-            // Key should no longer exist
-            assertThat(connection.keyCommands().exists(keyBytes)).isFalse();
-        } finally {
-            cleanupKey(key);
-        }
-    }
+		try {
+			// Set up test data
+			connection.stringCommands().set(oldKey.getBytes(), value);
 
-    @Test
-    @EnabledOnCommand("DIGEST")
-    void testDigestShouldReturnDigestForExistingKey() {
-        String key = "test:key:digest";
-        byte[] keyBytes = key.getBytes();
-        byte[] value = "bar".getBytes();
+			// Test rename
+			connection.keyCommands().rename(oldKey.getBytes(), newKey.getBytes());
 
-        try {
-            // Set a key
-            connection.stringCommands().set(keyBytes, value);
+			// Verify old key no longer exists
+			Boolean oldExists = connection.keyCommands().exists(oldKey.getBytes());
+			assertThat(oldExists).isFalse();
 
-            // Get digest
-            String digest = connection.keyCommands().digest(keyBytes);
-            assertThat(digest).isNotNull();
-            assertThat(digest).hasSize(16); // digest is a 16-character hex string
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Verify new key exists with correct value
+			Boolean newExists = connection.keyCommands().exists(newKey.getBytes());
+			assertThat(newExists).isTrue();
+
+			byte[] newValue = connection.stringCommands().get(newKey.getBytes());
+			assertThat(newValue).isEqualTo(value);
+		}
+		finally {
+			cleanupKey(oldKey);
+			cleanupKey(newKey);
+		}
+	}
+
+	@Test
+	void testRenameNX() {
+		String oldKey = "test:key:renamenx:old";
+		String newKey = "test:key:renamenx:new";
+		String existingKey = "test:key:renamenx:existing";
+		byte[] value = "test_value".getBytes();
+		byte[] existingValue = "existing_value".getBytes();
+
+		try {
+			// Set up test data
+			connection.stringCommands().set(oldKey.getBytes(), value);
+			connection.stringCommands().set(existingKey.getBytes(), existingValue);
+
+			// Test renameNX to non-existing key (should succeed)
+			Boolean renameResult1 = connection.keyCommands().renameNX(oldKey.getBytes(), newKey.getBytes());
+			assertThat(renameResult1).isTrue();
+
+			// Verify rename was successful
+			Boolean oldExists = connection.keyCommands().exists(oldKey.getBytes());
+			assertThat(oldExists).isFalse();
+
+			Boolean newExists = connection.keyCommands().exists(newKey.getBytes());
+			assertThat(newExists).isTrue();
+
+			// Test renameNX to existing key (should fail)
+			Boolean renameResult2 = connection.keyCommands().renameNX(newKey.getBytes(), existingKey.getBytes());
+			assertThat(renameResult2).isFalse();
+
+			// Verify keys remain unchanged
+			Boolean newStillExists = connection.keyCommands().exists(newKey.getBytes());
+			assertThat(newStillExists).isTrue();
+
+			byte[] existingStillValue = connection.stringCommands().get(existingKey.getBytes());
+			assertThat(existingStillValue).isEqualTo(existingValue);
+		}
+		finally {
+			cleanupKey(oldKey);
+			cleanupKey(newKey);
+			cleanupKey(existingKey);
+		}
+	}
+
+	@Test
+	void testExpire() {
+		String key = "test:key:expire";
+		byte[] value = "test_value".getBytes();
+
+		try {
+			// Test expire
+			connection.stringCommands().set(key.getBytes(), value);
+			Boolean expireResult = connection.keyCommands().expire(key.getBytes(), 1);
+			assertThat(expireResult).isTrue();
+
+			// Verify key still exists initially
+			Boolean exists1 = connection.keyCommands().exists(key.getBytes());
+			assertThat(exists1).isTrue();
+
+			// Wait for expiration
+			Thread.sleep(2000);
+			Boolean exists2 = connection.keyCommands().exists(key.getBytes());
+			assertThat(exists2).isFalse();
+
+			// Test expire on non-existent key
+			Boolean expireNonExistent = connection.keyCommands().expire("non:existent:key".getBytes(), 1);
+			assertThat(expireNonExistent).isFalse();
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	@EnabledOnValkeyVersion("7.0") // ExpirationOptions conditions (NX, XX, GT, LT) added
+									// in Redis 7.0
+	void testExpirationConditions() {
+		String key = "test:key:expire";
+		byte[] value = "test_value".getBytes();
+
+		try {
+			// Test expire with NX condition (key must not have expiration)
+			connection.stringCommands().set(key.getBytes(), value);
+			Boolean expireNX1 = connection.keyCommands().expire(key.getBytes(), 10, ExpirationOptions.Condition.NX);
+			assertThat(expireNX1).isTrue(); // Should succeed, key had no expiration
+
+			Boolean expireNX2 = connection.keyCommands().expire(key.getBytes(), 20, ExpirationOptions.Condition.NX);
+			assertThat(expireNX2).isFalse(); // Should fail, key already has expiration
+
+			// Test expire with XX condition (key must have expiration)
+			Boolean expireXX1 = connection.keyCommands().expire(key.getBytes(), 30, ExpirationOptions.Condition.XX);
+			assertThat(expireXX1).isTrue(); // Should succeed, key has expiration
+
+			// Test expire with GT condition (new expiration must be greater than current)
+			Boolean expireGT1 = connection.keyCommands().expire(key.getBytes(), 20, ExpirationOptions.Condition.GT);
+			assertThat(expireGT1).isFalse(); // Should fail, 20s < 30s (current)
+
+			Boolean expireGT2 = connection.keyCommands().expire(key.getBytes(), 40, ExpirationOptions.Condition.GT);
+			assertThat(expireGT2).isTrue(); // Should succeed, 40s > 30s (current)
+
+			// Test expire with LT condition (new expiration must be less than current)
+			Boolean expireLT1 = connection.keyCommands().expire(key.getBytes(), 50, ExpirationOptions.Condition.LT);
+			assertThat(expireLT1).isFalse(); // Should fail, 50s > 40s (current)
+
+			Boolean expireLT2 = connection.keyCommands().expire(key.getBytes(), 35, ExpirationOptions.Condition.LT);
+			assertThat(expireLT2).isTrue(); // Should succeed, 35s < 40s (current)
+
+			// Remove expiration
+			connection.keyCommands().persist(key.getBytes());
+
+			Boolean expireXX2 = connection.keyCommands().expire(key.getBytes(), 40, ExpirationOptions.Condition.XX);
+			assertThat(expireXX2).isFalse(); // Should fail, key has no expiration
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testPExpire() {
+		String key = "test:key:pexpire";
+		byte[] value = "test_value".getBytes();
+
+		try {
+			// Test pExpire (milliseconds)
+			connection.stringCommands().set(key.getBytes(), value);
+			Boolean pExpireResult = connection.keyCommands().pExpire(key.getBytes(), 1000);
+			assertThat(pExpireResult).isTrue();
+
+			// Verify key still exists initially
+			Boolean exists1 = connection.keyCommands().exists(key.getBytes());
+			assertThat(exists1).isTrue();
+
+			// Wait for expiration
+			Thread.sleep(2000);
+			Boolean exists2 = connection.keyCommands().exists(key.getBytes());
+			assertThat(exists2).isFalse();
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testExpireAt() {
+		String key = "test:key:expireat";
+		byte[] value = "test_value".getBytes();
+
+		try {
+			// Test expireAt
+			connection.stringCommands().set(key.getBytes(), value);
+			long futureTimestamp = System.currentTimeMillis() / 1000 + 1;
+
+			Boolean expireAtResult = connection.keyCommands().expireAt(key.getBytes(), futureTimestamp);
+			assertThat(expireAtResult).isTrue();
+
+			// Verify key still exists initially
+			Boolean exists1 = connection.keyCommands().exists(key.getBytes());
+			assertThat(exists1).isTrue();
+
+			// Wait for expiration
+			Thread.sleep(2000);
+			Boolean exists2 = connection.keyCommands().exists(key.getBytes());
+			assertThat(exists2).isFalse();
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testPExpireAt() {
+		String key = "test:key:pexpireat";
+		byte[] value = "test_value".getBytes();
+
+		try {
+			// Test pExpireAt
+			connection.stringCommands().set(key.getBytes(), value);
+			long futureTimestampMillis = System.currentTimeMillis() + 1000;
+
+			Boolean pExpireAtResult = connection.keyCommands().pExpireAt(key.getBytes(), futureTimestampMillis);
+			assertThat(pExpireAtResult).isTrue();
+
+			// Verify key still exists initially
+			Boolean exists1 = connection.keyCommands().exists(key.getBytes());
+			assertThat(exists1).isTrue();
+
+			// Wait for expiration
+			Thread.sleep(2000);
+			Boolean exists2 = connection.keyCommands().exists(key.getBytes());
+			assertThat(exists2).isFalse();
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testPersist() {
+		String key = "test:key:persist";
+		byte[] value = "test_value".getBytes();
+
+		try {
+			// Set up test data with expiration
+			connection.stringCommands().set(key.getBytes(), value);
+			connection.keyCommands().expire(key.getBytes(), 10); // 10 seconds
+
+			// Test persist
+			Boolean persistResult = connection.keyCommands().persist(key.getBytes());
+			assertThat(persistResult).isTrue();
+
+			// Verify TTL is now -1 (no expiration)
+			Long ttl = connection.keyCommands().ttl(key.getBytes());
+			assertThat(ttl).isEqualTo(-1L);
+
+			// Test persist on key without expiration
+			Boolean persistResult2 = connection.keyCommands().persist(key.getBytes());
+			assertThat(persistResult2).isFalse();
+
+			// Test persist on non-existent key
+			Boolean persistNonExistent = connection.keyCommands().persist("non:existent:key".getBytes());
+			assertThat(persistNonExistent).isFalse();
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testMove() {
+		String key = "test:key:move";
+		byte[] value = "test_value".getBytes();
+
+		try {
+			// Set up test data
+			connection.stringCommands().set(key.getBytes(), value);
+
+			// Test move to different database (assuming database 1 exists)
+			Boolean moveResult = connection.keyCommands().move(key.getBytes(), 1);
+			// Note: Move behavior depends on Valkey configuration and available databases
+			// In many test setups, only database 0 is available, so move might fail
+			// We'll just verify the method executes without throwing an exception
+			assertThat(moveResult).isNotNull();
+
+			// Test move non-existent key
+			Boolean moveNonExistent = connection.keyCommands().move("non:existent:key".getBytes(), 1);
+			assertThat(moveNonExistent).isFalse();
+		}
+		finally {
+			cleanupKey(key);
+			// Also cleanup from database 1 if move succeeded
+			try {
+				connection.select(1);
+				connection.keyCommands().del(key.getBytes());
+				connection.select(0);
+			}
+			catch (Exception e) {
+				// Ignore errors when switching databases in test environment
+			}
+		}
+	}
+
+	@Test
+	void testTtl() {
+		String key = "test:key:ttl";
+		byte[] value = "test_value".getBytes();
+
+		try {
+			// Test TTL on non-existent key
+			Long nonExistentTtl = connection.keyCommands().ttl("non:existent:key".getBytes());
+			assertThat(nonExistentTtl).isEqualTo(-2L); // Key doesn't exist
+
+			// Set up test data without expiration
+			connection.stringCommands().set(key.getBytes(), value);
+			Long noExpirationTtl = connection.keyCommands().ttl(key.getBytes());
+			assertThat(noExpirationTtl).isEqualTo(-1L); // No expiration set
+
+			// Set expiration and test TTL
+			connection.keyCommands().expire(key.getBytes(), 10);
+			Long ttl = connection.keyCommands().ttl(key.getBytes());
+			assertThat(ttl).isGreaterThan(0L).isLessThanOrEqualTo(10L);
+
+			// Test TTL with time unit conversion
+			Long ttlInMillis = connection.keyCommands().ttl(key.getBytes(), TimeUnit.MILLISECONDS);
+			assertThat(ttlInMillis).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testPTtl() {
+		String key = "test:key:pttl";
+		byte[] value = "test_value".getBytes();
+
+		try {
+			// Set up test data with expiration
+			connection.stringCommands().set(key.getBytes(), value);
+			connection.keyCommands().pExpire(key.getBytes(), 10000); // 10 seconds in
+																		// milliseconds
+
+			// Test pTtl
+			Long pTtl = connection.keyCommands().pTtl(key.getBytes());
+			assertThat(pTtl).isGreaterThan(0L).isLessThanOrEqualTo(10000L);
+
+			// Test pTtl with time unit conversion
+			Long pTtlInSeconds = connection.keyCommands().pTtl(key.getBytes(), TimeUnit.SECONDS);
+			assertThat(pTtlInSeconds).isGreaterThan(0L).isLessThanOrEqualTo(10L);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testTtlTimeUnitSpecialValues() {
+		String key = "test:key:ttl:special";
+		byte[] value = "test_value".getBytes();
+
+		try {
+			// Test TTL on non-existent key with TimeUnit conversion
+			// Should return -2 (key doesn't exist) without conversion
+			Long ttlNonExistentSeconds = connection.keyCommands().ttl("non:existent:key".getBytes(), TimeUnit.SECONDS);
+			assertThat(ttlNonExistentSeconds).isEqualTo(-2L);
+
+			Long ttlNonExistentMillis = connection.keyCommands()
+				.ttl("non:existent:key".getBytes(), TimeUnit.MILLISECONDS);
+			assertThat(ttlNonExistentMillis).isEqualTo(-2L);
+
+			Long ttlNonExistentMinutes = connection.keyCommands().ttl("non:existent:key".getBytes(), TimeUnit.MINUTES);
+			assertThat(ttlNonExistentMinutes).isEqualTo(-2L);
+
+			// Test TTL on key without expiration with TimeUnit conversion
+			// Should return -1 (no expiration) without conversion
+			connection.stringCommands().set(key.getBytes(), value);
+
+			Long ttlNoExpirationSeconds = connection.keyCommands().ttl(key.getBytes(), TimeUnit.SECONDS);
+			assertThat(ttlNoExpirationSeconds).isEqualTo(-1L);
+
+			Long ttlNoExpirationMillis = connection.keyCommands().ttl(key.getBytes(), TimeUnit.MILLISECONDS);
+			assertThat(ttlNoExpirationMillis).isEqualTo(-1L);
+
+			Long ttlNoExpirationMinutes = connection.keyCommands().ttl(key.getBytes(), TimeUnit.MINUTES);
+			assertThat(ttlNoExpirationMinutes).isEqualTo(-1L);
+
+			// Test TTL on key with expiration - should convert properly
+			connection.keyCommands().expire(key.getBytes(), 60); // 60 seconds
+
+			Long ttlWithExpirationSeconds = connection.keyCommands().ttl(key.getBytes(), TimeUnit.SECONDS);
+			assertThat(ttlWithExpirationSeconds).isGreaterThan(0L).isLessThanOrEqualTo(60L);
+
+			Long ttlWithExpirationMillis = connection.keyCommands().ttl(key.getBytes(), TimeUnit.MILLISECONDS);
+			assertThat(ttlWithExpirationMillis).isGreaterThan(0L).isLessThanOrEqualTo(60000L);
+
+			// Verify conversion is correct: milliseconds should be roughly 1000x seconds
+			if (ttlWithExpirationSeconds != null && ttlWithExpirationSeconds > 0) {
+				double ratio = (double) ttlWithExpirationMillis / ttlWithExpirationSeconds;
+				assertThat(ratio).isBetween(900.0, 1100.0); // Allow some timing variance
+			}
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testPTtlTimeUnitSpecialValues() {
+		String key = "test:key:pttl:special";
+		byte[] value = "test_value".getBytes();
+
+		try {
+			// Test PTTL on non-existent key with TimeUnit conversion
+			// Should return -2 (key doesn't exist) without conversion
+			Long pTtlNonExistentSeconds = connection.keyCommands()
+				.pTtl("non:existent:key".getBytes(), TimeUnit.SECONDS);
+			assertThat(pTtlNonExistentSeconds).isEqualTo(-2L);
+
+			Long pTtlNonExistentMillis = connection.keyCommands()
+				.pTtl("non:existent:key".getBytes(), TimeUnit.MILLISECONDS);
+			assertThat(pTtlNonExistentMillis).isEqualTo(-2L);
+
+			Long pTtlNonExistentMinutes = connection.keyCommands()
+				.pTtl("non:existent:key".getBytes(), TimeUnit.MINUTES);
+			assertThat(pTtlNonExistentMinutes).isEqualTo(-2L);
+
+			// Test PTTL on key without expiration with TimeUnit conversion
+			// Should return -1 (no expiration) without conversion
+			connection.stringCommands().set(key.getBytes(), value);
+
+			Long pTtlNoExpirationSeconds = connection.keyCommands().pTtl(key.getBytes(), TimeUnit.SECONDS);
+			assertThat(pTtlNoExpirationSeconds).isEqualTo(-1L);
+
+			Long pTtlNoExpirationMillis = connection.keyCommands().pTtl(key.getBytes(), TimeUnit.MILLISECONDS);
+			assertThat(pTtlNoExpirationMillis).isEqualTo(-1L);
+
+			Long pTtlNoExpirationMinutes = connection.keyCommands().pTtl(key.getBytes(), TimeUnit.MINUTES);
+			assertThat(pTtlNoExpirationMinutes).isEqualTo(-1L);
+
+			// Test PTTL on key with expiration - should convert properly
+			connection.keyCommands().pExpire(key.getBytes(), 60000); // 60 seconds in
+																		// milliseconds
+
+			Long pTtlWithExpirationMillis = connection.keyCommands().pTtl(key.getBytes(), TimeUnit.MILLISECONDS);
+			assertThat(pTtlWithExpirationMillis).isGreaterThan(0L).isLessThanOrEqualTo(60000L);
+
+			Long pTtlWithExpirationSeconds = connection.keyCommands().pTtl(key.getBytes(), TimeUnit.SECONDS);
+			assertThat(pTtlWithExpirationSeconds).isGreaterThan(0L).isLessThanOrEqualTo(60L);
+
+			// Verify conversion is correct: milliseconds should be roughly 1000x seconds
+			if (pTtlWithExpirationSeconds != null && pTtlWithExpirationSeconds > 0) {
+				double ratio = (double) pTtlWithExpirationMillis / pTtlWithExpirationSeconds;
+				assertThat(ratio).isBetween(900.0, 1100.0); // Allow some timing variance
+			}
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testSortComprehensive() {
+		String listKey = "test:key:sort:list";
+		String storeKey = "test:key:sort:store";
+
+		try {
+			// Set up test data - add some sortable values
+			connection.listCommands().lPush(listKey.getBytes(), "3".getBytes());
+			connection.listCommands().lPush(listKey.getBytes(), "1".getBytes());
+			connection.listCommands().lPush(listKey.getBytes(), "2".getBytes());
+
+			// Test sort without parameters
+			List<byte[]> sortedResult1 = connection.keyCommands().sort(listKey.getBytes(), null);
+			assertThat(sortedResult1).hasSize(3);
+			// Should be sorted as strings: "1", "2", "3"
+			assertThat(new String(sortedResult1.get(0))).isEqualTo("1");
+			assertThat(new String(sortedResult1.get(1))).isEqualTo("2");
+			assertThat(new String(sortedResult1.get(2))).isEqualTo("3");
+
+			// Test sort with LIMIT parameters
+			SortParameters params1 = new DefaultSortParameters().limit(0, 2);
+			List<byte[]> sortedResult2 = connection.keyCommands().sort(listKey.getBytes(), params1);
+			assertThat(sortedResult2).hasSize(2); // Limited by count
+			assertThat(new String(sortedResult2.get(0))).isEqualTo("1");
+			assertThat(new String(sortedResult2.get(1))).isEqualTo("2");
+
+			// Test sort with DESC order
+			SortParameters params2 = new DefaultSortParameters().desc();
+			List<byte[]> sortedResult3 = connection.keyCommands().sort(listKey.getBytes(), params2);
+			assertThat(sortedResult3).hasSize(3);
+			assertThat(new String(sortedResult3.get(0))).isEqualTo("3");
+			assertThat(new String(sortedResult3.get(1))).isEqualTo("2");
+			assertThat(new String(sortedResult3.get(2))).isEqualTo("1");
+
+			// Test sort with ASC order (explicit)
+			SortParameters params3 = new DefaultSortParameters().asc();
+			List<byte[]> sortedResult4 = connection.keyCommands().sort(listKey.getBytes(), params3);
+			assertThat(sortedResult4).hasSize(3);
+			assertThat(new String(sortedResult4.get(0))).isEqualTo("1");
+			assertThat(new String(sortedResult4.get(1))).isEqualTo("2");
+			assertThat(new String(sortedResult4.get(2))).isEqualTo("3");
+
+			// Test sort with alphabetic ordering
+			connection.keyCommands().del(listKey.getBytes());
+			connection.listCommands().lPush(listKey.getBytes(), "b".getBytes());
+			connection.listCommands().lPush(listKey.getBytes(), "a".getBytes());
+			connection.listCommands().lPush(listKey.getBytes(), "c".getBytes());
+
+			SortParameters params4 = new DefaultSortParameters().alpha();
+			List<byte[]> sortedResult5 = connection.keyCommands().sort(listKey.getBytes(), params4);
+			assertThat(sortedResult5).hasSize(3);
+			assertThat(new String(sortedResult5.get(0))).isEqualTo("a");
+			assertThat(new String(sortedResult5.get(1))).isEqualTo("b");
+			assertThat(new String(sortedResult5.get(2))).isEqualTo("c");
+
+			// Test sort with multiple parameters combined
+			SortParameters params5 = new DefaultSortParameters().alpha().desc().limit(0, 2);
+			List<byte[]> sortedResult6 = connection.keyCommands().sort(listKey.getBytes(), params5);
+			assertThat(sortedResult6).hasSize(2);
+			assertThat(new String(sortedResult6.get(0))).isEqualTo("c");
+			assertThat(new String(sortedResult6.get(1))).isEqualTo("b");
+
+			// Test sort with store (use alphabetic sort since list contains "a", "b",
+			// "c")
+			Long storeResult = connection.keyCommands().sort(listKey.getBytes(), params4, storeKey.getBytes());
+			assertThat(storeResult).isEqualTo(3L); // 3 elements stored
+
+			// Verify stored results
+			List<byte[]> storedList = connection.listCommands().lRange(storeKey.getBytes(), 0, -1);
+			assertThat(storedList).hasSize(3);
+
+			// Test sort with store and parameters
+			Long storeResult2 = connection.keyCommands().sort(listKey.getBytes(), params4, storeKey.getBytes());
+			assertThat(storeResult2).isEqualTo(3L);
+
+		}
+		finally {
+			cleanupKey(listKey);
+			cleanupKey(storeKey);
+		}
+	}
+
+	@Test
+	void testDumpRestore() {
+		String sourceKey = "test:key:dump";
+		String restoreKey = "test:key:restore";
+		byte[] value = "test_value".getBytes();
+
+		try {
+			// Set up test data
+			connection.stringCommands().set(sourceKey.getBytes(), value);
+
+			// Test dump
+			byte[] serialized = connection.keyCommands().dump(sourceKey.getBytes());
+			assertThat(serialized).isNotNull();
+
+			// Test dump on non-existent key
+			byte[] nonExistentDump = connection.keyCommands().dump("non:existent:key".getBytes());
+			assertThat(nonExistentDump).isNull();
+
+			// Test restore
+			connection.keyCommands().restore(restoreKey.getBytes(), 0, serialized, false);
+
+			// Verify restore was successful
+			byte[] restoredValue = connection.stringCommands().get(restoreKey.getBytes());
+			assertThat(restoredValue).isEqualTo(value);
+
+			// Test restore with replace
+			byte[] newValue = "new_value".getBytes();
+			connection.stringCommands().set(sourceKey.getBytes(), newValue);
+			byte[] newSerialized = connection.keyCommands().dump(sourceKey.getBytes());
+
+			connection.keyCommands().restore(restoreKey.getBytes(), 0, newSerialized, true);
+			byte[] replacedValue = connection.stringCommands().get(restoreKey.getBytes());
+			assertThat(replacedValue).isEqualTo(newValue);
+		}
+		finally {
+			cleanupKey(sourceKey);
+			cleanupKey(restoreKey);
+		}
+	}
+
+	@Test
+	void testObjectIntrospection() {
+		String key = "test:key:encoding";
+		byte[] value = "test_value".getBytes();
+
+		try {
+			// Set up test data
+			connection.stringCommands().set(key.getBytes(), value);
+
+			// Test encodingOf
+			ValueEncoding encoding = connection.keyCommands().encodingOf(key.getBytes());
+			assertThat(encoding).isNotNull();
+			// The exact encoding depends on Valkey/Valkey version and configuration
+
+			// Test encodingOf on non-existent key
+			ValueEncoding nonExistentEncoding = connection.keyCommands().encodingOf("non:existent:key".getBytes());
+			assertThat(nonExistentEncoding).isEqualTo(ValueEncoding.ValkeyValueEncoding.VACANT);
+
+			// Test idletime
+			Duration idletime = connection.keyCommands().idletime(key.getBytes());
+			assertThat(idletime).isNotNull();
+			assertThat(idletime.getSeconds()).isGreaterThanOrEqualTo(0);
+
+			// Test idletime on non-existent key
+			Duration nonExistentIdletime = connection.keyCommands().idletime("non:existent:key".getBytes());
+			assertThat(nonExistentIdletime).isNull();
+
+			// Test refcount
+			Long refcount = connection.keyCommands().refcount(key.getBytes());
+			assertThat(refcount).isNotNull();
+			assertThat(refcount).isGreaterThan(0);
+
+			// Test refcount on non-existent key
+			Long nonExistentRefcount = connection.keyCommands().refcount("non:existent:key".getBytes());
+			assertThat(nonExistentRefcount).isNull();
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== PIPELINE MODE TESTS ====================
+
+	@Test
+	void testKeyOperationsPipeline() {
+		String key1 = "test:key:pipeline:key1";
+		String key2 = "test:key:pipeline:key2";
+		String key3 = "test:key:pipeline:key3";
+		byte[] value = "test_value".getBytes();
+
+		try {
+			// Set up test data
+			connection.stringCommands().set(key1.getBytes(), value);
+			connection.stringCommands().set(key2.getBytes(), value);
+
+			// Start pipeline
+			connection.openPipeline();
+
+			// Pipeline commands should return null
+			Boolean existsResult = connection.keyCommands().exists(key1.getBytes());
+			assertThat(existsResult).isNull();
+
+			Long existsMultipleResult = connection.keyCommands()
+				.exists(key1.getBytes(), key2.getBytes(), key3.getBytes());
+			assertThat(existsMultipleResult).isNull();
+
+			DataType typeResult = connection.keyCommands().type(key1.getBytes());
+			assertThat(typeResult).isNull();
+
+			Long touchResult = connection.keyCommands().touch(key1.getBytes(), key2.getBytes());
+			assertThat(touchResult).isNull();
+
+			Boolean copyResult = connection.keyCommands().copy(key1.getBytes(), key3.getBytes(), false);
+			assertThat(copyResult).isNull();
+
+			Long delResult = connection.keyCommands().del(key2.getBytes());
+			assertThat(delResult).isNull();
+
+			// Execute pipeline and collect results
+			List<Object> results = connection.closePipeline();
+
+			// Verify results in order
+			assertThat(results).hasSize(6);
+			assertThat((Boolean) results.get(0)).isTrue(); // exists(key1)
+			assertThat((Long) results.get(1)).isEqualTo(2L); // exists multiple (key1,
+																// key2 existed)
+			assertThat((DataType) results.get(2)).isEqualTo(DataType.STRING); // type(key1)
+			assertThat((Long) results.get(3)).isEqualTo(2L); // touch(key1, key2)
+			assertThat((Boolean) results.get(4)).isTrue(); // copy(key1 -> key3)
+			assertThat((Long) results.get(5)).isEqualTo(1L); // del(key2)
+
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+			cleanupKey(key3);
+		}
+	}
+
+	@Test
+	void testExpirationOperationsPipeline() {
+		String key1 = "test:key:pipeline:expire1";
+		String key2 = "test:key:pipeline:expire2";
+		byte[] value = "test_value".getBytes();
+
+		try {
+			// Set up test data
+			connection.stringCommands().set(key1.getBytes(), value);
+			connection.stringCommands().set(key2.getBytes(), value);
+
+			// Start pipeline
+			connection.openPipeline();
+
+			// Pipeline commands should return null
+			Boolean expireResult = connection.keyCommands().expire(key1.getBytes(), 10);
+			assertThat(expireResult).isNull();
+
+			Boolean pExpireResult = connection.keyCommands().pExpire(key2.getBytes(), 20000);
+			assertThat(pExpireResult).isNull();
+
+			Long ttlResult = connection.keyCommands().ttl(key1.getBytes());
+			assertThat(ttlResult).isNull();
+
+			Long pTtlResult = connection.keyCommands().pTtl(key2.getBytes());
+			assertThat(pTtlResult).isNull();
+
+			Boolean persistResult = connection.keyCommands().persist(key1.getBytes());
+			assertThat(persistResult).isNull();
+
+			// Execute pipeline and collect results
+			List<Object> results = connection.closePipeline();
+
+			// Verify results in order
+			assertThat(results).hasSize(5);
+			assertThat((Boolean) results.get(0)).isTrue(); // expire
+			assertThat((Boolean) results.get(1)).isTrue(); // pExpire
+			assertThat((Long) results.get(2)).isGreaterThan(0L).isLessThanOrEqualTo(10L); // ttl
+			assertThat((Long) results.get(3)).isGreaterThan(0L).isLessThanOrEqualTo(20000L); // pTtl
+			assertThat((Boolean) results.get(4)).isTrue(); // persist
+
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+		}
+	}
+
+	@Test
+	void testVoidMethodsPipeline() {
+		String oldKey = "test:key:pipeline:rename:old";
+		String newKey = "test:key:pipeline:rename:new";
+		String restoreKey = "test:key:pipeline:restore";
+		byte[] value = "test_value".getBytes();
+
+		try {
+			// Set up test data
+			connection.stringCommands().set(oldKey.getBytes(), value);
+			byte[] serialized = connection.keyCommands().dump(oldKey.getBytes());
+
+			// Start pipeline
+			connection.openPipeline();
+
+			// Void methods should return null in pipeline mode but still queue the
+			// command
+			connection.keyCommands().rename(oldKey.getBytes(), newKey.getBytes());
+			connection.keyCommands().restore(restoreKey.getBytes(), 0, serialized, false);
+
+			// Execute pipeline and collect results
+			List<Object> results = connection.closePipeline();
+
+			// Verify results - void methods should return "OK" responses
+			assertThat(results).hasSize(2);
+			assertThat(results.get(0)).isEqualTo("OK"); // rename
+			assertThat(results.get(1)).isEqualTo("OK"); // restore
+
+			// Verify operations actually succeeded
+			Boolean newExists = connection.keyCommands().exists(newKey.getBytes());
+			assertThat(newExists).isTrue();
+
+			Boolean restoreExists = connection.keyCommands().exists(restoreKey.getBytes());
+			assertThat(restoreExists).isTrue();
+
+		}
+		finally {
+			cleanupKey(oldKey);
+			cleanupKey(newKey);
+			cleanupKey(restoreKey);
+		}
+	}
+
+	@Test
+	void testAdvancedKeyOperationsPipeline() {
+		String key1 = "test:key:pipeline:advanced:key1";
+		String key2 = "test:key:pipeline:advanced:key2";
+		String key3 = "test:key:pipeline:advanced:key3";
+		String listKey = "test:key:pipeline:advanced:list";
+		String storeKey = "test:key:pipeline:advanced:store";
+		String renameKey = "test:key:pipeline:advanced:rename";
+		String newRenameKey = "test:key:pipeline:advanced:newrename";
+		String basePattern = "test:key:pipeline:advanced:";
+		byte[] value = "test_value".getBytes();
+
+		try {
+			// Set up test data
+			connection.stringCommands().set(key1.getBytes(), value);
+			connection.stringCommands().set(key2.getBytes(), value);
+			connection.stringCommands().set(key3.getBytes(), value);
+			connection.stringCommands().set(renameKey.getBytes(), value);
+			connection.listCommands().lPush(listKey.getBytes(), "c".getBytes());
+			connection.listCommands().lPush(listKey.getBytes(), "a".getBytes());
+			connection.listCommands().lPush(listKey.getBytes(), "b".getBytes());
+
+			// Start pipeline
+			connection.openPipeline();
+
+			// Test all missing operations - pipeline commands should return null
+			Long unlinkResult = connection.keyCommands().unlink(key1.getBytes(), key2.getBytes());
+			assertThat(unlinkResult).isNull();
+
+			Set<byte[]> keysResult = connection.keyCommands().keys((basePattern + "*").getBytes());
+			assertThat(keysResult).isNull();
+
+			byte[] randomKeyResult = connection.keyCommands().randomKey();
+			assertThat(randomKeyResult).isNull();
+
+			Boolean renameNXResult = connection.keyCommands().renameNX(renameKey.getBytes(), newRenameKey.getBytes());
+			assertThat(renameNXResult).isNull();
+
+			Boolean moveResult = connection.keyCommands().move(key3.getBytes(), 1);
+			assertThat(moveResult).isNull();
+
+			long futureTimestamp = System.currentTimeMillis() / 1000 + 30;
+			Boolean expireAtResult = connection.keyCommands().expireAt(newRenameKey.getBytes(), futureTimestamp);
+			assertThat(expireAtResult).isNull();
+
+			long futureTimestampMillis = System.currentTimeMillis() + 30000;
+			Boolean pExpireAtResult = connection.keyCommands()
+				.pExpireAt(newRenameKey.getBytes(), futureTimestampMillis);
+			assertThat(pExpireAtResult).isNull();
+
+			Long ttlTimeUnitResult = connection.keyCommands().ttl(newRenameKey.getBytes(), TimeUnit.MILLISECONDS);
+			assertThat(ttlTimeUnitResult).isNull();
+
+			SortParameters sortParams = new DefaultSortParameters().alpha();
+			List<byte[]> sortResult = connection.keyCommands().sort(listKey.getBytes(), sortParams);
+			assertThat(sortResult).isNull();
+
+			Long sortStoreResult = connection.keyCommands().sort(listKey.getBytes(), sortParams, storeKey.getBytes());
+			assertThat(sortStoreResult).isNull();
+
+			byte[] dumpResult = connection.keyCommands().dump(newRenameKey.getBytes());
+			assertThat(dumpResult).isNull();
+
+			ValueEncoding encodingResult = connection.keyCommands().encodingOf(newRenameKey.getBytes());
+			assertThat(encodingResult).isNull();
+
+			Duration idletimeResult = connection.keyCommands().idletime(newRenameKey.getBytes());
+			assertThat(idletimeResult).isNull();
+
+			Long refcountResult = connection.keyCommands().refcount(newRenameKey.getBytes());
+			assertThat(refcountResult).isNull();
+
+			// Execute pipeline and collect results
+			List<Object> results = connection.closePipeline();
+
+			// Verify results in order
+			assertThat(results).hasSize(14);
+			assertThat((Long) results.get(0)).isEqualTo(2L); // unlink(key1, key2)
+			assertThat((Set<?>) results.get(1)).isNotNull(); // keys(pattern)
+			assertThat(results.get(2)).isNotNull(); // randomKey() - should return some
+													// key
+			assertThat((Boolean) results.get(3)).isTrue(); // renameNX succeeded
+			assertThat(results.get(4)).isNotNull(); // move result (depends on DB config)
+			assertThat((Boolean) results.get(5)).isTrue(); // expireAt
+			assertThat((Boolean) results.get(6)).isTrue(); // pExpireAt
+			assertThat(results.get(7)).isNotNull(); // ttl with TimeUnit
+			assertThat((List<?>) results.get(8)).hasSize(3); // sort result
+			assertThat((Long) results.get(9)).isEqualTo(3L); // sort store result
+			assertThat(results.get(10)).isNotNull(); // dump result
+			assertThat(results.get(11)).isNotNull(); // encodingOf result
+			assertThat(results.get(12)).isNotNull(); // idletime result
+			assertThat(results.get(13)).isNotNull(); // refcount result
+
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+			cleanupKey(key3);
+			cleanupKey(listKey);
+			cleanupKey(storeKey);
+			cleanupKey(renameKey);
+			cleanupKey(newRenameKey);
+		}
+	}
+
+	// ==================== TRANSACTION MODE TESTS ====================
+
+	@Test
+	void testKeyOperationsTransaction() {
+		String key1 = "test:key:transaction:key1";
+		String key2 = "test:key:transaction:key2";
+		String key3 = "test:key:transaction:key3";
+		byte[] value = "test_value".getBytes();
+
+		try {
+			// Set up test data
+			connection.stringCommands().set(key1.getBytes(), value);
+			connection.stringCommands().set(key2.getBytes(), value);
+
+			// Start transaction
+			connection.multi();
+
+			// Transaction commands should return null
+			Boolean existsResult = connection.keyCommands().exists(key1.getBytes());
+			assertThat(existsResult).isNull();
+
+			Long existsMultipleResult = connection.keyCommands()
+				.exists(key1.getBytes(), key2.getBytes(), key3.getBytes());
+			assertThat(existsMultipleResult).isNull();
+
+			DataType typeResult = connection.keyCommands().type(key1.getBytes());
+			assertThat(typeResult).isNull();
+
+			Long touchResult = connection.keyCommands().touch(key1.getBytes(), key2.getBytes());
+			assertThat(touchResult).isNull();
+
+			Boolean copyResult = connection.keyCommands().copy(key1.getBytes(), key3.getBytes(), false);
+			assertThat(copyResult).isNull();
+
+			Long delResult = connection.keyCommands().del(key2.getBytes());
+			assertThat(delResult).isNull();
+
+			// Execute transaction and collect results
+			List<Object> results = connection.exec();
+
+			// Verify results in order
+			assertThat(results).hasSize(6);
+			assertThat((Boolean) results.get(0)).isTrue(); // exists(key1)
+			assertThat((Long) results.get(1)).isEqualTo(2L); // exists multiple (key1,
+																// key2 existed)
+			assertThat((DataType) results.get(2)).isEqualTo(DataType.STRING); // type(key1)
+			assertThat((Long) results.get(3)).isEqualTo(2L); // touch(key1, key2)
+			assertThat((Boolean) results.get(4)).isTrue(); // copy(key1 -> key3)
+			assertThat((Long) results.get(5)).isEqualTo(1L); // del(key2)
+
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+			cleanupKey(key3);
+		}
+	}
+
+	@Test
+	void testExpirationOperationsTransaction() {
+		String key1 = "test:key:transaction:expire1";
+		String key2 = "test:key:transaction:expire2";
+		byte[] value = "test_value".getBytes();
+
+		try {
+			// Set up test data
+			connection.stringCommands().set(key1.getBytes(), value);
+			connection.stringCommands().set(key2.getBytes(), value);
+
+			// Start transaction
+			connection.multi();
+
+			// Transaction commands should return null
+			Boolean expireResult = connection.keyCommands().expire(key1.getBytes(), 10);
+			assertThat(expireResult).isNull();
+
+			Boolean pExpireResult = connection.keyCommands().pExpire(key2.getBytes(), 20000);
+			assertThat(pExpireResult).isNull();
+
+			Long ttlResult = connection.keyCommands().ttl(key1.getBytes());
+			assertThat(ttlResult).isNull();
+
+			Long pTtlResult = connection.keyCommands().pTtl(key2.getBytes());
+			assertThat(pTtlResult).isNull();
+
+			Boolean persistResult = connection.keyCommands().persist(key1.getBytes());
+			assertThat(persistResult).isNull();
+
+			// Execute transaction and collect results
+			List<Object> results = connection.exec();
+
+			// Verify results in order
+			assertThat(results).hasSize(5);
+			assertThat((Boolean) results.get(0)).isTrue(); // expire
+			assertThat((Boolean) results.get(1)).isTrue(); // pExpire
+			assertThat((Long) results.get(2)).isGreaterThan(0L).isLessThanOrEqualTo(10L); // ttl
+			assertThat((Long) results.get(3)).isGreaterThan(0L).isLessThanOrEqualTo(20000L); // pTtl
+			assertThat((Boolean) results.get(4)).isTrue(); // persist
+
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+		}
+	}
+
+	@Test
+	void testVoidMethodsTransaction() {
+		String oldKey = "test:key:transaction:rename:old";
+		String newKey = "test:key:transaction:rename:new";
+		String restoreKey = "test:key:transaction:restore";
+		byte[] value = "test_value".getBytes();
+
+		try {
+			// Set up test data
+			connection.stringCommands().set(oldKey.getBytes(), value);
+			byte[] serialized = connection.keyCommands().dump(oldKey.getBytes());
+
+			// Start transaction
+			connection.multi();
+
+			// Void methods should return null in transaction mode but still queue the
+			// command
+			connection.keyCommands().rename(oldKey.getBytes(), newKey.getBytes());
+			connection.keyCommands().restore(restoreKey.getBytes(), 0, serialized, false);
+
+			// Execute transaction and collect results
+			List<Object> results = connection.exec();
+
+			// Verify results - void methods should return "OK" responses
+			assertThat(results).hasSize(2);
+			assertThat(results.get(0)).isEqualTo("OK"); // rename
+			assertThat(results.get(1)).isEqualTo("OK"); // restore
+
+			// Verify operations actually succeeded
+			Boolean newExists = connection.keyCommands().exists(newKey.getBytes());
+			assertThat(newExists).isTrue();
+
+			Boolean restoreExists = connection.keyCommands().exists(restoreKey.getBytes());
+			assertThat(restoreExists).isTrue();
+
+		}
+		finally {
+			cleanupKey(oldKey);
+			cleanupKey(newKey);
+			cleanupKey(restoreKey);
+		}
+	}
+
+	@Test
+	void testAdvancedKeyOperationsTransaction() {
+		String key1 = "test:key:transaction:advanced:key1";
+		String key2 = "test:key:transaction:advanced:key2";
+		String key3 = "test:key:transaction:advanced:key3";
+		String listKey = "test:key:transaction:advanced:list";
+		String storeKey = "test:key:transaction:advanced:store";
+		String renameKey = "test:key:transaction:advanced:rename";
+		String newRenameKey = "test:key:transaction:advanced:newrename";
+		String basePattern = "test:key:transaction:advanced:";
+		byte[] value = "test_value".getBytes();
+
+		try {
+			// Set up test data
+			connection.stringCommands().set(key1.getBytes(), value);
+			connection.stringCommands().set(key2.getBytes(), value);
+			connection.stringCommands().set(key3.getBytes(), value);
+			connection.stringCommands().set(renameKey.getBytes(), value);
+			connection.listCommands().lPush(listKey.getBytes(), "c".getBytes());
+			connection.listCommands().lPush(listKey.getBytes(), "a".getBytes());
+			connection.listCommands().lPush(listKey.getBytes(), "b".getBytes());
+
+			// Start transaction
+			connection.multi();
+
+			// Test all missing operations - transaction commands should return null
+			Long unlinkResult = connection.keyCommands().unlink(key1.getBytes(), key2.getBytes());
+			assertThat(unlinkResult).isNull();
+
+			Set<byte[]> keysResult = connection.keyCommands().keys((basePattern + "*").getBytes());
+			assertThat(keysResult).isNull();
+
+			byte[] randomKeyResult = connection.keyCommands().randomKey();
+			assertThat(randomKeyResult).isNull();
+
+			Boolean renameNXResult = connection.keyCommands().renameNX(renameKey.getBytes(), newRenameKey.getBytes());
+			assertThat(renameNXResult).isNull();
+
+			Boolean moveResult = connection.keyCommands().move(key3.getBytes(), 1);
+			assertThat(moveResult).isNull();
+
+			long futureTimestamp = System.currentTimeMillis() / 1000 + 30;
+			Boolean expireAtResult = connection.keyCommands().expireAt(newRenameKey.getBytes(), futureTimestamp);
+			assertThat(expireAtResult).isNull();
+
+			long futureTimestampMillis = System.currentTimeMillis() + 30000;
+			Boolean pExpireAtResult = connection.keyCommands()
+				.pExpireAt(newRenameKey.getBytes(), futureTimestampMillis);
+			assertThat(pExpireAtResult).isNull();
+
+			Long ttlTimeUnitResult = connection.keyCommands().ttl(newRenameKey.getBytes(), TimeUnit.MILLISECONDS);
+			assertThat(ttlTimeUnitResult).isNull();
+
+			SortParameters sortParams = new DefaultSortParameters().alpha();
+			List<byte[]> sortResult = connection.keyCommands().sort(listKey.getBytes(), sortParams);
+			assertThat(sortResult).isNull();
+
+			Long sortStoreResult = connection.keyCommands().sort(listKey.getBytes(), sortParams, storeKey.getBytes());
+			assertThat(sortStoreResult).isNull();
+
+			byte[] dumpResult = connection.keyCommands().dump(newRenameKey.getBytes());
+			assertThat(dumpResult).isNull();
+
+			ValueEncoding encodingResult = connection.keyCommands().encodingOf(newRenameKey.getBytes());
+			assertThat(encodingResult).isNull();
+
+			Duration idletimeResult = connection.keyCommands().idletime(newRenameKey.getBytes());
+			assertThat(idletimeResult).isNull();
+
+			Long refcountResult = connection.keyCommands().refcount(newRenameKey.getBytes());
+			assertThat(refcountResult).isNull();
+
+			// Execute transaction and collect results
+			List<Object> results = connection.exec();
+
+			// Verify results in order
+			assertThat(results).hasSize(14);
+			assertThat((Long) results.get(0)).isEqualTo(2L); // unlink(key1, key2)
+			assertThat((Set<?>) results.get(1)).isNotNull(); // keys(pattern)
+			assertThat(results.get(2)).isNotNull(); // randomKey() - should return some
+													// key
+			assertThat((Boolean) results.get(3)).isTrue(); // renameNX succeeded
+			assertThat(results.get(4)).isNotNull(); // move result (depends on DB config)
+			assertThat((Boolean) results.get(5)).isTrue(); // expireAt
+			assertThat((Boolean) results.get(6)).isTrue(); // pExpireAt
+			assertThat(results.get(7)).isNotNull(); // ttl with TimeUnit
+			assertThat((List<?>) results.get(8)).hasSize(3); // sort result
+			assertThat((Long) results.get(9)).isEqualTo(3L); // sort store result
+			assertThat(results.get(10)).isNotNull(); // dump result
+			assertThat(results.get(11)).isNotNull(); // encodingOf result
+			assertThat(results.get(12)).isNotNull(); // idletime result
+			assertThat(results.get(13)).isNotNull(); // refcount result
+
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+			cleanupKey(key3);
+			cleanupKey(listKey);
+			cleanupKey(storeKey);
+			cleanupKey(renameKey);
+			cleanupKey(newRenameKey);
+		}
+	}
+
+	// ==================== PIPELINE MODE TTL TIMEUNIT CONVERSION TESTS
+	// ====================
+
+	@Test
+	void testTtlTimeUnitConversionPipeline() {
+		String key = "test:key:pipeline:ttl:conversion";
+		byte[] value = "test_value".getBytes();
+
+		try {
+			// Set up test data
+			connection.stringCommands().set(key.getBytes(), value);
+
+			// Start pipeline
+			connection.openPipeline();
+
+			// Set 1 day expiration (86400 seconds)
+			Boolean expireResult = connection.keyCommands().expire(key.getBytes(), 86400);
+			assertThat(expireResult).isNull(); // Should be null in pipeline mode
+
+			// Get TTL in various time units - all should return null in pipeline mode
+			Long ttlSeconds = connection.keyCommands().ttl(key.getBytes());
+			assertThat(ttlSeconds).isNull();
+
+			Long ttlMinutes = connection.keyCommands().ttl(key.getBytes(), TimeUnit.MINUTES);
+			assertThat(ttlMinutes).isNull();
+
+			Long ttlHours = connection.keyCommands().ttl(key.getBytes(), TimeUnit.HOURS);
+			assertThat(ttlHours).isNull();
+
+			Long ttlMilliseconds = connection.keyCommands().ttl(key.getBytes(), TimeUnit.MILLISECONDS);
+			assertThat(ttlMilliseconds).isNull();
+
+			// Execute pipeline and collect results
+			List<Object> results = connection.closePipeline();
+
+			// Verify results - this is the critical test case that was failing
+			assertThat(results).hasSize(5);
+			assertThat((Boolean) results.get(0)).isTrue(); // expire succeeded
+
+			// TTL in seconds should be around 86400 (1 day)
+			Long actualTtlSeconds = (Long) results.get(1);
+			assertThat(actualTtlSeconds).isGreaterThanOrEqualTo(86390L).isLessThanOrEqualTo(86400L);
+
+			// TTL in minutes should be around 1440 (24 hours * 60 minutes)
+			Long actualTtlMinutes = (Long) results.get(2);
+			assertThat(actualTtlMinutes).isGreaterThanOrEqualTo(1439L).isLessThanOrEqualTo(1440L);
+
+			// TTL in hours should be around 24 - THIS WAS THE FAILING CASE
+			Long actualTtlHours = (Long) results.get(3);
+			assertThat(actualTtlHours).isGreaterThanOrEqualTo(23L).isLessThanOrEqualTo(24L);
+
+			// TTL in milliseconds should be around 86400000 (1 day in ms)
+			Long actualTtlMilliseconds = (Long) results.get(4);
+			assertThat(actualTtlMilliseconds).isGreaterThanOrEqualTo(86390000L).isLessThanOrEqualTo(86400000L);
+
+			// Verify conversion relationships
+			if (actualTtlHours != null && actualTtlHours > 0) {
+				double hoursToSecondsRatio = (double) actualTtlSeconds / actualTtlHours;
+				assertThat(hoursToSecondsRatio).isBetween(3500.0, 3700.0); // ~3600
+																			// seconds per
+																			// hour
+
+				double hoursToMillisecondsRatio = (double) actualTtlMilliseconds / actualTtlHours;
+				assertThat(hoursToMillisecondsRatio).isBetween(3500000.0, 3800000.0); // ~3600000
+																						// ms
+																						// per
+																						// hour
+			}
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testPTtlTimeUnitConversionPipeline() {
+		String key = "test:key:pipeline:pttl:conversion";
+		byte[] value = "test_value".getBytes();
+
+		try {
+			// Set up test data
+			connection.stringCommands().set(key.getBytes(), value);
+
+			// Start pipeline
+			connection.openPipeline();
+
+			// Set 1 day expiration in milliseconds (86400000 ms)
+			Boolean pExpireResult = connection.keyCommands().pExpire(key.getBytes(), 86400000L);
+			assertThat(pExpireResult).isNull(); // Should be null in pipeline mode
+
+			// Get PTTL in various time units - all should return null in pipeline mode
+			Long pTtlMilliseconds = connection.keyCommands().pTtl(key.getBytes());
+			assertThat(pTtlMilliseconds).isNull();
+
+			Long pTtlSeconds = connection.keyCommands().pTtl(key.getBytes(), TimeUnit.SECONDS);
+			assertThat(pTtlSeconds).isNull();
+
+			Long pTtlMinutes = connection.keyCommands().pTtl(key.getBytes(), TimeUnit.MINUTES);
+			assertThat(pTtlMinutes).isNull();
+
+			Long pTtlHours = connection.keyCommands().pTtl(key.getBytes(), TimeUnit.HOURS);
+			assertThat(pTtlHours).isNull();
+
+			// Execute pipeline and collect results
+			List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(5);
+			assertThat((Boolean) results.get(0)).isTrue(); // pExpire succeeded
+
+			// PTTL in milliseconds should be around 86400000 (1 day)
+			Long actualPTtlMilliseconds = (Long) results.get(1);
+			assertThat(actualPTtlMilliseconds).isGreaterThanOrEqualTo(86390000L).isLessThanOrEqualTo(86400000L);
+
+			// PTTL in seconds should be around 86400 (1 day in seconds)
+			Long actualPTtlSeconds = (Long) results.get(2);
+			assertThat(actualPTtlSeconds).isGreaterThanOrEqualTo(86390L).isLessThanOrEqualTo(86400L);
+
+			// PTTL in minutes should be around 1440 (24 hours * 60 minutes)
+			Long actualPTtlMinutes = (Long) results.get(3);
+			assertThat(actualPTtlMinutes).isGreaterThanOrEqualTo(1439L).isLessThanOrEqualTo(1440L);
+
+			// PTTL in hours should be around 24
+			Long actualPTtlHours = (Long) results.get(4);
+			assertThat(actualPTtlHours).isGreaterThanOrEqualTo(23L).isLessThanOrEqualTo(24L);
+
+			// Verify conversion relationships
+			if (actualPTtlHours != null && actualPTtlHours > 0) {
+				double hoursToMillisecondsRatio = (double) actualPTtlMilliseconds / actualPTtlHours;
+				assertThat(hoursToMillisecondsRatio).isBetween(3500000.0, 3800000.0); // ~3600000
+																						// ms
+																						// per
+																						// hour
+			}
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== TRANSACTION MODE TTL TIMEUNIT CONVERSION TESTS
+	// ====================
+
+	@Test
+	void testTtlTimeUnitConversionTransaction() {
+		String key = "test:key:transaction:ttl:conversion";
+		byte[] value = "test_value".getBytes();
+
+		try {
+			// Set up test data
+			connection.stringCommands().set(key.getBytes(), value);
+
+			// Start transaction
+			connection.multi();
+
+			// Set 1 day expiration (86400 seconds)
+			Boolean expireResult = connection.keyCommands().expire(key.getBytes(), 86400);
+			assertThat(expireResult).isNull(); // Should be null in transaction mode
+
+			// Get TTL in various time units - all should return null in transaction mode
+			Long ttlSeconds = connection.keyCommands().ttl(key.getBytes());
+			assertThat(ttlSeconds).isNull();
+
+			Long ttlMinutes = connection.keyCommands().ttl(key.getBytes(), TimeUnit.MINUTES);
+			assertThat(ttlMinutes).isNull();
+
+			Long ttlHours = connection.keyCommands().ttl(key.getBytes(), TimeUnit.HOURS);
+			assertThat(ttlHours).isNull();
+
+			Long ttlMilliseconds = connection.keyCommands().ttl(key.getBytes(), TimeUnit.MILLISECONDS);
+			assertThat(ttlMilliseconds).isNull();
+
+			// Execute transaction and collect results
+			List<Object> results = connection.exec();
+
+			// Verify results - this is the critical test case that was failing
+			assertThat(results).hasSize(5);
+			assertThat((Boolean) results.get(0)).isTrue(); // expire succeeded
+
+			// TTL in seconds should be around 86400 (1 day)
+			Long actualTtlSeconds = (Long) results.get(1);
+			assertThat(actualTtlSeconds).isGreaterThanOrEqualTo(86390L).isLessThanOrEqualTo(86400L);
+
+			// TTL in minutes should be around 1440 (24 hours * 60 minutes)
+			Long actualTtlMinutes = (Long) results.get(2);
+			assertThat(actualTtlMinutes).isGreaterThanOrEqualTo(1439L).isLessThanOrEqualTo(1440L);
+
+			// TTL in hours should be around 24 - THIS WAS THE FAILING CASE
+			Long actualTtlHours = (Long) results.get(3);
+			assertThat(actualTtlHours).isGreaterThanOrEqualTo(23L).isLessThanOrEqualTo(24L);
+
+			// TTL in milliseconds should be around 86400000 (1 day in ms)
+			Long actualTtlMilliseconds = (Long) results.get(4);
+			assertThat(actualTtlMilliseconds).isGreaterThanOrEqualTo(86390000L).isLessThanOrEqualTo(86400000L);
+
+			// Verify conversion relationships
+			if (actualTtlHours != null && actualTtlHours > 0) {
+				double hoursToSecondsRatio = (double) actualTtlSeconds / actualTtlHours;
+				assertThat(hoursToSecondsRatio).isBetween(3500.0, 3700.0); // ~3600
+																			// seconds per
+																			// hour
+
+				double hoursToMillisecondsRatio = (double) actualTtlMilliseconds / actualTtlHours;
+				assertThat(hoursToMillisecondsRatio).isBetween(3500000.0, 3800000.0); // ~3600000
+																						// ms
+																						// per
+																						// hour
+			}
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testPTtlTimeUnitConversionTransaction() {
+		String key = "test:key:transaction:pttl:conversion";
+		byte[] value = "test_value".getBytes();
+
+		try {
+			// Set up test data
+			connection.stringCommands().set(key.getBytes(), value);
+
+			// Start transaction
+			connection.multi();
+
+			// Set 1 day expiration in milliseconds (86400000 ms)
+			Boolean pExpireResult = connection.keyCommands().pExpire(key.getBytes(), 86400000L);
+			assertThat(pExpireResult).isNull(); // Should be null in transaction mode
+
+			// Get PTTL in various time units - all should return null in transaction mode
+			Long pTtlMilliseconds = connection.keyCommands().pTtl(key.getBytes());
+			assertThat(pTtlMilliseconds).isNull();
+
+			Long pTtlSeconds = connection.keyCommands().pTtl(key.getBytes(), TimeUnit.SECONDS);
+			assertThat(pTtlSeconds).isNull();
+
+			Long pTtlMinutes = connection.keyCommands().pTtl(key.getBytes(), TimeUnit.MINUTES);
+			assertThat(pTtlMinutes).isNull();
+
+			Long pTtlHours = connection.keyCommands().pTtl(key.getBytes(), TimeUnit.HOURS);
+			assertThat(pTtlHours).isNull();
+
+			// Execute transaction and collect results
+			List<Object> results = connection.exec();
+
+			// Verify results
+			assertThat(results).hasSize(5);
+			assertThat((Boolean) results.get(0)).isTrue(); // pExpire succeeded
+
+			// PTTL in milliseconds should be around 86400000 (1 day)
+			Long actualPTtlMilliseconds = (Long) results.get(1);
+			assertThat(actualPTtlMilliseconds).isGreaterThanOrEqualTo(86390000L).isLessThanOrEqualTo(86400000L);
+
+			// PTTL in seconds should be around 86400 (1 day in seconds)
+			Long actualPTtlSeconds = (Long) results.get(2);
+			assertThat(actualPTtlSeconds).isGreaterThanOrEqualTo(86390L).isLessThanOrEqualTo(86400L);
+
+			// PTTL in minutes should be around 1440 (24 hours * 60 minutes)
+			Long actualPTtlMinutes = (Long) results.get(3);
+			assertThat(actualPTtlMinutes).isGreaterThanOrEqualTo(1439L).isLessThanOrEqualTo(1440L);
+
+			// PTTL in hours should be around 24
+			Long actualPTtlHours = (Long) results.get(4);
+			assertThat(actualPTtlHours).isGreaterThanOrEqualTo(23L).isLessThanOrEqualTo(24L);
+
+			// Verify conversion relationships
+			if (actualPTtlHours != null && actualPTtlHours > 0) {
+				double hoursToMillisecondsRatio = (double) actualPTtlMilliseconds / actualPTtlHours;
+				assertThat(hoursToMillisecondsRatio).isBetween(3500000.0, 3800000.0); // ~3600000
+																						// ms
+																						// per
+																						// hour
+			}
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== ERROR HANDLING AND EDGE CASES ====================
+
+	@Test
+	void testKeyOperationsErrorHandling() {
+		// Test operations on null keys (should throw IllegalArgumentException)
+		assertThatThrownBy(() -> connection.keyCommands().exists((byte[]) null))
+			.isInstanceOf(IllegalArgumentException.class);
+
+		assertThatThrownBy(() -> connection.keyCommands().del((byte[]) null))
+			.isInstanceOf(IllegalArgumentException.class);
+
+		// Test rename with non-existent key (should throw an exception)
+		assertThatThrownBy(() -> connection.keyCommands().rename("non:existent:key".getBytes(), "new:key".getBytes()))
+			.isInstanceOf(Exception.class);
+	}
+
+	@Test
+	@EnabledOnValkeyVersion("7.0") // ExpirationOptions conditions (NX, XX, GT, LT) added
+									// in Redis 7.0
+	void testAdvancedExpirationConditions() {
+		String key = "test:key:advanced:expiration";
+		byte[] value = "test_value".getBytes();
+
+		try {
+			// ========== expireAt with conditions ==========
+			connection.stringCommands().set(key.getBytes(), value);
+			long futureTimestamp = System.currentTimeMillis() / 1000 + 30;
+
+			// Test expireAt with NX condition (key must not have expiration)
+			Boolean expireAtNX1 = connection.keyCommands()
+				.expireAt(key.getBytes(), futureTimestamp, ExpirationOptions.Condition.NX);
+			assertThat(expireAtNX1).isTrue(); // Should succeed, key had no expiration
+
+			Boolean expireAtNX2 = connection.keyCommands()
+				.expireAt(key.getBytes(), futureTimestamp + 10, ExpirationOptions.Condition.NX);
+			assertThat(expireAtNX2).isFalse(); // Should fail, key already has expiration
+
+			// Test expireAt with XX condition (key must have expiration)
+			Boolean expireAtXX1 = connection.keyCommands()
+				.expireAt(key.getBytes(), futureTimestamp + 20, ExpirationOptions.Condition.XX);
+			assertThat(expireAtXX1).isTrue(); // Should succeed, key has expiration
+
+			// Remove expiration
+			connection.keyCommands().persist(key.getBytes());
+
+			Boolean expireAtXX2 = connection.keyCommands()
+				.expireAt(key.getBytes(), futureTimestamp + 30, ExpirationOptions.Condition.XX);
+			assertThat(expireAtXX2).isFalse(); // Should fail, key has no expiration
+
+			// ========== pExpireAt with conditions ==========
+			long futureTimestampMillis = System.currentTimeMillis() + 30000;
+
+			// Test pExpireAt with NX condition (key must not have expiration)
+			Boolean pExpireAtNX1 = connection.keyCommands()
+				.pExpireAt(key.getBytes(), futureTimestampMillis, ExpirationOptions.Condition.NX);
+			assertThat(pExpireAtNX1).isTrue(); // Should succeed, key had no expiration
+
+			Boolean pExpireAtNX2 = connection.keyCommands()
+				.pExpireAt(key.getBytes(), futureTimestampMillis + 10000, ExpirationOptions.Condition.NX);
+			assertThat(pExpireAtNX2).isFalse(); // Should fail, key already has expiration
+
+			// Test pExpireAt with XX condition (key must have expiration)
+			Boolean pExpireAtXX1 = connection.keyCommands()
+				.pExpireAt(key.getBytes(), futureTimestampMillis + 20000, ExpirationOptions.Condition.XX);
+			assertThat(pExpireAtXX1).isTrue(); // Should succeed, key has expiration
+
+			// Remove expiration
+			connection.keyCommands().persist(key.getBytes());
+
+			Boolean pExpireAtXX2 = connection.keyCommands()
+				.pExpireAt(key.getBytes(), futureTimestampMillis + 30000, ExpirationOptions.Condition.XX);
+			assertThat(pExpireAtXX2).isFalse(); // Should fail, key has no expiration
+
+			// ========== Test cross-validation between methods ==========
+			// Set expiration with expire, then test with expireAt XX condition
+			connection.keyCommands().expire(key.getBytes(), 60); // 60 seconds
+			Boolean expireAtXXAfterExpire = connection.keyCommands()
+				.expireAt(key.getBytes(), futureTimestamp + 60, ExpirationOptions.Condition.XX);
+			assertThat(expireAtXXAfterExpire).isTrue(); // Should succeed, key has
+														// expiration from expire()
+
+			// Set expiration with pExpire, then test with pExpireAt XX condition
+			connection.keyCommands().pExpire(key.getBytes(), 120000); // 120 seconds in
+																		// milliseconds
+			Boolean pExpireAtXXAfterPExpire = connection.keyCommands()
+				.pExpireAt(key.getBytes(), futureTimestampMillis + 120000, ExpirationOptions.Condition.XX);
+			assertThat(pExpireAtXXAfterPExpire).isTrue(); // Should succeed, key has
+															// expiration from pExpire()
+
+			// ========== Test conditions on non-existent key ==========
+			Boolean expireAtNonExistent = connection.keyCommands()
+				.expireAt("non:existent:key".getBytes(), futureTimestamp, ExpirationOptions.Condition.NX);
+			assertThat(expireAtNonExistent).isFalse(); // Should fail, key doesn't exist
+
+			Boolean pExpireAtNonExistent = connection.keyCommands()
+				.pExpireAt("non:existent:key".getBytes(), futureTimestampMillis, ExpirationOptions.Condition.XX);
+			assertThat(pExpireAtNonExistent).isFalse(); // Should fail, key doesn't exist
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testExpirationOperationsEdgeCases() {
+		String key = "test:key:expiration:edge";
+		byte[] value = "test_value".getBytes();
+
+		try {
+			// Test expiration operations on non-existent key (should return false)
+			Boolean expireNonExistent = connection.keyCommands().expire("non:existent:key".getBytes(), 10);
+			assertThat(expireNonExistent).isFalse();
+
+			// Test with zero expiration (should delete the key immediately)
+			connection.stringCommands().set(key.getBytes(), value);
+			Boolean expireZero = connection.keyCommands().expire(key.getBytes(), 0);
+			assertThat(expireZero).isTrue(); // Should return true since key existed
+			Boolean keyExistsAfterZero = connection.keyCommands().exists(key.getBytes());
+			assertThat(keyExistsAfterZero).isFalse(); // Key should be deleted
+
+			// Test with negative expiration (should delete the key immediately)
+			connection.stringCommands().set(key.getBytes(), value);
+			Boolean expireNegative = connection.keyCommands().expire(key.getBytes(), -1);
+			assertThat(expireNegative).isTrue(); // Should return true since key existed
+			Boolean keyExistsAfterNegative = connection.keyCommands().exists(key.getBytes());
+			assertThat(keyExistsAfterNegative).isFalse(); // Key should be deleted
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== DELEX / DIGEST Tests ====================
+
+	@Test
+	@EnabledOnCommand("DELEX")
+	void testDelexShouldDeleteKeyWhenValueEqual() {
+		String key = "test:key:delex";
+		byte[] keyBytes = key.getBytes();
+		byte[] value = "bar".getBytes();
+
+		try {
+			// Set a key
+			connection.stringCommands().set(keyBytes, value);
+
+			// Test delex with condition that does NOT match - should not delete
+			Boolean result1 = connection.keyCommands().delex(keyBytes, CompareCondition.ifNotEquals(value));
+			assertThat(result1).isFalse();
+
+			// Key should still exist
+			assertThat(connection.keyCommands().exists(keyBytes)).isTrue();
+
+			// Test delex with condition that DOES match - should delete
+			Boolean result2 = connection.keyCommands().delex(keyBytes, CompareCondition.ifEquals(value));
+			assertThat(result2).isTrue();
+
+			// Key should no longer exist
+			assertThat(connection.keyCommands().exists(keyBytes)).isFalse();
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	@EnabledOnCommand("DELEX")
+	void testDelexShouldDeleteKeyWhenDigestEqual() {
+		String key = "test:key:delex:digest";
+		byte[] keyBytes = key.getBytes();
+		byte[] value = "bar".getBytes();
+
+		try {
+			// Set a key
+			connection.stringCommands().set(keyBytes, value);
+
+			// Get the actual digest for the value
+			String actualDigest = connection.keyCommands().digest(keyBytes);
+
+			// Test delex with wrong digest - should not delete
+			Boolean result1 = connection.keyCommands()
+				.delex(keyBytes, CompareCondition.ifDigestEquals("aabbccddeeff0000"));
+			assertThat(result1).isFalse();
+
+			// Key should still exist
+			assertThat(connection.keyCommands().exists(keyBytes)).isTrue();
+
+			// Test delex with correct digest - should delete
+			Boolean result2 = connection.keyCommands().delex(keyBytes, CompareCondition.ifDigestEquals(actualDigest));
+			assertThat(result2).isTrue();
+
+			// Key should no longer exist
+			assertThat(connection.keyCommands().exists(keyBytes)).isFalse();
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	@EnabledOnCommand("DIGEST")
+	void testDigestShouldReturnDigestForExistingKey() {
+		String key = "test:key:digest";
+		byte[] keyBytes = key.getBytes();
+		byte[] value = "bar".getBytes();
+
+		try {
+			// Set a key
+			connection.stringCommands().set(keyBytes, value);
+
+			// Get digest
+			String digest = connection.keyCommands().digest(keyBytes);
+			assertThat(digest).isNotNull();
+			assertThat(digest).hasSize(16); // digest is a 16-character hex string
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
 }

--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionListCommandsIntegrationTests.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionListCommandsIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,1584 +27,1632 @@ import io.valkey.springframework.data.valkey.connection.ValkeyListCommands.Direc
 import io.valkey.springframework.data.valkey.connection.ValkeyListCommands.Position;
 
 /**
- * Comprehensive low-level integration tests for {@link ValkeyGlideConnection} 
- * list functionality using the ValkeyListCommands interface directly.
- * 
- * These tests validate the implementation of all ValkeyListCommands methods:
- * - Basic list operations (rPush, lPush, rPushX, lPushX)
- * - List position operations (lPos variants)
- * - List size operations (lLen)
- * - List range operations (lRange, lTrim)
- * - List index operations (lIndex, lSet)
- * - List insertion operations (lInsert)
- * - List movement operations (lMove, bLMove)
- * - List removal operations (lRem, lPop, rPop with count variants)
- * - Blocking operations (bLPop, bRPop)
- * - Pop and push operations (rPopLPush, bRPopLPush)
+ * Comprehensive low-level integration tests for {@link ValkeyGlideConnection} list
+ * functionality using the ValkeyListCommands interface directly.
+ *
+ * These tests validate the implementation of all ValkeyListCommands methods: - Basic list
+ * operations (rPush, lPush, rPushX, lPushX) - List position operations (lPos variants) -
+ * List size operations (lLen) - List range operations (lRange, lTrim) - List index
+ * operations (lIndex, lSet) - List insertion operations (lInsert) - List movement
+ * operations (lMove, bLMove) - List removal operations (lRem, lPop, rPop with count
+ * variants) - Blocking operations (bLPop, bRPop) - Pop and push operations (rPopLPush,
+ * bRPopLPush)
  *
  * @author Ilia Kolominsky
  * @since 2.0
  */
 public class ValkeyGlideConnectionListCommandsIntegrationTests extends AbstractValkeyGlideIntegrationTests {
 
-    @Override
-    protected String[] getTestKeyPatterns() {
-        return new String[]{
-            "test:list:pushpop", "test:list:pushx:existing", "test:list:pushx:nonexistent",
-            "test:list:lpos", "test:list:len:range", "test:list:trim", "test:list:index",
-            "test:list:insert", "test:list:move:source", "test:list:move:dest",
-            "test:list:blmove:source", "test:list:blmove:dest", "test:list:rem", "test:list:pop",
-            "test:list:blpop:key1", "test:list:blpop:key2", "test:list:rpoplpush:source",
-            "test:list:rpoplpush:dest", "test:list:brpoplpush:source", "test:list:brpoplpush:dest",
-            "test:list:error:string", "test:list:empty", "test:list:binary", "non:existent:key"
-        };
-    }
+	@Override
+	protected String[] getTestKeyPatterns() {
+		return new String[] { "test:list:pushpop", "test:list:pushx:existing", "test:list:pushx:nonexistent",
+				"test:list:lpos", "test:list:len:range", "test:list:trim", "test:list:index", "test:list:insert",
+				"test:list:move:source", "test:list:move:dest", "test:list:blmove:source", "test:list:blmove:dest",
+				"test:list:rem", "test:list:pop", "test:list:blpop:key1", "test:list:blpop:key2",
+				"test:list:rpoplpush:source", "test:list:rpoplpush:dest", "test:list:brpoplpush:source",
+				"test:list:brpoplpush:dest", "test:list:error:string", "test:list:empty", "test:list:binary",
+				"non:existent:key" };
+	}
 
-    // ==================== Basic List Operations ====================
+	// ==================== Basic List Operations ====================
 
-    @Test
-    void testRPushAndLPush() {
-        String key = "test:list:pushpop";
-        byte[] keyBytes = key.getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        byte[] value3 = "value3".getBytes();
-        
-        try {
-            // Test rPush (right push - append to tail)
-            Long rPushResult1 = connection.listCommands().rPush(keyBytes, value1);
-            assertThat(rPushResult1).isEqualTo(1L); // List length after push
-            
-            Long rPushResult2 = connection.listCommands().rPush(keyBytes, value2);
-            assertThat(rPushResult2).isEqualTo(2L);
-            
-            // Test lPush (left push - prepend to head)
-            Long lPushResult = connection.listCommands().lPush(keyBytes, value3);
-            assertThat(lPushResult).isEqualTo(3L);
-            
-            // Verify list contents: value3, value1, value2
-            List<byte[]> range = connection.listCommands().lRange(keyBytes, 0, -1);
-            assertThat(range).hasSize(3);
-            assertThat(range.get(0)).isEqualTo(value3); // head
-            assertThat(range.get(1)).isEqualTo(value1);
-            assertThat(range.get(2)).isEqualTo(value2); // tail
-            
-            // Test multiple values in single push
-            byte[] value4 = "value4".getBytes();
-            byte[] value5 = "value5".getBytes();
-            Long multiPushResult = connection.listCommands().rPush(keyBytes, value4, value5);
-            assertThat(multiPushResult).isEqualTo(5L);
-            
-            // Verify final list length
-            Long listLength = connection.listCommands().lLen(keyBytes);
-            assertThat(listLength).isEqualTo(5L);
-        } finally {
-            cleanupKey(key);
-        }
-    }
+	@Test
+	void testRPushAndLPush() {
+		String key = "test:list:pushpop";
+		byte[] keyBytes = key.getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+		byte[] value3 = "value3".getBytes();
 
-    @Test
-    void testRPushXAndLPushX() {
-        String existingKey = "test:list:pushx:existing";
-        String nonExistentKey = "test:list:pushx:nonexistent";
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        
-        try {
-            // Create an existing list
-            connection.listCommands().rPush(existingKey.getBytes(), value1);
-            
-            // Test rPushX on existing list
-            Long rPushXResult1 = connection.listCommands().rPushX(existingKey.getBytes(), value2);
-            assertThat(rPushXResult1).isEqualTo(2L); // Should succeed
-            
-            // Test rPushX on non-existent list
-            Long rPushXResult2 = connection.listCommands().rPushX(nonExistentKey.getBytes(), value1);
-            assertThat(rPushXResult2).isEqualTo(0L); // Should fail
-            
-            // Test lPushX on existing list
-            Long lPushXResult1 = connection.listCommands().lPushX(existingKey.getBytes(), "newhead".getBytes());
-            assertThat(lPushXResult1).isEqualTo(3L); // Should succeed
-            
-            // Test lPushX on non-existent list
-            Long lPushXResult2 = connection.listCommands().lPushX(nonExistentKey.getBytes(), value1);
-            assertThat(lPushXResult2).isEqualTo(0L); // Should fail
-            
-            // Verify non-existent key was not created
-            Boolean keyExists = connection.keyCommands().exists(nonExistentKey.getBytes());
-            assertThat(keyExists).isFalse();
-        } finally {
-            cleanupKey(existingKey);
-            cleanupKey(nonExistentKey);
-        }
-    }
+		try {
+			// Test rPush (right push - append to tail)
+			Long rPushResult1 = connection.listCommands().rPush(keyBytes, value1);
+			assertThat(rPushResult1).isEqualTo(1L); // List length after push
 
-    // ==================== List Position Operations ====================
+			Long rPushResult2 = connection.listCommands().rPush(keyBytes, value2);
+			assertThat(rPushResult2).isEqualTo(2L);
 
-    @Test
-    void testLPos() {
-        String key = "test:list:lpos";
-        byte[] keyBytes = key.getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        byte[] value3 = "value1".getBytes(); // duplicate
-        byte[] value4 = "value3".getBytes();
-        
-        try {
-            // Set up test data: [value1, value2, value1, value3]
-            connection.listCommands().rPush(keyBytes, value1, value2, value3, value4);
-            
-            // Test basic lPos (find first occurrence)
-            Long pos1 = connection.listCommands().lPos(keyBytes, value1);
-            assertThat(pos1).isEqualTo(0L); // First occurrence at index 0
-            
-            Long pos2 = connection.listCommands().lPos(keyBytes, value2);
-            assertThat(pos2).isEqualTo(1L); // At index 1
-            
-            Long pos4 = connection.listCommands().lPos(keyBytes, value4);
-            assertThat(pos4).isEqualTo(3L); // At index 3
-            
-            // Test lPos with non-existent element
-            Long posNon = connection.listCommands().lPos(keyBytes, "nonexistent".getBytes());
-            assertThat(posNon).isNull();
-            
-            // Test lPos with rank and count
-            List<Long> positions = connection.listCommands().lPos(keyBytes, value1, null, 2);
-            assertThat(positions).containsExactly(0L, 2L); // Both occurrences of value1
-            
-            // Test lPos with rank (second occurrence)
-            List<Long> secondOccurrence = connection.listCommands().lPos(keyBytes, value1, 2, null);
-            assertThat(secondOccurrence).containsExactly(2L); // Second occurrence
-            
-            // Test on non-existent key
-            Long posNonKey = connection.listCommands().lPos("non:existent:key".getBytes(), value1);
-            assertThat(posNonKey).isNull();
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test lPush (left push - prepend to head)
+			Long lPushResult = connection.listCommands().lPush(keyBytes, value3);
+			assertThat(lPushResult).isEqualTo(3L);
 
-    // ==================== List Size and Range Operations ====================
+			// Verify list contents: value3, value1, value2
+			List<byte[]> range = connection.listCommands().lRange(keyBytes, 0, -1);
+			assertThat(range).hasSize(3);
+			assertThat(range.get(0)).isEqualTo(value3); // head
+			assertThat(range.get(1)).isEqualTo(value1);
+			assertThat(range.get(2)).isEqualTo(value2); // tail
 
-    @Test
-    void testLLenAndLRange() {
-        String key = "test:list:len:range";
-        byte[] keyBytes = key.getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        byte[] value3 = "value3".getBytes();
-        byte[] value4 = "value4".getBytes();
-        byte[] value5 = "value5".getBytes();
-        
-        try {
-            // Test lLen on non-existent key
-            Long emptyLen = connection.listCommands().lLen(keyBytes);
-            assertThat(emptyLen).isEqualTo(0L);
-            
-            // Test lRange on non-existent key
-            List<byte[]> emptyRange = connection.listCommands().lRange(keyBytes, 0, -1);
-            assertThat(emptyRange).isEmpty();
-            
-            // Set up test data
-            connection.listCommands().rPush(keyBytes, value1, value2, value3, value4, value5);
-            
-            // Test lLen
-            Long len = connection.listCommands().lLen(keyBytes);
-            assertThat(len).isEqualTo(5L);
-            
-            // Test lRange - full range
-            List<byte[]> fullRange = connection.listCommands().lRange(keyBytes, 0, -1);
-            assertThat(fullRange).hasSize(5);
-            assertThat(fullRange.get(0)).isEqualTo(value1);
-            assertThat(fullRange.get(4)).isEqualTo(value5);
-            
-            // Test lRange - partial range
-            List<byte[]> partialRange = connection.listCommands().lRange(keyBytes, 1, 3);
-            assertThat(partialRange).hasSize(3);
-            assertThat(partialRange.get(0)).isEqualTo(value2);
-            assertThat(partialRange.get(1)).isEqualTo(value3);
-            assertThat(partialRange.get(2)).isEqualTo(value4);
-            
-            // Test lRange - negative indices
-            List<byte[]> negativeRange = connection.listCommands().lRange(keyBytes, -2, -1);
-            assertThat(negativeRange).hasSize(2);
-            assertThat(negativeRange.get(0)).isEqualTo(value4);
-            assertThat(negativeRange.get(1)).isEqualTo(value5);
-            
-            // Test lRange - out of bounds
-            List<byte[]> outOfBounds = connection.listCommands().lRange(keyBytes, 10, 20);
-            assertThat(outOfBounds).isEmpty();
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test multiple values in single push
+			byte[] value4 = "value4".getBytes();
+			byte[] value5 = "value5".getBytes();
+			Long multiPushResult = connection.listCommands().rPush(keyBytes, value4, value5);
+			assertThat(multiPushResult).isEqualTo(5L);
 
-    @Test
-    void testLTrim() {
-        String key = "test:list:trim";
-        byte[] keyBytes = key.getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        byte[] value3 = "value3".getBytes();
-        byte[] value4 = "value4".getBytes();
-        byte[] value5 = "value5".getBytes();
-        
-        try {
-            // Set up test data
-            connection.listCommands().rPush(keyBytes, value1, value2, value3, value4, value5);
-            
-            // Trim to keep only middle elements (indices 1-3)
-            connection.listCommands().lTrim(keyBytes, 1, 3);
-            
-            // Verify trim result
-            List<byte[]> trimmedList = connection.listCommands().lRange(keyBytes, 0, -1);
-            assertThat(trimmedList).hasSize(3);
-            assertThat(trimmedList.get(0)).isEqualTo(value2);
-            assertThat(trimmedList.get(1)).isEqualTo(value3);
-            assertThat(trimmedList.get(2)).isEqualTo(value4);
-            
-            // Trim to single element
-            connection.listCommands().lTrim(keyBytes, 0, 0);
-            List<byte[]> singleElement = connection.listCommands().lRange(keyBytes, 0, -1);
-            assertThat(singleElement).hasSize(1);
-            assertThat(singleElement.get(0)).isEqualTo(value2);
-            
-            // Trim to empty (out of range)
-            connection.listCommands().lTrim(keyBytes, 10, 20);
-            List<byte[]> emptyList = connection.listCommands().lRange(keyBytes, 0, -1);
-            assertThat(emptyList).isEmpty();
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Verify final list length
+			Long listLength = connection.listCommands().lLen(keyBytes);
+			assertThat(listLength).isEqualTo(5L);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
 
-    // ==================== List Index Operations ====================
+	@Test
+	void testRPushXAndLPushX() {
+		String existingKey = "test:list:pushx:existing";
+		String nonExistentKey = "test:list:pushx:nonexistent";
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
 
-    @Test
-    void testLIndexAndLSet() {
-        String key = "test:list:index";
-        byte[] keyBytes = key.getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        byte[] value3 = "value3".getBytes();
-        byte[] newValue = "newvalue".getBytes();
-        
-        try {
-            // Test lIndex on non-existent key
-            byte[] nonExistentValue = connection.listCommands().lIndex(keyBytes, 0);
-            assertThat(nonExistentValue).isNull();
-            
-            // Set up test data
-            connection.listCommands().rPush(keyBytes, value1, value2, value3);
-            
-            // Test lIndex with positive indices
-            byte[] index0 = connection.listCommands().lIndex(keyBytes, 0);
-            assertThat(index0).isEqualTo(value1);
-            
-            byte[] index1 = connection.listCommands().lIndex(keyBytes, 1);
-            assertThat(index1).isEqualTo(value2);
-            
-            byte[] index2 = connection.listCommands().lIndex(keyBytes, 2);
-            assertThat(index2).isEqualTo(value3);
-            
-            // Test lIndex with negative indices
-            byte[] indexNeg1 = connection.listCommands().lIndex(keyBytes, -1);
-            assertThat(indexNeg1).isEqualTo(value3); // Last element
-            
-            byte[] indexNeg2 = connection.listCommands().lIndex(keyBytes, -2);
-            assertThat(indexNeg2).isEqualTo(value2); // Second to last
-            
-            byte[] indexNeg3 = connection.listCommands().lIndex(keyBytes, -3);
-            assertThat(indexNeg3).isEqualTo(value1); // Third to last (first)
-            
-            // Test lIndex out of bounds
-            byte[] outOfBounds = connection.listCommands().lIndex(keyBytes, 10);
-            assertThat(outOfBounds).isNull();
-            
-            // Test lSet
-            connection.listCommands().lSet(keyBytes, 1, newValue);
-            
-            // Verify lSet result
-            byte[] updatedValue = connection.listCommands().lIndex(keyBytes, 1);
-            assertThat(updatedValue).isEqualTo(newValue);
-            
-            // Verify other elements unchanged
-            assertThat(connection.listCommands().lIndex(keyBytes, 0)).isEqualTo(value1);
-            assertThat(connection.listCommands().lIndex(keyBytes, 2)).isEqualTo(value3);
-            
-            // Test lSet with negative index
-            connection.listCommands().lSet(keyBytes, -1, "lastvalue".getBytes());
-            byte[] lastValue = connection.listCommands().lIndex(keyBytes, -1);
-            assertThat(lastValue).isEqualTo("lastvalue".getBytes());
-        } finally {
-            cleanupKey(key);
-        }
-    }
+		try {
+			// Create an existing list
+			connection.listCommands().rPush(existingKey.getBytes(), value1);
 
-    // ==================== List Insertion Operations ====================
+			// Test rPushX on existing list
+			Long rPushXResult1 = connection.listCommands().rPushX(existingKey.getBytes(), value2);
+			assertThat(rPushXResult1).isEqualTo(2L); // Should succeed
 
-    @Test
-    void testLInsert() {
-        String key = "test:list:insert";
-        byte[] keyBytes = key.getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        byte[] value3 = "value3".getBytes();
-        byte[] beforeValue = "before".getBytes();
-        byte[] afterValue = "after".getBytes();
-        
-        try {
-            // Test lInsert on non-existent key
-            Long insertNonExistent = connection.listCommands().lInsert(keyBytes, Position.BEFORE, value1, beforeValue);
-            assertThat(insertNonExistent).isEqualTo(0L); // Key doesn't exist
-            
-            // Set up test data: [value1, value2, value3]
-            connection.listCommands().rPush(keyBytes, value1, value2, value3);
-            
-            // Test lInsert BEFORE
-            Long insertBefore = connection.listCommands().lInsert(keyBytes, Position.BEFORE, value2, beforeValue);
-            assertThat(insertBefore).isEqualTo(4L); // New list length
-            
-            // Verify insertion: [value1, before, value2, value3]
-            List<byte[]> afterBeforeInsert = connection.listCommands().lRange(keyBytes, 0, -1);
-            assertThat(afterBeforeInsert).hasSize(4);
-            assertThat(afterBeforeInsert.get(0)).isEqualTo(value1);
-            assertThat(afterBeforeInsert.get(1)).isEqualTo(beforeValue);
-            assertThat(afterBeforeInsert.get(2)).isEqualTo(value2);
-            assertThat(afterBeforeInsert.get(3)).isEqualTo(value3);
-            
-            // Test lInsert AFTER
-            Long insertAfter = connection.listCommands().lInsert(keyBytes, Position.AFTER, value2, afterValue);
-            assertThat(insertAfter).isEqualTo(5L); // New list length
-            
-            // Verify insertion: [value1, before, value2, after, value3]
-            List<byte[]> afterAfterInsert = connection.listCommands().lRange(keyBytes, 0, -1);
-            assertThat(afterAfterInsert).hasSize(5);
-            assertThat(afterAfterInsert.get(0)).isEqualTo(value1);
-            assertThat(afterAfterInsert.get(1)).isEqualTo(beforeValue);
-            assertThat(afterAfterInsert.get(2)).isEqualTo(value2);
-            assertThat(afterAfterInsert.get(3)).isEqualTo(afterValue);
-            assertThat(afterAfterInsert.get(4)).isEqualTo(value3);
-            
-            // Test lInsert with non-existent pivot
-            Long insertNonPivot = connection.listCommands().lInsert(keyBytes, Position.BEFORE, 
-                "nonexistent".getBytes(), "newvalue".getBytes());
-            assertThat(insertNonPivot).isEqualTo(-1L); // Pivot not found
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test rPushX on non-existent list
+			Long rPushXResult2 = connection.listCommands().rPushX(nonExistentKey.getBytes(), value1);
+			assertThat(rPushXResult2).isEqualTo(0L); // Should fail
 
-    // ==================== List Movement Operations ====================
+			// Test lPushX on existing list
+			Long lPushXResult1 = connection.listCommands().lPushX(existingKey.getBytes(), "newhead".getBytes());
+			assertThat(lPushXResult1).isEqualTo(3L); // Should succeed
 
-    @Test
-    void testLMove() {
-        String sourceKey = "test:list:move:source";
-        String destKey = "test:list:move:dest";
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        byte[] value3 = "value3".getBytes();
-        
-        try {
-            // Set up source list: [value1, value2, value3]
-            connection.listCommands().rPush(sourceKey.getBytes(), value1, value2, value3);
-            
-            // Test lMove LEFT to LEFT (head to head)
-            byte[] movedValue1 = connection.listCommands().lMove(sourceKey.getBytes(), destKey.getBytes(), 
-                Direction.LEFT, Direction.LEFT);
-            assertThat(movedValue1).isEqualTo(value1);
-            
-            // Verify source: [value2, value3]
-            List<byte[]> sourceAfterMove1 = connection.listCommands().lRange(sourceKey.getBytes(), 0, -1);
-            assertThat(sourceAfterMove1).hasSize(2);
-            assertThat(sourceAfterMove1.get(0)).isEqualTo(value2);
-            
-            // Verify dest: [value1]
-            List<byte[]> destAfterMove1 = connection.listCommands().lRange(destKey.getBytes(), 0, -1);
-            assertThat(destAfterMove1).hasSize(1);
-            assertThat(destAfterMove1.get(0)).isEqualTo(value1);
-            
-            // Test lMove RIGHT to RIGHT (tail to tail)
-            byte[] movedValue2 = connection.listCommands().lMove(sourceKey.getBytes(), destKey.getBytes(), 
-                Direction.RIGHT, Direction.RIGHT);
-            assertThat(movedValue2).isEqualTo(value3);
-            
-            // Verify source: [value2]
-            List<byte[]> sourceAfterMove2 = connection.listCommands().lRange(sourceKey.getBytes(), 0, -1);
-            assertThat(sourceAfterMove2).hasSize(1);
-            assertThat(sourceAfterMove2.get(0)).isEqualTo(value2);
-            
-            // Verify dest: [value1, value3]
-            List<byte[]> destAfterMove2 = connection.listCommands().lRange(destKey.getBytes(), 0, -1);
-            assertThat(destAfterMove2).hasSize(2);
-            assertThat(destAfterMove2.get(0)).isEqualTo(value1);
-            assertThat(destAfterMove2.get(1)).isEqualTo(value3);
-            
-            // Test lMove LEFT to RIGHT (head to tail)
-            byte[] movedValue3 = connection.listCommands().lMove(sourceKey.getBytes(), destKey.getBytes(), 
-                Direction.LEFT, Direction.RIGHT);
-            assertThat(movedValue3).isEqualTo(value2);
-            
-            // Verify source is empty
-            List<byte[]> sourceEmpty = connection.listCommands().lRange(sourceKey.getBytes(), 0, -1);
-            assertThat(sourceEmpty).isEmpty();
-            
-            // Verify dest: [value1, value3, value2]
-            List<byte[]> destFinal = connection.listCommands().lRange(destKey.getBytes(), 0, -1);
-            assertThat(destFinal).hasSize(3);
-            assertThat(destFinal.get(0)).isEqualTo(value1);
-            assertThat(destFinal.get(1)).isEqualTo(value3);
-            assertThat(destFinal.get(2)).isEqualTo(value2);
-            
-            // Test lMove on empty source
-            byte[] moveFromEmpty = connection.listCommands().lMove(sourceKey.getBytes(), destKey.getBytes(), 
-                Direction.LEFT, Direction.LEFT);
-            assertThat(moveFromEmpty).isNull();
-        } finally {
-            cleanupKey(sourceKey);
-            cleanupKey(destKey);
-        }
-    }
+			// Test lPushX on non-existent list
+			Long lPushXResult2 = connection.listCommands().lPushX(nonExistentKey.getBytes(), value1);
+			assertThat(lPushXResult2).isEqualTo(0L); // Should fail
 
-    @Test
-    void testBLMove() {
-        String sourceKey = "test:list:blmove:source";
-        String destKey = "test:list:blmove:dest";
-        byte[] value1 = "value1".getBytes();
-        
-        try {
-            // Set up source list
-            connection.listCommands().rPush(sourceKey.getBytes(), value1);
-            
-            // Test bLMove with immediate availability (timeout not reached)
-            byte[] movedValue = connection.listCommands().bLMove(sourceKey.getBytes(), destKey.getBytes(), 
-                Direction.LEFT, Direction.RIGHT, 1.0);
-            assertThat(movedValue).isEqualTo(value1);
-            
-            // Verify movement
-            List<byte[]> sourceEmpty = connection.listCommands().lRange(sourceKey.getBytes(), 0, -1);
-            assertThat(sourceEmpty).isEmpty();
-            
-            List<byte[]> destWithValue = connection.listCommands().lRange(destKey.getBytes(), 0, -1);
-            assertThat(destWithValue).hasSize(1);
-            assertThat(destWithValue.get(0)).isEqualTo(value1);
-            
-            // Test bLMove on empty source with timeout
-            long startTime = System.currentTimeMillis();
-            byte[] timeoutResult = connection.listCommands().bLMove(sourceKey.getBytes(), destKey.getBytes(), 
-                Direction.LEFT, Direction.LEFT, 0.1); // 100ms timeout
-            long endTime = System.currentTimeMillis();
-            
-            assertThat(timeoutResult).isNull();
-            // Verify timeout occurred (allow some margin for execution time)
-            assertThat(endTime - startTime).isGreaterThanOrEqualTo(90L).isLessThan(300L);
-        } finally {
-            cleanupKey(sourceKey);
-            cleanupKey(destKey);
-        }
-    }
+			// Verify non-existent key was not created
+			Boolean keyExists = connection.keyCommands().exists(nonExistentKey.getBytes());
+			assertThat(keyExists).isFalse();
+		}
+		finally {
+			cleanupKey(existingKey);
+			cleanupKey(nonExistentKey);
+		}
+	}
 
-    // ==================== List Removal Operations ====================
+	// ==================== List Position Operations ====================
 
-    @Test
-    void testLRem() {
-        String key = "test:list:rem";
-        byte[] keyBytes = key.getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        byte[] value3 = "value1".getBytes(); // duplicate
-        byte[] value4 = "value2".getBytes(); // duplicate
-        byte[] value5 = "value1".getBytes(); // duplicate
-        
-        try {
-            // Set up test data: [value1, value2, value1, value2, value1]
-            connection.listCommands().rPush(keyBytes, value1, value2, value3, value4, value5);
-            
-            // Test lRem with positive count (remove from head)
-            Long remResult1 = connection.listCommands().lRem(keyBytes, 2, value1);
-            assertThat(remResult1).isEqualTo(2L); // Removed 2 occurrences
-            
-            // Verify: [value2, value2, value1]
-            List<byte[]> afterRem1 = connection.listCommands().lRange(keyBytes, 0, -1);
-            assertThat(afterRem1).hasSize(3);
-            assertThat(afterRem1.get(0)).isEqualTo(value2);
-            assertThat(afterRem1.get(1)).isEqualTo(value2);
-            assertThat(afterRem1.get(2)).isEqualTo(value1);
-            
-            // Test lRem with negative count (remove from tail)
-            Long remResult2 = connection.listCommands().lRem(keyBytes, -1, value2);
-            assertThat(remResult2).isEqualTo(1L); // Removed 1 occurrence from tail
-            
-            // Verify: [value2, value1]
-            List<byte[]> afterRem2 = connection.listCommands().lRange(keyBytes, 0, -1);
-            assertThat(afterRem2).hasSize(2);
-            assertThat(afterRem2.get(0)).isEqualTo(value2);
-            assertThat(afterRem2.get(1)).isEqualTo(value1);
-            
-            // Test lRem with count 0 (remove all occurrences)
-            connection.listCommands().rPush(keyBytes, value1, value1); // Add more duplicates
-            Long remResult3 = connection.listCommands().lRem(keyBytes, 0, value1);
-            assertThat(remResult3).isEqualTo(3L); // Removed all 3 occurrences
-            
-            // Verify: [value2]
-            List<byte[]> afterRem3 = connection.listCommands().lRange(keyBytes, 0, -1);
-            assertThat(afterRem3).hasSize(1);
-            assertThat(afterRem3.get(0)).isEqualTo(value2);
-            
-            // Test lRem on non-existent element
-            Long remNonExistent = connection.listCommands().lRem(keyBytes, 1, "nonexistent".getBytes());
-            assertThat(remNonExistent).isEqualTo(0L);
-        } finally {
-            cleanupKey(key);
-        }
-    }
+	@Test
+	void testLPos() {
+		String key = "test:list:lpos";
+		byte[] keyBytes = key.getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+		byte[] value3 = "value1".getBytes(); // duplicate
+		byte[] value4 = "value3".getBytes();
 
-    @Test
-    void testLPopAndRPop() {
-        String key = "test:list:pop";
-        byte[] keyBytes = key.getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        byte[] value3 = "value3".getBytes();
-        byte[] value4 = "value4".getBytes();
-        byte[] value5 = "value5".getBytes();
-        
-        try {
-            // Test pop on non-existent key
-            byte[] nonExistentPop = connection.listCommands().lPop(keyBytes);
-            assertThat(nonExistentPop).isNull();
-            
-            byte[] nonExistentRPop = connection.listCommands().rPop(keyBytes);
-            assertThat(nonExistentRPop).isNull();
-            
-            // Set up test data: [value1, value2, value3, value4, value5]
-            connection.listCommands().rPush(keyBytes, value1, value2, value3, value4, value5);
-            
-            // Test lPop (left pop - from head)
-            byte[] leftPopped1 = connection.listCommands().lPop(keyBytes);
-            assertThat(leftPopped1).isEqualTo(value1);
-            
-            // Test rPop (right pop - from tail)
-            byte[] rightPopped1 = connection.listCommands().rPop(keyBytes);
-            assertThat(rightPopped1).isEqualTo(value5);
-            
-            // Verify remaining: [value2, value3, value4]
-            List<byte[]> remaining = connection.listCommands().lRange(keyBytes, 0, -1);
-            assertThat(remaining).hasSize(3);
-            assertThat(remaining.get(0)).isEqualTo(value2);
-            assertThat(remaining.get(1)).isEqualTo(value3);
-            assertThat(remaining.get(2)).isEqualTo(value4);
-            
-            // Test lPop with count
-            List<byte[]> leftPoppedMultiple = connection.listCommands().lPop(keyBytes, 2);
-            assertThat(leftPoppedMultiple).hasSize(2);
-            assertThat(leftPoppedMultiple.get(0)).isEqualTo(value2);
-            assertThat(leftPoppedMultiple.get(1)).isEqualTo(value3);
-            
-            // Test rPop with count
-            List<byte[]> rightPoppedMultiple = connection.listCommands().rPop(keyBytes, 1);
-            assertThat(rightPoppedMultiple).hasSize(1);
-            assertThat(rightPoppedMultiple.get(0)).isEqualTo(value4);
-            
-            // Verify list is empty
-            Long finalLength = connection.listCommands().lLen(keyBytes);
-            assertThat(finalLength).isEqualTo(0L);
-            
-            // Test pop with count on empty list
-            List<byte[]> emptyPop = connection.listCommands().lPop(keyBytes, 3);
-            assertThat(emptyPop).isNull();
-        } finally {
-            cleanupKey(key);
-        }
-    }
+		try {
+			// Set up test data: [value1, value2, value1, value3]
+			connection.listCommands().rPush(keyBytes, value1, value2, value3, value4);
 
-    // ==================== Blocking Operations ====================
+			// Test basic lPos (find first occurrence)
+			Long pos1 = connection.listCommands().lPos(keyBytes, value1);
+			assertThat(pos1).isEqualTo(0L); // First occurrence at index 0
 
-    @Test
-    void testBLPopAndBRPop() {
-        String key1 = "test:list:blpop:key1";
-        String key2 = "test:list:blpop:key2";
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        
-        try {
-            // Set up test data
-            connection.listCommands().rPush(key1.getBytes(), value1);
-            connection.listCommands().rPush(key2.getBytes(), value2);
-            
-            // Test bLPop with immediate availability (timeout not reached)
-            List<byte[]> blPopResult = connection.listCommands().bLPop(1, key1.getBytes(), key2.getBytes());
-            assertThat(blPopResult).hasSize(2);
-            assertThat(blPopResult.get(0)).isEqualTo(key1.getBytes()); // Key that had the element
-            assertThat(blPopResult.get(1)).isEqualTo(value1); // Popped element
-            
-            // Test bRPop with immediate availability
-            List<byte[]> brPopResult = connection.listCommands().bRPop(1, key1.getBytes(), key2.getBytes());
-            assertThat(brPopResult).hasSize(2);
-            assertThat(brPopResult.get(0)).isEqualTo(key2.getBytes()); // Key that had the element
-            assertThat(brPopResult.get(1)).isEqualTo(value2); // Popped element
-            
-            // Test blocking with timeout (both keys are empty now)
-            long startTime = System.currentTimeMillis();
-            List<byte[]> timeoutResult = connection.listCommands().bLPop(1, key1.getBytes(), key2.getBytes());
-            long endTime = System.currentTimeMillis();
-            
-            assertThat(timeoutResult).isEmpty(); // Timeout occurred
-            // Verify timeout occurred (allow some margin for execution time)
-            assertThat(endTime - startTime).isGreaterThanOrEqualTo(900L).isLessThan(1200L);
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-        }
-    }
+			Long pos2 = connection.listCommands().lPos(keyBytes, value2);
+			assertThat(pos2).isEqualTo(1L); // At index 1
 
-    // ==================== Pop and Push Operations ====================
+			Long pos4 = connection.listCommands().lPos(keyBytes, value4);
+			assertThat(pos4).isEqualTo(3L); // At index 3
 
-    @Test
-    void testRPopLPush() {
-        String sourceKey = "test:list:rpoplpush:source";
-        String destKey = "test:list:rpoplpush:dest";
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        byte[] value3 = "value3".getBytes();
-        
-        try {
-            // Test rPopLPush on non-existent source
-            byte[] nonExistentResult = connection.listCommands().rPopLPush(sourceKey.getBytes(), destKey.getBytes());
-            assertThat(nonExistentResult).isNull();
-            
-            // Set up source list: [value1, value2, value3]
-            connection.listCommands().rPush(sourceKey.getBytes(), value1, value2, value3);
-            
-            // Test rPopLPush (pop from tail of source, push to head of dest)
-            byte[] poppedValue1 = connection.listCommands().rPopLPush(sourceKey.getBytes(), destKey.getBytes());
-            assertThat(poppedValue1).isEqualTo(value3);
-            
-            // Verify source: [value1, value2]
-            List<byte[]> sourceAfterPop1 = connection.listCommands().lRange(sourceKey.getBytes(), 0, -1);
-            assertThat(sourceAfterPop1).hasSize(2);
-            assertThat(sourceAfterPop1.get(0)).isEqualTo(value1);
-            assertThat(sourceAfterPop1.get(1)).isEqualTo(value2);
-            
-            // Verify dest: [value3]
-            List<byte[]> destAfterPush1 = connection.listCommands().lRange(destKey.getBytes(), 0, -1);
-            assertThat(destAfterPush1).hasSize(1);
-            assertThat(destAfterPush1.get(0)).isEqualTo(value3);
-            
-            // Test another rPopLPush
-            byte[] poppedValue2 = connection.listCommands().rPopLPush(sourceKey.getBytes(), destKey.getBytes());
-            assertThat(poppedValue2).isEqualTo(value2);
-            
-            // Verify final state
-            // Source: [value1]
-            List<byte[]> sourceFinal = connection.listCommands().lRange(sourceKey.getBytes(), 0, -1);
-            assertThat(sourceFinal).hasSize(1);
-            assertThat(sourceFinal.get(0)).isEqualTo(value1);
-            
-            // Dest: [value2, value3]
-            List<byte[]> destFinal = connection.listCommands().lRange(destKey.getBytes(), 0, -1);
-            assertThat(destFinal).hasSize(2);
-            assertThat(destFinal.get(0)).isEqualTo(value2);
-            assertThat(destFinal.get(1)).isEqualTo(value3);
-            
-            // Test rPopLPush to same key (rotate list)
-            connection.listCommands().rPopLPush(destKey.getBytes(), destKey.getBytes());
-            List<byte[]> rotatedDest = connection.listCommands().lRange(destKey.getBytes(), 0, -1);
-            assertThat(rotatedDest).hasSize(2);
-            assertThat(rotatedDest.get(0)).isEqualTo(value3); // Last element moved to first
-            assertThat(rotatedDest.get(1)).isEqualTo(value2);
-        } finally {
-            cleanupKey(sourceKey);
-            cleanupKey(destKey);
-        }
-    }
+			// Test lPos with non-existent element
+			Long posNon = connection.listCommands().lPos(keyBytes, "nonexistent".getBytes());
+			assertThat(posNon).isNull();
 
-    @Test
-    void testBRPopLPush() {
-        String sourceKey = "test:list:brpoplpush:source";
-        String destKey = "test:list:brpoplpush:dest";
-        byte[] value1 = "value1".getBytes();
-        
-        try {
-            // Set up source list
-            connection.listCommands().rPush(sourceKey.getBytes(), value1);
-            
-            // Test bRPopLPush with immediate availability
-            byte[] poppedValue = connection.listCommands().bRPopLPush(1, sourceKey.getBytes(), destKey.getBytes());
-            assertThat(poppedValue).isEqualTo(value1);
-            
-            // Verify movement
-            List<byte[]> sourceEmpty = connection.listCommands().lRange(sourceKey.getBytes(), 0, -1);
-            assertThat(sourceEmpty).isEmpty();
-            
-            List<byte[]> destWithValue = connection.listCommands().lRange(destKey.getBytes(), 0, -1);
-            assertThat(destWithValue).hasSize(1);
-            assertThat(destWithValue.get(0)).isEqualTo(value1);
-            
-            // Test bRPopLPush with timeout (source is empty)
-            long startTime = System.currentTimeMillis();
-            byte[] timeoutResult = connection.listCommands().bRPopLPush(1, sourceKey.getBytes(), destKey.getBytes());
-            long endTime = System.currentTimeMillis();
-            
-            assertThat(timeoutResult).isNull();
-            // Verify timeout occurred (allow some margin for execution time)
-            assertThat(endTime - startTime).isGreaterThanOrEqualTo(900L).isLessThan(1200L);
-        } finally {
-            cleanupKey(sourceKey);
-            cleanupKey(destKey);
-        }
-    }
+			// Test lPos with rank and count
+			List<Long> positions = connection.listCommands().lPos(keyBytes, value1, null, 2);
+			assertThat(positions).containsExactly(0L, 2L); // Both occurrences of value1
 
-    // ==================== Error Handling and Edge Cases ====================
+			// Test lPos with rank (second occurrence)
+			List<Long> secondOccurrence = connection.listCommands().lPos(keyBytes, value1, 2, null);
+			assertThat(secondOccurrence).containsExactly(2L); // Second occurrence
 
-    @Test
-    void testListOperationsOnNonListTypes() {
-        String stringKey = "test:list:error:string";
-        
-        try {
-            // Create a string key
-            connection.stringCommands().set(stringKey.getBytes(), "stringvalue".getBytes());
-            
-            // Try list operations on string key - should fail or return appropriate response
-            assertThatThrownBy(() -> connection.listCommands().lPush(stringKey.getBytes(), "value".getBytes()))
-                .isInstanceOf(DataAccessException.class);
-        } finally {
-            cleanupKey(stringKey);
-        }
-    }
+			// Test on non-existent key
+			Long posNonKey = connection.listCommands().lPos("non:existent:key".getBytes(), value1);
+			assertThat(posNonKey).isNull();
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
 
-    @Test
-    void testEmptyListOperations() {
-        String key = "test:list:empty";
-        byte[] keyBytes = key.getBytes();
-        byte[] emptyValue = new byte[0];
-        
-        try {
-            // Push empty value
-            Long pushResult = connection.listCommands().rPush(keyBytes, emptyValue);
-            assertThat(pushResult).isEqualTo(1L);
-            
-            // Get empty value
-            byte[] retrievedValue = connection.listCommands().lIndex(keyBytes, 0);
-            assertThat(retrievedValue).isEqualTo(emptyValue);
-            
-            // List should have 1 element
-            Long listLen = connection.listCommands().lLen(keyBytes);
-            assertThat(listLen).isEqualTo(1L);
-            
-            // Pop empty value
-            byte[] poppedValue = connection.listCommands().lPop(keyBytes);
-            assertThat(poppedValue).isEqualTo(emptyValue);
-        } finally {
-            cleanupKey(key);
-        }
-    }
+	// ==================== List Size and Range Operations ====================
 
-    @Test
-    void testListOperationsWithBinaryData() {
-        String key = "test:list:binary";
-        byte[] keyBytes = key.getBytes();
-        byte[] binaryValue1 = new byte[]{0x00, 0x01, 0x02, (byte) 0xFF};
-        byte[] binaryValue2 = new byte[]{(byte) 0xFF, (byte) 0xFE, 0x00, 0x01, 0x7F};
-        
-        try {
-            // Test with binary values
-            Long pushResult = connection.listCommands().rPush(keyBytes, binaryValue1, binaryValue2);
-            assertThat(pushResult).isEqualTo(2L);
-            
-            // Retrieve binary values
-            List<byte[]> retrievedValues = connection.listCommands().lRange(keyBytes, 0, -1);
-            assertThat(retrievedValues).hasSize(2);
-            assertThat(retrievedValues.get(0)).isEqualTo(binaryValue1);
-            assertThat(retrievedValues.get(1)).isEqualTo(binaryValue2);
-            
-            // Test binary value operations
-            byte[] poppedBinary = connection.listCommands().lPop(keyBytes);
-            assertThat(poppedBinary).isEqualTo(binaryValue1);
-        } finally {
-            cleanupKey(key);
-        }
-    }
+	@Test
+	void testLLenAndLRange() {
+		String key = "test:list:len:range";
+		byte[] keyBytes = key.getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+		byte[] value3 = "value3".getBytes();
+		byte[] value4 = "value4".getBytes();
+		byte[] value5 = "value5".getBytes();
 
-    // ==================== Pipeline Mode Tests ====================
+		try {
+			// Test lLen on non-existent key
+			Long emptyLen = connection.listCommands().lLen(keyBytes);
+			assertThat(emptyLen).isEqualTo(0L);
 
-    @Test
-    void testBasicListCommandsInPipelineMode() {
-        String key = "test:list:pipeline:basic";
-        byte[] keyBytes = key.getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        byte[] value3 = "value3".getBytes();
-        
-        try {
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Queue basic list commands - assert they return null in pipeline mode
-            assertThat(connection.listCommands().rPush(keyBytes, value1, value2)).isNull();
-            assertThat(connection.listCommands().lPush(keyBytes, value3)).isNull();
-            assertThat(connection.listCommands().lLen(keyBytes)).isNull();
-            assertThat(connection.listCommands().lRange(keyBytes, 0, -1)).isNull();
-            assertThat(connection.listCommands().lIndex(keyBytes, 0)).isNull();
-            assertThat(connection.listCommands().rPop(keyBytes)).isNull();
-            assertThat(connection.listCommands().lPop(keyBytes)).isNull();
-            
-            // Execute pipeline
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(7);
-            assertThat(results.get(0)).isEqualTo(2L);     // rPush result
-            assertThat(results.get(1)).isEqualTo(3L);     // lPush result
-            assertThat(results.get(2)).isEqualTo(3L);     // lLen result
-            
-            @SuppressWarnings("unchecked")
-            List<byte[]> rangeResult = (List<byte[]>) results.get(3);
-            assertThat(rangeResult).hasSize(3);
-            assertThat(rangeResult.get(0)).isEqualTo(value3); // Head after lPush
-            assertThat(rangeResult.get(1)).isEqualTo(value1);
-            assertThat(rangeResult.get(2)).isEqualTo(value2); // Tail
-            
-            assertThat(results.get(4)).isEqualTo(value3); // lIndex result
-            assertThat(results.get(5)).isEqualTo(value2); // rPop result (from tail)
-            assertThat(results.get(6)).isEqualTo(value3); // lPop result (from head)
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test lRange on non-existent key
+			List<byte[]> emptyRange = connection.listCommands().lRange(keyBytes, 0, -1);
+			assertThat(emptyRange).isEmpty();
 
-    @Test
-    void testConditionalListCommandsInPipelineMode() {
-        String existingKey = "test:list:pipeline:conditional:existing";
-        String nonExistentKey = "test:list:pipeline:conditional:nonexistent";
-        byte[] existingKeyBytes = existingKey.getBytes();
-        byte[] nonExistentKeyBytes = nonExistentKey.getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        
-        try {
-            // Set up existing list
-            connection.listCommands().rPush(existingKeyBytes, value1);
-            
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Queue conditional commands - assert they return null in pipeline mode
-            assertThat(connection.listCommands().rPushX(existingKeyBytes, value2)).isNull();
-            assertThat(connection.listCommands().lPushX(existingKeyBytes, "head".getBytes())).isNull();
-            assertThat(connection.listCommands().rPushX(nonExistentKeyBytes, value1)).isNull();
-            assertThat(connection.listCommands().lPushX(nonExistentKeyBytes, value1)).isNull();
-            assertThat(connection.listCommands().lLen(existingKeyBytes)).isNull();
-            assertThat(connection.listCommands().lLen(nonExistentKeyBytes)).isNull();
-            
-            // Execute pipeline
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(6);
-            assertThat(results.get(0)).isEqualTo(2L);  // rPushX on existing - success
-            assertThat(results.get(1)).isEqualTo(3L);  // lPushX on existing - success
-            assertThat(results.get(2)).isEqualTo(0L);  // rPushX on non-existent - fail
-            assertThat(results.get(3)).isEqualTo(0L);  // lPushX on non-existent - fail
-            assertThat(results.get(4)).isEqualTo(3L);  // lLen on existing
-            assertThat(results.get(5)).isEqualTo(0L);  // lLen on non-existent
-            
-        } finally {
-            cleanupKey(existingKey);
-            cleanupKey(nonExistentKey);
-        }
-    }
+			// Set up test data
+			connection.listCommands().rPush(keyBytes, value1, value2, value3, value4, value5);
 
-    @Test
-    void testListPositionCommandsInPipelineMode() {
-        String key = "test:list:pipeline:position";
-        byte[] keyBytes = key.getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        byte[] value3 = "value1".getBytes(); // duplicate
-        byte[] insertValue = "inserted".getBytes();
-        
-        try {
-            // Set up test data
-            connection.listCommands().rPush(keyBytes, value1, value2, value3);
-            
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Queue position commands - assert they return null in pipeline mode
-            assertThat(connection.listCommands().lPos(keyBytes, value1, null, 2)).isNull();
-            assertThat(connection.listCommands().lInsert(keyBytes, Position.BEFORE, value2, insertValue)).isNull();
-            assertThat(connection.listCommands().lIndex(keyBytes, 1)).isNull();
-            assertThat(connection.listCommands().lLen(keyBytes)).isNull();
-            
-            // Execute pipeline
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(4);
-            
-            @SuppressWarnings("unchecked")
-            List<Long> lPosResults = (List<Long>) results.get(0);
-            assertThat(lPosResults).containsExactly(0L, 2L); // Both occurrences of value1
-            
-            assertThat(results.get(1)).isEqualTo(4L);  // lInsert result (new list length)
-            assertThat(results.get(2)).isEqualTo(insertValue); // lIndex result
-            assertThat(results.get(3)).isEqualTo(4L);  // lLen result
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test lLen
+			Long len = connection.listCommands().lLen(keyBytes);
+			assertThat(len).isEqualTo(5L);
 
-    @Test
-    void testListMovementCommandsInPipelineMode() {
-        String sourceKey = "test:list:pipeline:move:source";
-        String destKey = "test:list:pipeline:move:dest";
-        byte[] sourceKeyBytes = sourceKey.getBytes();
-        byte[] destKeyBytes = destKey.getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        byte[] value3 = "value3".getBytes();
-        
-        try {
-            // Set up test data
-            connection.listCommands().rPush(sourceKeyBytes, value1, value2, value3);
-            
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Queue movement commands - assert they return null in pipeline mode
-            assertThat(connection.listCommands().lMove(sourceKeyBytes, destKeyBytes, Direction.LEFT, Direction.RIGHT)).isNull();
-            assertThat(connection.listCommands().rPopLPush(sourceKeyBytes, destKeyBytes)).isNull();
-            assertThat(connection.listCommands().lLen(sourceKeyBytes)).isNull();
-            assertThat(connection.listCommands().lLen(destKeyBytes)).isNull();
-            assertThat(connection.listCommands().lRange(destKeyBytes, 0, -1)).isNull();
-            
-            // Execute pipeline
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(5);
-            assertThat(results.get(0)).isEqualTo(value1); // lMove result
-            assertThat(results.get(1)).isEqualTo(value3); // rPopLPush result
-            assertThat(results.get(2)).isEqualTo(1L);     // Source length after moves
-            assertThat(results.get(3)).isEqualTo(2L);     // Dest length after moves
-            
-            @SuppressWarnings("unchecked")
-            List<byte[]> destRange = (List<byte[]>) results.get(4);
-            assertThat(destRange).hasSize(2);
-            assertThat(destRange.get(0)).isEqualTo(value3); // Head (from rPopLPush)
-            assertThat(destRange.get(1)).isEqualTo(value1); // Tail (from lMove RIGHT)
-            
-        } finally {
-            cleanupKey(sourceKey);
-            cleanupKey(destKey);
-        }
-    }
+			// Test lRange - full range
+			List<byte[]> fullRange = connection.listCommands().lRange(keyBytes, 0, -1);
+			assertThat(fullRange).hasSize(5);
+			assertThat(fullRange.get(0)).isEqualTo(value1);
+			assertThat(fullRange.get(4)).isEqualTo(value5);
 
-    @Test
-    void testListRemovalCommandsInPipelineMode() {
-        String key = "test:list:pipeline:removal";
-        byte[] keyBytes = key.getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        byte[] value3 = "value1".getBytes(); // duplicate
-        byte[] value4 = "value2".getBytes(); // duplicate
-        
-        try {
-            // Set up test data
-            connection.listCommands().rPush(keyBytes, value1, value2, value3, value4);
-            
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Queue removal commands - assert they return null in pipeline mode
-            assertThat(connection.listCommands().lRem(keyBytes, 1, value1)).isNull();
-            assertThat(connection.listCommands().lPop(keyBytes, 2)).isNull();
-            assertThat(connection.listCommands().rPop(keyBytes)).isNull();
-            assertThat(connection.listCommands().lLen(keyBytes)).isNull();
-            
-            // Execute pipeline
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(4);
-            assertThat(results.get(0)).isEqualTo(1L); // lRem result (removed 1 occurrence)
-            
-            @SuppressWarnings("unchecked")
-            List<byte[]> lPopResults = (List<byte[]>) results.get(1);
-            assertThat(lPopResults).hasSize(2);
-            assertThat(lPopResults.get(0)).isEqualTo(value2); // First remaining element
-            assertThat(lPopResults.get(1)).isEqualTo(value3); // Second remaining element
-            
-            assertThat(results.get(2)).isEqualTo(value4); // rPop result
-            assertThat(results.get(3)).isEqualTo(0L);     // Final length (empty)
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test lRange - partial range
+			List<byte[]> partialRange = connection.listCommands().lRange(keyBytes, 1, 3);
+			assertThat(partialRange).hasSize(3);
+			assertThat(partialRange.get(0)).isEqualTo(value2);
+			assertThat(partialRange.get(1)).isEqualTo(value3);
+			assertThat(partialRange.get(2)).isEqualTo(value4);
 
-    @Test
-    void testListBlockingCommandsInPipelineMode() {
-        String key1 = "test:list:pipeline:blocking:key1";
-        String key2 = "test:list:pipeline:blocking:key2";
-        byte[] key1Bytes = key1.getBytes();
-        byte[] key2Bytes = key2.getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        
-        try {
-            // Set up test data
-            connection.listCommands().rPush(key1Bytes, value1);
-            connection.listCommands().rPush(key2Bytes, value2);
-            
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Queue blocking commands with short timeout - assert they return null in pipeline mode
-            assertThat(connection.listCommands().bLPop(1, key1Bytes, key2Bytes)).isNull();
-            assertThat(connection.listCommands().bRPop(1, key1Bytes, key2Bytes)).isNull();
-            
-            // Execute pipeline
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(2);
-            
-            @SuppressWarnings("unchecked")
-            List<byte[]> blPopResult = (List<byte[]>) results.get(0);
-            assertThat(blPopResult).hasSize(2);
-            assertThat(blPopResult.get(0)).isEqualTo(key1Bytes); // Key that had element
-            assertThat(blPopResult.get(1)).isEqualTo(value1);    // Popped element
-            
-            @SuppressWarnings("unchecked")
-            List<byte[]> brPopResult = (List<byte[]>) results.get(1);
-            assertThat(brPopResult).hasSize(2);
-            assertThat(brPopResult.get(0)).isEqualTo(key2Bytes); // Key that had element
-            assertThat(brPopResult.get(1)).isEqualTo(value2);    // Popped element
-            
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-        }
-    }
+			// Test lRange - negative indices
+			List<byte[]> negativeRange = connection.listCommands().lRange(keyBytes, -2, -1);
+			assertThat(negativeRange).hasSize(2);
+			assertThat(negativeRange.get(0)).isEqualTo(value4);
+			assertThat(negativeRange.get(1)).isEqualTo(value5);
 
-    @Test
-    void testListTrimCommandInPipelineMode() {
-        String key = "test:list:pipeline:trim";
-        byte[] keyBytes = key.getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        byte[] value3 = "value3".getBytes();
-        byte[] value4 = "value4".getBytes();
-        byte[] value5 = "value5".getBytes();
-        
-        try {
-            // Set up test data
-            connection.listCommands().rPush(keyBytes, value1, value2, value3, value4, value5);
-            
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Queue trim and verification commands
-            connection.listCommands().lTrim(keyBytes, 1, 3); // void method, no assertion needed
-            assertThat(connection.listCommands().lLen(keyBytes)).isNull();
-            assertThat(connection.listCommands().lRange(keyBytes, 0, -1)).isNull();
-            
-            // Execute pipeline
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(3);
-            assertThat(results.get(0)).isEqualTo("OK"); // lTrim result
-            assertThat(results.get(1)).isEqualTo(3L);   // lLen result after trim
-            
-            @SuppressWarnings("unchecked")
-            List<byte[]> rangeResult = (List<byte[]>) results.get(2);
-            assertThat(rangeResult).hasSize(3);
-            assertThat(rangeResult.get(0)).isEqualTo(value2); // Trimmed list starts with value2
-            assertThat(rangeResult.get(1)).isEqualTo(value3);
-            assertThat(rangeResult.get(2)).isEqualTo(value4); // Trimmed list ends with value4
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test lRange - out of bounds
+			List<byte[]> outOfBounds = connection.listCommands().lRange(keyBytes, 10, 20);
+			assertThat(outOfBounds).isEmpty();
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
 
-    @Test
-    void testListAdvancedCommandsInPipelineMode() {
-        String sourceKey1 = "test:list:pipeline:advanced:source1";
-        String destKey1 = "test:list:pipeline:advanced:dest1";
-        String sourceKey2 = "test:list:pipeline:advanced:source2";
-        String destKey2 = "test:list:pipeline:advanced:dest2";
-        byte[] sourceKey1Bytes = sourceKey1.getBytes();
-        byte[] destKey1Bytes = destKey1.getBytes();
-        byte[] sourceKey2Bytes = sourceKey2.getBytes();
-        byte[] destKey2Bytes = destKey2.getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        
-        try {
-            // Set up test data
-            connection.listCommands().rPush(sourceKey1Bytes, value1);
-            connection.listCommands().rPush(sourceKey2Bytes, value2);
-            
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Queue advanced commands - assert they return null in pipeline mode
-            assertThat(connection.listCommands().bLMove(sourceKey1Bytes, destKey1Bytes, Direction.LEFT, Direction.RIGHT, 0.1)).isNull();
-            assertThat(connection.listCommands().bRPopLPush(1, sourceKey2Bytes, destKey2Bytes)).isNull();
-            assertThat(connection.listCommands().lLen(destKey1Bytes)).isNull();
-            assertThat(connection.listCommands().lLen(destKey2Bytes)).isNull();
-            
-            // Execute pipeline
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(4);
-            assertThat(results.get(0)).isEqualTo(value1); // bLMove result
-            assertThat(results.get(1)).isEqualTo(value2); // bRPopLPush result
-            assertThat(results.get(2)).isEqualTo(1L);     // destKey1 length
-            assertThat(results.get(3)).isEqualTo(1L);     // destKey2 length
-            
-        } finally {
-            cleanupKey(sourceKey1);
-            cleanupKey(destKey1);
-            cleanupKey(sourceKey2);
-            cleanupKey(destKey2);
-        }
-    }
+	@Test
+	void testLTrim() {
+		String key = "test:list:trim";
+		byte[] keyBytes = key.getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+		byte[] value3 = "value3".getBytes();
+		byte[] value4 = "value4".getBytes();
+		byte[] value5 = "value5".getBytes();
 
-    // ==================== Transaction Mode Tests ====================
+		try {
+			// Set up test data
+			connection.listCommands().rPush(keyBytes, value1, value2, value3, value4, value5);
 
-    @Test
-    void testBasicListCommandsInTransactionMode() {
-        String key = "test:list:transaction:basic";
-        byte[] keyBytes = key.getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        byte[] value3 = "value3".getBytes();
-        
-        try {
-            // Start transaction
-            connection.multi();
-            
-            // Queue basic list commands - assert they return null in transaction mode
-            assertThat(connection.listCommands().rPush(keyBytes, value1, value2)).isNull();
-            assertThat(connection.listCommands().lPush(keyBytes, value3)).isNull();
-            assertThat(connection.listCommands().lLen(keyBytes)).isNull();
-            assertThat(connection.listCommands().lRange(keyBytes, 0, -1)).isNull();
-            assertThat(connection.listCommands().lIndex(keyBytes, 0)).isNull();
-            assertThat(connection.listCommands().rPop(keyBytes)).isNull();
-            assertThat(connection.listCommands().lPop(keyBytes)).isNull();
-            
-            // Execute transaction
-            List<Object> results = connection.exec();
-            
-            // Verify results
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(7);
-            assertThat(results.get(0)).isEqualTo(2L);     // rPush result
-            assertThat(results.get(1)).isEqualTo(3L);     // lPush result
-            assertThat(results.get(2)).isEqualTo(3L);     // lLen result
-            
-            @SuppressWarnings("unchecked")
-            List<byte[]> rangeResult = (List<byte[]>) results.get(3);
-            assertThat(rangeResult).hasSize(3);
-            assertThat(rangeResult.get(0)).isEqualTo(value3); // Head after lPush
-            assertThat(rangeResult.get(1)).isEqualTo(value1);
-            assertThat(rangeResult.get(2)).isEqualTo(value2); // Tail
-            
-            assertThat(results.get(4)).isEqualTo(value3); // lIndex result
-            assertThat(results.get(5)).isEqualTo(value2); // rPop result (from tail)
-            assertThat(results.get(6)).isEqualTo(value3); // lPop result (from head)
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Trim to keep only middle elements (indices 1-3)
+			connection.listCommands().lTrim(keyBytes, 1, 3);
 
-    @Test
-    void testConditionalListCommandsInTransactionMode() {
-        String existingKey = "test:list:transaction:conditional:existing";
-        String nonExistentKey = "test:list:transaction:conditional:nonexistent";
-        byte[] existingKeyBytes = existingKey.getBytes();
-        byte[] nonExistentKeyBytes = nonExistentKey.getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        
-        try {
-            // Set up existing list
-            connection.listCommands().rPush(existingKeyBytes, value1);
-            
-            // Start transaction
-            connection.multi();
-            
-            // Queue conditional commands - assert they return null in transaction mode
-            assertThat(connection.listCommands().rPushX(existingKeyBytes, value2)).isNull();
-            assertThat(connection.listCommands().lPushX(existingKeyBytes, "head".getBytes())).isNull();
-            assertThat(connection.listCommands().rPushX(nonExistentKeyBytes, value1)).isNull();
-            assertThat(connection.listCommands().lPushX(nonExistentKeyBytes, value1)).isNull();
-            assertThat(connection.listCommands().lLen(existingKeyBytes)).isNull();
-            assertThat(connection.listCommands().lLen(nonExistentKeyBytes)).isNull();
-            
-            // Execute transaction
-            List<Object> results = connection.exec();
-            
-            // Verify results
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(6);
-            assertThat(results.get(0)).isEqualTo(2L);  // rPushX on existing - success
-            assertThat(results.get(1)).isEqualTo(3L);  // lPushX on existing - success
-            assertThat(results.get(2)).isEqualTo(0L);  // rPushX on non-existent - fail
-            assertThat(results.get(3)).isEqualTo(0L);  // lPushX on non-existent - fail
-            assertThat(results.get(4)).isEqualTo(3L);  // lLen on existing
-            assertThat(results.get(5)).isEqualTo(0L);  // lLen on non-existent
-            
-        } finally {
-            cleanupKey(existingKey);
-            cleanupKey(nonExistentKey);
-        }
-    }
+			// Verify trim result
+			List<byte[]> trimmedList = connection.listCommands().lRange(keyBytes, 0, -1);
+			assertThat(trimmedList).hasSize(3);
+			assertThat(trimmedList.get(0)).isEqualTo(value2);
+			assertThat(trimmedList.get(1)).isEqualTo(value3);
+			assertThat(trimmedList.get(2)).isEqualTo(value4);
 
-    @Test
-    void testListPositionCommandsInTransactionMode() {
-        String key = "test:list:transaction:position";
-        byte[] keyBytes = key.getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        byte[] value3 = "value1".getBytes(); // duplicate
-        byte[] insertValue = "inserted".getBytes();
-        
-        try {
-            // Set up test data
-            connection.listCommands().rPush(keyBytes, value1, value2, value3);
-            
-            // Start transaction
-            connection.multi();
-            
-            // Queue position commands - assert they return null in transaction mode
-            assertThat(connection.listCommands().lPos(keyBytes, value1, null, 2)).isNull();
-            assertThat(connection.listCommands().lInsert(keyBytes, Position.BEFORE, value2, insertValue)).isNull();
-            assertThat(connection.listCommands().lIndex(keyBytes, 1)).isNull();
-            assertThat(connection.listCommands().lLen(keyBytes)).isNull();
-            
-            // Execute transaction
-            List<Object> results = connection.exec();
-            
-            // Verify results
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(4);
-            
-            @SuppressWarnings("unchecked")
-            List<Long> lPosResults = (List<Long>) results.get(0);
-            assertThat(lPosResults).containsExactly(0L, 2L); // Both occurrences of value1
-            
-            assertThat(results.get(1)).isEqualTo(4L);  // lInsert result (new list length)
-            assertThat(results.get(2)).isEqualTo(insertValue); // lIndex result
-            assertThat(results.get(3)).isEqualTo(4L);  // lLen result
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Trim to single element
+			connection.listCommands().lTrim(keyBytes, 0, 0);
+			List<byte[]> singleElement = connection.listCommands().lRange(keyBytes, 0, -1);
+			assertThat(singleElement).hasSize(1);
+			assertThat(singleElement.get(0)).isEqualTo(value2);
 
-    @Test
-    void testListMovementCommandsInTransactionMode() {
-        String sourceKey = "test:list:transaction:move:source";
-        String destKey = "test:list:transaction:move:dest";
-        byte[] sourceKeyBytes = sourceKey.getBytes();
-        byte[] destKeyBytes = destKey.getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        byte[] value3 = "value3".getBytes();
-        
-        try {
-            // Set up test data
-            connection.listCommands().rPush(sourceKeyBytes, value1, value2, value3);
-            
-            // Start transaction
-            connection.multi();
-            
-            // Queue movement commands - assert they return null in transaction mode
-            assertThat(connection.listCommands().lMove(sourceKeyBytes, destKeyBytes, Direction.LEFT, Direction.RIGHT)).isNull();
-            assertThat(connection.listCommands().rPopLPush(sourceKeyBytes, destKeyBytes)).isNull();
-            assertThat(connection.listCommands().lLen(sourceKeyBytes)).isNull();
-            assertThat(connection.listCommands().lLen(destKeyBytes)).isNull();
-            assertThat(connection.listCommands().lRange(destKeyBytes, 0, -1)).isNull();
-            
-            // Execute transaction
-            List<Object> results = connection.exec();
-            
-            // Verify results
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(5);
-            assertThat(results.get(0)).isEqualTo(value1); // lMove result
-            assertThat(results.get(1)).isEqualTo(value3); // rPopLPush result
-            assertThat(results.get(2)).isEqualTo(1L);     // Source length after moves
-            assertThat(results.get(3)).isEqualTo(2L);     // Dest length after moves
-            
-            @SuppressWarnings("unchecked")
-            List<byte[]> destRange = (List<byte[]>) results.get(4);
-            assertThat(destRange).hasSize(2);
-            assertThat(destRange.get(0)).isEqualTo(value3); // Head (from rPopLPush)
-            assertThat(destRange.get(1)).isEqualTo(value1); // Tail (from lMove RIGHT)
-            
-        } finally {
-            cleanupKey(sourceKey);
-            cleanupKey(destKey);
-        }
-    }
+			// Trim to empty (out of range)
+			connection.listCommands().lTrim(keyBytes, 10, 20);
+			List<byte[]> emptyList = connection.listCommands().lRange(keyBytes, 0, -1);
+			assertThat(emptyList).isEmpty();
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
 
-    @Test
-    void testListRemovalCommandsInTransactionMode() {
-        String key = "test:list:transaction:removal";
-        byte[] keyBytes = key.getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        byte[] value3 = "value1".getBytes(); // duplicate
-        byte[] value4 = "value2".getBytes(); // duplicate
-        
-        try {
-            // Set up test data
-            connection.listCommands().rPush(keyBytes, value1, value2, value3, value4);
-            
-            // Start transaction
-            connection.multi();
-            
-            // Queue removal commands - assert they return null in transaction mode
-            assertThat(connection.listCommands().lRem(keyBytes, 1, value1)).isNull();
-            assertThat(connection.listCommands().lPop(keyBytes, 2)).isNull();
-            assertThat(connection.listCommands().rPop(keyBytes)).isNull();
-            assertThat(connection.listCommands().lLen(keyBytes)).isNull();
-            
-            // Execute transaction
-            List<Object> results = connection.exec();
-            
-            // Verify results
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(4);
-            assertThat(results.get(0)).isEqualTo(1L); // lRem result (removed 1 occurrence)
-            
-            @SuppressWarnings("unchecked")
-            List<byte[]> lPopResults = (List<byte[]>) results.get(1);
-            assertThat(lPopResults).hasSize(2);
-            assertThat(lPopResults.get(0)).isEqualTo(value2); // First remaining element
-            assertThat(lPopResults.get(1)).isEqualTo(value3); // Second remaining element
-            
-            assertThat(results.get(2)).isEqualTo(value4); // rPop result
-            assertThat(results.get(3)).isEqualTo(0L);     // Final length (empty)
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+	// ==================== List Index Operations ====================
 
-    @Test
-    void testListBlockingCommandsInTransactionMode() {
-        String key1 = "test:list:transaction:blocking:key1";
-        String key2 = "test:list:transaction:blocking:key2";
-        byte[] key1Bytes = key1.getBytes();
-        byte[] key2Bytes = key2.getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        
-        try {
-            // Set up test data
-            connection.listCommands().rPush(key1Bytes, value1);
-            connection.listCommands().rPush(key2Bytes, value2);
-            
-            // Start transaction
-            connection.multi();
-            
-            // Queue blocking commands with short timeout - assert they return null in transaction mode
-            assertThat(connection.listCommands().bLPop(1, key1Bytes, key2Bytes)).isNull();
-            assertThat(connection.listCommands().bRPop(1, key1Bytes, key2Bytes)).isNull();
-            
-            // Execute transaction
-            List<Object> results = connection.exec();
-            
-            // Verify results
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(2);
-            
-            @SuppressWarnings("unchecked")
-            List<byte[]> blPopResult = (List<byte[]>) results.get(0);
-            assertThat(blPopResult).hasSize(2);
-            assertThat(blPopResult.get(0)).isEqualTo(key1Bytes); // Key that had element
-            assertThat(blPopResult.get(1)).isEqualTo(value1);    // Popped element
-            
-            @SuppressWarnings("unchecked")
-            List<byte[]> brPopResult = (List<byte[]>) results.get(1);
-            assertThat(brPopResult).hasSize(2);
-            assertThat(brPopResult.get(0)).isEqualTo(key2Bytes); // Key that had element
-            assertThat(brPopResult.get(1)).isEqualTo(value2);    // Popped element
-            
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-        }
-    }
+	@Test
+	void testLIndexAndLSet() {
+		String key = "test:list:index";
+		byte[] keyBytes = key.getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+		byte[] value3 = "value3".getBytes();
+		byte[] newValue = "newvalue".getBytes();
 
-    @Test
-    void testListTrimCommandInTransactionMode() {
-        String key = "test:list:transaction:trim";
-        byte[] keyBytes = key.getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        byte[] value3 = "value3".getBytes();
-        byte[] value4 = "value4".getBytes();
-        byte[] value5 = "value5".getBytes();
-        
-        try {
-            // Set up test data
-            connection.listCommands().rPush(keyBytes, value1, value2, value3, value4, value5);
-            
-            // Start transaction
-            connection.multi();
-            
-            // Queue trim and verification commands
-            connection.listCommands().lTrim(keyBytes, 1, 3); // void method, no assertion
-            assertThat(connection.listCommands().lLen(keyBytes)).isNull();
-            assertThat(connection.listCommands().lRange(keyBytes, 0, -1)).isNull();
-            
-            // Execute transaction
-            List<Object> results = connection.exec();
-            
-            // Verify results
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(3);
-            assertThat(results.get(0)).isEqualTo("OK"); // lTrim result
-            assertThat(results.get(1)).isEqualTo(3L);   // lLen result after trim
-            
-            @SuppressWarnings("unchecked")
-            List<byte[]> rangeResult = (List<byte[]>) results.get(2);
-            assertThat(rangeResult).hasSize(3);
-            assertThat(rangeResult.get(0)).isEqualTo(value2); // Trimmed list starts with value2
-            assertThat(rangeResult.get(1)).isEqualTo(value3);
-            assertThat(rangeResult.get(2)).isEqualTo(value4); // Trimmed list ends with value4
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+		try {
+			// Test lIndex on non-existent key
+			byte[] nonExistentValue = connection.listCommands().lIndex(keyBytes, 0);
+			assertThat(nonExistentValue).isNull();
 
-    @Test
-    void testTransactionDiscardWithListCommands() {
-        String key = "test:list:transaction:discard";
-        byte[] keyBytes = key.getBytes();
-        byte[] value = "value".getBytes();
-        
-        try {
-            // Start transaction
-            connection.multi();
-            
-            // Queue list commands
-            connection.listCommands().rPush(keyBytes, value);
-            connection.listCommands().lLen(keyBytes);
-            
-            // Discard transaction
-            connection.discard();
-            
-            // Verify key doesn't exist (transaction was discarded)
-            Long len = connection.listCommands().lLen(keyBytes);
-            assertThat(len).isEqualTo(0L);
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Set up test data
+			connection.listCommands().rPush(keyBytes, value1, value2, value3);
 
-    @Test
-    void testListAdvancedCommandsInTransactionMode() {
-        String sourceKey1 = "test:list:transaction:advanced:source1";
-        String destKey1 = "test:list:transaction:advanced:dest1";
-        String sourceKey2 = "test:list:transaction:advanced:source2";
-        String destKey2 = "test:list:transaction:advanced:dest2";
-        byte[] sourceKey1Bytes = sourceKey1.getBytes();
-        byte[] destKey1Bytes = destKey1.getBytes();
-        byte[] sourceKey2Bytes = sourceKey2.getBytes();
-        byte[] destKey2Bytes = destKey2.getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        
-        try {
-            // Set up test data
-            connection.listCommands().rPush(sourceKey1Bytes, value1);
-            connection.listCommands().rPush(sourceKey2Bytes, value2);
-            
-            // Start transaction
-            connection.multi();
-            
-            // Queue advanced commands - assert they return null in transaction mode
-            assertThat(connection.listCommands().bLMove(sourceKey1Bytes, destKey1Bytes, Direction.LEFT, Direction.RIGHT, 0.1)).isNull();
-            assertThat(connection.listCommands().bRPopLPush(1, sourceKey2Bytes, destKey2Bytes)).isNull();
-            assertThat(connection.listCommands().lLen(destKey1Bytes)).isNull();
-            assertThat(connection.listCommands().lLen(destKey2Bytes)).isNull();
-            
-            // Execute transaction
-            List<Object> results = connection.exec();
-            
-            // Verify results
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(4);
-            assertThat(results.get(0)).isEqualTo(value1); // bLMove result
-            assertThat(results.get(1)).isEqualTo(value2); // bRPopLPush result
-            assertThat(results.get(2)).isEqualTo(1L);     // destKey1 length
-            assertThat(results.get(3)).isEqualTo(1L);     // destKey2 length
-            
-        } finally {
-            cleanupKey(sourceKey1);
-            cleanupKey(destKey1);
-            cleanupKey(sourceKey2);
-            cleanupKey(destKey2);
-        }
-    }
+			// Test lIndex with positive indices
+			byte[] index0 = connection.listCommands().lIndex(keyBytes, 0);
+			assertThat(index0).isEqualTo(value1);
 
-    @Test
-    void testWatchWithListCommandsTransaction() throws InterruptedException {
-        String watchKey = "test:list:transaction:watch";
-        String otherKey = "test:list:transaction:other";
-        byte[] watchKeyBytes = watchKey.getBytes();
-        byte[] otherKeyBytes = otherKey.getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        
-        try {
-            // Setup initial data
-            connection.listCommands().rPush(watchKeyBytes, value1);
-            
-            // Watch the key
-            connection.watch(watchKeyBytes);
-            
-            // Modify the watched key from "outside" the transaction
-            // (simulating another client)
-            connection.listCommands().rPush(watchKeyBytes, value2);
-            
-            // Start transaction
-            connection.multi();
-            
-            // Queue list commands
-            connection.listCommands().rPush(otherKeyBytes, value1);
-            connection.listCommands().lLen(otherKeyBytes);
-            
-            // Execute transaction - should be aborted due to WATCH
-            List<Object> results = connection.exec();
-            
-            // Transaction should be aborted (results should be null)
-            assertThat(results).isNotNull().isEmpty();
-            
-            // Verify that the other key was not set
-            Long len = connection.listCommands().lLen(otherKeyBytes);
-            assertThat(len).isEqualTo(0L);
-            
-        } finally {
-            cleanupKey(watchKey);
-            cleanupKey(otherKey);
-        }
-    }
+			byte[] index1 = connection.listCommands().lIndex(keyBytes, 1);
+			assertThat(index1).isEqualTo(value2);
+
+			byte[] index2 = connection.listCommands().lIndex(keyBytes, 2);
+			assertThat(index2).isEqualTo(value3);
+
+			// Test lIndex with negative indices
+			byte[] indexNeg1 = connection.listCommands().lIndex(keyBytes, -1);
+			assertThat(indexNeg1).isEqualTo(value3); // Last element
+
+			byte[] indexNeg2 = connection.listCommands().lIndex(keyBytes, -2);
+			assertThat(indexNeg2).isEqualTo(value2); // Second to last
+
+			byte[] indexNeg3 = connection.listCommands().lIndex(keyBytes, -3);
+			assertThat(indexNeg3).isEqualTo(value1); // Third to last (first)
+
+			// Test lIndex out of bounds
+			byte[] outOfBounds = connection.listCommands().lIndex(keyBytes, 10);
+			assertThat(outOfBounds).isNull();
+
+			// Test lSet
+			connection.listCommands().lSet(keyBytes, 1, newValue);
+
+			// Verify lSet result
+			byte[] updatedValue = connection.listCommands().lIndex(keyBytes, 1);
+			assertThat(updatedValue).isEqualTo(newValue);
+
+			// Verify other elements unchanged
+			assertThat(connection.listCommands().lIndex(keyBytes, 0)).isEqualTo(value1);
+			assertThat(connection.listCommands().lIndex(keyBytes, 2)).isEqualTo(value3);
+
+			// Test lSet with negative index
+			connection.listCommands().lSet(keyBytes, -1, "lastvalue".getBytes());
+			byte[] lastValue = connection.listCommands().lIndex(keyBytes, -1);
+			assertThat(lastValue).isEqualTo("lastvalue".getBytes());
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== List Insertion Operations ====================
+
+	@Test
+	void testLInsert() {
+		String key = "test:list:insert";
+		byte[] keyBytes = key.getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+		byte[] value3 = "value3".getBytes();
+		byte[] beforeValue = "before".getBytes();
+		byte[] afterValue = "after".getBytes();
+
+		try {
+			// Test lInsert on non-existent key
+			Long insertNonExistent = connection.listCommands().lInsert(keyBytes, Position.BEFORE, value1, beforeValue);
+			assertThat(insertNonExistent).isEqualTo(0L); // Key doesn't exist
+
+			// Set up test data: [value1, value2, value3]
+			connection.listCommands().rPush(keyBytes, value1, value2, value3);
+
+			// Test lInsert BEFORE
+			Long insertBefore = connection.listCommands().lInsert(keyBytes, Position.BEFORE, value2, beforeValue);
+			assertThat(insertBefore).isEqualTo(4L); // New list length
+
+			// Verify insertion: [value1, before, value2, value3]
+			List<byte[]> afterBeforeInsert = connection.listCommands().lRange(keyBytes, 0, -1);
+			assertThat(afterBeforeInsert).hasSize(4);
+			assertThat(afterBeforeInsert.get(0)).isEqualTo(value1);
+			assertThat(afterBeforeInsert.get(1)).isEqualTo(beforeValue);
+			assertThat(afterBeforeInsert.get(2)).isEqualTo(value2);
+			assertThat(afterBeforeInsert.get(3)).isEqualTo(value3);
+
+			// Test lInsert AFTER
+			Long insertAfter = connection.listCommands().lInsert(keyBytes, Position.AFTER, value2, afterValue);
+			assertThat(insertAfter).isEqualTo(5L); // New list length
+
+			// Verify insertion: [value1, before, value2, after, value3]
+			List<byte[]> afterAfterInsert = connection.listCommands().lRange(keyBytes, 0, -1);
+			assertThat(afterAfterInsert).hasSize(5);
+			assertThat(afterAfterInsert.get(0)).isEqualTo(value1);
+			assertThat(afterAfterInsert.get(1)).isEqualTo(beforeValue);
+			assertThat(afterAfterInsert.get(2)).isEqualTo(value2);
+			assertThat(afterAfterInsert.get(3)).isEqualTo(afterValue);
+			assertThat(afterAfterInsert.get(4)).isEqualTo(value3);
+
+			// Test lInsert with non-existent pivot
+			Long insertNonPivot = connection.listCommands()
+				.lInsert(keyBytes, Position.BEFORE, "nonexistent".getBytes(), "newvalue".getBytes());
+			assertThat(insertNonPivot).isEqualTo(-1L); // Pivot not found
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== List Movement Operations ====================
+
+	@Test
+	void testLMove() {
+		String sourceKey = "test:list:move:source";
+		String destKey = "test:list:move:dest";
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+		byte[] value3 = "value3".getBytes();
+
+		try {
+			// Set up source list: [value1, value2, value3]
+			connection.listCommands().rPush(sourceKey.getBytes(), value1, value2, value3);
+
+			// Test lMove LEFT to LEFT (head to head)
+			byte[] movedValue1 = connection.listCommands()
+				.lMove(sourceKey.getBytes(), destKey.getBytes(), Direction.LEFT, Direction.LEFT);
+			assertThat(movedValue1).isEqualTo(value1);
+
+			// Verify source: [value2, value3]
+			List<byte[]> sourceAfterMove1 = connection.listCommands().lRange(sourceKey.getBytes(), 0, -1);
+			assertThat(sourceAfterMove1).hasSize(2);
+			assertThat(sourceAfterMove1.get(0)).isEqualTo(value2);
+
+			// Verify dest: [value1]
+			List<byte[]> destAfterMove1 = connection.listCommands().lRange(destKey.getBytes(), 0, -1);
+			assertThat(destAfterMove1).hasSize(1);
+			assertThat(destAfterMove1.get(0)).isEqualTo(value1);
+
+			// Test lMove RIGHT to RIGHT (tail to tail)
+			byte[] movedValue2 = connection.listCommands()
+				.lMove(sourceKey.getBytes(), destKey.getBytes(), Direction.RIGHT, Direction.RIGHT);
+			assertThat(movedValue2).isEqualTo(value3);
+
+			// Verify source: [value2]
+			List<byte[]> sourceAfterMove2 = connection.listCommands().lRange(sourceKey.getBytes(), 0, -1);
+			assertThat(sourceAfterMove2).hasSize(1);
+			assertThat(sourceAfterMove2.get(0)).isEqualTo(value2);
+
+			// Verify dest: [value1, value3]
+			List<byte[]> destAfterMove2 = connection.listCommands().lRange(destKey.getBytes(), 0, -1);
+			assertThat(destAfterMove2).hasSize(2);
+			assertThat(destAfterMove2.get(0)).isEqualTo(value1);
+			assertThat(destAfterMove2.get(1)).isEqualTo(value3);
+
+			// Test lMove LEFT to RIGHT (head to tail)
+			byte[] movedValue3 = connection.listCommands()
+				.lMove(sourceKey.getBytes(), destKey.getBytes(), Direction.LEFT, Direction.RIGHT);
+			assertThat(movedValue3).isEqualTo(value2);
+
+			// Verify source is empty
+			List<byte[]> sourceEmpty = connection.listCommands().lRange(sourceKey.getBytes(), 0, -1);
+			assertThat(sourceEmpty).isEmpty();
+
+			// Verify dest: [value1, value3, value2]
+			List<byte[]> destFinal = connection.listCommands().lRange(destKey.getBytes(), 0, -1);
+			assertThat(destFinal).hasSize(3);
+			assertThat(destFinal.get(0)).isEqualTo(value1);
+			assertThat(destFinal.get(1)).isEqualTo(value3);
+			assertThat(destFinal.get(2)).isEqualTo(value2);
+
+			// Test lMove on empty source
+			byte[] moveFromEmpty = connection.listCommands()
+				.lMove(sourceKey.getBytes(), destKey.getBytes(), Direction.LEFT, Direction.LEFT);
+			assertThat(moveFromEmpty).isNull();
+		}
+		finally {
+			cleanupKey(sourceKey);
+			cleanupKey(destKey);
+		}
+	}
+
+	@Test
+	void testBLMove() {
+		String sourceKey = "test:list:blmove:source";
+		String destKey = "test:list:blmove:dest";
+		byte[] value1 = "value1".getBytes();
+
+		try {
+			// Set up source list
+			connection.listCommands().rPush(sourceKey.getBytes(), value1);
+
+			// Test bLMove with immediate availability (timeout not reached)
+			byte[] movedValue = connection.listCommands()
+				.bLMove(sourceKey.getBytes(), destKey.getBytes(), Direction.LEFT, Direction.RIGHT, 1.0);
+			assertThat(movedValue).isEqualTo(value1);
+
+			// Verify movement
+			List<byte[]> sourceEmpty = connection.listCommands().lRange(sourceKey.getBytes(), 0, -1);
+			assertThat(sourceEmpty).isEmpty();
+
+			List<byte[]> destWithValue = connection.listCommands().lRange(destKey.getBytes(), 0, -1);
+			assertThat(destWithValue).hasSize(1);
+			assertThat(destWithValue.get(0)).isEqualTo(value1);
+
+			// Test bLMove on empty source with timeout
+			long startTime = System.currentTimeMillis();
+			byte[] timeoutResult = connection.listCommands()
+				.bLMove(sourceKey.getBytes(), destKey.getBytes(), Direction.LEFT, Direction.LEFT, 0.1); // 100ms
+																										// timeout
+			long endTime = System.currentTimeMillis();
+
+			assertThat(timeoutResult).isNull();
+			// Verify timeout occurred (allow some margin for execution time)
+			assertThat(endTime - startTime).isGreaterThanOrEqualTo(90L).isLessThan(300L);
+		}
+		finally {
+			cleanupKey(sourceKey);
+			cleanupKey(destKey);
+		}
+	}
+
+	// ==================== List Removal Operations ====================
+
+	@Test
+	void testLRem() {
+		String key = "test:list:rem";
+		byte[] keyBytes = key.getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+		byte[] value3 = "value1".getBytes(); // duplicate
+		byte[] value4 = "value2".getBytes(); // duplicate
+		byte[] value5 = "value1".getBytes(); // duplicate
+
+		try {
+			// Set up test data: [value1, value2, value1, value2, value1]
+			connection.listCommands().rPush(keyBytes, value1, value2, value3, value4, value5);
+
+			// Test lRem with positive count (remove from head)
+			Long remResult1 = connection.listCommands().lRem(keyBytes, 2, value1);
+			assertThat(remResult1).isEqualTo(2L); // Removed 2 occurrences
+
+			// Verify: [value2, value2, value1]
+			List<byte[]> afterRem1 = connection.listCommands().lRange(keyBytes, 0, -1);
+			assertThat(afterRem1).hasSize(3);
+			assertThat(afterRem1.get(0)).isEqualTo(value2);
+			assertThat(afterRem1.get(1)).isEqualTo(value2);
+			assertThat(afterRem1.get(2)).isEqualTo(value1);
+
+			// Test lRem with negative count (remove from tail)
+			Long remResult2 = connection.listCommands().lRem(keyBytes, -1, value2);
+			assertThat(remResult2).isEqualTo(1L); // Removed 1 occurrence from tail
+
+			// Verify: [value2, value1]
+			List<byte[]> afterRem2 = connection.listCommands().lRange(keyBytes, 0, -1);
+			assertThat(afterRem2).hasSize(2);
+			assertThat(afterRem2.get(0)).isEqualTo(value2);
+			assertThat(afterRem2.get(1)).isEqualTo(value1);
+
+			// Test lRem with count 0 (remove all occurrences)
+			connection.listCommands().rPush(keyBytes, value1, value1); // Add more
+																		// duplicates
+			Long remResult3 = connection.listCommands().lRem(keyBytes, 0, value1);
+			assertThat(remResult3).isEqualTo(3L); // Removed all 3 occurrences
+
+			// Verify: [value2]
+			List<byte[]> afterRem3 = connection.listCommands().lRange(keyBytes, 0, -1);
+			assertThat(afterRem3).hasSize(1);
+			assertThat(afterRem3.get(0)).isEqualTo(value2);
+
+			// Test lRem on non-existent element
+			Long remNonExistent = connection.listCommands().lRem(keyBytes, 1, "nonexistent".getBytes());
+			assertThat(remNonExistent).isEqualTo(0L);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testLPopAndRPop() {
+		String key = "test:list:pop";
+		byte[] keyBytes = key.getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+		byte[] value3 = "value3".getBytes();
+		byte[] value4 = "value4".getBytes();
+		byte[] value5 = "value5".getBytes();
+
+		try {
+			// Test pop on non-existent key
+			byte[] nonExistentPop = connection.listCommands().lPop(keyBytes);
+			assertThat(nonExistentPop).isNull();
+
+			byte[] nonExistentRPop = connection.listCommands().rPop(keyBytes);
+			assertThat(nonExistentRPop).isNull();
+
+			// Set up test data: [value1, value2, value3, value4, value5]
+			connection.listCommands().rPush(keyBytes, value1, value2, value3, value4, value5);
+
+			// Test lPop (left pop - from head)
+			byte[] leftPopped1 = connection.listCommands().lPop(keyBytes);
+			assertThat(leftPopped1).isEqualTo(value1);
+
+			// Test rPop (right pop - from tail)
+			byte[] rightPopped1 = connection.listCommands().rPop(keyBytes);
+			assertThat(rightPopped1).isEqualTo(value5);
+
+			// Verify remaining: [value2, value3, value4]
+			List<byte[]> remaining = connection.listCommands().lRange(keyBytes, 0, -1);
+			assertThat(remaining).hasSize(3);
+			assertThat(remaining.get(0)).isEqualTo(value2);
+			assertThat(remaining.get(1)).isEqualTo(value3);
+			assertThat(remaining.get(2)).isEqualTo(value4);
+
+			// Test lPop with count
+			List<byte[]> leftPoppedMultiple = connection.listCommands().lPop(keyBytes, 2);
+			assertThat(leftPoppedMultiple).hasSize(2);
+			assertThat(leftPoppedMultiple.get(0)).isEqualTo(value2);
+			assertThat(leftPoppedMultiple.get(1)).isEqualTo(value3);
+
+			// Test rPop with count
+			List<byte[]> rightPoppedMultiple = connection.listCommands().rPop(keyBytes, 1);
+			assertThat(rightPoppedMultiple).hasSize(1);
+			assertThat(rightPoppedMultiple.get(0)).isEqualTo(value4);
+
+			// Verify list is empty
+			Long finalLength = connection.listCommands().lLen(keyBytes);
+			assertThat(finalLength).isEqualTo(0L);
+
+			// Test pop with count on empty list
+			List<byte[]> emptyPop = connection.listCommands().lPop(keyBytes, 3);
+			assertThat(emptyPop).isNull();
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== Blocking Operations ====================
+
+	@Test
+	void testBLPopAndBRPop() {
+		String key1 = "test:list:blpop:key1";
+		String key2 = "test:list:blpop:key2";
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+
+		try {
+			// Set up test data
+			connection.listCommands().rPush(key1.getBytes(), value1);
+			connection.listCommands().rPush(key2.getBytes(), value2);
+
+			// Test bLPop with immediate availability (timeout not reached)
+			List<byte[]> blPopResult = connection.listCommands().bLPop(1, key1.getBytes(), key2.getBytes());
+			assertThat(blPopResult).hasSize(2);
+			assertThat(blPopResult.get(0)).isEqualTo(key1.getBytes()); // Key that had the
+																		// element
+			assertThat(blPopResult.get(1)).isEqualTo(value1); // Popped element
+
+			// Test bRPop with immediate availability
+			List<byte[]> brPopResult = connection.listCommands().bRPop(1, key1.getBytes(), key2.getBytes());
+			assertThat(brPopResult).hasSize(2);
+			assertThat(brPopResult.get(0)).isEqualTo(key2.getBytes()); // Key that had the
+																		// element
+			assertThat(brPopResult.get(1)).isEqualTo(value2); // Popped element
+
+			// Test blocking with timeout (both keys are empty now)
+			long startTime = System.currentTimeMillis();
+			List<byte[]> timeoutResult = connection.listCommands().bLPop(1, key1.getBytes(), key2.getBytes());
+			long endTime = System.currentTimeMillis();
+
+			assertThat(timeoutResult).isEmpty(); // Timeout occurred
+			// Verify timeout occurred (allow some margin for execution time)
+			assertThat(endTime - startTime).isGreaterThanOrEqualTo(900L).isLessThan(1200L);
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+		}
+	}
+
+	// ==================== Pop and Push Operations ====================
+
+	@Test
+	void testRPopLPush() {
+		String sourceKey = "test:list:rpoplpush:source";
+		String destKey = "test:list:rpoplpush:dest";
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+		byte[] value3 = "value3".getBytes();
+
+		try {
+			// Test rPopLPush on non-existent source
+			byte[] nonExistentResult = connection.listCommands().rPopLPush(sourceKey.getBytes(), destKey.getBytes());
+			assertThat(nonExistentResult).isNull();
+
+			// Set up source list: [value1, value2, value3]
+			connection.listCommands().rPush(sourceKey.getBytes(), value1, value2, value3);
+
+			// Test rPopLPush (pop from tail of source, push to head of dest)
+			byte[] poppedValue1 = connection.listCommands().rPopLPush(sourceKey.getBytes(), destKey.getBytes());
+			assertThat(poppedValue1).isEqualTo(value3);
+
+			// Verify source: [value1, value2]
+			List<byte[]> sourceAfterPop1 = connection.listCommands().lRange(sourceKey.getBytes(), 0, -1);
+			assertThat(sourceAfterPop1).hasSize(2);
+			assertThat(sourceAfterPop1.get(0)).isEqualTo(value1);
+			assertThat(sourceAfterPop1.get(1)).isEqualTo(value2);
+
+			// Verify dest: [value3]
+			List<byte[]> destAfterPush1 = connection.listCommands().lRange(destKey.getBytes(), 0, -1);
+			assertThat(destAfterPush1).hasSize(1);
+			assertThat(destAfterPush1.get(0)).isEqualTo(value3);
+
+			// Test another rPopLPush
+			byte[] poppedValue2 = connection.listCommands().rPopLPush(sourceKey.getBytes(), destKey.getBytes());
+			assertThat(poppedValue2).isEqualTo(value2);
+
+			// Verify final state
+			// Source: [value1]
+			List<byte[]> sourceFinal = connection.listCommands().lRange(sourceKey.getBytes(), 0, -1);
+			assertThat(sourceFinal).hasSize(1);
+			assertThat(sourceFinal.get(0)).isEqualTo(value1);
+
+			// Dest: [value2, value3]
+			List<byte[]> destFinal = connection.listCommands().lRange(destKey.getBytes(), 0, -1);
+			assertThat(destFinal).hasSize(2);
+			assertThat(destFinal.get(0)).isEqualTo(value2);
+			assertThat(destFinal.get(1)).isEqualTo(value3);
+
+			// Test rPopLPush to same key (rotate list)
+			connection.listCommands().rPopLPush(destKey.getBytes(), destKey.getBytes());
+			List<byte[]> rotatedDest = connection.listCommands().lRange(destKey.getBytes(), 0, -1);
+			assertThat(rotatedDest).hasSize(2);
+			assertThat(rotatedDest.get(0)).isEqualTo(value3); // Last element moved to
+																// first
+			assertThat(rotatedDest.get(1)).isEqualTo(value2);
+		}
+		finally {
+			cleanupKey(sourceKey);
+			cleanupKey(destKey);
+		}
+	}
+
+	@Test
+	void testBRPopLPush() {
+		String sourceKey = "test:list:brpoplpush:source";
+		String destKey = "test:list:brpoplpush:dest";
+		byte[] value1 = "value1".getBytes();
+
+		try {
+			// Set up source list
+			connection.listCommands().rPush(sourceKey.getBytes(), value1);
+
+			// Test bRPopLPush with immediate availability
+			byte[] poppedValue = connection.listCommands().bRPopLPush(1, sourceKey.getBytes(), destKey.getBytes());
+			assertThat(poppedValue).isEqualTo(value1);
+
+			// Verify movement
+			List<byte[]> sourceEmpty = connection.listCommands().lRange(sourceKey.getBytes(), 0, -1);
+			assertThat(sourceEmpty).isEmpty();
+
+			List<byte[]> destWithValue = connection.listCommands().lRange(destKey.getBytes(), 0, -1);
+			assertThat(destWithValue).hasSize(1);
+			assertThat(destWithValue.get(0)).isEqualTo(value1);
+
+			// Test bRPopLPush with timeout (source is empty)
+			long startTime = System.currentTimeMillis();
+			byte[] timeoutResult = connection.listCommands().bRPopLPush(1, sourceKey.getBytes(), destKey.getBytes());
+			long endTime = System.currentTimeMillis();
+
+			assertThat(timeoutResult).isNull();
+			// Verify timeout occurred (allow some margin for execution time)
+			assertThat(endTime - startTime).isGreaterThanOrEqualTo(900L).isLessThan(1200L);
+		}
+		finally {
+			cleanupKey(sourceKey);
+			cleanupKey(destKey);
+		}
+	}
+
+	// ==================== Error Handling and Edge Cases ====================
+
+	@Test
+	void testListOperationsOnNonListTypes() {
+		String stringKey = "test:list:error:string";
+
+		try {
+			// Create a string key
+			connection.stringCommands().set(stringKey.getBytes(), "stringvalue".getBytes());
+
+			// Try list operations on string key - should fail or return appropriate
+			// response
+			assertThatThrownBy(() -> connection.listCommands().lPush(stringKey.getBytes(), "value".getBytes()))
+				.isInstanceOf(DataAccessException.class);
+		}
+		finally {
+			cleanupKey(stringKey);
+		}
+	}
+
+	@Test
+	void testEmptyListOperations() {
+		String key = "test:list:empty";
+		byte[] keyBytes = key.getBytes();
+		byte[] emptyValue = new byte[0];
+
+		try {
+			// Push empty value
+			Long pushResult = connection.listCommands().rPush(keyBytes, emptyValue);
+			assertThat(pushResult).isEqualTo(1L);
+
+			// Get empty value
+			byte[] retrievedValue = connection.listCommands().lIndex(keyBytes, 0);
+			assertThat(retrievedValue).isEqualTo(emptyValue);
+
+			// List should have 1 element
+			Long listLen = connection.listCommands().lLen(keyBytes);
+			assertThat(listLen).isEqualTo(1L);
+
+			// Pop empty value
+			byte[] poppedValue = connection.listCommands().lPop(keyBytes);
+			assertThat(poppedValue).isEqualTo(emptyValue);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testListOperationsWithBinaryData() {
+		String key = "test:list:binary";
+		byte[] keyBytes = key.getBytes();
+		byte[] binaryValue1 = new byte[] { 0x00, 0x01, 0x02, (byte) 0xFF };
+		byte[] binaryValue2 = new byte[] { (byte) 0xFF, (byte) 0xFE, 0x00, 0x01, 0x7F };
+
+		try {
+			// Test with binary values
+			Long pushResult = connection.listCommands().rPush(keyBytes, binaryValue1, binaryValue2);
+			assertThat(pushResult).isEqualTo(2L);
+
+			// Retrieve binary values
+			List<byte[]> retrievedValues = connection.listCommands().lRange(keyBytes, 0, -1);
+			assertThat(retrievedValues).hasSize(2);
+			assertThat(retrievedValues.get(0)).isEqualTo(binaryValue1);
+			assertThat(retrievedValues.get(1)).isEqualTo(binaryValue2);
+
+			// Test binary value operations
+			byte[] poppedBinary = connection.listCommands().lPop(keyBytes);
+			assertThat(poppedBinary).isEqualTo(binaryValue1);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== Pipeline Mode Tests ====================
+
+	@Test
+	void testBasicListCommandsInPipelineMode() {
+		String key = "test:list:pipeline:basic";
+		byte[] keyBytes = key.getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+		byte[] value3 = "value3".getBytes();
+
+		try {
+			// Start pipeline
+			connection.openPipeline();
+
+			// Queue basic list commands - assert they return null in pipeline mode
+			assertThat(connection.listCommands().rPush(keyBytes, value1, value2)).isNull();
+			assertThat(connection.listCommands().lPush(keyBytes, value3)).isNull();
+			assertThat(connection.listCommands().lLen(keyBytes)).isNull();
+			assertThat(connection.listCommands().lRange(keyBytes, 0, -1)).isNull();
+			assertThat(connection.listCommands().lIndex(keyBytes, 0)).isNull();
+			assertThat(connection.listCommands().rPop(keyBytes)).isNull();
+			assertThat(connection.listCommands().lPop(keyBytes)).isNull();
+
+			// Execute pipeline
+			List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(7);
+			assertThat(results.get(0)).isEqualTo(2L); // rPush result
+			assertThat(results.get(1)).isEqualTo(3L); // lPush result
+			assertThat(results.get(2)).isEqualTo(3L); // lLen result
+
+			@SuppressWarnings("unchecked")
+			List<byte[]> rangeResult = (List<byte[]>) results.get(3);
+			assertThat(rangeResult).hasSize(3);
+			assertThat(rangeResult.get(0)).isEqualTo(value3); // Head after lPush
+			assertThat(rangeResult.get(1)).isEqualTo(value1);
+			assertThat(rangeResult.get(2)).isEqualTo(value2); // Tail
+
+			assertThat(results.get(4)).isEqualTo(value3); // lIndex result
+			assertThat(results.get(5)).isEqualTo(value2); // rPop result (from tail)
+			assertThat(results.get(6)).isEqualTo(value3); // lPop result (from head)
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testConditionalListCommandsInPipelineMode() {
+		String existingKey = "test:list:pipeline:conditional:existing";
+		String nonExistentKey = "test:list:pipeline:conditional:nonexistent";
+		byte[] existingKeyBytes = existingKey.getBytes();
+		byte[] nonExistentKeyBytes = nonExistentKey.getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+
+		try {
+			// Set up existing list
+			connection.listCommands().rPush(existingKeyBytes, value1);
+
+			// Start pipeline
+			connection.openPipeline();
+
+			// Queue conditional commands - assert they return null in pipeline mode
+			assertThat(connection.listCommands().rPushX(existingKeyBytes, value2)).isNull();
+			assertThat(connection.listCommands().lPushX(existingKeyBytes, "head".getBytes())).isNull();
+			assertThat(connection.listCommands().rPushX(nonExistentKeyBytes, value1)).isNull();
+			assertThat(connection.listCommands().lPushX(nonExistentKeyBytes, value1)).isNull();
+			assertThat(connection.listCommands().lLen(existingKeyBytes)).isNull();
+			assertThat(connection.listCommands().lLen(nonExistentKeyBytes)).isNull();
+
+			// Execute pipeline
+			List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(6);
+			assertThat(results.get(0)).isEqualTo(2L); // rPushX on existing - success
+			assertThat(results.get(1)).isEqualTo(3L); // lPushX on existing - success
+			assertThat(results.get(2)).isEqualTo(0L); // rPushX on non-existent - fail
+			assertThat(results.get(3)).isEqualTo(0L); // lPushX on non-existent - fail
+			assertThat(results.get(4)).isEqualTo(3L); // lLen on existing
+			assertThat(results.get(5)).isEqualTo(0L); // lLen on non-existent
+
+		}
+		finally {
+			cleanupKey(existingKey);
+			cleanupKey(nonExistentKey);
+		}
+	}
+
+	@Test
+	void testListPositionCommandsInPipelineMode() {
+		String key = "test:list:pipeline:position";
+		byte[] keyBytes = key.getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+		byte[] value3 = "value1".getBytes(); // duplicate
+		byte[] insertValue = "inserted".getBytes();
+
+		try {
+			// Set up test data
+			connection.listCommands().rPush(keyBytes, value1, value2, value3);
+
+			// Start pipeline
+			connection.openPipeline();
+
+			// Queue position commands - assert they return null in pipeline mode
+			assertThat(connection.listCommands().lPos(keyBytes, value1, null, 2)).isNull();
+			assertThat(connection.listCommands().lInsert(keyBytes, Position.BEFORE, value2, insertValue)).isNull();
+			assertThat(connection.listCommands().lIndex(keyBytes, 1)).isNull();
+			assertThat(connection.listCommands().lLen(keyBytes)).isNull();
+
+			// Execute pipeline
+			List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(4);
+
+			@SuppressWarnings("unchecked")
+			List<Long> lPosResults = (List<Long>) results.get(0);
+			assertThat(lPosResults).containsExactly(0L, 2L); // Both occurrences of value1
+
+			assertThat(results.get(1)).isEqualTo(4L); // lInsert result (new list length)
+			assertThat(results.get(2)).isEqualTo(insertValue); // lIndex result
+			assertThat(results.get(3)).isEqualTo(4L); // lLen result
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testListMovementCommandsInPipelineMode() {
+		String sourceKey = "test:list:pipeline:move:source";
+		String destKey = "test:list:pipeline:move:dest";
+		byte[] sourceKeyBytes = sourceKey.getBytes();
+		byte[] destKeyBytes = destKey.getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+		byte[] value3 = "value3".getBytes();
+
+		try {
+			// Set up test data
+			connection.listCommands().rPush(sourceKeyBytes, value1, value2, value3);
+
+			// Start pipeline
+			connection.openPipeline();
+
+			// Queue movement commands - assert they return null in pipeline mode
+			assertThat(connection.listCommands().lMove(sourceKeyBytes, destKeyBytes, Direction.LEFT, Direction.RIGHT))
+				.isNull();
+			assertThat(connection.listCommands().rPopLPush(sourceKeyBytes, destKeyBytes)).isNull();
+			assertThat(connection.listCommands().lLen(sourceKeyBytes)).isNull();
+			assertThat(connection.listCommands().lLen(destKeyBytes)).isNull();
+			assertThat(connection.listCommands().lRange(destKeyBytes, 0, -1)).isNull();
+
+			// Execute pipeline
+			List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(5);
+			assertThat(results.get(0)).isEqualTo(value1); // lMove result
+			assertThat(results.get(1)).isEqualTo(value3); // rPopLPush result
+			assertThat(results.get(2)).isEqualTo(1L); // Source length after moves
+			assertThat(results.get(3)).isEqualTo(2L); // Dest length after moves
+
+			@SuppressWarnings("unchecked")
+			List<byte[]> destRange = (List<byte[]>) results.get(4);
+			assertThat(destRange).hasSize(2);
+			assertThat(destRange.get(0)).isEqualTo(value3); // Head (from rPopLPush)
+			assertThat(destRange.get(1)).isEqualTo(value1); // Tail (from lMove RIGHT)
+
+		}
+		finally {
+			cleanupKey(sourceKey);
+			cleanupKey(destKey);
+		}
+	}
+
+	@Test
+	void testListRemovalCommandsInPipelineMode() {
+		String key = "test:list:pipeline:removal";
+		byte[] keyBytes = key.getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+		byte[] value3 = "value1".getBytes(); // duplicate
+		byte[] value4 = "value2".getBytes(); // duplicate
+
+		try {
+			// Set up test data
+			connection.listCommands().rPush(keyBytes, value1, value2, value3, value4);
+
+			// Start pipeline
+			connection.openPipeline();
+
+			// Queue removal commands - assert they return null in pipeline mode
+			assertThat(connection.listCommands().lRem(keyBytes, 1, value1)).isNull();
+			assertThat(connection.listCommands().lPop(keyBytes, 2)).isNull();
+			assertThat(connection.listCommands().rPop(keyBytes)).isNull();
+			assertThat(connection.listCommands().lLen(keyBytes)).isNull();
+
+			// Execute pipeline
+			List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(4);
+			assertThat(results.get(0)).isEqualTo(1L); // lRem result (removed 1
+														// occurrence)
+
+			@SuppressWarnings("unchecked")
+			List<byte[]> lPopResults = (List<byte[]>) results.get(1);
+			assertThat(lPopResults).hasSize(2);
+			assertThat(lPopResults.get(0)).isEqualTo(value2); // First remaining element
+			assertThat(lPopResults.get(1)).isEqualTo(value3); // Second remaining element
+
+			assertThat(results.get(2)).isEqualTo(value4); // rPop result
+			assertThat(results.get(3)).isEqualTo(0L); // Final length (empty)
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testListBlockingCommandsInPipelineMode() {
+		String key1 = "test:list:pipeline:blocking:key1";
+		String key2 = "test:list:pipeline:blocking:key2";
+		byte[] key1Bytes = key1.getBytes();
+		byte[] key2Bytes = key2.getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+
+		try {
+			// Set up test data
+			connection.listCommands().rPush(key1Bytes, value1);
+			connection.listCommands().rPush(key2Bytes, value2);
+
+			// Start pipeline
+			connection.openPipeline();
+
+			// Queue blocking commands with short timeout - assert they return null in
+			// pipeline mode
+			assertThat(connection.listCommands().bLPop(1, key1Bytes, key2Bytes)).isNull();
+			assertThat(connection.listCommands().bRPop(1, key1Bytes, key2Bytes)).isNull();
+
+			// Execute pipeline
+			List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(2);
+
+			@SuppressWarnings("unchecked")
+			List<byte[]> blPopResult = (List<byte[]>) results.get(0);
+			assertThat(blPopResult).hasSize(2);
+			assertThat(blPopResult.get(0)).isEqualTo(key1Bytes); // Key that had element
+			assertThat(blPopResult.get(1)).isEqualTo(value1); // Popped element
+
+			@SuppressWarnings("unchecked")
+			List<byte[]> brPopResult = (List<byte[]>) results.get(1);
+			assertThat(brPopResult).hasSize(2);
+			assertThat(brPopResult.get(0)).isEqualTo(key2Bytes); // Key that had element
+			assertThat(brPopResult.get(1)).isEqualTo(value2); // Popped element
+
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+		}
+	}
+
+	@Test
+	void testListTrimCommandInPipelineMode() {
+		String key = "test:list:pipeline:trim";
+		byte[] keyBytes = key.getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+		byte[] value3 = "value3".getBytes();
+		byte[] value4 = "value4".getBytes();
+		byte[] value5 = "value5".getBytes();
+
+		try {
+			// Set up test data
+			connection.listCommands().rPush(keyBytes, value1, value2, value3, value4, value5);
+
+			// Start pipeline
+			connection.openPipeline();
+
+			// Queue trim and verification commands
+			connection.listCommands().lTrim(keyBytes, 1, 3); // void method, no assertion
+																// needed
+			assertThat(connection.listCommands().lLen(keyBytes)).isNull();
+			assertThat(connection.listCommands().lRange(keyBytes, 0, -1)).isNull();
+
+			// Execute pipeline
+			List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(3);
+			assertThat(results.get(0)).isEqualTo("OK"); // lTrim result
+			assertThat(results.get(1)).isEqualTo(3L); // lLen result after trim
+
+			@SuppressWarnings("unchecked")
+			List<byte[]> rangeResult = (List<byte[]>) results.get(2);
+			assertThat(rangeResult).hasSize(3);
+			assertThat(rangeResult.get(0)).isEqualTo(value2); // Trimmed list starts with
+																// value2
+			assertThat(rangeResult.get(1)).isEqualTo(value3);
+			assertThat(rangeResult.get(2)).isEqualTo(value4); // Trimmed list ends with
+																// value4
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testListAdvancedCommandsInPipelineMode() {
+		String sourceKey1 = "test:list:pipeline:advanced:source1";
+		String destKey1 = "test:list:pipeline:advanced:dest1";
+		String sourceKey2 = "test:list:pipeline:advanced:source2";
+		String destKey2 = "test:list:pipeline:advanced:dest2";
+		byte[] sourceKey1Bytes = sourceKey1.getBytes();
+		byte[] destKey1Bytes = destKey1.getBytes();
+		byte[] sourceKey2Bytes = sourceKey2.getBytes();
+		byte[] destKey2Bytes = destKey2.getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+
+		try {
+			// Set up test data
+			connection.listCommands().rPush(sourceKey1Bytes, value1);
+			connection.listCommands().rPush(sourceKey2Bytes, value2);
+
+			// Start pipeline
+			connection.openPipeline();
+
+			// Queue advanced commands - assert they return null in pipeline mode
+			assertThat(connection.listCommands()
+				.bLMove(sourceKey1Bytes, destKey1Bytes, Direction.LEFT, Direction.RIGHT, 0.1)).isNull();
+			assertThat(connection.listCommands().bRPopLPush(1, sourceKey2Bytes, destKey2Bytes)).isNull();
+			assertThat(connection.listCommands().lLen(destKey1Bytes)).isNull();
+			assertThat(connection.listCommands().lLen(destKey2Bytes)).isNull();
+
+			// Execute pipeline
+			List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(4);
+			assertThat(results.get(0)).isEqualTo(value1); // bLMove result
+			assertThat(results.get(1)).isEqualTo(value2); // bRPopLPush result
+			assertThat(results.get(2)).isEqualTo(1L); // destKey1 length
+			assertThat(results.get(3)).isEqualTo(1L); // destKey2 length
+
+		}
+		finally {
+			cleanupKey(sourceKey1);
+			cleanupKey(destKey1);
+			cleanupKey(sourceKey2);
+			cleanupKey(destKey2);
+		}
+	}
+
+	// ==================== Transaction Mode Tests ====================
+
+	@Test
+	void testBasicListCommandsInTransactionMode() {
+		String key = "test:list:transaction:basic";
+		byte[] keyBytes = key.getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+		byte[] value3 = "value3".getBytes();
+
+		try {
+			// Start transaction
+			connection.multi();
+
+			// Queue basic list commands - assert they return null in transaction mode
+			assertThat(connection.listCommands().rPush(keyBytes, value1, value2)).isNull();
+			assertThat(connection.listCommands().lPush(keyBytes, value3)).isNull();
+			assertThat(connection.listCommands().lLen(keyBytes)).isNull();
+			assertThat(connection.listCommands().lRange(keyBytes, 0, -1)).isNull();
+			assertThat(connection.listCommands().lIndex(keyBytes, 0)).isNull();
+			assertThat(connection.listCommands().rPop(keyBytes)).isNull();
+			assertThat(connection.listCommands().lPop(keyBytes)).isNull();
+
+			// Execute transaction
+			List<Object> results = connection.exec();
+
+			// Verify results
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(7);
+			assertThat(results.get(0)).isEqualTo(2L); // rPush result
+			assertThat(results.get(1)).isEqualTo(3L); // lPush result
+			assertThat(results.get(2)).isEqualTo(3L); // lLen result
+
+			@SuppressWarnings("unchecked")
+			List<byte[]> rangeResult = (List<byte[]>) results.get(3);
+			assertThat(rangeResult).hasSize(3);
+			assertThat(rangeResult.get(0)).isEqualTo(value3); // Head after lPush
+			assertThat(rangeResult.get(1)).isEqualTo(value1);
+			assertThat(rangeResult.get(2)).isEqualTo(value2); // Tail
+
+			assertThat(results.get(4)).isEqualTo(value3); // lIndex result
+			assertThat(results.get(5)).isEqualTo(value2); // rPop result (from tail)
+			assertThat(results.get(6)).isEqualTo(value3); // lPop result (from head)
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testConditionalListCommandsInTransactionMode() {
+		String existingKey = "test:list:transaction:conditional:existing";
+		String nonExistentKey = "test:list:transaction:conditional:nonexistent";
+		byte[] existingKeyBytes = existingKey.getBytes();
+		byte[] nonExistentKeyBytes = nonExistentKey.getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+
+		try {
+			// Set up existing list
+			connection.listCommands().rPush(existingKeyBytes, value1);
+
+			// Start transaction
+			connection.multi();
+
+			// Queue conditional commands - assert they return null in transaction mode
+			assertThat(connection.listCommands().rPushX(existingKeyBytes, value2)).isNull();
+			assertThat(connection.listCommands().lPushX(existingKeyBytes, "head".getBytes())).isNull();
+			assertThat(connection.listCommands().rPushX(nonExistentKeyBytes, value1)).isNull();
+			assertThat(connection.listCommands().lPushX(nonExistentKeyBytes, value1)).isNull();
+			assertThat(connection.listCommands().lLen(existingKeyBytes)).isNull();
+			assertThat(connection.listCommands().lLen(nonExistentKeyBytes)).isNull();
+
+			// Execute transaction
+			List<Object> results = connection.exec();
+
+			// Verify results
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(6);
+			assertThat(results.get(0)).isEqualTo(2L); // rPushX on existing - success
+			assertThat(results.get(1)).isEqualTo(3L); // lPushX on existing - success
+			assertThat(results.get(2)).isEqualTo(0L); // rPushX on non-existent - fail
+			assertThat(results.get(3)).isEqualTo(0L); // lPushX on non-existent - fail
+			assertThat(results.get(4)).isEqualTo(3L); // lLen on existing
+			assertThat(results.get(5)).isEqualTo(0L); // lLen on non-existent
+
+		}
+		finally {
+			cleanupKey(existingKey);
+			cleanupKey(nonExistentKey);
+		}
+	}
+
+	@Test
+	void testListPositionCommandsInTransactionMode() {
+		String key = "test:list:transaction:position";
+		byte[] keyBytes = key.getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+		byte[] value3 = "value1".getBytes(); // duplicate
+		byte[] insertValue = "inserted".getBytes();
+
+		try {
+			// Set up test data
+			connection.listCommands().rPush(keyBytes, value1, value2, value3);
+
+			// Start transaction
+			connection.multi();
+
+			// Queue position commands - assert they return null in transaction mode
+			assertThat(connection.listCommands().lPos(keyBytes, value1, null, 2)).isNull();
+			assertThat(connection.listCommands().lInsert(keyBytes, Position.BEFORE, value2, insertValue)).isNull();
+			assertThat(connection.listCommands().lIndex(keyBytes, 1)).isNull();
+			assertThat(connection.listCommands().lLen(keyBytes)).isNull();
+
+			// Execute transaction
+			List<Object> results = connection.exec();
+
+			// Verify results
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(4);
+
+			@SuppressWarnings("unchecked")
+			List<Long> lPosResults = (List<Long>) results.get(0);
+			assertThat(lPosResults).containsExactly(0L, 2L); // Both occurrences of value1
+
+			assertThat(results.get(1)).isEqualTo(4L); // lInsert result (new list length)
+			assertThat(results.get(2)).isEqualTo(insertValue); // lIndex result
+			assertThat(results.get(3)).isEqualTo(4L); // lLen result
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testListMovementCommandsInTransactionMode() {
+		String sourceKey = "test:list:transaction:move:source";
+		String destKey = "test:list:transaction:move:dest";
+		byte[] sourceKeyBytes = sourceKey.getBytes();
+		byte[] destKeyBytes = destKey.getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+		byte[] value3 = "value3".getBytes();
+
+		try {
+			// Set up test data
+			connection.listCommands().rPush(sourceKeyBytes, value1, value2, value3);
+
+			// Start transaction
+			connection.multi();
+
+			// Queue movement commands - assert they return null in transaction mode
+			assertThat(connection.listCommands().lMove(sourceKeyBytes, destKeyBytes, Direction.LEFT, Direction.RIGHT))
+				.isNull();
+			assertThat(connection.listCommands().rPopLPush(sourceKeyBytes, destKeyBytes)).isNull();
+			assertThat(connection.listCommands().lLen(sourceKeyBytes)).isNull();
+			assertThat(connection.listCommands().lLen(destKeyBytes)).isNull();
+			assertThat(connection.listCommands().lRange(destKeyBytes, 0, -1)).isNull();
+
+			// Execute transaction
+			List<Object> results = connection.exec();
+
+			// Verify results
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(5);
+			assertThat(results.get(0)).isEqualTo(value1); // lMove result
+			assertThat(results.get(1)).isEqualTo(value3); // rPopLPush result
+			assertThat(results.get(2)).isEqualTo(1L); // Source length after moves
+			assertThat(results.get(3)).isEqualTo(2L); // Dest length after moves
+
+			@SuppressWarnings("unchecked")
+			List<byte[]> destRange = (List<byte[]>) results.get(4);
+			assertThat(destRange).hasSize(2);
+			assertThat(destRange.get(0)).isEqualTo(value3); // Head (from rPopLPush)
+			assertThat(destRange.get(1)).isEqualTo(value1); // Tail (from lMove RIGHT)
+
+		}
+		finally {
+			cleanupKey(sourceKey);
+			cleanupKey(destKey);
+		}
+	}
+
+	@Test
+	void testListRemovalCommandsInTransactionMode() {
+		String key = "test:list:transaction:removal";
+		byte[] keyBytes = key.getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+		byte[] value3 = "value1".getBytes(); // duplicate
+		byte[] value4 = "value2".getBytes(); // duplicate
+
+		try {
+			// Set up test data
+			connection.listCommands().rPush(keyBytes, value1, value2, value3, value4);
+
+			// Start transaction
+			connection.multi();
+
+			// Queue removal commands - assert they return null in transaction mode
+			assertThat(connection.listCommands().lRem(keyBytes, 1, value1)).isNull();
+			assertThat(connection.listCommands().lPop(keyBytes, 2)).isNull();
+			assertThat(connection.listCommands().rPop(keyBytes)).isNull();
+			assertThat(connection.listCommands().lLen(keyBytes)).isNull();
+
+			// Execute transaction
+			List<Object> results = connection.exec();
+
+			// Verify results
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(4);
+			assertThat(results.get(0)).isEqualTo(1L); // lRem result (removed 1
+														// occurrence)
+
+			@SuppressWarnings("unchecked")
+			List<byte[]> lPopResults = (List<byte[]>) results.get(1);
+			assertThat(lPopResults).hasSize(2);
+			assertThat(lPopResults.get(0)).isEqualTo(value2); // First remaining element
+			assertThat(lPopResults.get(1)).isEqualTo(value3); // Second remaining element
+
+			assertThat(results.get(2)).isEqualTo(value4); // rPop result
+			assertThat(results.get(3)).isEqualTo(0L); // Final length (empty)
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testListBlockingCommandsInTransactionMode() {
+		String key1 = "test:list:transaction:blocking:key1";
+		String key2 = "test:list:transaction:blocking:key2";
+		byte[] key1Bytes = key1.getBytes();
+		byte[] key2Bytes = key2.getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+
+		try {
+			// Set up test data
+			connection.listCommands().rPush(key1Bytes, value1);
+			connection.listCommands().rPush(key2Bytes, value2);
+
+			// Start transaction
+			connection.multi();
+
+			// Queue blocking commands with short timeout - assert they return null in
+			// transaction mode
+			assertThat(connection.listCommands().bLPop(1, key1Bytes, key2Bytes)).isNull();
+			assertThat(connection.listCommands().bRPop(1, key1Bytes, key2Bytes)).isNull();
+
+			// Execute transaction
+			List<Object> results = connection.exec();
+
+			// Verify results
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(2);
+
+			@SuppressWarnings("unchecked")
+			List<byte[]> blPopResult = (List<byte[]>) results.get(0);
+			assertThat(blPopResult).hasSize(2);
+			assertThat(blPopResult.get(0)).isEqualTo(key1Bytes); // Key that had element
+			assertThat(blPopResult.get(1)).isEqualTo(value1); // Popped element
+
+			@SuppressWarnings("unchecked")
+			List<byte[]> brPopResult = (List<byte[]>) results.get(1);
+			assertThat(brPopResult).hasSize(2);
+			assertThat(brPopResult.get(0)).isEqualTo(key2Bytes); // Key that had element
+			assertThat(brPopResult.get(1)).isEqualTo(value2); // Popped element
+
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+		}
+	}
+
+	@Test
+	void testListTrimCommandInTransactionMode() {
+		String key = "test:list:transaction:trim";
+		byte[] keyBytes = key.getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+		byte[] value3 = "value3".getBytes();
+		byte[] value4 = "value4".getBytes();
+		byte[] value5 = "value5".getBytes();
+
+		try {
+			// Set up test data
+			connection.listCommands().rPush(keyBytes, value1, value2, value3, value4, value5);
+
+			// Start transaction
+			connection.multi();
+
+			// Queue trim and verification commands
+			connection.listCommands().lTrim(keyBytes, 1, 3); // void method, no assertion
+			assertThat(connection.listCommands().lLen(keyBytes)).isNull();
+			assertThat(connection.listCommands().lRange(keyBytes, 0, -1)).isNull();
+
+			// Execute transaction
+			List<Object> results = connection.exec();
+
+			// Verify results
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(3);
+			assertThat(results.get(0)).isEqualTo("OK"); // lTrim result
+			assertThat(results.get(1)).isEqualTo(3L); // lLen result after trim
+
+			@SuppressWarnings("unchecked")
+			List<byte[]> rangeResult = (List<byte[]>) results.get(2);
+			assertThat(rangeResult).hasSize(3);
+			assertThat(rangeResult.get(0)).isEqualTo(value2); // Trimmed list starts with
+																// value2
+			assertThat(rangeResult.get(1)).isEqualTo(value3);
+			assertThat(rangeResult.get(2)).isEqualTo(value4); // Trimmed list ends with
+																// value4
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testTransactionDiscardWithListCommands() {
+		String key = "test:list:transaction:discard";
+		byte[] keyBytes = key.getBytes();
+		byte[] value = "value".getBytes();
+
+		try {
+			// Start transaction
+			connection.multi();
+
+			// Queue list commands
+			connection.listCommands().rPush(keyBytes, value);
+			connection.listCommands().lLen(keyBytes);
+
+			// Discard transaction
+			connection.discard();
+
+			// Verify key doesn't exist (transaction was discarded)
+			Long len = connection.listCommands().lLen(keyBytes);
+			assertThat(len).isEqualTo(0L);
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testListAdvancedCommandsInTransactionMode() {
+		String sourceKey1 = "test:list:transaction:advanced:source1";
+		String destKey1 = "test:list:transaction:advanced:dest1";
+		String sourceKey2 = "test:list:transaction:advanced:source2";
+		String destKey2 = "test:list:transaction:advanced:dest2";
+		byte[] sourceKey1Bytes = sourceKey1.getBytes();
+		byte[] destKey1Bytes = destKey1.getBytes();
+		byte[] sourceKey2Bytes = sourceKey2.getBytes();
+		byte[] destKey2Bytes = destKey2.getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+
+		try {
+			// Set up test data
+			connection.listCommands().rPush(sourceKey1Bytes, value1);
+			connection.listCommands().rPush(sourceKey2Bytes, value2);
+
+			// Start transaction
+			connection.multi();
+
+			// Queue advanced commands - assert they return null in transaction mode
+			assertThat(connection.listCommands()
+				.bLMove(sourceKey1Bytes, destKey1Bytes, Direction.LEFT, Direction.RIGHT, 0.1)).isNull();
+			assertThat(connection.listCommands().bRPopLPush(1, sourceKey2Bytes, destKey2Bytes)).isNull();
+			assertThat(connection.listCommands().lLen(destKey1Bytes)).isNull();
+			assertThat(connection.listCommands().lLen(destKey2Bytes)).isNull();
+
+			// Execute transaction
+			List<Object> results = connection.exec();
+
+			// Verify results
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(4);
+			assertThat(results.get(0)).isEqualTo(value1); // bLMove result
+			assertThat(results.get(1)).isEqualTo(value2); // bRPopLPush result
+			assertThat(results.get(2)).isEqualTo(1L); // destKey1 length
+			assertThat(results.get(3)).isEqualTo(1L); // destKey2 length
+
+		}
+		finally {
+			cleanupKey(sourceKey1);
+			cleanupKey(destKey1);
+			cleanupKey(sourceKey2);
+			cleanupKey(destKey2);
+		}
+	}
+
+	@Test
+	void testWatchWithListCommandsTransaction() throws InterruptedException {
+		String watchKey = "test:list:transaction:watch";
+		String otherKey = "test:list:transaction:other";
+		byte[] watchKeyBytes = watchKey.getBytes();
+		byte[] otherKeyBytes = otherKey.getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
+
+		try {
+			// Setup initial data
+			connection.listCommands().rPush(watchKeyBytes, value1);
+
+			// Watch the key
+			connection.watch(watchKeyBytes);
+
+			// Modify the watched key from "outside" the transaction
+			// (simulating another client)
+			connection.listCommands().rPush(watchKeyBytes, value2);
+
+			// Start transaction
+			connection.multi();
+
+			// Queue list commands
+			connection.listCommands().rPush(otherKeyBytes, value1);
+			connection.listCommands().lLen(otherKeyBytes);
+
+			// Execute transaction - should be aborted due to WATCH
+			List<Object> results = connection.exec();
+
+			// Transaction should be aborted (results should be null)
+			assertThat(results).isNotNull().isEmpty();
+
+			// Verify that the other key was not set
+			Long len = connection.listCommands().lLen(otherKeyBytes);
+			assertThat(len).isEqualTo(0L);
+
+		}
+		finally {
+			cleanupKey(watchKey);
+			cleanupKey(otherKey);
+		}
+	}
 
 }

--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionScriptingCommandsIntegrationTests.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionScriptingCommandsIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,799 +26,872 @@ import io.valkey.springframework.data.valkey.connection.ReturnType;
 import io.valkey.springframework.data.valkey.test.condition.EnabledOnValkeyVersion;
 
 /**
- * Comprehensive low-level integration tests for {@link ValkeyGlideConnection} 
- * Scripting functionality using the ValkeyScriptingCommands interface directly.
- * 
- * These tests validate the implementation of all ValkeyScriptingCommands methods:
- * - eval: Execute Lua scripts directly
- * - evalSha: Execute Lua scripts by SHA hash
- * - scriptLoad: Load scripts into cache
- * - scriptExists: Check script existence in cache
- * - scriptFlush: Clear script cache
- * - scriptKill: Kill running scripts
+ * Comprehensive low-level integration tests for {@link ValkeyGlideConnection} Scripting
+ * functionality using the ValkeyScriptingCommands interface directly.
  *
- * Tests cover all three invocation modes:
- * - Immediate mode: Direct execution with results
- * - Pipeline mode: Commands return null, results collected in closePipeline()
- * - Transaction mode: Commands return null, results collected in exec()
+ * These tests validate the implementation of all ValkeyScriptingCommands methods: - eval:
+ * Execute Lua scripts directly - evalSha: Execute Lua scripts by SHA hash - scriptLoad:
+ * Load scripts into cache - scriptExists: Check script existence in cache - scriptFlush:
+ * Clear script cache - scriptKill: Kill running scripts
+ *
+ * Tests cover all three invocation modes: - Immediate mode: Direct execution with results
+ * - Pipeline mode: Commands return null, results collected in closePipeline() -
+ * Transaction mode: Commands return null, results collected in exec()
  *
  * @author Ilia Kolominsky
  * @since 2.0
  */
 public class ValkeyGlideConnectionScriptingCommandsIntegrationTests extends AbstractValkeyGlideIntegrationTests {
 
-    // Test Lua scripts
-    private static final byte[] SIMPLE_RETURN_SCRIPT = "return 'hello'".getBytes();
-    private static final byte[] KEY_VALUE_SCRIPT = "return redis.call('get', KEYS[1])".getBytes();
-    private static final byte[] ARITHMETIC_SCRIPT = "return tonumber(ARGV[1]) + tonumber(ARGV[2])".getBytes();
-    private static final byte[] SET_KEY_SCRIPT = "redis.call('set', KEYS[1], ARGV[1]); return 'OK'".getBytes();
-    private static final byte[] BOOLEAN_SCRIPT = "return tonumber(ARGV[1]) > 0".getBytes();
-    private static final byte[] MULTI_RETURN_SCRIPT = "return {KEYS[1], ARGV[1], 'static'}".getBytes();
-    private static final byte[] COUNT_KEYS_SCRIPT = "return #KEYS".getBytes();
+	// Test Lua scripts
+	private static final byte[] SIMPLE_RETURN_SCRIPT = "return 'hello'".getBytes();
 
-    @Override
-    protected String[] getTestKeyPatterns() {
-        return new String[]{
-            "test:script:key1", "test:script:key2", "test:script:set:key", "test:script:get:key",
-            "test:script:pipeline:key1", "test:script:pipeline:key2", "test:script:pipeline:set",
-            "test:script:transaction:key1", "test:script:transaction:key2", "test:script:transaction:set",
-            "test:script:workflow:counter", "test:script:workflow:data", "test:script:workflow:result"
-        };
-    }
+	private static final byte[] KEY_VALUE_SCRIPT = "return redis.call('get', KEYS[1])".getBytes();
 
-    // ==================== Basic Scripting Operations (Immediate Mode) ====================
+	private static final byte[] ARITHMETIC_SCRIPT = "return tonumber(ARGV[1]) + tonumber(ARGV[2])".getBytes();
 
-    @Test
-    void testEvalBasicScripts() {
-        try {
-            // Test simple return script
-            byte[] result1 = connection.scriptingCommands().eval(SIMPLE_RETURN_SCRIPT, ReturnType.VALUE, 0);
-            assertThat(new String(result1)).isEqualTo("hello");
-            
-            // Test arithmetic script
-            Long result2 = connection.scriptingCommands().eval(ARITHMETIC_SCRIPT, ReturnType.INTEGER, 0, "5".getBytes(), "3".getBytes());
-            assertThat(result2).isEqualTo(8L);
-            
-            // Test boolean script
-            Boolean result3 = connection.scriptingCommands().eval(BOOLEAN_SCRIPT, ReturnType.BOOLEAN, 0, "1".getBytes());
-            assertThat(result3).isTrue();
-            
-            Boolean result4 = connection.scriptingCommands().eval(BOOLEAN_SCRIPT, ReturnType.BOOLEAN, 0, "0".getBytes());
-            assertThat(result4).isFalse();
-            
-            // Test count keys script
-            Long result5 = connection.scriptingCommands().eval(COUNT_KEYS_SCRIPT, ReturnType.INTEGER, 2, "key1".getBytes(), "key2".getBytes());
-            assertThat(result5).isEqualTo(2L);
-            
-        } finally {
-            connection.scriptingCommands().scriptFlush();
-        }
-    }
+	private static final byte[] SET_KEY_SCRIPT = "redis.call('set', KEYS[1], ARGV[1]); return 'OK'".getBytes();
 
-    @Test
-    void testEvalWithKeysAndArgs() {
-        String testKey = "test:script:key1";
-        byte[] testKeyBytes = testKey.getBytes();
-        byte[] testValue = "testvalue".getBytes();
-        
-        try {
-            // Set up test data
-            connection.stringCommands().set(testKeyBytes, testValue);
-            
-            // Test script that reads a key
-            byte[] result1 = connection.scriptingCommands().eval(KEY_VALUE_SCRIPT, ReturnType.VALUE, 1, testKeyBytes);
-            assertThat(new String(result1)).isEqualTo("testvalue");
-            
-            // Test script that sets a key
-            String setKey = "test:script:set:key";
-            byte[] setKeyBytes = setKey.getBytes();
-            byte[] setValue = "newvalue".getBytes();
-            
-            // Note, the docs for ReturnType.STATUS is probably incorrect by stating that STATUS should return byte[]
-            String result2 = connection.scriptingCommands().eval(SET_KEY_SCRIPT, ReturnType.STATUS, 1, setKeyBytes, setValue);
-            assertThat(new String(result2)).isEqualTo("OK");
-            
-            // Verify the key was set
-            byte[] retrievedValue = connection.stringCommands().get(setKeyBytes);
-            assertThat(retrievedValue).isEqualTo(setValue);
-            
-        } finally {
-            cleanupKey(testKey);
-            cleanupKey("test:script:set:key");
-            connection.scriptingCommands().scriptFlush();
-        }
-    }
+	private static final byte[] BOOLEAN_SCRIPT = "return tonumber(ARGV[1]) > 0".getBytes();
 
-    @Test
-    void testEvalMultiReturnTypes() {
-        try {
-            // Test MULTI return type
-            Object[] result = connection.scriptingCommands().eval(MULTI_RETURN_SCRIPT, ReturnType.MULTI, 1, "mykey".getBytes(), "myarg".getBytes());
-            assertThat(result).hasSize(3);
-            assertThat(new String((byte[]) result[0])).isEqualTo("mykey");
-            assertThat(new String((byte[]) result[1])).isEqualTo("myarg");
-            assertThat(new String((byte[]) result[2])).isEqualTo("static");
-            
-        } finally {
-            connection.scriptingCommands().scriptFlush();
-        }
-    }
+	private static final byte[] MULTI_RETURN_SCRIPT = "return {KEYS[1], ARGV[1], 'static'}".getBytes();
 
-    @Test
-    @EnabledOnValkeyVersion("7.0") // Error handling for scriptExists() with no args differs in Valkey < 7.0
-    void testScriptLoadAndExists() {
-        try {
-            // Test scriptLoad
-            String sha1 = connection.scriptingCommands().scriptLoad(SIMPLE_RETURN_SCRIPT);
-            assertThat(sha1).isNotNull();
-            assertThat(sha1).hasSize(40); // SHA1 hash is 40 characters
-            
-            String sha2 = connection.scriptingCommands().scriptLoad(ARITHMETIC_SCRIPT);
-            assertThat(sha2).isNotNull();
-            assertThat(sha2).hasSize(40);
-            assertThat(sha2).isNotEqualTo(sha1); // Different scripts should have different hashes
-            
-            // Test scriptExists with single script
-            List<Boolean> exists1 = connection.scriptingCommands().scriptExists(sha1);
-            assertThat(exists1).hasSize(1);
-            assertThat(exists1.get(0)).isTrue();
-            
-            // Test scriptExists with multiple scripts
-            List<Boolean> exists2 = connection.scriptingCommands().scriptExists(sha1, sha2);
-            assertThat(exists2).hasSize(2);
-            assertThat(exists2.get(0)).isTrue();
-            assertThat(exists2.get(1)).isTrue();
-            
-            // Test scriptExists with non-existent script
-            String fakeSha = "0123456789abcdef0123456789abcdef01234567";
-            List<Boolean> exists3 = connection.scriptingCommands().scriptExists(sha1, fakeSha, sha2);
-            assertThat(exists3).hasSize(3);
-            assertThat(exists3.get(0)).isTrue();
-            assertThat(exists3.get(1)).isFalse();
-            assertThat(exists3.get(2)).isTrue();
-            
-            // Test scriptExists with empty array
-            assertThatThrownBy(() -> connection.scriptingCommands().scriptExists())
-                .isInstanceOf(ValkeySystemException.class)
-                .hasMessageContaining("wrong number of arguments for 'script|exists' command");
+	private static final byte[] COUNT_KEYS_SCRIPT = "return #KEYS".getBytes();
 
-            
-        } finally {
-            connection.scriptingCommands().scriptFlush();
-        }
-    }
+	@Override
+	protected String[] getTestKeyPatterns() {
+		return new String[] { "test:script:key1", "test:script:key2", "test:script:set:key", "test:script:get:key",
+				"test:script:pipeline:key1", "test:script:pipeline:key2", "test:script:pipeline:set",
+				"test:script:transaction:key1", "test:script:transaction:key2", "test:script:transaction:set",
+				"test:script:workflow:counter", "test:script:workflow:data", "test:script:workflow:result" };
+	}
 
-    @Test
-    void testEvalShaScripts() {
-        try {
-            // Load scripts
-            String sha1 = connection.scriptingCommands().scriptLoad(SIMPLE_RETURN_SCRIPT);
-            String sha2 = connection.scriptingCommands().scriptLoad(ARITHMETIC_SCRIPT);
-            
-            // Test evalSha with String SHA
-            byte[] result1 = connection.scriptingCommands().evalSha(sha1, ReturnType.VALUE, 0);
-            assertThat(new String(result1)).isEqualTo("hello");
-            
-            Long result2 = connection.scriptingCommands().evalSha(sha2, ReturnType.INTEGER, 0, "10".getBytes(), "20".getBytes());
-            assertThat(result2).isEqualTo(30L);
-            
-            // Test evalSha with byte[] SHA
-            byte[] sha1Bytes = sha1.getBytes();
-            byte[] sha2Bytes = sha2.getBytes();
-            
-            byte[] result3 = connection.scriptingCommands().evalSha(sha1Bytes, ReturnType.VALUE, 0);
-            assertThat(new String(result3)).isEqualTo("hello");
-            
-            Long result4 = connection.scriptingCommands().evalSha(sha2Bytes, ReturnType.INTEGER, 0, "15".getBytes(), "25".getBytes());
-            assertThat(result4).isEqualTo(40L);
-            
-        } finally {
-            connection.scriptingCommands().scriptFlush();
-        }
-    }
+	// ==================== Basic Scripting Operations (Immediate Mode)
+	// ====================
 
-    @Test
-    void testScriptFlush() {
-        try {
-            // Load a script
-            String sha = connection.scriptingCommands().scriptLoad(SIMPLE_RETURN_SCRIPT);
-            
-            // Verify script exists
-            List<Boolean> existsBefore = connection.scriptingCommands().scriptExists(sha);
-            assertThat(existsBefore.get(0)).isTrue();
-            
-            // Flush script cache
-            connection.scriptingCommands().scriptFlush();
-            
-            // Verify script no longer exists
-            List<Boolean> existsAfter = connection.scriptingCommands().scriptExists(sha);
-            assertThat(existsAfter.get(0)).isFalse();
-            
-        } finally {
-            connection.scriptingCommands().scriptFlush();
-        }
-    }
+	@Test
+	void testEvalBasicScripts() {
+		try {
+			// Test simple return script
+			byte[] result1 = connection.scriptingCommands().eval(SIMPLE_RETURN_SCRIPT, ReturnType.VALUE, 0);
+			assertThat(new String(result1)).isEqualTo("hello");
 
-    @Test
-    void testScriptKill() {
-        try {
-            // Note: SCRIPT KILL is typically used to kill long-running scripts
-            // Since we can't easily create a long-running script in tests,
-            // we test that the command executes without error when no script is running
-            // This should complete without throwing an exception or return an error message
-            assertThatThrownBy(() -> connection.scriptingCommands().scriptKill())
-                .isInstanceOf(DataAccessException.class)
-                .hasMessageContaining("No scripts in execution right now");
-            
-        } finally {
-            connection.scriptingCommands().scriptFlush();
-        }
-    }
+			// Test arithmetic script
+			Long result2 = connection.scriptingCommands()
+				.eval(ARITHMETIC_SCRIPT, ReturnType.INTEGER, 0, "5".getBytes(), "3".getBytes());
+			assertThat(result2).isEqualTo(8L);
 
-    // ==================== Edge Cases and Error Handling ====================
+			// Test boolean script
+			Boolean result3 = connection.scriptingCommands()
+				.eval(BOOLEAN_SCRIPT, ReturnType.BOOLEAN, 0, "1".getBytes());
+			assertThat(result3).isTrue();
 
-    @Test
-    void testScriptingWithBinaryData() {
-        String testKey = "test:script:binary";
-        byte[] binaryData = new byte[]{0x00, 0x01, 0x02, (byte) 0xFF, (byte) 0xFE};
-        byte[] setBinaryScript = "redis.call('set', KEYS[1], ARGV[1]); return redis.call('get', KEYS[1])".getBytes();
-        
-        try {
-            // Test script with binary data
-            byte[] result = connection.scriptingCommands().eval(setBinaryScript, ReturnType.VALUE, 1, testKey.getBytes(), binaryData);
-            assertThat(result).isEqualTo(binaryData);
-            
-        } finally {
-            cleanupKey(testKey);
-            connection.scriptingCommands().scriptFlush();
-        }
-    }
+			Boolean result4 = connection.scriptingCommands()
+				.eval(BOOLEAN_SCRIPT, ReturnType.BOOLEAN, 0, "0".getBytes());
+			assertThat(result4).isFalse();
 
-    @Test
-    void testScriptingErrorHandling() {
-        try {
-            // Test script with syntax error
-            byte[] invalidScript = "return invalid syntax here".getBytes();
-            assertThatThrownBy(() -> connection.scriptingCommands().eval(invalidScript, ReturnType.VALUE, 0))
-                .isInstanceOf(DataAccessException.class);
-            
-            // Test evalSha with non-existent SHA
-            String fakeSha = "0123456789abcdef0123456789abcdef01234567";
-            assertThatThrownBy(() -> connection.scriptingCommands().evalSha(fakeSha, ReturnType.VALUE, 0))
-                .isInstanceOf(DataAccessException.class);
-            
-            // Test script with wrong number of keys
-            byte[] keyScript = "return KEYS[2]".getBytes();
-            Object result = connection.scriptingCommands().eval(keyScript, ReturnType.VALUE, 1, "key1".getBytes());
-            assertThat(result).isNull(); // KEYS[2] does not exist, should return nil
-        } finally {
-            connection.scriptingCommands().scriptFlush();
-        }
-    }
+			// Test count keys script
+			Long result5 = connection.scriptingCommands()
+				.eval(COUNT_KEYS_SCRIPT, ReturnType.INTEGER, 2, "key1".getBytes(), "key2".getBytes());
+			assertThat(result5).isEqualTo(2L);
 
-    @Test
-    void testEvalShaWithoutPreLoadingScript() {
-        // This test simulates what DefaultScriptExecutor does: try evalSha first without loading
-        try {
-            // Use a fake SHA1 hash that definitely doesn't exist in Valkey
-            // This should trigger a NOSCRIPT error, which is what we need to test
-            String fakeSha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"; // 40 chars of 'a'
-            
-            // Try to execute using evalSha WITHOUT loading the script first
-            // This should fail with NOSCRIPT error, which is what we need to test
-            Exception caughtException = null;
-            try {
-                connection.scriptingCommands().evalSha(fakeSha, ReturnType.VALUE, 0);
-            } catch (Exception ex) {
-                caughtException = ex;
-            }
-            
-            // Verify we got an exception
-            assertThat(caughtException).as("Expected NOSCRIPT exception when calling evalSha with uncached script").isNotNull();
-        } finally {
-            connection.scriptingCommands().scriptFlush();
-        }
-    }
+		}
+		finally {
+			connection.scriptingCommands().scriptFlush();
+		}
+	}
 
-    @Test
-    void testScriptingWithEmptyKeysAndArgs() {
-        try {
-            // Test script with no keys or args
-            byte[] result1 = connection.scriptingCommands().eval(SIMPLE_RETURN_SCRIPT, ReturnType.VALUE, 0);
-            assertThat(new String(result1)).isEqualTo("hello");
-            
-            // Test script that expects args but gets none
-            byte[] argScript = "return ARGV[1] or 'default'".getBytes();
-            byte[] result2 = connection.scriptingCommands().eval(argScript, ReturnType.VALUE, 0);
-            assertThat(new String(result2)).isEqualTo("default");
-            
-        } finally {
-            connection.scriptingCommands().scriptFlush();
-        }
-    }
+	@Test
+	void testEvalWithKeysAndArgs() {
+		String testKey = "test:script:key1";
+		byte[] testKeyBytes = testKey.getBytes();
+		byte[] testValue = "testvalue".getBytes();
 
-    // ==================== Pipeline Mode Tests ====================
+		try {
+			// Set up test data
+			connection.stringCommands().set(testKeyBytes, testValue);
 
-    @Test
-    void testBasicScriptingCommandsInPipelineMode() {
-        try {
-            // Load scripts first
-            String sha1 = connection.scriptingCommands().scriptLoad(SIMPLE_RETURN_SCRIPT);
-            String sha2 = connection.scriptingCommands().scriptLoad(ARITHMETIC_SCRIPT);
-            
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Queue scripting commands - assert they return null in pipeline mode
-            assertThat((Object) connection.scriptingCommands().eval(SIMPLE_RETURN_SCRIPT, ReturnType.VALUE, 0)).isNull();
-            assertThat((Object) connection.scriptingCommands().evalSha(sha1, ReturnType.VALUE, 0)).isNull();
-            assertThat((Object) connection.scriptingCommands().eval(ARITHMETIC_SCRIPT, ReturnType.INTEGER, 0, "7".getBytes(), "3".getBytes())).isNull();
-            assertThat((Object) connection.scriptingCommands().evalSha(sha2, ReturnType.INTEGER, 0, "10".getBytes(), "5".getBytes())).isNull();
-            assertThat((Object) connection.scriptingCommands().scriptExists(sha1, sha2)).isNull();
-            
-            // Execute pipeline
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(5);
-            assertThat((byte[]) results.get(0)).isEqualTo("hello".getBytes()); // eval result
-            assertThat((byte[]) results.get(1)).isEqualTo("hello".getBytes()); // evalSha result
-            assertThat((Long) results.get(2)).isEqualTo(10L); // arithmetic eval result
-            assertThat((Long) results.get(3)).isEqualTo(15L); // arithmetic evalSha result
-            
-            @SuppressWarnings("unchecked")
-            List<Boolean> existsResult = (List<Boolean>) results.get(4);
-            assertThat(existsResult).hasSize(2);
-            assertThat(existsResult.get(0)).isTrue();
-            assertThat(existsResult.get(1)).isTrue();
-            
-        } finally {
-            connection.scriptingCommands().scriptFlush();
-        }
-    }
+			// Test script that reads a key
+			byte[] result1 = connection.scriptingCommands().eval(KEY_VALUE_SCRIPT, ReturnType.VALUE, 1, testKeyBytes);
+			assertThat(new String(result1)).isEqualTo("testvalue");
 
-    @Test
-    void testScriptLoadAndFlushInPipelineMode() {
-        try {
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Queue script management commands - assert they return null in pipeline mode
-            assertThat(connection.scriptingCommands().scriptLoad(SIMPLE_RETURN_SCRIPT)).isNull();
-            assertThat(connection.scriptingCommands().scriptLoad(ARITHMETIC_SCRIPT)).isNull();
-            connection.scriptingCommands().scriptFlush(); // void method, no assertion
-            
-            // Execute pipeline
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(3);
-            assertThat(results.get(0)).isInstanceOf(String.class); // SHA1 hash
-            assertThat(results.get(1)).isInstanceOf(String.class); // SHA1 hash
-            assertThat((String) results.get(2)).isEqualTo("OK"); // scriptFlush result
-            
-            String sha1 = (String) results.get(0);
-            String sha2 = (String) results.get(1);
-            assertThat(sha1).hasSize(40);
-            assertThat(sha2).hasSize(40);
-            assertThat(sha1).isNotEqualTo(sha2);
-            
-        } finally {
-            connection.scriptingCommands().scriptFlush();
-        }
-    }
+			// Test script that sets a key
+			String setKey = "test:script:set:key";
+			byte[] setKeyBytes = setKey.getBytes();
+			byte[] setValue = "newvalue".getBytes();
 
-    @Test
-    void testEvalShaByteArrayInPipelineMode() {
-        try {
-            // Load scripts first
-            String sha1 = connection.scriptingCommands().scriptLoad(SIMPLE_RETURN_SCRIPT);
-            String sha2 = connection.scriptingCommands().scriptLoad(ARITHMETIC_SCRIPT);
-            
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Queue evalSha commands with byte[] SHA - assert they return null in pipeline mode
-            assertThat((Object) connection.scriptingCommands().evalSha(sha1.getBytes(), ReturnType.VALUE, 0)).isNull();
-            assertThat((Object) connection.scriptingCommands().evalSha(sha2.getBytes(), ReturnType.INTEGER, 0, "9".getBytes(), "3".getBytes())).isNull();
-            
-            // Execute pipeline
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(2);
-            assertThat((byte[]) results.get(0)).isEqualTo("hello".getBytes()); // evalSha result
-            assertThat((Long) results.get(1)).isEqualTo(12L); // arithmetic evalSha result
-            
-        } finally {
-            connection.scriptingCommands().scriptFlush();
-        }
-    }
+			// Note, the docs for ReturnType.STATUS is probably incorrect by stating that
+			// STATUS should return byte[]
+			String result2 = connection.scriptingCommands()
+				.eval(SET_KEY_SCRIPT, ReturnType.STATUS, 1, setKeyBytes, setValue);
+			assertThat(new String(result2)).isEqualTo("OK");
 
-    @Test
-    void testScriptKillInPipelineMode() {
-        try {
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Queue scriptKill command - should return null in pipeline mode
-            connection.scriptingCommands().scriptKill(); // void method, no assertion
-            
-            // Execute pipeline - expect error since no script is running
-            List<Object> result = connection.closePipeline();
-            assertThat(result).hasSize(1);
-            assertThat(result.get(0)).isInstanceOf(DataAccessException.class);
-            assertThat(((DataAccessException) result.get(0)).getMessage()).contains("No scripts in execution right now");
-        } finally {
-            connection.scriptingCommands().scriptFlush();
-        }
-    }
+			// Verify the key was set
+			byte[] retrievedValue = connection.stringCommands().get(setKeyBytes);
+			assertThat(retrievedValue).isEqualTo(setValue);
 
-    @Test
-    void testScriptingWithKeysInPipelineMode() {
-        String key1 = "test:script:pipeline:key1";
-        String key2 = "test:script:pipeline:key2";
-        String setKey = "test:script:pipeline:set";
-        
-        try {
-            // Setup test data
-            connection.stringCommands().set(key1.getBytes(), "value1".getBytes());
-            connection.stringCommands().set(key2.getBytes(), "value2".getBytes());
-            
-            // Start pipeline
-            connection.openPipeline();
-            // Queue script commands with keys - assert they return null in pipeline mode
-            assertThat((Object) connection.scriptingCommands().eval(KEY_VALUE_SCRIPT, ReturnType.VALUE, 1, key1.getBytes())).isNull();
-            assertThat((Object) connection.scriptingCommands().eval(KEY_VALUE_SCRIPT, ReturnType.VALUE, 1, key2.getBytes())).isNull();
-            assertThat((Object) connection.scriptingCommands().eval(SET_KEY_SCRIPT, ReturnType.STATUS, 1, setKey.getBytes(), "newvalue".getBytes())).isNull();
-            assertThat((Object) connection.scriptingCommands().eval(KEY_VALUE_SCRIPT, ReturnType.VALUE, 1, setKey.getBytes())).isNull();
-            
-            // Execute pipeline
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(4);
-            assertThat((byte[]) results.get(0)).isEqualTo("value1".getBytes());
-            assertThat((byte[]) results.get(1)).isEqualTo("value2".getBytes());
-            assertThat((String) results.get(2)).isEqualTo("OK");
-            assertThat((byte[]) results.get(3)).isEqualTo("newvalue".getBytes());
-            
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-            cleanupKey(setKey);
-            connection.scriptingCommands().scriptFlush();
-        }
-    }
+		}
+		finally {
+			cleanupKey(testKey);
+			cleanupKey("test:script:set:key");
+			connection.scriptingCommands().scriptFlush();
+		}
+	}
 
-    // ==================== Transaction Mode Tests ====================
+	@Test
+	void testEvalMultiReturnTypes() {
+		try {
+			// Test MULTI return type
+			Object[] result = connection.scriptingCommands()
+				.eval(MULTI_RETURN_SCRIPT, ReturnType.MULTI, 1, "mykey".getBytes(), "myarg".getBytes());
+			assertThat(result).hasSize(3);
+			assertThat(new String((byte[]) result[0])).isEqualTo("mykey");
+			assertThat(new String((byte[]) result[1])).isEqualTo("myarg");
+			assertThat(new String((byte[]) result[2])).isEqualTo("static");
 
-    @Test
-    void testBasicScriptingCommandsInTransactionMode() {
-        try {
-            // Load scripts first
-            String sha1 = connection.scriptingCommands().scriptLoad(SIMPLE_RETURN_SCRIPT);
-            String sha2 = connection.scriptingCommands().scriptLoad(ARITHMETIC_SCRIPT);
-            
-            // Start transaction
-            connection.multi();
-            
-            // Queue scripting commands - assert they return null in transaction mode
-            assertThat((Object) connection.scriptingCommands().eval(SIMPLE_RETURN_SCRIPT, ReturnType.VALUE, 0)).isNull();
-            assertThat((Object) connection.scriptingCommands().evalSha(sha1, ReturnType.VALUE, 0)).isNull();
-            assertThat((Object) connection.scriptingCommands().eval(ARITHMETIC_SCRIPT, ReturnType.INTEGER, 0, "8".getBytes(), "4".getBytes())).isNull();
-            assertThat((Object) connection.scriptingCommands().evalSha(sha2, ReturnType.INTEGER, 0, "12".getBytes(), "6".getBytes())).isNull();
-            assertThat((Object) connection.scriptingCommands().scriptExists(sha1, sha2)).isNull();
-            
-            // Execute transaction
-            List<Object> results = connection.exec();
-            
-            // Verify results
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(5);
-            assertThat((byte[]) results.get(0)).isEqualTo("hello".getBytes()); // eval result
-            assertThat((byte[]) results.get(1)).isEqualTo("hello".getBytes()); // evalSha result
-            assertThat((Long) results.get(2)).isEqualTo(12L); // arithmetic eval result
-            assertThat((Long) results.get(3)).isEqualTo(18L); // arithmetic evalSha result
-            
-            @SuppressWarnings("unchecked")
-            List<Boolean> existsResult = (List<Boolean>) results.get(4);
-            assertThat(existsResult).hasSize(2);
-            assertThat(existsResult.get(0)).isTrue();
-            assertThat(existsResult.get(1)).isTrue();
-            
-        } finally {
-            connection.scriptingCommands().scriptFlush();
-        }
-    }
+		}
+		finally {
+			connection.scriptingCommands().scriptFlush();
+		}
+	}
 
-    @Test
-    void testScriptManagementInTransactionMode() {
-        try {
-            // Start transaction
-            connection.multi();
-            
-            // Queue script management commands - assert they return null in transaction mode
-            assertThat((Object) connection.scriptingCommands().scriptLoad(SIMPLE_RETURN_SCRIPT)).isNull();
-            assertThat((Object) connection.scriptingCommands().scriptLoad(ARITHMETIC_SCRIPT)).isNull();
-            connection.scriptingCommands().scriptFlush(); // void method, no assertion
-            
-            // Execute transaction
-            List<Object> results = connection.exec();
-            
-            // Verify results
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(3);
-            assertThat(results.get(0)).isInstanceOf(String.class); // SHA1 hash
-            assertThat(results.get(1)).isInstanceOf(String.class); // SHA1 hash
-            assertThat((String) results.get(2)).isEqualTo("OK"); // scriptFlush result
-            
-        } finally {
-            connection.scriptingCommands().scriptFlush();
-        }
-    }
+	@Test
+	@EnabledOnValkeyVersion("7.0") // Error handling for scriptExists() with no args
+									// differs in Valkey < 7.0
+	void testScriptLoadAndExists() {
+		try {
+			// Test scriptLoad
+			String sha1 = connection.scriptingCommands().scriptLoad(SIMPLE_RETURN_SCRIPT);
+			assertThat(sha1).isNotNull();
+			assertThat(sha1).hasSize(40); // SHA1 hash is 40 characters
 
-    @Test
-    void testEvalShaByteArrayInTransactionMode() {
-        try {
-            // Load scripts first
-            String sha1 = connection.scriptingCommands().scriptLoad(SIMPLE_RETURN_SCRIPT);
-            String sha2 = connection.scriptingCommands().scriptLoad(ARITHMETIC_SCRIPT);
-            
-            // Start transaction
-            connection.multi();
-            
-            // Queue evalSha commands with byte[] SHA - assert they return null in transaction mode
-            assertThat((Object) connection.scriptingCommands().evalSha(sha1.getBytes(), ReturnType.VALUE, 0)).isNull();
-            assertThat((Object) connection.scriptingCommands().evalSha(sha2.getBytes(), ReturnType.INTEGER, 0, "11".getBytes(), "4".getBytes())).isNull();
-            
-            // Execute transaction
-            List<Object> results = connection.exec();
-            
-            // Verify results
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(2);
-            assertThat((byte[]) results.get(0)).isEqualTo("hello".getBytes()); // evalSha result
-            assertThat((Long) results.get(1)).isEqualTo(15L); // arithmetic evalSha result
-        } finally {
-            connection.scriptingCommands().scriptFlush();
-        }
-    }
+			String sha2 = connection.scriptingCommands().scriptLoad(ARITHMETIC_SCRIPT);
+			assertThat(sha2).isNotNull();
+			assertThat(sha2).hasSize(40);
+			assertThat(sha2).isNotEqualTo(sha1); // Different scripts should have
+													// different hashes
 
-    @Test
-    void testScriptKillInTransactionMode() {
-        try {
-            // Start transaction
-            connection.multi();
-            
-            // Queue scriptKill command - should return null in transaction mode
-            connection.scriptingCommands().scriptKill(); // void method, no assertion
-            
-            // Execute transaction - expect error since no script is running
-            List<Object> result = connection.exec();
-            assertThat(result).hasSize(1);
-            assertThat(result.get(0)).isInstanceOf(DataAccessException.class);
-            assertThat(((DataAccessException) result.get(0)).getMessage()).contains("No scripts in execution right now");
-        } finally {
-            connection.scriptingCommands().scriptFlush();
-        }
-    }
+			// Test scriptExists with single script
+			List<Boolean> exists1 = connection.scriptingCommands().scriptExists(sha1);
+			assertThat(exists1).hasSize(1);
+			assertThat(exists1.get(0)).isTrue();
 
-    @Test
-    void testScriptingWithKeysInTransactionMode() {
-        String key1 = "test:script:transaction:key1";
-        String key2 = "test:script:transaction:key2";
-        String setKey = "test:script:transaction:set";
-        
-        try {
-            // Setup test data
-            connection.stringCommands().set(key1.getBytes(), "value1".getBytes());
-            connection.stringCommands().set(key2.getBytes(), "value2".getBytes());
-            
-            // Start transaction
-            connection.multi();
-            
-            // Queue script commands with keys - assert they return null in transaction mode
-            assertThat((Object) connection.scriptingCommands().eval(KEY_VALUE_SCRIPT, ReturnType.VALUE, 1, key1.getBytes())).isNull();
-            assertThat((Object) connection.scriptingCommands().eval(KEY_VALUE_SCRIPT, ReturnType.VALUE, 1, key2.getBytes())).isNull();
-            assertThat((Object) connection.scriptingCommands().eval(SET_KEY_SCRIPT, ReturnType.STATUS, 1, setKey.getBytes(), "transactionvalue".getBytes())).isNull();
-            assertThat((Object) connection.scriptingCommands().eval(KEY_VALUE_SCRIPT, ReturnType.VALUE, 1, setKey.getBytes())).isNull();
-            
-            // Execute transaction
-            List<Object> results = connection.exec();
-            
-            // Verify results
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(4);
-            assertThat((byte[]) results.get(0)).isEqualTo("value1".getBytes());
-            assertThat((byte[]) results.get(1)).isEqualTo("value2".getBytes());
-            assertThat((String) results.get(2)).isEqualTo("OK");
-            assertThat((byte[]) results.get(3)).isEqualTo("transactionvalue".getBytes());
-            
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-            cleanupKey(setKey);
-            connection.scriptingCommands().scriptFlush();
-        }
-    }
+			// Test scriptExists with multiple scripts
+			List<Boolean> exists2 = connection.scriptingCommands().scriptExists(sha1, sha2);
+			assertThat(exists2).hasSize(2);
+			assertThat(exists2.get(0)).isTrue();
+			assertThat(exists2.get(1)).isTrue();
 
-    @Test
-    void testTransactionDiscardWithScriptingCommands() {
-        String key = "test:script:transaction:discard";
-        
-        try {
-            // Start transaction
-            connection.multi();
-            
-            // Queue script commands
-            connection.scriptingCommands().eval(SET_KEY_SCRIPT, ReturnType.STATUS, 1, key.getBytes(), "shouldnotbeset".getBytes());
-            connection.scriptingCommands().eval(KEY_VALUE_SCRIPT, ReturnType.VALUE, 1, key.getBytes());
-            
-            // Discard transaction
-            connection.discard();
-            
-            // Verify key doesn not exist (transaction was discarded)
-            byte[] value = connection.stringCommands().get(key.getBytes());
-            assertThat(value).isNull();
-            
-        } finally {
-            cleanupKey(key);
-            connection.scriptingCommands().scriptFlush();
-        }
-    }
+			// Test scriptExists with non-existent script
+			String fakeSha = "0123456789abcdef0123456789abcdef01234567";
+			List<Boolean> exists3 = connection.scriptingCommands().scriptExists(sha1, fakeSha, sha2);
+			assertThat(exists3).hasSize(3);
+			assertThat(exists3.get(0)).isTrue();
+			assertThat(exists3.get(1)).isFalse();
+			assertThat(exists3.get(2)).isTrue();
 
-    @Test
-    void testWatchWithScriptingCommandsTransaction() throws InterruptedException {
-        String watchKey = "test:script:transaction:watch";
-        String otherKey = "test:script:transaction:other";
-        
-        try {
-            // Setup initial data
-            connection.stringCommands().set(watchKey.getBytes(), "initial".getBytes());
-            
-            // Watch the key
-            connection.watch(watchKey.getBytes());
-            
-            // Modify the watched key from "outside" the transaction
-            connection.stringCommands().set(watchKey.getBytes(), "modified".getBytes());
-            
-            // Start transaction
-            connection.multi();
-            
-            // Queue script commands
-            connection.scriptingCommands().eval(SET_KEY_SCRIPT, ReturnType.STATUS, 1, otherKey.getBytes(), "value".getBytes());
-            connection.scriptingCommands().eval(KEY_VALUE_SCRIPT, ReturnType.VALUE, 1, otherKey.getBytes());
-            
-            // Execute transaction - should be aborted due to WATCH
-            List<Object> results = connection.exec();
-            
-            // Transaction should be aborted (results should be null)
-            assertThat(results).isNotNull().isEmpty();
-            
-            // Verify that the other key was not set
-            byte[] value = connection.stringCommands().get(otherKey.getBytes());
-            assertThat(value).isNull();
-            
-        } finally {
-            cleanupKey(watchKey);
-            cleanupKey(otherKey);
-            connection.scriptingCommands().scriptFlush();
-        }
-    }
+			// Test scriptExists with empty array
+			assertThatThrownBy(() -> connection.scriptingCommands().scriptExists())
+				.isInstanceOf(ValkeySystemException.class)
+				.hasMessageContaining("wrong number of arguments for 'script|exists' command");
 
-    // ==================== Comprehensive Scripting Workflow Tests ====================
+		}
+		finally {
+			connection.scriptingCommands().scriptFlush();
+		}
+	}
 
-    @Test
-    void testScriptingComprehensiveWorkflow() {
-        String counterKey = "test:script:workflow:counter";
-        String dataKey = "test:script:workflow:data";
-        String resultKey = "test:script:workflow:result";
-        
-        // Complex script that increments counter and processes data
-        byte[] workflowScript = (
-            "local counter = redis.call('incr', KEYS[1]) " +
-            "redis.call('hset', KEYS[2], 'count', counter) " +
-            "redis.call('hset', KEYS[2], 'data', ARGV[1]) " +
-            "redis.call('set', KEYS[3], 'processed:' .. ARGV[1] .. ':' .. counter) " +
-            "return {counter, 'processed'}"
-        ).getBytes();
-        
-        try {
-            // Load the complex script
-            String sha = connection.scriptingCommands().scriptLoad(workflowScript);
-            assertThat(sha).isNotNull();
-            
-            // Execute workflow multiple times using eval
-            Object[] result1 = connection.scriptingCommands().eval(workflowScript, ReturnType.MULTI, 3, 
-                counterKey.getBytes(), dataKey.getBytes(), resultKey.getBytes(), "data1".getBytes());
-            assertThat(result1).hasSize(2);
-            assertThat((Long) result1[0]).isEqualTo(1L);
-            assertThat(new String((byte[]) result1[1])).isEqualTo("processed");
-            
-            // Execute workflow using evalSha
-            Object[] result2 = connection.scriptingCommands().evalSha(sha, ReturnType.MULTI, 3,
-                counterKey.getBytes(), dataKey.getBytes(), resultKey.getBytes(), "data2".getBytes());
-            assertThat(result2).hasSize(2);
-            assertThat((Long) result2[0]).isEqualTo(2L);
-            assertThat(new String((byte[]) result2[1])).isEqualTo("processed");
-            
-            // Verify final state
-            byte[] counterValue = connection.stringCommands().get(counterKey.getBytes());
-            assertThat(new String(counterValue)).isEqualTo("2");
-            
-            byte[] resultValue = connection.stringCommands().get(resultKey.getBytes());
-            assertThat(new String(resultValue)).isEqualTo("processed:data2:2");
-            
-            // Verify hash data
-            byte[] hashCount = connection.hashCommands().hGet(dataKey.getBytes(), "count".getBytes());
-            byte[] hashData = connection.hashCommands().hGet(dataKey.getBytes(), "data".getBytes());
-            assertThat(new String(hashCount)).isEqualTo("2");
-            assertThat(new String(hashData)).isEqualTo("data2");
-            
-            // Test script exists
-            List<Boolean> scriptExists = connection.scriptingCommands().scriptExists(sha);
-            assertThat(scriptExists.get(0)).isTrue();
-            
-        } finally {
-            cleanupKey(counterKey);
-            cleanupKey(dataKey);
-            cleanupKey(resultKey);
-            connection.scriptingCommands().scriptFlush();
-        }
-    }
+	@Test
+	void testEvalShaScripts() {
+		try {
+			// Load scripts
+			String sha1 = connection.scriptingCommands().scriptLoad(SIMPLE_RETURN_SCRIPT);
+			String sha2 = connection.scriptingCommands().scriptLoad(ARITHMETIC_SCRIPT);
 
-    @Test
-    void testComplexScriptingWithPipelineAndTransaction() {
-        String key1 = "test:script:complex:key1";
-        String key2 = "test:script:complex:key2";
-        String key3 = "test:script:complex:key3";
-        
-        // Script that performs multiple operations
-        byte[] complexScript = (
-            "redis.call('set', KEYS[1], ARGV[1]) " +
-            "redis.call('set', KEYS[2], ARGV[2]) " +
-            "local val1 = redis.call('get', KEYS[1]) " +
-            "local val2 = redis.call('get', KEYS[2]) " +
-            "redis.call('set', KEYS[3], val1 .. ':' .. val2) " +
-            "return redis.call('get', KEYS[3])"
-        ).getBytes();
-        
-        try {
-            // Test in immediate mode
-            byte[] result1 = connection.scriptingCommands().eval(complexScript, ReturnType.VALUE, 3,
-                key1.getBytes(), key2.getBytes(), key3.getBytes(), "value1".getBytes(), "value2".getBytes());
-            assertThat(new String(result1)).isEqualTo("value1:value2");
-            
-            // Clear keys
-            connection.keyCommands().del(key1.getBytes(), key2.getBytes(), key3.getBytes());
-            
-            // Test in pipeline mode
-            connection.openPipeline();
-            assertThat((Object) connection.scriptingCommands().eval(complexScript, ReturnType.VALUE, 3,
-                key1.getBytes(), key2.getBytes(), key3.getBytes(), "pipe1".getBytes(), "pipe2".getBytes())).isNull();
-            List<Object> pipeResults = connection.closePipeline();
-            assertThat(pipeResults).hasSize(1);
-            assertThat((byte[]) pipeResults.get(0)).isEqualTo("pipe1:pipe2".getBytes());
-            
-            // Clear keys
-            connection.keyCommands().del(key1.getBytes(), key2.getBytes(), key3.getBytes());
-            
-            // Test in transaction mode
-            connection.multi();
-            assertThat((Object) connection.scriptingCommands().eval(complexScript, ReturnType.VALUE, 3,
-                key1.getBytes(), key2.getBytes(), key3.getBytes(), "tx1".getBytes(), "tx2".getBytes())).isNull();
-            List<Object> txResults = connection.exec();
-            assertThat(txResults).isNotNull();
-            assertThat(txResults).hasSize(1);
-            assertThat((byte[]) txResults.get(0)).isEqualTo("tx1:tx2".getBytes());
-            
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-            cleanupKey(key3);
-            connection.scriptingCommands().scriptFlush();
-        }
-    }
+			// Test evalSha with String SHA
+			byte[] result1 = connection.scriptingCommands().evalSha(sha1, ReturnType.VALUE, 0);
+			assertThat(new String(result1)).isEqualTo("hello");
+
+			Long result2 = connection.scriptingCommands()
+				.evalSha(sha2, ReturnType.INTEGER, 0, "10".getBytes(), "20".getBytes());
+			assertThat(result2).isEqualTo(30L);
+
+			// Test evalSha with byte[] SHA
+			byte[] sha1Bytes = sha1.getBytes();
+			byte[] sha2Bytes = sha2.getBytes();
+
+			byte[] result3 = connection.scriptingCommands().evalSha(sha1Bytes, ReturnType.VALUE, 0);
+			assertThat(new String(result3)).isEqualTo("hello");
+
+			Long result4 = connection.scriptingCommands()
+				.evalSha(sha2Bytes, ReturnType.INTEGER, 0, "15".getBytes(), "25".getBytes());
+			assertThat(result4).isEqualTo(40L);
+
+		}
+		finally {
+			connection.scriptingCommands().scriptFlush();
+		}
+	}
+
+	@Test
+	void testScriptFlush() {
+		try {
+			// Load a script
+			String sha = connection.scriptingCommands().scriptLoad(SIMPLE_RETURN_SCRIPT);
+
+			// Verify script exists
+			List<Boolean> existsBefore = connection.scriptingCommands().scriptExists(sha);
+			assertThat(existsBefore.get(0)).isTrue();
+
+			// Flush script cache
+			connection.scriptingCommands().scriptFlush();
+
+			// Verify script no longer exists
+			List<Boolean> existsAfter = connection.scriptingCommands().scriptExists(sha);
+			assertThat(existsAfter.get(0)).isFalse();
+
+		}
+		finally {
+			connection.scriptingCommands().scriptFlush();
+		}
+	}
+
+	@Test
+	void testScriptKill() {
+		try {
+			// Note: SCRIPT KILL is typically used to kill long-running scripts
+			// Since we can't easily create a long-running script in tests,
+			// we test that the command executes without error when no script is running
+			// This should complete without throwing an exception or return an error
+			// message
+			assertThatThrownBy(() -> connection.scriptingCommands().scriptKill())
+				.isInstanceOf(DataAccessException.class)
+				.hasMessageContaining("No scripts in execution right now");
+
+		}
+		finally {
+			connection.scriptingCommands().scriptFlush();
+		}
+	}
+
+	// ==================== Edge Cases and Error Handling ====================
+
+	@Test
+	void testScriptingWithBinaryData() {
+		String testKey = "test:script:binary";
+		byte[] binaryData = new byte[] { 0x00, 0x01, 0x02, (byte) 0xFF, (byte) 0xFE };
+		byte[] setBinaryScript = "redis.call('set', KEYS[1], ARGV[1]); return redis.call('get', KEYS[1])".getBytes();
+
+		try {
+			// Test script with binary data
+			byte[] result = connection.scriptingCommands()
+				.eval(setBinaryScript, ReturnType.VALUE, 1, testKey.getBytes(), binaryData);
+			assertThat(result).isEqualTo(binaryData);
+
+		}
+		finally {
+			cleanupKey(testKey);
+			connection.scriptingCommands().scriptFlush();
+		}
+	}
+
+	@Test
+	void testScriptingErrorHandling() {
+		try {
+			// Test script with syntax error
+			byte[] invalidScript = "return invalid syntax here".getBytes();
+			assertThatThrownBy(() -> connection.scriptingCommands().eval(invalidScript, ReturnType.VALUE, 0))
+				.isInstanceOf(DataAccessException.class);
+
+			// Test evalSha with non-existent SHA
+			String fakeSha = "0123456789abcdef0123456789abcdef01234567";
+			assertThatThrownBy(() -> connection.scriptingCommands().evalSha(fakeSha, ReturnType.VALUE, 0))
+				.isInstanceOf(DataAccessException.class);
+
+			// Test script with wrong number of keys
+			byte[] keyScript = "return KEYS[2]".getBytes();
+			Object result = connection.scriptingCommands().eval(keyScript, ReturnType.VALUE, 1, "key1".getBytes());
+			assertThat(result).isNull(); // KEYS[2] does not exist, should return nil
+		}
+		finally {
+			connection.scriptingCommands().scriptFlush();
+		}
+	}
+
+	@Test
+	void testEvalShaWithoutPreLoadingScript() {
+		// This test simulates what DefaultScriptExecutor does: try evalSha first without
+		// loading
+		try {
+			// Use a fake SHA1 hash that definitely doesn't exist in Valkey
+			// This should trigger a NOSCRIPT error, which is what we need to test
+			String fakeSha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"; // 40 chars of
+																			// 'a'
+
+			// Try to execute using evalSha WITHOUT loading the script first
+			// This should fail with NOSCRIPT error, which is what we need to test
+			Exception caughtException = null;
+			try {
+				connection.scriptingCommands().evalSha(fakeSha, ReturnType.VALUE, 0);
+			}
+			catch (Exception ex) {
+				caughtException = ex;
+			}
+
+			// Verify we got an exception
+			assertThat(caughtException).as("Expected NOSCRIPT exception when calling evalSha with uncached script")
+				.isNotNull();
+		}
+		finally {
+			connection.scriptingCommands().scriptFlush();
+		}
+	}
+
+	@Test
+	void testScriptingWithEmptyKeysAndArgs() {
+		try {
+			// Test script with no keys or args
+			byte[] result1 = connection.scriptingCommands().eval(SIMPLE_RETURN_SCRIPT, ReturnType.VALUE, 0);
+			assertThat(new String(result1)).isEqualTo("hello");
+
+			// Test script that expects args but gets none
+			byte[] argScript = "return ARGV[1] or 'default'".getBytes();
+			byte[] result2 = connection.scriptingCommands().eval(argScript, ReturnType.VALUE, 0);
+			assertThat(new String(result2)).isEqualTo("default");
+
+		}
+		finally {
+			connection.scriptingCommands().scriptFlush();
+		}
+	}
+
+	// ==================== Pipeline Mode Tests ====================
+
+	@Test
+	void testBasicScriptingCommandsInPipelineMode() {
+		try {
+			// Load scripts first
+			String sha1 = connection.scriptingCommands().scriptLoad(SIMPLE_RETURN_SCRIPT);
+			String sha2 = connection.scriptingCommands().scriptLoad(ARITHMETIC_SCRIPT);
+
+			// Start pipeline
+			connection.openPipeline();
+
+			// Queue scripting commands - assert they return null in pipeline mode
+			assertThat((Object) connection.scriptingCommands().eval(SIMPLE_RETURN_SCRIPT, ReturnType.VALUE, 0))
+				.isNull();
+			assertThat((Object) connection.scriptingCommands().evalSha(sha1, ReturnType.VALUE, 0)).isNull();
+			assertThat((Object) connection.scriptingCommands()
+				.eval(ARITHMETIC_SCRIPT, ReturnType.INTEGER, 0, "7".getBytes(), "3".getBytes())).isNull();
+			assertThat((Object) connection.scriptingCommands()
+				.evalSha(sha2, ReturnType.INTEGER, 0, "10".getBytes(), "5".getBytes())).isNull();
+			assertThat((Object) connection.scriptingCommands().scriptExists(sha1, sha2)).isNull();
+
+			// Execute pipeline
+			List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(5);
+			assertThat((byte[]) results.get(0)).isEqualTo("hello".getBytes()); // eval
+																				// result
+			assertThat((byte[]) results.get(1)).isEqualTo("hello".getBytes()); // evalSha
+																				// result
+			assertThat((Long) results.get(2)).isEqualTo(10L); // arithmetic eval result
+			assertThat((Long) results.get(3)).isEqualTo(15L); // arithmetic evalSha result
+
+			@SuppressWarnings("unchecked")
+			List<Boolean> existsResult = (List<Boolean>) results.get(4);
+			assertThat(existsResult).hasSize(2);
+			assertThat(existsResult.get(0)).isTrue();
+			assertThat(existsResult.get(1)).isTrue();
+
+		}
+		finally {
+			connection.scriptingCommands().scriptFlush();
+		}
+	}
+
+	@Test
+	void testScriptLoadAndFlushInPipelineMode() {
+		try {
+			// Start pipeline
+			connection.openPipeline();
+
+			// Queue script management commands - assert they return null in pipeline mode
+			assertThat(connection.scriptingCommands().scriptLoad(SIMPLE_RETURN_SCRIPT)).isNull();
+			assertThat(connection.scriptingCommands().scriptLoad(ARITHMETIC_SCRIPT)).isNull();
+			connection.scriptingCommands().scriptFlush(); // void method, no assertion
+
+			// Execute pipeline
+			List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(3);
+			assertThat(results.get(0)).isInstanceOf(String.class); // SHA1 hash
+			assertThat(results.get(1)).isInstanceOf(String.class); // SHA1 hash
+			assertThat((String) results.get(2)).isEqualTo("OK"); // scriptFlush result
+
+			String sha1 = (String) results.get(0);
+			String sha2 = (String) results.get(1);
+			assertThat(sha1).hasSize(40);
+			assertThat(sha2).hasSize(40);
+			assertThat(sha1).isNotEqualTo(sha2);
+
+		}
+		finally {
+			connection.scriptingCommands().scriptFlush();
+		}
+	}
+
+	@Test
+	void testEvalShaByteArrayInPipelineMode() {
+		try {
+			// Load scripts first
+			String sha1 = connection.scriptingCommands().scriptLoad(SIMPLE_RETURN_SCRIPT);
+			String sha2 = connection.scriptingCommands().scriptLoad(ARITHMETIC_SCRIPT);
+
+			// Start pipeline
+			connection.openPipeline();
+
+			// Queue evalSha commands with byte[] SHA - assert they return null in
+			// pipeline mode
+			assertThat((Object) connection.scriptingCommands().evalSha(sha1.getBytes(), ReturnType.VALUE, 0)).isNull();
+			assertThat((Object) connection.scriptingCommands()
+				.evalSha(sha2.getBytes(), ReturnType.INTEGER, 0, "9".getBytes(), "3".getBytes())).isNull();
+
+			// Execute pipeline
+			List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(2);
+			assertThat((byte[]) results.get(0)).isEqualTo("hello".getBytes()); // evalSha
+																				// result
+			assertThat((Long) results.get(1)).isEqualTo(12L); // arithmetic evalSha result
+
+		}
+		finally {
+			connection.scriptingCommands().scriptFlush();
+		}
+	}
+
+	@Test
+	void testScriptKillInPipelineMode() {
+		try {
+			// Start pipeline
+			connection.openPipeline();
+
+			// Queue scriptKill command - should return null in pipeline mode
+			connection.scriptingCommands().scriptKill(); // void method, no assertion
+
+			// Execute pipeline - expect error since no script is running
+			List<Object> result = connection.closePipeline();
+			assertThat(result).hasSize(1);
+			assertThat(result.get(0)).isInstanceOf(DataAccessException.class);
+			assertThat(((DataAccessException) result.get(0)).getMessage())
+				.contains("No scripts in execution right now");
+		}
+		finally {
+			connection.scriptingCommands().scriptFlush();
+		}
+	}
+
+	@Test
+	void testScriptingWithKeysInPipelineMode() {
+		String key1 = "test:script:pipeline:key1";
+		String key2 = "test:script:pipeline:key2";
+		String setKey = "test:script:pipeline:set";
+
+		try {
+			// Setup test data
+			connection.stringCommands().set(key1.getBytes(), "value1".getBytes());
+			connection.stringCommands().set(key2.getBytes(), "value2".getBytes());
+
+			// Start pipeline
+			connection.openPipeline();
+			// Queue script commands with keys - assert they return null in pipeline mode
+			assertThat((Object) connection.scriptingCommands()
+				.eval(KEY_VALUE_SCRIPT, ReturnType.VALUE, 1, key1.getBytes())).isNull();
+			assertThat((Object) connection.scriptingCommands()
+				.eval(KEY_VALUE_SCRIPT, ReturnType.VALUE, 1, key2.getBytes())).isNull();
+			assertThat((Object) connection.scriptingCommands()
+				.eval(SET_KEY_SCRIPT, ReturnType.STATUS, 1, setKey.getBytes(), "newvalue".getBytes())).isNull();
+			assertThat((Object) connection.scriptingCommands()
+				.eval(KEY_VALUE_SCRIPT, ReturnType.VALUE, 1, setKey.getBytes())).isNull();
+
+			// Execute pipeline
+			List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(4);
+			assertThat((byte[]) results.get(0)).isEqualTo("value1".getBytes());
+			assertThat((byte[]) results.get(1)).isEqualTo("value2".getBytes());
+			assertThat((String) results.get(2)).isEqualTo("OK");
+			assertThat((byte[]) results.get(3)).isEqualTo("newvalue".getBytes());
+
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+			cleanupKey(setKey);
+			connection.scriptingCommands().scriptFlush();
+		}
+	}
+
+	// ==================== Transaction Mode Tests ====================
+
+	@Test
+	void testBasicScriptingCommandsInTransactionMode() {
+		try {
+			// Load scripts first
+			String sha1 = connection.scriptingCommands().scriptLoad(SIMPLE_RETURN_SCRIPT);
+			String sha2 = connection.scriptingCommands().scriptLoad(ARITHMETIC_SCRIPT);
+
+			// Start transaction
+			connection.multi();
+
+			// Queue scripting commands - assert they return null in transaction mode
+			assertThat((Object) connection.scriptingCommands().eval(SIMPLE_RETURN_SCRIPT, ReturnType.VALUE, 0))
+				.isNull();
+			assertThat((Object) connection.scriptingCommands().evalSha(sha1, ReturnType.VALUE, 0)).isNull();
+			assertThat((Object) connection.scriptingCommands()
+				.eval(ARITHMETIC_SCRIPT, ReturnType.INTEGER, 0, "8".getBytes(), "4".getBytes())).isNull();
+			assertThat((Object) connection.scriptingCommands()
+				.evalSha(sha2, ReturnType.INTEGER, 0, "12".getBytes(), "6".getBytes())).isNull();
+			assertThat((Object) connection.scriptingCommands().scriptExists(sha1, sha2)).isNull();
+
+			// Execute transaction
+			List<Object> results = connection.exec();
+
+			// Verify results
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(5);
+			assertThat((byte[]) results.get(0)).isEqualTo("hello".getBytes()); // eval
+																				// result
+			assertThat((byte[]) results.get(1)).isEqualTo("hello".getBytes()); // evalSha
+																				// result
+			assertThat((Long) results.get(2)).isEqualTo(12L); // arithmetic eval result
+			assertThat((Long) results.get(3)).isEqualTo(18L); // arithmetic evalSha result
+
+			@SuppressWarnings("unchecked")
+			List<Boolean> existsResult = (List<Boolean>) results.get(4);
+			assertThat(existsResult).hasSize(2);
+			assertThat(existsResult.get(0)).isTrue();
+			assertThat(existsResult.get(1)).isTrue();
+
+		}
+		finally {
+			connection.scriptingCommands().scriptFlush();
+		}
+	}
+
+	@Test
+	void testScriptManagementInTransactionMode() {
+		try {
+			// Start transaction
+			connection.multi();
+
+			// Queue script management commands - assert they return null in transaction
+			// mode
+			assertThat((Object) connection.scriptingCommands().scriptLoad(SIMPLE_RETURN_SCRIPT)).isNull();
+			assertThat((Object) connection.scriptingCommands().scriptLoad(ARITHMETIC_SCRIPT)).isNull();
+			connection.scriptingCommands().scriptFlush(); // void method, no assertion
+
+			// Execute transaction
+			List<Object> results = connection.exec();
+
+			// Verify results
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(3);
+			assertThat(results.get(0)).isInstanceOf(String.class); // SHA1 hash
+			assertThat(results.get(1)).isInstanceOf(String.class); // SHA1 hash
+			assertThat((String) results.get(2)).isEqualTo("OK"); // scriptFlush result
+
+		}
+		finally {
+			connection.scriptingCommands().scriptFlush();
+		}
+	}
+
+	@Test
+	void testEvalShaByteArrayInTransactionMode() {
+		try {
+			// Load scripts first
+			String sha1 = connection.scriptingCommands().scriptLoad(SIMPLE_RETURN_SCRIPT);
+			String sha2 = connection.scriptingCommands().scriptLoad(ARITHMETIC_SCRIPT);
+
+			// Start transaction
+			connection.multi();
+
+			// Queue evalSha commands with byte[] SHA - assert they return null in
+			// transaction mode
+			assertThat((Object) connection.scriptingCommands().evalSha(sha1.getBytes(), ReturnType.VALUE, 0)).isNull();
+			assertThat((Object) connection.scriptingCommands()
+				.evalSha(sha2.getBytes(), ReturnType.INTEGER, 0, "11".getBytes(), "4".getBytes())).isNull();
+
+			// Execute transaction
+			List<Object> results = connection.exec();
+
+			// Verify results
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(2);
+			assertThat((byte[]) results.get(0)).isEqualTo("hello".getBytes()); // evalSha
+																				// result
+			assertThat((Long) results.get(1)).isEqualTo(15L); // arithmetic evalSha result
+		}
+		finally {
+			connection.scriptingCommands().scriptFlush();
+		}
+	}
+
+	@Test
+	void testScriptKillInTransactionMode() {
+		try {
+			// Start transaction
+			connection.multi();
+
+			// Queue scriptKill command - should return null in transaction mode
+			connection.scriptingCommands().scriptKill(); // void method, no assertion
+
+			// Execute transaction - expect error since no script is running
+			List<Object> result = connection.exec();
+			assertThat(result).hasSize(1);
+			assertThat(result.get(0)).isInstanceOf(DataAccessException.class);
+			assertThat(((DataAccessException) result.get(0)).getMessage())
+				.contains("No scripts in execution right now");
+		}
+		finally {
+			connection.scriptingCommands().scriptFlush();
+		}
+	}
+
+	@Test
+	void testScriptingWithKeysInTransactionMode() {
+		String key1 = "test:script:transaction:key1";
+		String key2 = "test:script:transaction:key2";
+		String setKey = "test:script:transaction:set";
+
+		try {
+			// Setup test data
+			connection.stringCommands().set(key1.getBytes(), "value1".getBytes());
+			connection.stringCommands().set(key2.getBytes(), "value2".getBytes());
+
+			// Start transaction
+			connection.multi();
+
+			// Queue script commands with keys - assert they return null in transaction
+			// mode
+			assertThat((Object) connection.scriptingCommands()
+				.eval(KEY_VALUE_SCRIPT, ReturnType.VALUE, 1, key1.getBytes())).isNull();
+			assertThat((Object) connection.scriptingCommands()
+				.eval(KEY_VALUE_SCRIPT, ReturnType.VALUE, 1, key2.getBytes())).isNull();
+			assertThat((Object) connection.scriptingCommands()
+				.eval(SET_KEY_SCRIPT, ReturnType.STATUS, 1, setKey.getBytes(), "transactionvalue".getBytes())).isNull();
+			assertThat((Object) connection.scriptingCommands()
+				.eval(KEY_VALUE_SCRIPT, ReturnType.VALUE, 1, setKey.getBytes())).isNull();
+
+			// Execute transaction
+			List<Object> results = connection.exec();
+
+			// Verify results
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(4);
+			assertThat((byte[]) results.get(0)).isEqualTo("value1".getBytes());
+			assertThat((byte[]) results.get(1)).isEqualTo("value2".getBytes());
+			assertThat((String) results.get(2)).isEqualTo("OK");
+			assertThat((byte[]) results.get(3)).isEqualTo("transactionvalue".getBytes());
+
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+			cleanupKey(setKey);
+			connection.scriptingCommands().scriptFlush();
+		}
+	}
+
+	@Test
+	void testTransactionDiscardWithScriptingCommands() {
+		String key = "test:script:transaction:discard";
+
+		try {
+			// Start transaction
+			connection.multi();
+
+			// Queue script commands
+			connection.scriptingCommands()
+				.eval(SET_KEY_SCRIPT, ReturnType.STATUS, 1, key.getBytes(), "shouldnotbeset".getBytes());
+			connection.scriptingCommands().eval(KEY_VALUE_SCRIPT, ReturnType.VALUE, 1, key.getBytes());
+
+			// Discard transaction
+			connection.discard();
+
+			// Verify key doesn not exist (transaction was discarded)
+			byte[] value = connection.stringCommands().get(key.getBytes());
+			assertThat(value).isNull();
+
+		}
+		finally {
+			cleanupKey(key);
+			connection.scriptingCommands().scriptFlush();
+		}
+	}
+
+	@Test
+	void testWatchWithScriptingCommandsTransaction() throws InterruptedException {
+		String watchKey = "test:script:transaction:watch";
+		String otherKey = "test:script:transaction:other";
+
+		try {
+			// Setup initial data
+			connection.stringCommands().set(watchKey.getBytes(), "initial".getBytes());
+
+			// Watch the key
+			connection.watch(watchKey.getBytes());
+
+			// Modify the watched key from "outside" the transaction
+			connection.stringCommands().set(watchKey.getBytes(), "modified".getBytes());
+
+			// Start transaction
+			connection.multi();
+
+			// Queue script commands
+			connection.scriptingCommands()
+				.eval(SET_KEY_SCRIPT, ReturnType.STATUS, 1, otherKey.getBytes(), "value".getBytes());
+			connection.scriptingCommands().eval(KEY_VALUE_SCRIPT, ReturnType.VALUE, 1, otherKey.getBytes());
+
+			// Execute transaction - should be aborted due to WATCH
+			List<Object> results = connection.exec();
+
+			// Transaction should be aborted (results should be null)
+			assertThat(results).isNotNull().isEmpty();
+
+			// Verify that the other key was not set
+			byte[] value = connection.stringCommands().get(otherKey.getBytes());
+			assertThat(value).isNull();
+
+		}
+		finally {
+			cleanupKey(watchKey);
+			cleanupKey(otherKey);
+			connection.scriptingCommands().scriptFlush();
+		}
+	}
+
+	// ==================== Comprehensive Scripting Workflow Tests ====================
+
+	@Test
+	void testScriptingComprehensiveWorkflow() {
+		String counterKey = "test:script:workflow:counter";
+		String dataKey = "test:script:workflow:data";
+		String resultKey = "test:script:workflow:result";
+
+		// Complex script that increments counter and processes data
+		byte[] workflowScript = ("local counter = redis.call('incr', KEYS[1]) "
+				+ "redis.call('hset', KEYS[2], 'count', counter) " + "redis.call('hset', KEYS[2], 'data', ARGV[1]) "
+				+ "redis.call('set', KEYS[3], 'processed:' .. ARGV[1] .. ':' .. counter) "
+				+ "return {counter, 'processed'}")
+			.getBytes();
+
+		try {
+			// Load the complex script
+			String sha = connection.scriptingCommands().scriptLoad(workflowScript);
+			assertThat(sha).isNotNull();
+
+			// Execute workflow multiple times using eval
+			Object[] result1 = connection.scriptingCommands()
+				.eval(workflowScript, ReturnType.MULTI, 3, counterKey.getBytes(), dataKey.getBytes(),
+						resultKey.getBytes(), "data1".getBytes());
+			assertThat(result1).hasSize(2);
+			assertThat((Long) result1[0]).isEqualTo(1L);
+			assertThat(new String((byte[]) result1[1])).isEqualTo("processed");
+
+			// Execute workflow using evalSha
+			Object[] result2 = connection.scriptingCommands()
+				.evalSha(sha, ReturnType.MULTI, 3, counterKey.getBytes(), dataKey.getBytes(), resultKey.getBytes(),
+						"data2".getBytes());
+			assertThat(result2).hasSize(2);
+			assertThat((Long) result2[0]).isEqualTo(2L);
+			assertThat(new String((byte[]) result2[1])).isEqualTo("processed");
+
+			// Verify final state
+			byte[] counterValue = connection.stringCommands().get(counterKey.getBytes());
+			assertThat(new String(counterValue)).isEqualTo("2");
+
+			byte[] resultValue = connection.stringCommands().get(resultKey.getBytes());
+			assertThat(new String(resultValue)).isEqualTo("processed:data2:2");
+
+			// Verify hash data
+			byte[] hashCount = connection.hashCommands().hGet(dataKey.getBytes(), "count".getBytes());
+			byte[] hashData = connection.hashCommands().hGet(dataKey.getBytes(), "data".getBytes());
+			assertThat(new String(hashCount)).isEqualTo("2");
+			assertThat(new String(hashData)).isEqualTo("data2");
+
+			// Test script exists
+			List<Boolean> scriptExists = connection.scriptingCommands().scriptExists(sha);
+			assertThat(scriptExists.get(0)).isTrue();
+
+		}
+		finally {
+			cleanupKey(counterKey);
+			cleanupKey(dataKey);
+			cleanupKey(resultKey);
+			connection.scriptingCommands().scriptFlush();
+		}
+	}
+
+	@Test
+	void testComplexScriptingWithPipelineAndTransaction() {
+		String key1 = "test:script:complex:key1";
+		String key2 = "test:script:complex:key2";
+		String key3 = "test:script:complex:key3";
+
+		// Script that performs multiple operations
+		byte[] complexScript = ("redis.call('set', KEYS[1], ARGV[1]) " + "redis.call('set', KEYS[2], ARGV[2]) "
+				+ "local val1 = redis.call('get', KEYS[1]) " + "local val2 = redis.call('get', KEYS[2]) "
+				+ "redis.call('set', KEYS[3], val1 .. ':' .. val2) " + "return redis.call('get', KEYS[3])")
+			.getBytes();
+
+		try {
+			// Test in immediate mode
+			byte[] result1 = connection.scriptingCommands()
+				.eval(complexScript, ReturnType.VALUE, 3, key1.getBytes(), key2.getBytes(), key3.getBytes(),
+						"value1".getBytes(), "value2".getBytes());
+			assertThat(new String(result1)).isEqualTo("value1:value2");
+
+			// Clear keys
+			connection.keyCommands().del(key1.getBytes(), key2.getBytes(), key3.getBytes());
+
+			// Test in pipeline mode
+			connection.openPipeline();
+			assertThat((Object) connection.scriptingCommands()
+				.eval(complexScript, ReturnType.VALUE, 3, key1.getBytes(), key2.getBytes(), key3.getBytes(),
+						"pipe1".getBytes(), "pipe2".getBytes()))
+				.isNull();
+			List<Object> pipeResults = connection.closePipeline();
+			assertThat(pipeResults).hasSize(1);
+			assertThat((byte[]) pipeResults.get(0)).isEqualTo("pipe1:pipe2".getBytes());
+
+			// Clear keys
+			connection.keyCommands().del(key1.getBytes(), key2.getBytes(), key3.getBytes());
+
+			// Test in transaction mode
+			connection.multi();
+			assertThat((Object) connection.scriptingCommands()
+				.eval(complexScript, ReturnType.VALUE, 3, key1.getBytes(), key2.getBytes(), key3.getBytes(),
+						"tx1".getBytes(), "tx2".getBytes()))
+				.isNull();
+			List<Object> txResults = connection.exec();
+			assertThat(txResults).isNotNull();
+			assertThat(txResults).hasSize(1);
+			assertThat((byte[]) txResults.get(0)).isEqualTo("tx1:tx2".getBytes());
+
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+			cleanupKey(key3);
+			connection.scriptingCommands().scriptFlush();
+		}
+	}
 
 }

--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionServerCommandsIntegrationTests.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionServerCommandsIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,1314 +32,1393 @@ import io.valkey.springframework.data.valkey.connection.ValkeyServerCommands.Shu
 import io.valkey.springframework.data.valkey.core.types.ValkeyClientInfo;
 
 /**
- * Comprehensive low-level integration tests for {@link ValkeyGlideConnection} 
- * server functionality using the ValkeyServerCommands interface directly.
- * 
- * These tests validate the implementation of all ValkeyServerCommands methods:
- * - Background operations (bgReWriteAof, bgSave, lastSave, save)
- * - Database operations (dbSize, flushDb, flushAll)
- * - Server information (info, time)
- * - Configuration management (getConfig, setConfig, resetConfigStats, rewriteConfig)
- * - Client management (killClient, setClientName, getClientName, getClientList)
- * - Replication commands (replicaOf, replicaOfNoOne)
- * - Data migration (migrate)
- * - Server control (shutdown) - tested with caution
- * - Error handling and validation
+ * Comprehensive low-level integration tests for {@link ValkeyGlideConnection} server
+ * functionality using the ValkeyServerCommands interface directly.
+ *
+ * These tests validate the implementation of all ValkeyServerCommands methods: -
+ * Background operations (bgReWriteAof, bgSave, lastSave, save) - Database operations
+ * (dbSize, flushDb, flushAll) - Server information (info, time) - Configuration
+ * management (getConfig, setConfig, resetConfigStats, rewriteConfig) - Client management
+ * (killClient, setClientName, getClientName, getClientList) - Replication commands
+ * (replicaOf, replicaOfNoOne) - Data migration (migrate) - Server control (shutdown) -
+ * tested with caution - Error handling and validation
  *
  * @author Ilia Kolominsky
  * @since 2.0
  */
 public class ValkeyGlideConnectionServerCommandsIntegrationTests extends AbstractValkeyGlideIntegrationTests {
 
-    @Override
-    protected String[] getTestKeyPatterns() {
-        return new String[]{
-            "test:server:db:key", "test:server:flush:key1", "test:server:flush:key2",
-            "test:server:migrate:key", "test:server:config:key", "test:server:client:key",
-            "test:server:info:key", "test:server:time:key", "test:server:replication:key",
-            "test:server:save:key", "test:server:validation:key", "test:server:edge:key"
-        };
-    }
+	@Override
+	protected String[] getTestKeyPatterns() {
+		return new String[] { "test:server:db:key", "test:server:flush:key1", "test:server:flush:key2",
+				"test:server:migrate:key", "test:server:config:key", "test:server:client:key", "test:server:info:key",
+				"test:server:time:key", "test:server:replication:key", "test:server:save:key",
+				"test:server:validation:key", "test:server:edge:key" };
+	}
 
-    // ==================== Background Operations ====================
+	// ==================== Background Operations ====================
 
-    @Test
-    void testBgReWriteAof() {
-        try {
-            // Test background AOF rewrite
-            connection.serverCommands().bgReWriteAof();
-            
-            // Command should execute without throwing an exception
-            // We can't easily verify the actual AOF rewrite without server configuration
-            // but we can verify the command was accepted
-        } catch (Exception e) {
-            // Check for the specific error message when AOF is not enabled
-            if (e.getMessage() != null && e.getMessage().contains("NOAPPENDONLYFILE")) {
-                logger.warn("BGREWRITEAOF test skipped: AOF not enabled on server");
-                return;
-            } else {
-                throw e;
-            }
-        }
-    }
+	@Test
+	void testBgReWriteAof() {
+		try {
+			// Test background AOF rewrite
+			connection.serverCommands().bgReWriteAof();
 
-    @Test
-    void testBgSave() {
-        try {
-            // Test background save
-            connection.serverCommands().bgSave();
-            
-            // Command should execute without throwing an exception
-            // We can't easily verify the actual save without filesystem access
-            // but we can verify the command was accepted
-        } catch (Exception e) {
-            // Check for the specific error message when background save is already in progress
-            if (e.getMessage() != null && e.getMessage().contains("Background save already in progress")) {
-                logger.warn("BGSAVE test skipped: Background save already in progress");
-                return;
-            } else {
-                throw e;
-            }
-        }
-    }
+			// Command should execute without throwing an exception
+			// We can't easily verify the actual AOF rewrite without server configuration
+			// but we can verify the command was accepted
+		}
+		catch (Exception e) {
+			// Check for the specific error message when AOF is not enabled
+			if (e.getMessage() != null && e.getMessage().contains("NOAPPENDONLYFILE")) {
+				logger.warn("BGREWRITEAOF test skipped: AOF not enabled on server");
+				return;
+			}
+			else {
+				throw e;
+			}
+		}
+	}
 
-    @Test
-    void testLastSave() {
-        Long lastSaveTime = connection.serverCommands().lastSave();
-        
-        // lastSave should return a timestamp or null
-        if (lastSaveTime != null) {
-            assertThat(lastSaveTime).isGreaterThan(0L);
-            // The timestamp should be reasonable (not in the future, allowing for clock skew)
-            long currentTimeSeconds = System.currentTimeMillis() / 1000;
-            assertThat(lastSaveTime).isLessThanOrEqualTo(currentTimeSeconds + 60); // Allow 1 minute clock skew
-        } else {
-            logger.warn("LASTSAVE returned null - no previous save recorded");
-        }
-    }
+	@Test
+	void testBgSave() {
+		try {
+			// Test background save
+			connection.serverCommands().bgSave();
 
-    @Test
-    void testSave() {
-        try {
-            // Get lastSave time before save operation
-            Long lastSaveTimeBefore = connection.serverCommands().lastSave();
-            
-            // Test synchronous save
-            connection.serverCommands().save();
-            
-            // Command should execute without throwing an exception
-            // Verify that lastSave timestamp is updated
-            Long lastSaveTimeAfter = connection.serverCommands().lastSave();
-            assertThat(lastSaveTimeAfter).isNotNull();
-            assertThat(lastSaveTimeAfter).isGreaterThan(0L);
-            
-            // If we had a previous save time, the new one should be >= the old one
-            if (lastSaveTimeBefore != null) {
-                assertThat(lastSaveTimeAfter).isGreaterThanOrEqualTo(lastSaveTimeBefore);
-            }
-        } catch (Exception e) {
-            // Check for the specific error message when save is disabled
-            if (e.getMessage() != null && e.getMessage().contains("Background save already in progress")) {
-                logger.warn("SAVE test skipped: Background save already in progress");
-                return;
-            } else {
-                throw e;
-            }
-        }
-    }
+			// Command should execute without throwing an exception
+			// We can't easily verify the actual save without filesystem access
+			// but we can verify the command was accepted
+		}
+		catch (Exception e) {
+			// Check for the specific error message when background save is already in
+			// progress
+			if (e.getMessage() != null && e.getMessage().contains("Background save already in progress")) {
+				logger.warn("BGSAVE test skipped: Background save already in progress");
+				return;
+			}
+			else {
+				throw e;
+			}
+		}
+	}
 
-    // ==================== Database Operations ====================
+	@Test
+	void testLastSave() {
+		Long lastSaveTime = connection.serverCommands().lastSave();
 
-    @Test
-    void testDbSize() {
-        String key = "test:server:db:key";
-        
-        try {
-            // Get initial database size
-            Long initialSize = connection.serverCommands().dbSize();
-            assertThat(initialSize).isNotNull();
-            assertThat(initialSize).isGreaterThanOrEqualTo(0L);
-            
-            // Add a key
-            connection.stringCommands().set(key.getBytes(), "value".getBytes());
-            
-            // Database size should increase
-            Long newSize = connection.serverCommands().dbSize();
-            assertThat(newSize).isNotNull();
-            assertThat(newSize).isGreaterThan(initialSize);
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+		// lastSave should return a timestamp or null
+		if (lastSaveTime != null) {
+			assertThat(lastSaveTime).isGreaterThan(0L);
+			// The timestamp should be reasonable (not in the future, allowing for clock
+			// skew)
+			long currentTimeSeconds = System.currentTimeMillis() / 1000;
+			assertThat(lastSaveTime).isLessThanOrEqualTo(currentTimeSeconds + 60); // Allow
+																					// 1
+																					// minute
+																					// clock
+																					// skew
+		}
+		else {
+			logger.warn("LASTSAVE returned null - no previous save recorded");
+		}
+	}
 
-    @Test
-    void testFlushDb() {
-        String key1 = "test:server:flush:key1";
-        String key2 = "test:server:flush:key2";
-        
-        try {
-            // Add some test keys
-            connection.stringCommands().set(key1.getBytes(), "value1".getBytes());
-            connection.stringCommands().set(key2.getBytes(), "value2".getBytes());
-            
-            // Verify keys exist
-            assertThat(connection.keyCommands().exists(key1.getBytes())).isTrue();
-            assertThat(connection.keyCommands().exists(key2.getBytes())).isTrue();
-            
-            // Flush database
-            connection.serverCommands().flushDb();
-            
-            // Verify keys are gone
-            assertThat(connection.keyCommands().exists(key1.getBytes())).isFalse();
-            assertThat(connection.keyCommands().exists(key2.getBytes())).isFalse();
-            
-        } finally {
-            cleanupKeys(key1, key2);
-        }
-    }
+	@Test
+	void testSave() {
+		try {
+			// Get lastSave time before save operation
+			Long lastSaveTimeBefore = connection.serverCommands().lastSave();
 
-    @Test
-    void testFlushDbWithOption() {
-        String key1 = "test:server:flush:key1";
-        String key2 = "test:server:flush:key2";
-        
-        try {
-            // Add some test keys
-            connection.stringCommands().set(key1.getBytes(), "value1".getBytes());
-            connection.stringCommands().set(key2.getBytes(), "value2".getBytes());
-            
-            // Verify keys exist
-            assertThat(connection.keyCommands().exists(key1.getBytes())).isTrue();
-            assertThat(connection.keyCommands().exists(key2.getBytes())).isTrue();
-            
-            // Test flush with ASYNC option
-            connection.serverCommands().flushDb(FlushOption.ASYNC);
-            
-            // Verify keys are gone (may take a moment with ASYNC)
-            assertThat(connection.keyCommands().exists(key1.getBytes())).isFalse();
-            assertThat(connection.keyCommands().exists(key2.getBytes())).isFalse();
-            
-        } finally {
-            cleanupKeys(key1, key2);
-        }
-    }
+			// Test synchronous save
+			connection.serverCommands().save();
 
-    @Test
-    void testFlushAll() {
-        String key1 = "test:server:flush:key1";
-        String key2 = "test:server:flush:key2";
-        
-        try {
-            // Add some test keys
-            connection.stringCommands().set(key1.getBytes(), "value1".getBytes());
-            connection.stringCommands().set(key2.getBytes(), "value2".getBytes());
-            
-            // Get initial database size
-            Long initialSize = connection.serverCommands().dbSize();
-            assertThat(initialSize).isGreaterThan(0L);
-            
-            // Flush all databases
-            connection.serverCommands().flushAll();
-            
-            // Database should be empty or much smaller
-            Long newSize = connection.serverCommands().dbSize();
-            assertThat(newSize).isLessThan(initialSize);
-            
-        } finally {
-            cleanupKeys(key1, key2);
-        }
-    }
+			// Command should execute without throwing an exception
+			// Verify that lastSave timestamp is updated
+			Long lastSaveTimeAfter = connection.serverCommands().lastSave();
+			assertThat(lastSaveTimeAfter).isNotNull();
+			assertThat(lastSaveTimeAfter).isGreaterThan(0L);
 
-    @Test
-    void testFlushAllWithOption() {
-        String key1 = "test:server:flush:key1";
-        String key2 = "test:server:flush:key2";
-        
-        try {
-            // Add some test keys
-            connection.stringCommands().set(key1.getBytes(), "value1".getBytes());
-            connection.stringCommands().set(key2.getBytes(), "value2".getBytes());
-            
-            // Get initial database size
-            Long initialSize = connection.serverCommands().dbSize();
-            assertThat(initialSize).isGreaterThan(0L);
-            
-            // Flush all databases with ASYNC option
-            connection.serverCommands().flushAll(FlushOption.ASYNC);
-            
-            // Database should be empty or much smaller
-            Long newSize = connection.serverCommands().dbSize();
-            assertThat(newSize).isLessThan(initialSize);
-            
-        } finally {
-            cleanupKeys(key1, key2);
-        }
-    }
+			// If we had a previous save time, the new one should be >= the old one
+			if (lastSaveTimeBefore != null) {
+				assertThat(lastSaveTimeAfter).isGreaterThanOrEqualTo(lastSaveTimeBefore);
+			}
+		}
+		catch (Exception e) {
+			// Check for the specific error message when save is disabled
+			if (e.getMessage() != null && e.getMessage().contains("Background save already in progress")) {
+				logger.warn("SAVE test skipped: Background save already in progress");
+				return;
+			}
+			else {
+				throw e;
+			}
+		}
+	}
 
-    // ==================== Server Information ====================
+	// ==================== Database Operations ====================
 
-    @Test
-    void testInfo() {
-        // Test getting all server info
-        Properties allInfo = connection.serverCommands().info();
-        assertThat(allInfo).isNotNull();
-        assertThat(allInfo).isNotEmpty();
-        
-        // Test getting specific section
-        Properties serverInfo = connection.serverCommands().info("server");
-        assertThat(serverInfo).isNotNull();
-        assertThat(serverInfo.containsKey("valkey_version") || serverInfo.containsKey("redis_version")).isTrue();
-        
-        // Test getting memory info
-        Properties memoryInfo = connection.serverCommands().info("memory");
-        assertThat(memoryInfo).isNotNull();
-        assertThat(memoryInfo.containsKey("used_memory")).isTrue();
-        
-        // Test non-existent section (should return empty or minimal info)
-        Properties nonExistentInfo = connection.serverCommands().info("nonexistent");
-        assertThat(nonExistentInfo).isNotNull();
-    }
+	@Test
+	void testDbSize() {
+		String key = "test:server:db:key";
 
-    @Test
-    void testTime() {
-        // Test getting server time in different units
-        Long timeMillis = connection.serverCommands().time(TimeUnit.MILLISECONDS);
-        assertThat(timeMillis).isNotNull();
-        assertThat(timeMillis).isGreaterThan(0L);
-        
-        Long timeSeconds = connection.serverCommands().time(TimeUnit.SECONDS);
-        assertThat(timeSeconds).isNotNull();
-        assertThat(timeSeconds).isGreaterThan(0L);
-        
-        Long timeMicros = connection.serverCommands().time(TimeUnit.MICROSECONDS);
-        assertThat(timeMicros).isNotNull();
-        assertThat(timeMicros).isGreaterThan(0L);
-        
-        // Verify time relationships (allow for some timing variance)
-        // Convert to same units for comparison
-        long timeSecondsInMillis = timeSeconds * 1000;
-        long timeMillisInMicros = timeMillis * 1000;
-        
-        // Times should be reasonably close (within 1 second)
-        assertThat(Math.abs(timeMillis - timeSecondsInMillis)).isLessThan(1000);
-        assertThat(Math.abs(timeMicros - timeMillisInMicros)).isLessThan(1000000);
-    }
+		try {
+			// Get initial database size
+			Long initialSize = connection.serverCommands().dbSize();
+			assertThat(initialSize).isNotNull();
+			assertThat(initialSize).isGreaterThanOrEqualTo(0L);
 
-    // ==================== Configuration Management ====================
+			// Add a key
+			connection.stringCommands().set(key.getBytes(), "value".getBytes());
 
-    @Test
-    void testConfigGetSet() {
-        // Test getting configuration
-        Properties maxMemoryConfig = connection.serverCommands().getConfig("maxmemory");
-        assertThat(maxMemoryConfig).isNotNull();
-        
-        // Test getting multiple configs with wildcard
-        Properties allConfigs = connection.serverCommands().getConfig("*");
-        assertThat(allConfigs).isNotNull();
-        assertThat(allConfigs).isNotEmpty();
-        
-        // Test setting and getting a safe configuration parameter
-        // Use timeout as it's generally safe to modify
-        Properties timeoutConfig = connection.serverCommands().getConfig("timeout");
-        assertThat(timeoutConfig).isNotNull();
-        
-        String originalTimeout = timeoutConfig.getProperty("timeout");
-        
-        try {
-            // Only test config modification if we have write permissions
-            if (originalTimeout != null) {
-                // Set timeout to a safe value
-                connection.serverCommands().setConfig("timeout", "60");
-                
-                // Verify it was set
-                Properties newTimeoutConfig = connection.serverCommands().getConfig("timeout");
-                assertThat(newTimeoutConfig.getProperty("timeout")).isEqualTo("60");
-            }
-        } catch (Exception e) {
-            // Check for the specific error message when config modification is not allowed
-            if (e.getMessage() != null && e.getMessage().contains("read-only")) {
-                logger.warn("CONFIG SET test skipped: Server is in read-only mode");
-                return;
-            } else {
-                throw e;
-            }
-        } finally {
-            // Restore original timeout
-            if (originalTimeout != null) {
-                connection.serverCommands().setConfig("timeout", originalTimeout);
-            }
-        }
-    }
+			// Database size should increase
+			Long newSize = connection.serverCommands().dbSize();
+			assertThat(newSize).isNotNull();
+			assertThat(newSize).isGreaterThan(initialSize);
 
-    @Test
-    void testResetConfigStats() {
-        // Test resetting config stats
-        // This command resets statistical counters, so we mainly test that it doesn't throw
-        assertThatNoException().isThrownBy(() -> connection.serverCommands().resetConfigStats());
-    }
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
 
-    @Test
-    void testRewriteConfig() {
-        // Test rewriting config file
-        // This command rewrites the config file, so we mainly test that it doesn't throw
-        // Note: This might fail if Valkey is running without a config file
-        try {
-            connection.serverCommands().rewriteConfig();
-        } catch (Exception e) {
-            // Check for the specific error message when config rewrite is not supported
-            // Need to check the exception chain as the message might be wrapped
-            Throwable cause = e;
-            while (cause != null) {
-                String causeMessage = cause.getMessage();
-                if (causeMessage != null && causeMessage.contains("The server is running without a config file")) {
-                    logger.warn("CONFIG REWRITE test skipped: Server is running without a config file");
-                    return;
-                }
-                cause = cause.getCause();
-            }
-            
-            // If we get here, it's an unexpected error
-            throw e;
-        }
-    }
+	@Test
+	void testFlushDb() {
+		String key1 = "test:server:flush:key1";
+		String key2 = "test:server:flush:key2";
 
-    // ==================== Client Management ====================
+		try {
+			// Add some test keys
+			connection.stringCommands().set(key1.getBytes(), "value1".getBytes());
+			connection.stringCommands().set(key2.getBytes(), "value2".getBytes());
 
-    @Test
-    void testClientNameOperations() {
-        // Test setting and getting client name
-        byte[] clientName = "test-client".getBytes();
-        String originalName = null;
-        
-        try {
-            // Get original client name
-            originalName = connection.serverCommands().getClientName();
-            
-            // Set client name
-            connection.serverCommands().setClientName(clientName);
-            
-            // Get client name
-            String retrievedName = connection.serverCommands().getClientName();
-            assertThat(retrievedName).isEqualTo("test-client");
-            
-        } finally {
-            // Clean up - restore original name or set empty name
-            if (originalName != null && !originalName.isEmpty()) {
-                connection.serverCommands().setClientName(originalName.getBytes());
-            } else {
-                connection.serverCommands().setClientName("".getBytes());
-            }
-        }
-    }
+			// Verify keys exist
+			assertThat(connection.keyCommands().exists(key1.getBytes())).isTrue();
+			assertThat(connection.keyCommands().exists(key2.getBytes())).isTrue();
 
-    @Test
-    void testGetClientList() {
-        // Test getting client list
-        List<ValkeyClientInfo> clientList = connection.serverCommands().getClientList();
-        assertThat(clientList).isNotNull();
-        assertThat(clientList).isNotEmpty();
-        
-        // Verify client info properties
-        ValkeyClientInfo firstClient = clientList.get(0);
-        assertThat(firstClient).isNotNull();
-        
-        // Check that basic client info properties exist
-        // Some properties might be null or empty depending on Valkey version and configuration
-        assertThat(firstClient.get("addr")).isNotNull();
-        assertThat(firstClient.get("fd")).isNotNull();
-        
-        // Client name might be null or empty string - we'll skip detailed validation since it's optional
-        assertThat(firstClient.get("age")).isNotNull();
-        assertThat(firstClient.get("idle")).isNotNull();
-    }
+			// Flush database
+			connection.serverCommands().flushDb();
 
-    @Test
-    @EnabledOnValkeyVersion("7.2")
-    void testClientLibNameReported() {
-        List<ValkeyClientInfo> clientList = connection.serverCommands().getClientList();
-        assertThat(clientList).anyMatch(client -> "GlideSpringDataValkey".equals(client.get("lib-name")));
-    }
+			// Verify keys are gone
+			assertThat(connection.keyCommands().exists(key1.getBytes())).isFalse();
+			assertThat(connection.keyCommands().exists(key2.getBytes())).isFalse();
 
-    @Test
-    void testKillClient() {
-        // Test killing a client
-        // This is tricky to test safely, so we test with a non-existent client
-        // The command should throw an exception with "No such client" message in the cause chain
-        Throwable exception = catchThrowable(() -> 
-            connection.serverCommands().killClient("192.168.1.1", 12345));
-        
-        assertThat(exception).isNotNull();
-        
-        // Check the entire exception chain for the "No such client" message
-        // The actual message format is "An error was signalled by the server: - ResponseError: No such client"
-        boolean foundMessage = false;
-        Throwable cause = exception;
-        while (cause != null) {
-            if (cause.getMessage() != null && cause.getMessage().contains("ResponseError: No such client")) {
-                foundMessage = true;
-                break;
-            }
-            cause = cause.getCause();
-        }
-        
-        assertThat(foundMessage).isTrue();
-    }
+		}
+		finally {
+			cleanupKeys(key1, key2);
+		}
+	}
 
-    // ==================== Replication Commands ====================
+	@Test
+	void testFlushDbWithOption() {
+		String key1 = "test:server:flush:key1";
+		String key2 = "test:server:flush:key2";
 
-    @Test
-    void testReplicaCommands() {
-        // Test replication commands
-        // These are potentially destructive, so we mainly test that they don't throw
-        // and then immediately reset to no replication
-        
-        try {
-            // Test replicaOfNoOne (make this instance a master)
-            // This should always work unless replication is disabled
-            connection.serverCommands().replicaOfNoOne();
-            
-            // Test replicaOf with a non-existent master (should fail gracefully)
-            // We don't want to actually set up replication in tests
-            try {
-                connection.serverCommands().replicaOf("localhost", 9999);
-                // If this doesn't throw, reset to no replication
-                connection.serverCommands().replicaOfNoOne();
-            } catch (Exception e) {
-                // Expected to fail with non-existent master
-                // This is the normal case
-            }
-            
-        } catch (Exception e) {
-            // Check for the specific error message when replication commands are not allowed
-            if (e.getMessage() != null && e.getMessage().contains("REPLICAOF not allowed")) {
-                logger.warn("REPLICAOF test skipped: Replication commands not allowed");
-                return;
-            } else {
-                throw e;
-            }
-        }
-    }
+		try {
+			// Add some test keys
+			connection.stringCommands().set(key1.getBytes(), "value1".getBytes());
+			connection.stringCommands().set(key2.getBytes(), "value2".getBytes());
 
-    // ==================== Data Migration ====================
+			// Verify keys exist
+			assertThat(connection.keyCommands().exists(key1.getBytes())).isTrue();
+			assertThat(connection.keyCommands().exists(key2.getBytes())).isTrue();
 
-    @Test
-    void testMigrate() {
-        // Test migrate command
-        // This is complex to test as it requires another Valkey instance
-        // We test with a non-existent target to verify command structure
-        
-        String sourceKey = "test:server:migrate:source";
-        
-        try {
-            // Set up source data
-            connection.stringCommands().set(sourceKey.getBytes(), "migrate_test_value".getBytes());
-            
-            // Test migrate to non-existent target (should fail but not crash)
-            assertThatThrownBy(() -> 
-                connection.serverCommands().migrate(sourceKey.getBytes(), 
-                    ValkeyNode.newValkeyNode()
-                        .listeningAt("localhost", 9999).build(), 
-                    0, null))
-                .isInstanceOf(Exception.class);
-            
-            // Test migrate with timeout and options
-            assertThatThrownBy(() -> 
-                connection.serverCommands().migrate(sourceKey.getBytes(), 
-                    ValkeyNode.newValkeyNode()
-                        .listeningAt("localhost", 9999).build(), 
-                    0, 
-                    MigrateOption.COPY, 
-                    5000))
-                .isInstanceOf(Exception.class);
-                
-        } finally {
-            cleanupKey(sourceKey);
-        }
-    }
+			// Test flush with ASYNC option
+			connection.serverCommands().flushDb(FlushOption.ASYNC);
 
-    // ==================== Pipeline Mode Tests ====================
+			// Verify keys are gone (may take a moment with ASYNC)
+			assertThat(connection.keyCommands().exists(key1.getBytes())).isFalse();
+			assertThat(connection.keyCommands().exists(key2.getBytes())).isFalse();
 
-    @Test
-    void testBackgroundOperationsInPipelineMode() {
-        try {
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Queue background operations - assert they return null in pipeline mode
-            assertThat(connection.serverCommands().lastSave()).isNull();
-            // Note: bgReWriteAof, bgSave, save might fail due to server configuration, so we test lastSave
-            
-            // Execute pipeline
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(1);
-            // lastSave should return a timestamp or null
-            if (results.get(0) != null) {
-                assertThat(results.get(0)).isInstanceOf(Long.class);
-                assertThat(((Long) results.get(0))).isGreaterThan(0L);
-            }
-            
-        } finally {
-            if (connection.isPipelined()) {
-                connection.closePipeline();
-            }
-        }
-    }
+		}
+		finally {
+			cleanupKeys(key1, key2);
+		}
+	}
 
-    @Test
-    void testDatabaseOperationsInPipelineMode() {
-        String key1 = "test:server:pipeline:db:key1";
-        String key2 = "test:server:pipeline:db:key2";
-        
-        try {
-            // Set up test data
-            connection.stringCommands().set(key1.getBytes(), "value1".getBytes());
-            connection.stringCommands().set(key2.getBytes(), "value2".getBytes());
-            
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Queue database operations - assert they return null in pipeline mode
-            assertThat(connection.serverCommands().dbSize()).isNull();
-            connection.serverCommands().flushDb(); // void method, no assertion
-            
-            // Execute pipeline
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(2);
-            assertThat(results.get(0)).isInstanceOf(Long.class); // dbSize result
-            assertThat(((Long) results.get(0))).isGreaterThan(0L);
-            assertThat(results.get(1)).isEqualTo("OK"); // flushDb result
-            
-        } finally {
-            cleanupKeys(key1, key2);
-            if (connection.isPipelined()) {
-                connection.closePipeline();
-            }
-        }
-    }
+	@Test
+	void testFlushAll() {
+		String key1 = "test:server:flush:key1";
+		String key2 = "test:server:flush:key2";
 
-    @Test
-    void testDatabaseOperationsWithOptionsInPipelineMode() {
-        String key = "test:server:pipeline:flush:key";
-        
-        try {
-            // Set up test data
-            connection.stringCommands().set(key.getBytes(), "value".getBytes());
-            
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Queue database operations with options
-            connection.serverCommands().flushDb(FlushOption.ASYNC); // void method, no assertion
-            connection.serverCommands().flushAll(FlushOption.SYNC); // void method, no assertion
-            
-            // Execute pipeline
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(2);
-            assertThat(results.get(0)).isEqualTo("OK"); // flushDb result
-            assertThat(results.get(1)).isEqualTo("OK"); // flushAll result
-            
-        } finally {
-            cleanupKey(key);
-            if (connection.isPipelined()) {
-                connection.closePipeline();
-            }
-        }
-    }
+		try {
+			// Add some test keys
+			connection.stringCommands().set(key1.getBytes(), "value1".getBytes());
+			connection.stringCommands().set(key2.getBytes(), "value2".getBytes());
 
-    @Test
-    void testServerInformationInPipelineMode() {
-        try {
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Queue server information commands - assert they return null in pipeline mode
-            assertThat(connection.serverCommands().info()).isNull();
-            assertThat(connection.serverCommands().info("server")).isNull();
-            assertThat(connection.serverCommands().time(TimeUnit.MILLISECONDS)).isNull();
-            assertThat(connection.serverCommands().time(TimeUnit.SECONDS)).isNull();
-            
-            // Execute pipeline
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(4);
-            
-            // info() result
-            assertThat(results.get(0)).isInstanceOf(Properties.class);
-            Properties allInfo = (Properties) results.get(0);
-            assertThat(allInfo).isNotEmpty();
-            
-            // info("server") result
-            assertThat(results.get(1)).isInstanceOf(Properties.class);
-            Properties serverInfo = (Properties) results.get(1);
-            assertThat(serverInfo).isNotNull();
-            
-            // time() results
-            assertThat(results.get(2)).isInstanceOf(Long.class);
-            assertThat(((Long) results.get(2))).isGreaterThan(0L);
-            
-            assertThat(results.get(3)).isInstanceOf(Long.class);
-            assertThat(((Long) results.get(3))).isGreaterThan(0L);
-            
-        } finally {
-            if (connection.isPipelined()) {
-                connection.closePipeline();
-            }
-        }
-    }
+			// Get initial database size
+			Long initialSize = connection.serverCommands().dbSize();
+			assertThat(initialSize).isGreaterThan(0L);
 
-    @Test
-    void testConfigurationManagementInPipelineMode() {
-        try {
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Queue configuration commands - assert they return null in pipeline mode
-            assertThat(connection.serverCommands().getConfig("maxmemory")).isNull();
-            assertThat(connection.serverCommands().getConfig("*")).isNull();
-            connection.serverCommands().resetConfigStats(); // void method, no assertion
-            
-            // Execute pipeline
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(3);
-            
-            // getConfig results
-            assertThat(results.get(0)).isInstanceOf(Properties.class);
-            assertThat(results.get(1)).isInstanceOf(Properties.class);
-            Properties allConfigs = (Properties) results.get(1);
-            assertThat(allConfigs).isNotEmpty();
-            
-            // resetConfigStats result
-            assertThat(results.get(2)).isEqualTo("OK");
-            
-        } finally {
-            if (connection.isPipelined()) {
-                connection.closePipeline();
-            }
-        }
-    }
+			// Flush all databases
+			connection.serverCommands().flushAll();
 
-    @Test
-    void testConfigurationSetInPipelineMode() {
-        try {
-            // Get original timeout for restoration
-            Properties timeoutConfig = connection.serverCommands().getConfig("timeout");
-            String originalTimeout = timeoutConfig.getProperty("timeout", "0");
-            
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Queue config set command
-            connection.serverCommands().setConfig("timeout", "120"); // void method, no assertion
-            assertThat(connection.serverCommands().getConfig("timeout")).isNull();
-            
-            // Execute pipeline
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(2);
-            assertThat(results.get(0)).isEqualTo("OK"); // setConfig result
-            assertThat(results.get(1)).isInstanceOf(Properties.class); // getConfig result
-            
-            Properties newTimeoutConfig = (Properties) results.get(1);
-            assertThat(newTimeoutConfig.getProperty("timeout")).isEqualTo("120");
-            
-            // Restore original timeout
-            connection.serverCommands().setConfig("timeout", originalTimeout);
-            
-        } catch (Exception e) {
-            if (e.getMessage() != null && e.getMessage().contains("read-only")) {
-                logger.warn("CONFIG SET test skipped: Server is in read-only mode");
-                return;
-            } else {
-                throw e;
-            }
-        } finally {
-            if (connection.isPipelined()) {
-                connection.closePipeline();
-            }
-        }
-    }
+			// Database should be empty or much smaller
+			Long newSize = connection.serverCommands().dbSize();
+			assertThat(newSize).isLessThan(initialSize);
 
-    @Test
-    void testClientManagementInPipelineMode() {
-        try {
-            // Get original client name for restoration
-            String originalName = connection.serverCommands().getClientName();
-            
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Queue client management commands - assert they return null in pipeline mode
-            connection.serverCommands().setClientName("test-pipeline-client".getBytes()); // void method, no assertion
-            assertThat(connection.serverCommands().getClientName()).isNull();
-            assertThat(connection.serverCommands().getClientList()).isNull();
-            
-            // Execute pipeline
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(3);
-            assertThat(results.get(0)).isEqualTo("OK"); // setClientName result
-            assertThat(results.get(1)).isEqualTo("test-pipeline-client"); // getClientName result
-            
-            @SuppressWarnings("unchecked")
-            List<ValkeyClientInfo> clientList = (List<ValkeyClientInfo>) results.get(2);
-            assertThat(clientList).isNotEmpty();
-            
-            // Restore original client name
-            if (originalName != null && !originalName.isEmpty()) {
-                connection.serverCommands().setClientName(originalName.getBytes());
-            } else {
-                connection.serverCommands().setClientName("".getBytes());
-            }
-            
-        } finally {
-            if (connection.isPipelined()) {
-                connection.closePipeline();
-            }
-        }
-    }
+		}
+		finally {
+			cleanupKeys(key1, key2);
+		}
+	}
 
-    @Test
-    void testReplicationCommandsInPipelineMode() {
-        try {
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Queue replication commands - these are safe to test
-            connection.serverCommands().replicaOfNoOne(); // void method, no assertion
-            
-            // Execute pipeline
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(1);
-            assertThat(results.get(0)).isEqualTo("OK"); // replicaOfNoOne result
-            
-        } catch (Exception e) {
-            if (e.getMessage() != null && e.getMessage().contains("REPLICAOF not allowed")) {
-                logger.warn("REPLICAOF test skipped: Replication commands not allowed");
-                return;
-            } else {
-                throw e;
-            }
-        } finally {
-            if (connection.isPipelined()) {
-                connection.closePipeline();
-            }
-        }
-    }
+	@Test
+	void testFlushAllWithOption() {
+		String key1 = "test:server:flush:key1";
+		String key2 = "test:server:flush:key2";
 
-    // ==================== Transaction Mode Tests ====================
+		try {
+			// Add some test keys
+			connection.stringCommands().set(key1.getBytes(), "value1".getBytes());
+			connection.stringCommands().set(key2.getBytes(), "value2".getBytes());
 
-    @Test
-    void testBackgroundOperationsInTransactionMode() {
-        try {
-            // Start transaction
-            connection.multi();
-            
-            // Queue background operations - assert they return null in transaction mode
-            assertThat(connection.serverCommands().lastSave()).isNull();
-            
-            // Execute transaction
-            List<Object> results = connection.exec();
-            
-            // Verify results
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(1);
-            // lastSave should return a timestamp or null
-            if (results.get(0) != null) {
-                assertThat(results.get(0)).isInstanceOf(Long.class);
-                assertThat(((Long) results.get(0))).isGreaterThan(0L);
-            }
-            
-        } finally {
-            if (connection.isQueueing()) {
-                connection.discard();
-            }
-        }
-    }
+			// Get initial database size
+			Long initialSize = connection.serverCommands().dbSize();
+			assertThat(initialSize).isGreaterThan(0L);
 
-    @Test
-    void testDatabaseOperationsInTransactionMode() {
-        String key1 = "test:server:transaction:db:key1";
-        String key2 = "test:server:transaction:db:key2";
-        
-        try {
-            // Set up test data
-            connection.stringCommands().set(key1.getBytes(), "value1".getBytes());
-            connection.stringCommands().set(key2.getBytes(), "value2".getBytes());
-            
-            // Start transaction
-            connection.multi();
-            
-            // Queue database operations - assert they return null in transaction mode
-            assertThat(connection.serverCommands().dbSize()).isNull();
-            connection.serverCommands().flushDb(); // void method, no assertion
-            
-            // Execute transaction
-            List<Object> results = connection.exec();
-            
-            // Verify results
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(2);
-            assertThat(results.get(0)).isInstanceOf(Long.class); // dbSize result
-            assertThat(((Long) results.get(0))).isGreaterThan(0L);
-            assertThat(results.get(1)).isEqualTo("OK"); // flushDb result
-            
-        } finally {
-            cleanupKeys(key1, key2);
-            if (connection.isQueueing()) {
-                connection.discard();
-            }
-        }
-    }
+			// Flush all databases with ASYNC option
+			connection.serverCommands().flushAll(FlushOption.ASYNC);
 
-    @Test
-    void testDatabaseOperationsWithOptionsInTransactionMode() {
-        String key = "test:server:transaction:flush:key";
-        
-        try {
-            // Set up test data
-            connection.stringCommands().set(key.getBytes(), "value".getBytes());
-            
-            // Start transaction
-            connection.multi();
-            
-            // Queue database operations with options
-            connection.serverCommands().flushDb(FlushOption.ASYNC); // void method, no assertion
-            connection.serverCommands().flushAll(FlushOption.SYNC); // void method, no assertion
-            
-            // Execute transaction
-            List<Object> results = connection.exec();
-            
-            // Verify results
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(2);
-            assertThat(results.get(0)).isEqualTo("OK"); // flushDb result
-            assertThat(results.get(1)).isEqualTo("OK"); // flushAll result
-            
-        } finally {
-            cleanupKey(key);
-            if (connection.isQueueing()) {
-                connection.discard();
-            }
-        }
-    }
+			// Database should be empty or much smaller
+			Long newSize = connection.serverCommands().dbSize();
+			assertThat(newSize).isLessThan(initialSize);
 
-    @Test
-    void testServerInformationInTransactionMode() {
-        try {
-            // Start transaction
-            connection.multi();
-            
-            // Queue server information commands - assert they return null in transaction mode
-            assertThat(connection.serverCommands().info()).isNull();
-            assertThat(connection.serverCommands().info("server")).isNull();
-            assertThat(connection.serverCommands().time(TimeUnit.MILLISECONDS)).isNull();
-            assertThat(connection.serverCommands().time(TimeUnit.SECONDS)).isNull();
-            
-            // Execute transaction
-            List<Object> results = connection.exec();
-            
-            // Verify results
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(4);
-            
-            // info() result
-            assertThat(results.get(0)).isInstanceOf(Properties.class);
-            Properties allInfo = (Properties) results.get(0);
-            assertThat(allInfo).isNotEmpty();
-            
-            // info("server") result
-            assertThat(results.get(1)).isInstanceOf(Properties.class);
-            Properties serverInfo = (Properties) results.get(1);
-            assertThat(serverInfo).isNotNull();
-            
-            // time() results
-            assertThat(results.get(2)).isInstanceOf(Long.class);
-            assertThat(((Long) results.get(2))).isGreaterThan(0L);
-            
-            assertThat(results.get(3)).isInstanceOf(Long.class);
-            assertThat(((Long) results.get(3))).isGreaterThan(0L);
-            
-        } finally {
-            if (connection.isQueueing()) {
-                connection.discard();
-            }
-        }
-    }
+		}
+		finally {
+			cleanupKeys(key1, key2);
+		}
+	}
 
-    @Test
-    void testConfigurationManagementInTransactionMode() {
-        try {
-            // Start transaction
-            connection.multi();
-            
-            // Queue configuration commands - assert they return null in transaction mode
-            assertThat(connection.serverCommands().getConfig("maxmemory")).isNull();
-            assertThat(connection.serverCommands().getConfig("*")).isNull();
-            connection.serverCommands().resetConfigStats(); // void method, no assertion
-            
-            // Execute transaction
-            List<Object> results = connection.exec();
-            
-            // Verify results
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(3);
-            
-            // getConfig results
-            assertThat(results.get(0)).isInstanceOf(Properties.class);
-            assertThat(results.get(1)).isInstanceOf(Properties.class);
-            Properties allConfigs = (Properties) results.get(1);
-            assertThat(allConfigs).isNotEmpty();
-            
-            // resetConfigStats result
-            assertThat(results.get(2)).isEqualTo("OK");
-            
-        } finally {
-            if (connection.isQueueing()) {
-                connection.discard();
-            }
-        }
-    }
+	// ==================== Server Information ====================
 
-    @Test
-    void testConfigurationSetInTransactionMode() {
-        try {
-            // Get original timeout for restoration
-            Properties timeoutConfig = connection.serverCommands().getConfig("timeout");
-            String originalTimeout = timeoutConfig.getProperty("timeout", "0");
-            
-            // Start transaction
-            connection.multi();
-            
-            // Queue config set command
-            connection.serverCommands().setConfig("timeout", "120"); // void method, no assertion
-            assertThat(connection.serverCommands().getConfig("timeout")).isNull();
-            
-            // Execute transaction
-            List<Object> results = connection.exec();
-            
-            // Verify results
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(2);
-            assertThat(results.get(0)).isEqualTo("OK"); // setConfig result
-            assertThat(results.get(1)).isInstanceOf(Properties.class); // getConfig result
-            
-            Properties newTimeoutConfig = (Properties) results.get(1);
-            assertThat(newTimeoutConfig.getProperty("timeout")).isEqualTo("120");
-            
-            // Restore original timeout
-            connection.serverCommands().setConfig("timeout", originalTimeout);
-            
-        } catch (Exception e) {
-            if (e.getMessage() != null && e.getMessage().contains("read-only")) {
-                logger.warn("CONFIG SET test skipped: Server is in read-only mode");
-                return;
-            } else {
-                throw e;
-            }
-        } finally {
-            if (connection.isQueueing()) {
-                connection.discard();
-            }
-        }
-    }
+	@Test
+	void testInfo() {
+		// Test getting all server info
+		Properties allInfo = connection.serverCommands().info();
+		assertThat(allInfo).isNotNull();
+		assertThat(allInfo).isNotEmpty();
 
-    @Test
-    void testClientManagementInTransactionMode() {
-        try {
-            // Get original client name for restoration
-            String originalName = connection.serverCommands().getClientName();
-            
-            // Start transaction
-            connection.multi();
-            
-            // Queue client management commands - assert they return null in transaction mode
-            connection.serverCommands().setClientName("test-transaction-client".getBytes()); // void method, no assertion
-            assertThat(connection.serverCommands().getClientName()).isNull();
-            assertThat(connection.serverCommands().getClientList()).isNull();
-            
-            // Execute transaction
-            List<Object> results = connection.exec();
-            
-            // Verify results
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(3);
-            assertThat(results.get(0)).isEqualTo("OK"); // setClientName result
-            assertThat(results.get(1)).isEqualTo("test-transaction-client"); // getClientName result
-            
-            @SuppressWarnings("unchecked")
-            List<ValkeyClientInfo> clientList = (List<ValkeyClientInfo>) results.get(2);
-            assertThat(clientList).isNotEmpty();
-            
-            // Restore original client name
-            if (originalName != null && !originalName.isEmpty()) {
-                connection.serverCommands().setClientName(originalName.getBytes());
-            } else {
-                connection.serverCommands().setClientName("".getBytes());
-            }
-            
-        } finally {
-            if (connection.isQueueing()) {
-                connection.discard();
-            }
-        }
-    }
+		// Test getting specific section
+		Properties serverInfo = connection.serverCommands().info("server");
+		assertThat(serverInfo).isNotNull();
+		assertThat(serverInfo.containsKey("valkey_version") || serverInfo.containsKey("redis_version")).isTrue();
 
-    @Test
-    void testReplicationCommandsInTransactionMode() {
-        try {
-            // Start transaction
-            connection.multi();
-            
-            // Queue replication commands - these are safe to test
-            connection.serverCommands().replicaOfNoOne(); // void method, no assertion
-            
-            // Execute transaction
-            List<Object> results = connection.exec();
-            
-            // Verify results
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(1);
-            assertThat(results.get(0)).isEqualTo("OK"); // replicaOfNoOne result
-            
-        } catch (Exception e) {
-            if (e.getMessage() != null && e.getMessage().contains("REPLICAOF not allowed")) {
-                logger.warn("REPLICAOF test skipped: Replication commands not allowed");
-                return;
-            } else {
-                throw e;
-            }
-        } finally {
-            if (connection.isQueueing()) {
-                connection.discard();
-            }
-        }
-    }
+		// Test getting memory info
+		Properties memoryInfo = connection.serverCommands().info("memory");
+		assertThat(memoryInfo).isNotNull();
+		assertThat(memoryInfo.containsKey("used_memory")).isTrue();
 
-    @Test
-    void testMigrationCommandsInPipelineMode() {
-        String sourceKey = "test:server:pipeline:migrate:key";
-        
-        try {
-            // Set up source data
-            connection.stringCommands().set(sourceKey.getBytes(), "migrate_value".getBytes());
-            
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Test migrate to non-existent target (will fail but we test the pipeline behavior)
-            try {
-                connection.serverCommands().migrate(sourceKey.getBytes(), 
-                    ValkeyNode.newValkeyNode().listeningAt("localhost", 9999).build(), 
-                    0, null, 5000); // void method, no assertion
-            } catch (Exception e) {
-                // Expected to fail, but we're testing pipeline mode
-            }
-            
-            // Execute pipeline (may contain errors but should complete)
-            try {
-                List<Object> results = connection.closePipeline();
-                // Migration will likely fail but pipeline should handle it
-            } catch (Exception e) {
-                // Expected for migration to non-existent target
-                logger.info("Migration failed as expected: " + e.getMessage());
-            }
-            
-        } finally {
-            cleanupKey(sourceKey);
-            if (connection.isPipelined()) {
-                connection.closePipeline();
-            }
-        }
-    }
+		// Test non-existent section (should return empty or minimal info)
+		Properties nonExistentInfo = connection.serverCommands().info("nonexistent");
+		assertThat(nonExistentInfo).isNotNull();
+	}
 
-    @Test
-    void testMigrationCommandsInTransactionMode() {
-        String sourceKey = "test:server:transaction:migrate:key";
-        
-        try {
-            // Set up source data
-            connection.stringCommands().set(sourceKey.getBytes(), "migrate_value".getBytes());
-            
-            // Start transaction
-            connection.multi();
-            
-            // Test migrate to non-existent target (will fail but we test the transaction behavior)
-            connection.serverCommands().migrate(sourceKey.getBytes(), 
-                ValkeyNode.newValkeyNode().listeningAt("localhost", 9999).build(), 
-                0, MigrateOption.COPY, 5000); // void method, no assertion
-            
-            // Execute transaction (may contain errors but should complete)
-            try {
-                List<Object> results = connection.exec();
-                // Migration will likely fail but transaction should handle it
-            } catch (Exception e) {
-                // Expected for migration to non-existent target
-                logger.info("Migration failed as expected: " + e.getMessage());
-            }
-            
-        } finally {
-            cleanupKey(sourceKey);
-            if (connection.isQueueing()) {
-                connection.discard();
-            }
-        }
-    }
+	@Test
+	void testTime() {
+		// Test getting server time in different units
+		Long timeMillis = connection.serverCommands().time(TimeUnit.MILLISECONDS);
+		assertThat(timeMillis).isNotNull();
+		assertThat(timeMillis).isGreaterThan(0L);
 
-    @Test
-    void testTransactionDiscardWithServerCommands() {
-        String key = "test:server:transaction:discard";
-        
-        try {
-            // Start transaction
-            connection.multi();
-            
-            // Queue server commands
-            connection.serverCommands().dbSize(); // assert returns null in transaction mode
-            assertThat(connection.serverCommands().dbSize()).isNull();
-            assertThat(connection.serverCommands().time(TimeUnit.MILLISECONDS)).isNull();
-            
-            // Discard transaction
-            connection.discard();
-            
-            // Verify commands were not executed by checking current db state
-            Long currentDbSize = connection.serverCommands().dbSize();
-            assertThat(currentDbSize).isNotNull();
-            
-        } finally {
-            cleanupKey(key);
-            if (connection.isQueueing()) {
-                connection.discard();
-            }
-        }
-    }
+		Long timeSeconds = connection.serverCommands().time(TimeUnit.SECONDS);
+		assertThat(timeSeconds).isNotNull();
+		assertThat(timeSeconds).isGreaterThan(0L);
 
-    @Test
-    void testWatchWithServerCommandsTransaction() throws InterruptedException {
-        String watchKey = "test:server:transaction:watch";
-        String otherKey = "test:server:transaction:other";
-        
-        try {
-            // Setup initial data
-            connection.stringCommands().set(watchKey.getBytes(), "initial".getBytes());
-            
-            // Watch the key
-            connection.watch(watchKey.getBytes());
-            
-            // Modify the watched key from "outside" the transaction
-            connection.stringCommands().set(watchKey.getBytes(), "modified".getBytes());
-            
-            // Start transaction
-            connection.multi();
-            
-            // Queue server commands
-            connection.serverCommands().dbSize(); // assert returns null in transaction mode
-            assertThat(connection.serverCommands().dbSize()).isNull();
-            assertThat(connection.serverCommands().time(TimeUnit.MILLISECONDS)).isNull();
-            
-            // Execute transaction - should be aborted due to WATCH
-            List<Object> results = connection.exec();
-            
-            // Transaction should be aborted (results should be empty list)
-            assertThat(results).isNotNull().isEmpty();
-            
-        } finally {
-            cleanupKeys(watchKey, otherKey);
-            if (connection.isQueueing()) {
-                connection.discard();
-            }
-        }
-    }
+		Long timeMicros = connection.serverCommands().time(TimeUnit.MICROSECONDS);
+		assertThat(timeMicros).isNotNull();
+		assertThat(timeMicros).isGreaterThan(0L);
 
-    // ==================== Error Handling ====================
+		// Verify time relationships (allow for some timing variance)
+		// Convert to same units for comparison
+		long timeSecondsInMillis = timeSeconds * 1000;
+		long timeMillisInMicros = timeMillis * 1000;
 
-    @Test
-    void testErrorHandling() {
-        // Test error handling for invalid parameters
-        
-        // Test null parameter handling
-        assertThatThrownBy(() -> connection.serverCommands().info(null))
-            .isInstanceOf(IllegalArgumentException.class);
-            
-        assertThatThrownBy(() -> connection.serverCommands().getConfig(null))
-            .isInstanceOf(IllegalArgumentException.class);
-            
-        assertThatThrownBy(() -> connection.serverCommands().setConfig(null, "value"))
-            .isInstanceOf(IllegalArgumentException.class);
-            
-        assertThatThrownBy(() -> connection.serverCommands().setConfig("param", null))
-            .isInstanceOf(IllegalArgumentException.class);
-            
-        assertThatThrownBy(() -> connection.serverCommands().time(null))
-            .isInstanceOf(IllegalArgumentException.class);
-            
-        assertThatThrownBy(() -> connection.serverCommands().setClientName(null))
-            .isInstanceOf(IllegalArgumentException.class);
-            
-        assertThatThrownBy(() -> connection.serverCommands().killClient(null, 6379))
-            .isInstanceOf(IllegalArgumentException.class);
-            
-        assertThatThrownBy(() -> connection.serverCommands().replicaOf(null, 6379))
-            .isInstanceOf(IllegalArgumentException.class);
-    }
+		// Times should be reasonably close (within 1 second)
+		assertThat(Math.abs(timeMillis - timeSecondsInMillis)).isLessThan(1000);
+		assertThat(Math.abs(timeMicros - timeMillisInMicros)).isLessThan(1000000);
+	}
 
-    // ==================== Edge Cases ====================
+	// ==================== Configuration Management ====================
 
-    @Test
-    void testEdgeCases() {
-        // Test edge cases and boundary conditions
-        String originalClientName = null;
-        
-        try {
-            // Get original client name for cleanup
-            originalClientName = connection.serverCommands().getClientName();
-            // Handle null client name case
-            if (originalClientName == null) {
-                originalClientName = "";
-            }
-            
-            // Test empty string parameters where applicable
-            Properties emptyConfig = connection.serverCommands().getConfig("");
-            assertThat(emptyConfig).isNotNull();
-            
-            // Test getting non-existent config
-            Properties nonExistentConfig = connection.serverCommands().getConfig("nonexistent_config_param");
-            assertThat(nonExistentConfig).isNotNull();
-            assertThat(nonExistentConfig).isEmpty();
-            
-            // Test setting client name to empty string
-            connection.serverCommands().setClientName("".getBytes());
-            String emptyName = connection.serverCommands().getClientName();
-            // Client name might be null when set to empty string
-            assertThat(emptyName == null || emptyName.isEmpty()).isTrue();
-            
-            // Test time with different units (test a subset to avoid flakiness)
-            TimeUnit[] testUnits = {TimeUnit.SECONDS, TimeUnit.MILLISECONDS, TimeUnit.MICROSECONDS};
-            for (TimeUnit unit : testUnits) {
-                Long time = connection.serverCommands().time(unit);
-                assertThat(time).isNotNull();
-                assertThat(time).isGreaterThan(0L);
-            }
-        } finally {
-            // Clean up - restore original client name
-            if (originalClientName != null && !originalClientName.isEmpty()) {
-                connection.serverCommands().setClientName(originalClientName.getBytes());
-            } else {
-                connection.serverCommands().setClientName("".getBytes());
-            }
-        }
-    }
+	@Test
+	void testConfigGetSet() {
+		// Test getting configuration
+		Properties maxMemoryConfig = connection.serverCommands().getConfig("maxmemory");
+		assertThat(maxMemoryConfig).isNotNull();
+
+		// Test getting multiple configs with wildcard
+		Properties allConfigs = connection.serverCommands().getConfig("*");
+		assertThat(allConfigs).isNotNull();
+		assertThat(allConfigs).isNotEmpty();
+
+		// Test setting and getting a safe configuration parameter
+		// Use timeout as it's generally safe to modify
+		Properties timeoutConfig = connection.serverCommands().getConfig("timeout");
+		assertThat(timeoutConfig).isNotNull();
+
+		String originalTimeout = timeoutConfig.getProperty("timeout");
+
+		try {
+			// Only test config modification if we have write permissions
+			if (originalTimeout != null) {
+				// Set timeout to a safe value
+				connection.serverCommands().setConfig("timeout", "60");
+
+				// Verify it was set
+				Properties newTimeoutConfig = connection.serverCommands().getConfig("timeout");
+				assertThat(newTimeoutConfig.getProperty("timeout")).isEqualTo("60");
+			}
+		}
+		catch (Exception e) {
+			// Check for the specific error message when config modification is not
+			// allowed
+			if (e.getMessage() != null && e.getMessage().contains("read-only")) {
+				logger.warn("CONFIG SET test skipped: Server is in read-only mode");
+				return;
+			}
+			else {
+				throw e;
+			}
+		}
+		finally {
+			// Restore original timeout
+			if (originalTimeout != null) {
+				connection.serverCommands().setConfig("timeout", originalTimeout);
+			}
+		}
+	}
+
+	@Test
+	void testResetConfigStats() {
+		// Test resetting config stats
+		// This command resets statistical counters, so we mainly test that it doesn't
+		// throw
+		assertThatNoException().isThrownBy(() -> connection.serverCommands().resetConfigStats());
+	}
+
+	@Test
+	void testRewriteConfig() {
+		// Test rewriting config file
+		// This command rewrites the config file, so we mainly test that it doesn't throw
+		// Note: This might fail if Valkey is running without a config file
+		try {
+			connection.serverCommands().rewriteConfig();
+		}
+		catch (Exception e) {
+			// Check for the specific error message when config rewrite is not supported
+			// Need to check the exception chain as the message might be wrapped
+			Throwable cause = e;
+			while (cause != null) {
+				String causeMessage = cause.getMessage();
+				if (causeMessage != null && causeMessage.contains("The server is running without a config file")) {
+					logger.warn("CONFIG REWRITE test skipped: Server is running without a config file");
+					return;
+				}
+				cause = cause.getCause();
+			}
+
+			// If we get here, it's an unexpected error
+			throw e;
+		}
+	}
+
+	// ==================== Client Management ====================
+
+	@Test
+	void testClientNameOperations() {
+		// Test setting and getting client name
+		byte[] clientName = "test-client".getBytes();
+		String originalName = null;
+
+		try {
+			// Get original client name
+			originalName = connection.serverCommands().getClientName();
+
+			// Set client name
+			connection.serverCommands().setClientName(clientName);
+
+			// Get client name
+			String retrievedName = connection.serverCommands().getClientName();
+			assertThat(retrievedName).isEqualTo("test-client");
+
+		}
+		finally {
+			// Clean up - restore original name or set empty name
+			if (originalName != null && !originalName.isEmpty()) {
+				connection.serverCommands().setClientName(originalName.getBytes());
+			}
+			else {
+				connection.serverCommands().setClientName("".getBytes());
+			}
+		}
+	}
+
+	@Test
+	void testGetClientList() {
+		// Test getting client list
+		List<ValkeyClientInfo> clientList = connection.serverCommands().getClientList();
+		assertThat(clientList).isNotNull();
+		assertThat(clientList).isNotEmpty();
+
+		// Verify client info properties
+		ValkeyClientInfo firstClient = clientList.get(0);
+		assertThat(firstClient).isNotNull();
+
+		// Check that basic client info properties exist
+		// Some properties might be null or empty depending on Valkey version and
+		// configuration
+		assertThat(firstClient.get("addr")).isNotNull();
+		assertThat(firstClient.get("fd")).isNotNull();
+
+		// Client name might be null or empty string - we'll skip detailed validation
+		// since it's optional
+		assertThat(firstClient.get("age")).isNotNull();
+		assertThat(firstClient.get("idle")).isNotNull();
+	}
+
+	@Test
+	@EnabledOnValkeyVersion("7.2")
+	void testClientLibNameReported() {
+		List<ValkeyClientInfo> clientList = connection.serverCommands().getClientList();
+		assertThat(clientList).anyMatch(client -> "GlideSpringDataValkey".equals(client.get("lib-name")));
+	}
+
+	@Test
+	void testKillClient() {
+		// Test killing a client
+		// This is tricky to test safely, so we test with a non-existent client
+		// The command should throw an exception with "No such client" message in the
+		// cause chain
+		Throwable exception = catchThrowable(() -> connection.serverCommands().killClient("192.168.1.1", 12345));
+
+		assertThat(exception).isNotNull();
+
+		// Check the entire exception chain for the "No such client" message
+		// The actual message format is "An error was signalled by the server: -
+		// ResponseError: No such client"
+		boolean foundMessage = false;
+		Throwable cause = exception;
+		while (cause != null) {
+			if (cause.getMessage() != null && cause.getMessage().contains("ResponseError: No such client")) {
+				foundMessage = true;
+				break;
+			}
+			cause = cause.getCause();
+		}
+
+		assertThat(foundMessage).isTrue();
+	}
+
+	// ==================== Replication Commands ====================
+
+	@Test
+	void testReplicaCommands() {
+		// Test replication commands
+		// These are potentially destructive, so we mainly test that they don't throw
+		// and then immediately reset to no replication
+
+		try {
+			// Test replicaOfNoOne (make this instance a master)
+			// This should always work unless replication is disabled
+			connection.serverCommands().replicaOfNoOne();
+
+			// Test replicaOf with a non-existent master (should fail gracefully)
+			// We don't want to actually set up replication in tests
+			try {
+				connection.serverCommands().replicaOf("localhost", 9999);
+				// If this doesn't throw, reset to no replication
+				connection.serverCommands().replicaOfNoOne();
+			}
+			catch (Exception e) {
+				// Expected to fail with non-existent master
+				// This is the normal case
+			}
+
+		}
+		catch (Exception e) {
+			// Check for the specific error message when replication commands are not
+			// allowed
+			if (e.getMessage() != null && e.getMessage().contains("REPLICAOF not allowed")) {
+				logger.warn("REPLICAOF test skipped: Replication commands not allowed");
+				return;
+			}
+			else {
+				throw e;
+			}
+		}
+	}
+
+	// ==================== Data Migration ====================
+
+	@Test
+	void testMigrate() {
+		// Test migrate command
+		// This is complex to test as it requires another Valkey instance
+		// We test with a non-existent target to verify command structure
+
+		String sourceKey = "test:server:migrate:source";
+
+		try {
+			// Set up source data
+			connection.stringCommands().set(sourceKey.getBytes(), "migrate_test_value".getBytes());
+
+			// Test migrate to non-existent target (should fail but not crash)
+			assertThatThrownBy(() -> connection.serverCommands()
+				.migrate(sourceKey.getBytes(), ValkeyNode.newValkeyNode().listeningAt("localhost", 9999).build(), 0,
+						null))
+				.isInstanceOf(Exception.class);
+
+			// Test migrate with timeout and options
+			assertThatThrownBy(() -> connection.serverCommands()
+				.migrate(sourceKey.getBytes(), ValkeyNode.newValkeyNode().listeningAt("localhost", 9999).build(), 0,
+						MigrateOption.COPY, 5000))
+				.isInstanceOf(Exception.class);
+
+		}
+		finally {
+			cleanupKey(sourceKey);
+		}
+	}
+
+	// ==================== Pipeline Mode Tests ====================
+
+	@Test
+	void testBackgroundOperationsInPipelineMode() {
+		try {
+			// Start pipeline
+			connection.openPipeline();
+
+			// Queue background operations - assert they return null in pipeline mode
+			assertThat(connection.serverCommands().lastSave()).isNull();
+			// Note: bgReWriteAof, bgSave, save might fail due to server configuration, so
+			// we test lastSave
+
+			// Execute pipeline
+			List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(1);
+			// lastSave should return a timestamp or null
+			if (results.get(0) != null) {
+				assertThat(results.get(0)).isInstanceOf(Long.class);
+				assertThat(((Long) results.get(0))).isGreaterThan(0L);
+			}
+
+		}
+		finally {
+			if (connection.isPipelined()) {
+				connection.closePipeline();
+			}
+		}
+	}
+
+	@Test
+	void testDatabaseOperationsInPipelineMode() {
+		String key1 = "test:server:pipeline:db:key1";
+		String key2 = "test:server:pipeline:db:key2";
+
+		try {
+			// Set up test data
+			connection.stringCommands().set(key1.getBytes(), "value1".getBytes());
+			connection.stringCommands().set(key2.getBytes(), "value2".getBytes());
+
+			// Start pipeline
+			connection.openPipeline();
+
+			// Queue database operations - assert they return null in pipeline mode
+			assertThat(connection.serverCommands().dbSize()).isNull();
+			connection.serverCommands().flushDb(); // void method, no assertion
+
+			// Execute pipeline
+			List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(2);
+			assertThat(results.get(0)).isInstanceOf(Long.class); // dbSize result
+			assertThat(((Long) results.get(0))).isGreaterThan(0L);
+			assertThat(results.get(1)).isEqualTo("OK"); // flushDb result
+
+		}
+		finally {
+			cleanupKeys(key1, key2);
+			if (connection.isPipelined()) {
+				connection.closePipeline();
+			}
+		}
+	}
+
+	@Test
+	void testDatabaseOperationsWithOptionsInPipelineMode() {
+		String key = "test:server:pipeline:flush:key";
+
+		try {
+			// Set up test data
+			connection.stringCommands().set(key.getBytes(), "value".getBytes());
+
+			// Start pipeline
+			connection.openPipeline();
+
+			// Queue database operations with options
+			connection.serverCommands().flushDb(FlushOption.ASYNC); // void method, no
+																	// assertion
+			connection.serverCommands().flushAll(FlushOption.SYNC); // void method, no
+																	// assertion
+
+			// Execute pipeline
+			List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(2);
+			assertThat(results.get(0)).isEqualTo("OK"); // flushDb result
+			assertThat(results.get(1)).isEqualTo("OK"); // flushAll result
+
+		}
+		finally {
+			cleanupKey(key);
+			if (connection.isPipelined()) {
+				connection.closePipeline();
+			}
+		}
+	}
+
+	@Test
+	void testServerInformationInPipelineMode() {
+		try {
+			// Start pipeline
+			connection.openPipeline();
+
+			// Queue server information commands - assert they return null in pipeline
+			// mode
+			assertThat(connection.serverCommands().info()).isNull();
+			assertThat(connection.serverCommands().info("server")).isNull();
+			assertThat(connection.serverCommands().time(TimeUnit.MILLISECONDS)).isNull();
+			assertThat(connection.serverCommands().time(TimeUnit.SECONDS)).isNull();
+
+			// Execute pipeline
+			List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(4);
+
+			// info() result
+			assertThat(results.get(0)).isInstanceOf(Properties.class);
+			Properties allInfo = (Properties) results.get(0);
+			assertThat(allInfo).isNotEmpty();
+
+			// info("server") result
+			assertThat(results.get(1)).isInstanceOf(Properties.class);
+			Properties serverInfo = (Properties) results.get(1);
+			assertThat(serverInfo).isNotNull();
+
+			// time() results
+			assertThat(results.get(2)).isInstanceOf(Long.class);
+			assertThat(((Long) results.get(2))).isGreaterThan(0L);
+
+			assertThat(results.get(3)).isInstanceOf(Long.class);
+			assertThat(((Long) results.get(3))).isGreaterThan(0L);
+
+		}
+		finally {
+			if (connection.isPipelined()) {
+				connection.closePipeline();
+			}
+		}
+	}
+
+	@Test
+	void testConfigurationManagementInPipelineMode() {
+		try {
+			// Start pipeline
+			connection.openPipeline();
+
+			// Queue configuration commands - assert they return null in pipeline mode
+			assertThat(connection.serverCommands().getConfig("maxmemory")).isNull();
+			assertThat(connection.serverCommands().getConfig("*")).isNull();
+			connection.serverCommands().resetConfigStats(); // void method, no assertion
+
+			// Execute pipeline
+			List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(3);
+
+			// getConfig results
+			assertThat(results.get(0)).isInstanceOf(Properties.class);
+			assertThat(results.get(1)).isInstanceOf(Properties.class);
+			Properties allConfigs = (Properties) results.get(1);
+			assertThat(allConfigs).isNotEmpty();
+
+			// resetConfigStats result
+			assertThat(results.get(2)).isEqualTo("OK");
+
+		}
+		finally {
+			if (connection.isPipelined()) {
+				connection.closePipeline();
+			}
+		}
+	}
+
+	@Test
+	void testConfigurationSetInPipelineMode() {
+		try {
+			// Get original timeout for restoration
+			Properties timeoutConfig = connection.serverCommands().getConfig("timeout");
+			String originalTimeout = timeoutConfig.getProperty("timeout", "0");
+
+			// Start pipeline
+			connection.openPipeline();
+
+			// Queue config set command
+			connection.serverCommands().setConfig("timeout", "120"); // void method, no
+																		// assertion
+			assertThat(connection.serverCommands().getConfig("timeout")).isNull();
+
+			// Execute pipeline
+			List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(2);
+			assertThat(results.get(0)).isEqualTo("OK"); // setConfig result
+			assertThat(results.get(1)).isInstanceOf(Properties.class); // getConfig result
+
+			Properties newTimeoutConfig = (Properties) results.get(1);
+			assertThat(newTimeoutConfig.getProperty("timeout")).isEqualTo("120");
+
+			// Restore original timeout
+			connection.serverCommands().setConfig("timeout", originalTimeout);
+
+		}
+		catch (Exception e) {
+			if (e.getMessage() != null && e.getMessage().contains("read-only")) {
+				logger.warn("CONFIG SET test skipped: Server is in read-only mode");
+				return;
+			}
+			else {
+				throw e;
+			}
+		}
+		finally {
+			if (connection.isPipelined()) {
+				connection.closePipeline();
+			}
+		}
+	}
+
+	@Test
+	void testClientManagementInPipelineMode() {
+		try {
+			// Get original client name for restoration
+			String originalName = connection.serverCommands().getClientName();
+
+			// Start pipeline
+			connection.openPipeline();
+
+			// Queue client management commands - assert they return null in pipeline mode
+			connection.serverCommands().setClientName("test-pipeline-client".getBytes()); // void
+																							// method,
+																							// no
+																							// assertion
+			assertThat(connection.serverCommands().getClientName()).isNull();
+			assertThat(connection.serverCommands().getClientList()).isNull();
+
+			// Execute pipeline
+			List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(3);
+			assertThat(results.get(0)).isEqualTo("OK"); // setClientName result
+			assertThat(results.get(1)).isEqualTo("test-pipeline-client"); // getClientName
+																			// result
+
+			@SuppressWarnings("unchecked")
+			List<ValkeyClientInfo> clientList = (List<ValkeyClientInfo>) results.get(2);
+			assertThat(clientList).isNotEmpty();
+
+			// Restore original client name
+			if (originalName != null && !originalName.isEmpty()) {
+				connection.serverCommands().setClientName(originalName.getBytes());
+			}
+			else {
+				connection.serverCommands().setClientName("".getBytes());
+			}
+
+		}
+		finally {
+			if (connection.isPipelined()) {
+				connection.closePipeline();
+			}
+		}
+	}
+
+	@Test
+	void testReplicationCommandsInPipelineMode() {
+		try {
+			// Start pipeline
+			connection.openPipeline();
+
+			// Queue replication commands - these are safe to test
+			connection.serverCommands().replicaOfNoOne(); // void method, no assertion
+
+			// Execute pipeline
+			List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(1);
+			assertThat(results.get(0)).isEqualTo("OK"); // replicaOfNoOne result
+
+		}
+		catch (Exception e) {
+			if (e.getMessage() != null && e.getMessage().contains("REPLICAOF not allowed")) {
+				logger.warn("REPLICAOF test skipped: Replication commands not allowed");
+				return;
+			}
+			else {
+				throw e;
+			}
+		}
+		finally {
+			if (connection.isPipelined()) {
+				connection.closePipeline();
+			}
+		}
+	}
+
+	// ==================== Transaction Mode Tests ====================
+
+	@Test
+	void testBackgroundOperationsInTransactionMode() {
+		try {
+			// Start transaction
+			connection.multi();
+
+			// Queue background operations - assert they return null in transaction mode
+			assertThat(connection.serverCommands().lastSave()).isNull();
+
+			// Execute transaction
+			List<Object> results = connection.exec();
+
+			// Verify results
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(1);
+			// lastSave should return a timestamp or null
+			if (results.get(0) != null) {
+				assertThat(results.get(0)).isInstanceOf(Long.class);
+				assertThat(((Long) results.get(0))).isGreaterThan(0L);
+			}
+
+		}
+		finally {
+			if (connection.isQueueing()) {
+				connection.discard();
+			}
+		}
+	}
+
+	@Test
+	void testDatabaseOperationsInTransactionMode() {
+		String key1 = "test:server:transaction:db:key1";
+		String key2 = "test:server:transaction:db:key2";
+
+		try {
+			// Set up test data
+			connection.stringCommands().set(key1.getBytes(), "value1".getBytes());
+			connection.stringCommands().set(key2.getBytes(), "value2".getBytes());
+
+			// Start transaction
+			connection.multi();
+
+			// Queue database operations - assert they return null in transaction mode
+			assertThat(connection.serverCommands().dbSize()).isNull();
+			connection.serverCommands().flushDb(); // void method, no assertion
+
+			// Execute transaction
+			List<Object> results = connection.exec();
+
+			// Verify results
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(2);
+			assertThat(results.get(0)).isInstanceOf(Long.class); // dbSize result
+			assertThat(((Long) results.get(0))).isGreaterThan(0L);
+			assertThat(results.get(1)).isEqualTo("OK"); // flushDb result
+
+		}
+		finally {
+			cleanupKeys(key1, key2);
+			if (connection.isQueueing()) {
+				connection.discard();
+			}
+		}
+	}
+
+	@Test
+	void testDatabaseOperationsWithOptionsInTransactionMode() {
+		String key = "test:server:transaction:flush:key";
+
+		try {
+			// Set up test data
+			connection.stringCommands().set(key.getBytes(), "value".getBytes());
+
+			// Start transaction
+			connection.multi();
+
+			// Queue database operations with options
+			connection.serverCommands().flushDb(FlushOption.ASYNC); // void method, no
+																	// assertion
+			connection.serverCommands().flushAll(FlushOption.SYNC); // void method, no
+																	// assertion
+
+			// Execute transaction
+			List<Object> results = connection.exec();
+
+			// Verify results
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(2);
+			assertThat(results.get(0)).isEqualTo("OK"); // flushDb result
+			assertThat(results.get(1)).isEqualTo("OK"); // flushAll result
+
+		}
+		finally {
+			cleanupKey(key);
+			if (connection.isQueueing()) {
+				connection.discard();
+			}
+		}
+	}
+
+	@Test
+	void testServerInformationInTransactionMode() {
+		try {
+			// Start transaction
+			connection.multi();
+
+			// Queue server information commands - assert they return null in transaction
+			// mode
+			assertThat(connection.serverCommands().info()).isNull();
+			assertThat(connection.serverCommands().info("server")).isNull();
+			assertThat(connection.serverCommands().time(TimeUnit.MILLISECONDS)).isNull();
+			assertThat(connection.serverCommands().time(TimeUnit.SECONDS)).isNull();
+
+			// Execute transaction
+			List<Object> results = connection.exec();
+
+			// Verify results
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(4);
+
+			// info() result
+			assertThat(results.get(0)).isInstanceOf(Properties.class);
+			Properties allInfo = (Properties) results.get(0);
+			assertThat(allInfo).isNotEmpty();
+
+			// info("server") result
+			assertThat(results.get(1)).isInstanceOf(Properties.class);
+			Properties serverInfo = (Properties) results.get(1);
+			assertThat(serverInfo).isNotNull();
+
+			// time() results
+			assertThat(results.get(2)).isInstanceOf(Long.class);
+			assertThat(((Long) results.get(2))).isGreaterThan(0L);
+
+			assertThat(results.get(3)).isInstanceOf(Long.class);
+			assertThat(((Long) results.get(3))).isGreaterThan(0L);
+
+		}
+		finally {
+			if (connection.isQueueing()) {
+				connection.discard();
+			}
+		}
+	}
+
+	@Test
+	void testConfigurationManagementInTransactionMode() {
+		try {
+			// Start transaction
+			connection.multi();
+
+			// Queue configuration commands - assert they return null in transaction mode
+			assertThat(connection.serverCommands().getConfig("maxmemory")).isNull();
+			assertThat(connection.serverCommands().getConfig("*")).isNull();
+			connection.serverCommands().resetConfigStats(); // void method, no assertion
+
+			// Execute transaction
+			List<Object> results = connection.exec();
+
+			// Verify results
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(3);
+
+			// getConfig results
+			assertThat(results.get(0)).isInstanceOf(Properties.class);
+			assertThat(results.get(1)).isInstanceOf(Properties.class);
+			Properties allConfigs = (Properties) results.get(1);
+			assertThat(allConfigs).isNotEmpty();
+
+			// resetConfigStats result
+			assertThat(results.get(2)).isEqualTo("OK");
+
+		}
+		finally {
+			if (connection.isQueueing()) {
+				connection.discard();
+			}
+		}
+	}
+
+	@Test
+	void testConfigurationSetInTransactionMode() {
+		try {
+			// Get original timeout for restoration
+			Properties timeoutConfig = connection.serverCommands().getConfig("timeout");
+			String originalTimeout = timeoutConfig.getProperty("timeout", "0");
+
+			// Start transaction
+			connection.multi();
+
+			// Queue config set command
+			connection.serverCommands().setConfig("timeout", "120"); // void method, no
+																		// assertion
+			assertThat(connection.serverCommands().getConfig("timeout")).isNull();
+
+			// Execute transaction
+			List<Object> results = connection.exec();
+
+			// Verify results
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(2);
+			assertThat(results.get(0)).isEqualTo("OK"); // setConfig result
+			assertThat(results.get(1)).isInstanceOf(Properties.class); // getConfig result
+
+			Properties newTimeoutConfig = (Properties) results.get(1);
+			assertThat(newTimeoutConfig.getProperty("timeout")).isEqualTo("120");
+
+			// Restore original timeout
+			connection.serverCommands().setConfig("timeout", originalTimeout);
+
+		}
+		catch (Exception e) {
+			if (e.getMessage() != null && e.getMessage().contains("read-only")) {
+				logger.warn("CONFIG SET test skipped: Server is in read-only mode");
+				return;
+			}
+			else {
+				throw e;
+			}
+		}
+		finally {
+			if (connection.isQueueing()) {
+				connection.discard();
+			}
+		}
+	}
+
+	@Test
+	void testClientManagementInTransactionMode() {
+		try {
+			// Get original client name for restoration
+			String originalName = connection.serverCommands().getClientName();
+
+			// Start transaction
+			connection.multi();
+
+			// Queue client management commands - assert they return null in transaction
+			// mode
+			connection.serverCommands().setClientName("test-transaction-client".getBytes()); // void
+																								// method,
+																								// no
+																								// assertion
+			assertThat(connection.serverCommands().getClientName()).isNull();
+			assertThat(connection.serverCommands().getClientList()).isNull();
+
+			// Execute transaction
+			List<Object> results = connection.exec();
+
+			// Verify results
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(3);
+			assertThat(results.get(0)).isEqualTo("OK"); // setClientName result
+			assertThat(results.get(1)).isEqualTo("test-transaction-client"); // getClientName
+																				// result
+
+			@SuppressWarnings("unchecked")
+			List<ValkeyClientInfo> clientList = (List<ValkeyClientInfo>) results.get(2);
+			assertThat(clientList).isNotEmpty();
+
+			// Restore original client name
+			if (originalName != null && !originalName.isEmpty()) {
+				connection.serverCommands().setClientName(originalName.getBytes());
+			}
+			else {
+				connection.serverCommands().setClientName("".getBytes());
+			}
+
+		}
+		finally {
+			if (connection.isQueueing()) {
+				connection.discard();
+			}
+		}
+	}
+
+	@Test
+	void testReplicationCommandsInTransactionMode() {
+		try {
+			// Start transaction
+			connection.multi();
+
+			// Queue replication commands - these are safe to test
+			connection.serverCommands().replicaOfNoOne(); // void method, no assertion
+
+			// Execute transaction
+			List<Object> results = connection.exec();
+
+			// Verify results
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(1);
+			assertThat(results.get(0)).isEqualTo("OK"); // replicaOfNoOne result
+
+		}
+		catch (Exception e) {
+			if (e.getMessage() != null && e.getMessage().contains("REPLICAOF not allowed")) {
+				logger.warn("REPLICAOF test skipped: Replication commands not allowed");
+				return;
+			}
+			else {
+				throw e;
+			}
+		}
+		finally {
+			if (connection.isQueueing()) {
+				connection.discard();
+			}
+		}
+	}
+
+	@Test
+	void testMigrationCommandsInPipelineMode() {
+		String sourceKey = "test:server:pipeline:migrate:key";
+
+		try {
+			// Set up source data
+			connection.stringCommands().set(sourceKey.getBytes(), "migrate_value".getBytes());
+
+			// Start pipeline
+			connection.openPipeline();
+
+			// Test migrate to non-existent target (will fail but we test the pipeline
+			// behavior)
+			try {
+				connection.serverCommands()
+					.migrate(sourceKey.getBytes(), ValkeyNode.newValkeyNode().listeningAt("localhost", 9999).build(), 0,
+							null, 5000); // void method, no assertion
+			}
+			catch (Exception e) {
+				// Expected to fail, but we're testing pipeline mode
+			}
+
+			// Execute pipeline (may contain errors but should complete)
+			try {
+				List<Object> results = connection.closePipeline();
+				// Migration will likely fail but pipeline should handle it
+			}
+			catch (Exception e) {
+				// Expected for migration to non-existent target
+				logger.info("Migration failed as expected: " + e.getMessage());
+			}
+
+		}
+		finally {
+			cleanupKey(sourceKey);
+			if (connection.isPipelined()) {
+				connection.closePipeline();
+			}
+		}
+	}
+
+	@Test
+	void testMigrationCommandsInTransactionMode() {
+		String sourceKey = "test:server:transaction:migrate:key";
+
+		try {
+			// Set up source data
+			connection.stringCommands().set(sourceKey.getBytes(), "migrate_value".getBytes());
+
+			// Start transaction
+			connection.multi();
+
+			// Test migrate to non-existent target (will fail but we test the transaction
+			// behavior)
+			connection.serverCommands()
+				.migrate(sourceKey.getBytes(), ValkeyNode.newValkeyNode().listeningAt("localhost", 9999).build(), 0,
+						MigrateOption.COPY, 5000); // void method, no assertion
+
+			// Execute transaction (may contain errors but should complete)
+			try {
+				List<Object> results = connection.exec();
+				// Migration will likely fail but transaction should handle it
+			}
+			catch (Exception e) {
+				// Expected for migration to non-existent target
+				logger.info("Migration failed as expected: " + e.getMessage());
+			}
+
+		}
+		finally {
+			cleanupKey(sourceKey);
+			if (connection.isQueueing()) {
+				connection.discard();
+			}
+		}
+	}
+
+	@Test
+	void testTransactionDiscardWithServerCommands() {
+		String key = "test:server:transaction:discard";
+
+		try {
+			// Start transaction
+			connection.multi();
+
+			// Queue server commands
+			connection.serverCommands().dbSize(); // assert returns null in transaction
+													// mode
+			assertThat(connection.serverCommands().dbSize()).isNull();
+			assertThat(connection.serverCommands().time(TimeUnit.MILLISECONDS)).isNull();
+
+			// Discard transaction
+			connection.discard();
+
+			// Verify commands were not executed by checking current db state
+			Long currentDbSize = connection.serverCommands().dbSize();
+			assertThat(currentDbSize).isNotNull();
+
+		}
+		finally {
+			cleanupKey(key);
+			if (connection.isQueueing()) {
+				connection.discard();
+			}
+		}
+	}
+
+	@Test
+	void testWatchWithServerCommandsTransaction() throws InterruptedException {
+		String watchKey = "test:server:transaction:watch";
+		String otherKey = "test:server:transaction:other";
+
+		try {
+			// Setup initial data
+			connection.stringCommands().set(watchKey.getBytes(), "initial".getBytes());
+
+			// Watch the key
+			connection.watch(watchKey.getBytes());
+
+			// Modify the watched key from "outside" the transaction
+			connection.stringCommands().set(watchKey.getBytes(), "modified".getBytes());
+
+			// Start transaction
+			connection.multi();
+
+			// Queue server commands
+			connection.serverCommands().dbSize(); // assert returns null in transaction
+													// mode
+			assertThat(connection.serverCommands().dbSize()).isNull();
+			assertThat(connection.serverCommands().time(TimeUnit.MILLISECONDS)).isNull();
+
+			// Execute transaction - should be aborted due to WATCH
+			List<Object> results = connection.exec();
+
+			// Transaction should be aborted (results should be empty list)
+			assertThat(results).isNotNull().isEmpty();
+
+		}
+		finally {
+			cleanupKeys(watchKey, otherKey);
+			if (connection.isQueueing()) {
+				connection.discard();
+			}
+		}
+	}
+
+	// ==================== Error Handling ====================
+
+	@Test
+	void testErrorHandling() {
+		// Test error handling for invalid parameters
+
+		// Test null parameter handling
+		assertThatThrownBy(() -> connection.serverCommands().info(null)).isInstanceOf(IllegalArgumentException.class);
+
+		assertThatThrownBy(() -> connection.serverCommands().getConfig(null))
+			.isInstanceOf(IllegalArgumentException.class);
+
+		assertThatThrownBy(() -> connection.serverCommands().setConfig(null, "value"))
+			.isInstanceOf(IllegalArgumentException.class);
+
+		assertThatThrownBy(() -> connection.serverCommands().setConfig("param", null))
+			.isInstanceOf(IllegalArgumentException.class);
+
+		assertThatThrownBy(() -> connection.serverCommands().time(null)).isInstanceOf(IllegalArgumentException.class);
+
+		assertThatThrownBy(() -> connection.serverCommands().setClientName(null))
+			.isInstanceOf(IllegalArgumentException.class);
+
+		assertThatThrownBy(() -> connection.serverCommands().killClient(null, 6379))
+			.isInstanceOf(IllegalArgumentException.class);
+
+		assertThatThrownBy(() -> connection.serverCommands().replicaOf(null, 6379))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	// ==================== Edge Cases ====================
+
+	@Test
+	void testEdgeCases() {
+		// Test edge cases and boundary conditions
+		String originalClientName = null;
+
+		try {
+			// Get original client name for cleanup
+			originalClientName = connection.serverCommands().getClientName();
+			// Handle null client name case
+			if (originalClientName == null) {
+				originalClientName = "";
+			}
+
+			// Test empty string parameters where applicable
+			Properties emptyConfig = connection.serverCommands().getConfig("");
+			assertThat(emptyConfig).isNotNull();
+
+			// Test getting non-existent config
+			Properties nonExistentConfig = connection.serverCommands().getConfig("nonexistent_config_param");
+			assertThat(nonExistentConfig).isNotNull();
+			assertThat(nonExistentConfig).isEmpty();
+
+			// Test setting client name to empty string
+			connection.serverCommands().setClientName("".getBytes());
+			String emptyName = connection.serverCommands().getClientName();
+			// Client name might be null when set to empty string
+			assertThat(emptyName == null || emptyName.isEmpty()).isTrue();
+
+			// Test time with different units (test a subset to avoid flakiness)
+			TimeUnit[] testUnits = { TimeUnit.SECONDS, TimeUnit.MILLISECONDS, TimeUnit.MICROSECONDS };
+			for (TimeUnit unit : testUnits) {
+				Long time = connection.serverCommands().time(unit);
+				assertThat(time).isNotNull();
+				assertThat(time).isGreaterThan(0L);
+			}
+		}
+		finally {
+			// Clean up - restore original client name
+			if (originalClientName != null && !originalClientName.isEmpty()) {
+				connection.serverCommands().setClientName(originalClientName.getBytes());
+			}
+			else {
+				connection.serverCommands().setClientName("".getBytes());
+			}
+		}
+	}
+
 }

--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionSetCommandsIntegrationTests.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionSetCommandsIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,1536 +27,1607 @@ import io.valkey.springframework.data.valkey.core.ScanOptions;
 import io.valkey.springframework.data.valkey.test.condition.EnabledOnCommand;
 
 /**
- * Comprehensive low-level integration tests for {@link ValkeyGlideConnection} 
- * set functionality using the ValkeySetCommands interface directly.
- * 
- * These tests validate the implementation of all ValkeySetCommands methods:
- * - Basic set operations (sAdd, sRem, sCard, sMembers)
- * - Set membership operations (sIsMember, sMIsMember)
- * - Random operations (sRandMember, sPop)
- * - Set movement operations (sMove)
- * - Set algebra operations (sDiff, sInter, sUnion)
- * - Set store operations (sDiffStore, sInterStore, sUnionStore)
- * - Set scanning operations (sScan)
- * - Error handling and edge cases
+ * Comprehensive low-level integration tests for {@link ValkeyGlideConnection} set
+ * functionality using the ValkeySetCommands interface directly.
+ *
+ * These tests validate the implementation of all ValkeySetCommands methods: - Basic set
+ * operations (sAdd, sRem, sCard, sMembers) - Set membership operations (sIsMember,
+ * sMIsMember) - Random operations (sRandMember, sPop) - Set movement operations (sMove) -
+ * Set algebra operations (sDiff, sInter, sUnion) - Set store operations (sDiffStore,
+ * sInterStore, sUnionStore) - Set scanning operations (sScan) - Error handling and edge
+ * cases
  *
  * @author Ilia Kolominsky
  * @since 2.0
  */
 public class ValkeyGlideConnectionSetCommandsIntegrationTests extends AbstractValkeyGlideIntegrationTests {
 
-    @Override
-    protected String[] getTestKeyPatterns() {
-        return new String[]{
-            "test:set:add:key", "test:set:members:key", "test:set:mismember:key", "test:set:mismember:empty",
-            "test:set:rem:key", "test:set:randmember:key", "test:set:pop:key", "test:set:move:src",
-            "test:set:move:dest", "test:set:move:nonexistent", "test:set:diff:key1", "test:set:diff:key2",
-            "test:set:diff:key3", "test:set:diffstore:key1", "test:set:diffstore:key2", "test:set:diffstore:dest",
-            "test:set:inter:key1", "test:set:inter:key2", "test:set:inter:key3", "test:set:interstore:key1",
-            "test:set:interstore:key2", "test:set:interstore:dest", "test:set:union:key1", "test:set:union:key2",
-            "test:set:union:key3", "test:set:unionstore:key1", "test:set:unionstore:key2", "test:set:unionstore:dest",
-            "test:set:scan:key", "test:set:edge:key", "test:set:algebra:edge:key1", "test:set:algebra:edge:key2",
-            "test:set:algebra:edge:dest"
-        };
-    }
+	@Override
+	protected String[] getTestKeyPatterns() {
+		return new String[] { "test:set:add:key", "test:set:members:key", "test:set:mismember:key",
+				"test:set:mismember:empty", "test:set:rem:key", "test:set:randmember:key", "test:set:pop:key",
+				"test:set:move:src", "test:set:move:dest", "test:set:move:nonexistent", "test:set:diff:key1",
+				"test:set:diff:key2", "test:set:diff:key3", "test:set:diffstore:key1", "test:set:diffstore:key2",
+				"test:set:diffstore:dest", "test:set:inter:key1", "test:set:inter:key2", "test:set:inter:key3",
+				"test:set:interstore:key1", "test:set:interstore:key2", "test:set:interstore:dest",
+				"test:set:union:key1", "test:set:union:key2", "test:set:union:key3", "test:set:unionstore:key1",
+				"test:set:unionstore:key2", "test:set:unionstore:dest", "test:set:scan:key", "test:set:edge:key",
+				"test:set:algebra:edge:key1", "test:set:algebra:edge:key2", "test:set:algebra:edge:dest" };
+	}
 
-    // ==================== Basic Set Operations ====================
+	// ==================== Basic Set Operations ====================
 
-    @Test
-    void testSAddAndSCard() {
-        String key = "test:set:add:key";
-        byte[] value1 = "member1".getBytes();
-        byte[] value2 = "member2".getBytes();
-        byte[] value3 = "member3".getBytes();
-        
-        try {
-            // Test sCard on non-existent key
-            Long cardEmpty = connection.setCommands().sCard(key.getBytes());
-            assertThat(cardEmpty).isEqualTo(0L);
-            
-            // Test adding single value
-            Long addResult1 = connection.setCommands().sAdd(key.getBytes(), value1);
-            assertThat(addResult1).isEqualTo(1L);
-            
-            // Test cardinality after adding one element
-            Long card1 = connection.setCommands().sCard(key.getBytes());
-            assertThat(card1).isEqualTo(1L);
-            
-            // Test adding multiple values
-            Long addResult2 = connection.setCommands().sAdd(key.getBytes(), value2, value3);
-            assertThat(addResult2).isEqualTo(2L);
-            
-            // Test cardinality after adding three elements
-            Long card3 = connection.setCommands().sCard(key.getBytes());
-            assertThat(card3).isEqualTo(3L);
-            
-            // Test adding duplicate value (should return 0)
-            Long addDuplicate = connection.setCommands().sAdd(key.getBytes(), value1);
-            assertThat(addDuplicate).isEqualTo(0L);
-            
-            // Cardinality should remain the same
-            Long cardSame = connection.setCommands().sCard(key.getBytes());
-            assertThat(cardSame).isEqualTo(3L);
-        } finally {
-            cleanupKey(key);
-        }
-    }
+	@Test
+	void testSAddAndSCard() {
+		String key = "test:set:add:key";
+		byte[] value1 = "member1".getBytes();
+		byte[] value2 = "member2".getBytes();
+		byte[] value3 = "member3".getBytes();
 
-    @Test
-    void testSMembersAndSIsMember() {
-        String key = "test:set:members:key";
-        byte[] value1 = "member1".getBytes();
-        byte[] value2 = "member2".getBytes();
-        byte[] value3 = "member3".getBytes();
-        byte[] nonMember = "nonmember".getBytes();
-        
-        try {
-            // Test sMembers on empty set
-            Set<byte[]> emptyMembers = connection.setCommands().sMembers(key.getBytes());
-            assertThat(emptyMembers).isEmpty();
-            
-            // Test sIsMember on empty set
-            Boolean isMemberEmpty = connection.setCommands().sIsMember(key.getBytes(), value1);
-            assertThat(isMemberEmpty).isFalse();
-            
-            // Add some members
-            connection.setCommands().sAdd(key.getBytes(), value1, value2, value3);
-            
-            // Test sMembers
-            Set<byte[]> members = connection.setCommands().sMembers(key.getBytes());
-            assertThat(members).hasSize(3);
-            
-            // Convert to strings for easier comparison
-            Set<String> memberStrings = members.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toSet());
-            assertThat(memberStrings).containsExactlyInAnyOrder("member1", "member2", "member3");
-            
-            // Test sIsMember for existing members
-            Boolean isMember1 = connection.setCommands().sIsMember(key.getBytes(), value1);
-            assertThat(isMember1).isTrue();
-            
-            Boolean isMember2 = connection.setCommands().sIsMember(key.getBytes(), value2);
-            assertThat(isMember2).isTrue();
-            
-            // Test sIsMember for non-existing member
-            Boolean isNonMember = connection.setCommands().sIsMember(key.getBytes(), nonMember);
-            assertThat(isNonMember).isFalse();
-        } finally {
-            cleanupKey(key);
-        }
-    }
+		try {
+			// Test sCard on non-existent key
+			Long cardEmpty = connection.setCommands().sCard(key.getBytes());
+			assertThat(cardEmpty).isEqualTo(0L);
 
-    @Test
-    void testSMIsMember() {
-        String key = "test:set:mismember:key";
-        byte[] value1 = "member1".getBytes();
-        byte[] value2 = "member2".getBytes();
-        byte[] value3 = "member3".getBytes();
-        byte[] nonMember = "nonmember".getBytes();
-        
-        try {
-            // Add some members
-            connection.setCommands().sAdd(key.getBytes(), value1, value2);
-            
-            // Test sMIsMember with mixed existing and non-existing members
-            List<Boolean> results = connection.setCommands().sMIsMember(key.getBytes(), 
-                value1, value2, value3, nonMember);
-            
-            assertThat(results).hasSize(4);
-            assertThat(results.get(0)).isTrue();  // member1 exists
-            assertThat(results.get(1)).isTrue();  // member2 exists
-            assertThat(results.get(2)).isFalse(); // member3 doesn't exist
-            assertThat(results.get(3)).isFalse(); // nonmember doesn't exist
-            
-            // Test on empty set
-            String emptyKey = "test:set:mismember:empty";
-            List<Boolean> emptyResults = connection.setCommands().sMIsMember(emptyKey.getBytes(), 
-                value1, value2);
-            assertThat(emptyResults).containsOnly(false, false);
-        } finally {
-            cleanupKey(key);
-            cleanupKey("test:set:mismember:empty");
-        }
-    }
+			// Test adding single value
+			Long addResult1 = connection.setCommands().sAdd(key.getBytes(), value1);
+			assertThat(addResult1).isEqualTo(1L);
 
-    @Test
-    void testSRem() {
-        String key = "test:set:rem:key";
-        byte[] value1 = "member1".getBytes();
-        byte[] value2 = "member2".getBytes();
-        byte[] value3 = "member3".getBytes();
-        byte[] nonMember = "nonmember".getBytes();
-        
-        try {
-            // Add some members
-            connection.setCommands().sAdd(key.getBytes(), value1, value2, value3);
-            
-            // Test removing single member
-            Long remResult1 = connection.setCommands().sRem(key.getBytes(), value1);
-            assertThat(remResult1).isEqualTo(1L);
-            
-            // Verify member was removed
-            Boolean isMember = connection.setCommands().sIsMember(key.getBytes(), value1);
-            assertThat(isMember).isFalse();
-            
-            // Test removing multiple members
-            Long remResult2 = connection.setCommands().sRem(key.getBytes(), value2, value3);
-            assertThat(remResult2).isEqualTo(2L);
-            
-            // Test removing non-existing member
-            Long remNonExist = connection.setCommands().sRem(key.getBytes(), nonMember);
-            assertThat(remNonExist).isEqualTo(0L);
-            
-            // Verify set is empty
-            Long card = connection.setCommands().sCard(key.getBytes());
-            assertThat(card).isEqualTo(0L);
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test cardinality after adding one element
+			Long card1 = connection.setCommands().sCard(key.getBytes());
+			assertThat(card1).isEqualTo(1L);
 
-    // ==================== Random Operations ====================
+			// Test adding multiple values
+			Long addResult2 = connection.setCommands().sAdd(key.getBytes(), value2, value3);
+			assertThat(addResult2).isEqualTo(2L);
 
-    @Test
-    void testSRandMember() {
-        String key = "test:set:randmember:key";
-        byte[] value1 = "member1".getBytes();
-        byte[] value2 = "member2".getBytes();
-        byte[] value3 = "member3".getBytes();
-        
-        try {
-            // Test sRandMember on empty set
-            byte[] emptyRand = connection.setCommands().sRandMember(key.getBytes());
-            assertThat(emptyRand).isNull();
-            
-            // Add members
-            connection.setCommands().sAdd(key.getBytes(), value1, value2, value3);
-            
-            // Test single random member
-            byte[] randomMember = connection.setCommands().sRandMember(key.getBytes());
-            assertThat(randomMember).isNotNull();
-            
-            String randomMemberStr = new String(randomMember);
-            assertThat(randomMemberStr).isIn("member1", "member2", "member3");
-            
-            // Test multiple random members
-            List<byte[]> randomMembers = connection.setCommands().sRandMember(key.getBytes(), 2);
-            assertThat(randomMembers).hasSize(2);
-            
-            // Convert to strings for verification
-            List<String> randomMemberStrs = randomMembers.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toList());
-            
-            // All returned members should be valid
-            for (String member : randomMemberStrs) {
-                assertThat(member).isIn("member1", "member2", "member3");
-            }
-            
-            // Test with count larger than set size
-            List<byte[]> moreMembers = connection.setCommands().sRandMember(key.getBytes(), 5);
-            assertThat(moreMembers).hasSizeLessThanOrEqualTo(3); // Should not exceed set size
-            
-            // Test with negative count (allows duplicates)
-            List<byte[]> negativeCount = connection.setCommands().sRandMember(key.getBytes(), -5);
-            assertThat(negativeCount).hasSize(5); // Should return exactly 5 elements (with possible duplicates)
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test cardinality after adding three elements
+			Long card3 = connection.setCommands().sCard(key.getBytes());
+			assertThat(card3).isEqualTo(3L);
 
-    @Test
-    void testSPop() {
-        String key = "test:set:pop:key";
-        byte[] value1 = "member1".getBytes();
-        byte[] value2 = "member2".getBytes();
-        byte[] value3 = "member3".getBytes();
-        
-        try {
-            // Test sPop on empty set
-            byte[] emptyPop = connection.setCommands().sPop(key.getBytes());
-            assertThat(emptyPop).isNull();
-            
-            // Add members
-            connection.setCommands().sAdd(key.getBytes(), value1, value2, value3);
-            
-            // Test single pop
-            byte[] poppedMember = connection.setCommands().sPop(key.getBytes());
-            assertThat(poppedMember).isNotNull();
-            
-            String poppedStr = new String(poppedMember);
-            assertThat(poppedStr).isIn("member1", "member2", "member3");
-            
-            // Verify member was removed
-            Boolean stillMember = connection.setCommands().sIsMember(key.getBytes(), poppedMember);
-            assertThat(stillMember).isFalse();
-            
-            // Verify cardinality decreased
-            Long card = connection.setCommands().sCard(key.getBytes());
-            assertThat(card).isEqualTo(2L);
-            
-            // Test multiple pop
-            List<byte[]> poppedMembers = connection.setCommands().sPop(key.getBytes(), 2);
-            assertThat(poppedMembers).hasSize(2);
-            
-            // Verify all were removed
-            Long finalCard = connection.setCommands().sCard(key.getBytes());
-            assertThat(finalCard).isEqualTo(0L);
-            
-            // Test pop more than available
-            connection.setCommands().sAdd(key.getBytes(), value1);
-            List<byte[]> overPop = connection.setCommands().sPop(key.getBytes(), 5);
-            assertThat(overPop).hasSize(1); // Should only return what's available
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test adding duplicate value (should return 0)
+			Long addDuplicate = connection.setCommands().sAdd(key.getBytes(), value1);
+			assertThat(addDuplicate).isEqualTo(0L);
 
-    // ==================== Set Movement Operations ====================
+			// Cardinality should remain the same
+			Long cardSame = connection.setCommands().sCard(key.getBytes());
+			assertThat(cardSame).isEqualTo(3L);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
 
-    @Test
-    void testSMove() {
-        String srcKey = "test:set:move:src";
-        String destKey = "test:set:move:dest";
-        byte[] value1 = "member1".getBytes();
-        byte[] value2 = "member2".getBytes();
-        byte[] nonMember = "nonmember".getBytes();
-        
-        try {
-            // Setup source set
-            connection.setCommands().sAdd(srcKey.getBytes(), value1, value2);
-            
-            // Test moving existing member
-            Boolean moveResult1 = connection.setCommands().sMove(srcKey.getBytes(), destKey.getBytes(), value1);
-            assertThat(moveResult1).isTrue();
-            
-            // Verify member was removed from source
-            Boolean inSrc = connection.setCommands().sIsMember(srcKey.getBytes(), value1);
-            assertThat(inSrc).isFalse();
-            
-            // Verify member was added to destination
-            Boolean inDest = connection.setCommands().sIsMember(destKey.getBytes(), value1);
-            assertThat(inDest).isTrue();
-            
-            // Test moving non-existing member
-            Boolean moveResult2 = connection.setCommands().sMove(srcKey.getBytes(), destKey.getBytes(), nonMember);
-            assertThat(moveResult2).isFalse();
-            
-            // Test moving from non-existing set
-            String nonExistentKey = "test:set:move:nonexistent";
-            Boolean moveResult3 = connection.setCommands().sMove(nonExistentKey.getBytes(), destKey.getBytes(), value2);
-            assertThat(moveResult3).isFalse();
-        } finally {
-            cleanupKey(srcKey);
-            cleanupKey(destKey);
-            cleanupKey("test:set:move:nonexistent");
-        }
-    }
+	@Test
+	void testSMembersAndSIsMember() {
+		String key = "test:set:members:key";
+		byte[] value1 = "member1".getBytes();
+		byte[] value2 = "member2".getBytes();
+		byte[] value3 = "member3".getBytes();
+		byte[] nonMember = "nonmember".getBytes();
 
-    // ==================== Set Algebra Operations ====================
+		try {
+			// Test sMembers on empty set
+			Set<byte[]> emptyMembers = connection.setCommands().sMembers(key.getBytes());
+			assertThat(emptyMembers).isEmpty();
 
-    @Test
-    void testSDiff() {
-        String key1 = "test:set:diff:key1";
-        String key2 = "test:set:diff:key2";
-        String key3 = "test:set:diff:key3";
-        
-        try {
-            // Setup test sets
-            // key1: {a, b, c, d}
-            connection.setCommands().sAdd(key1.getBytes(), "a".getBytes(), "b".getBytes(), "c".getBytes(), "d".getBytes());
-            // key2: {b, c, e}
-            connection.setCommands().sAdd(key2.getBytes(), "b".getBytes(), "c".getBytes(), "e".getBytes());
-            // key3: {d, f}
-            connection.setCommands().sAdd(key3.getBytes(), "d".getBytes(), "f".getBytes());
-            
-            // Test diff of key1 - key2 (should be {a, d})
-            Set<byte[]> diff1 = connection.setCommands().sDiff(key1.getBytes(), key2.getBytes());
-            Set<String> diff1Strings = diff1.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toSet());
-            assertThat(diff1Strings).containsExactlyInAnyOrder("a", "d");
-            
-            // Test diff of key1 - key2 - key3 (should be {a})
-            Set<byte[]> diff2 = connection.setCommands().sDiff(key1.getBytes(), key2.getBytes(), key3.getBytes());
-            Set<String> diff2Strings = diff2.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toSet());
-            assertThat(diff2Strings).containsExactlyInAnyOrder("a");
-            
-            // Test diff with non-existent key
-            String nonExistentKey = "test:set:diff:nonexistent";
-            Set<byte[]> diff3 = connection.setCommands().sDiff(key1.getBytes(), nonExistentKey.getBytes());
-            Set<String> diff3Strings = diff3.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toSet());
-            assertThat(diff3Strings).containsExactlyInAnyOrder("a", "b", "c", "d");
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-            cleanupKey(key3);
-        }
-    }
+			// Test sIsMember on empty set
+			Boolean isMemberEmpty = connection.setCommands().sIsMember(key.getBytes(), value1);
+			assertThat(isMemberEmpty).isFalse();
 
-    @Test
-    void testSDiffStore() {
-        String key1 = "test:set:diffstore:key1";
-        String key2 = "test:set:diffstore:key2";
-        String destKey = "test:set:diffstore:dest";
-        
-        try {
-            // Setup test sets
-            connection.setCommands().sAdd(key1.getBytes(), "a".getBytes(), "b".getBytes(), "c".getBytes());
-            connection.setCommands().sAdd(key2.getBytes(), "b".getBytes(), "c".getBytes(), "d".getBytes());
-            
-            // Test sDiffStore
-            Long storeResult = connection.setCommands().sDiffStore(destKey.getBytes(), key1.getBytes(), key2.getBytes());
-            assertThat(storeResult).isEqualTo(1L); // Should store 1 element: "a"
-            
-            // Verify stored result
-            Set<byte[]> storedDiff = connection.setCommands().sMembers(destKey.getBytes());
-            Set<String> storedDiffStrings = storedDiff.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toSet());
-            assertThat(storedDiffStrings).containsExactlyInAnyOrder("a");
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-            cleanupKey(destKey);
-        }
-    }
+			// Add some members
+			connection.setCommands().sAdd(key.getBytes(), value1, value2, value3);
 
-    @Test
-    void testSInter() {
-        String key1 = "test:set:inter:key1";
-        String key2 = "test:set:inter:key2";
-        String key3 = "test:set:inter:key3";
-        
-        try {
-            // Setup test sets
-            // key1: {a, b, c}
-            connection.setCommands().sAdd(key1.getBytes(), "a".getBytes(), "b".getBytes(), "c".getBytes());
-            // key2: {b, c, d}
-            connection.setCommands().sAdd(key2.getBytes(), "b".getBytes(), "c".getBytes(), "d".getBytes());
-            // key3: {c, d, e}
-            connection.setCommands().sAdd(key3.getBytes(), "c".getBytes(), "d".getBytes(), "e".getBytes());
-            
-            // Test intersection of key1 and key2 (should be {b, c})
-            Set<byte[]> inter1 = connection.setCommands().sInter(key1.getBytes(), key2.getBytes());
-            Set<String> inter1Strings = inter1.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toSet());
-            assertThat(inter1Strings).containsExactlyInAnyOrder("b", "c");
-            
-            // Test intersection of all three (should be {c})
-            Set<byte[]> inter2 = connection.setCommands().sInter(key1.getBytes(), key2.getBytes(), key3.getBytes());
-            Set<String> inter2Strings = inter2.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toSet());
-            assertThat(inter2Strings).containsExactlyInAnyOrder("c");
-            
-            // Test intersection with non-existent key (should be empty)
-            String nonExistentKey = "test:set:inter:nonexistent";
-            Set<byte[]> inter3 = connection.setCommands().sInter(key1.getBytes(), nonExistentKey.getBytes());
-            assertThat(inter3).isEmpty();
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-            cleanupKey(key3);
-        }
-    }
+			// Test sMembers
+			Set<byte[]> members = connection.setCommands().sMembers(key.getBytes());
+			assertThat(members).hasSize(3);
 
-    @Test
-    void testSInterStore() {
-        String key1 = "test:set:interstore:key1";
-        String key2 = "test:set:interstore:key2";
-        String destKey = "test:set:interstore:dest";
-        
-        try {
-            // Setup test sets
-            connection.setCommands().sAdd(key1.getBytes(), "a".getBytes(), "b".getBytes(), "c".getBytes());
-            connection.setCommands().sAdd(key2.getBytes(), "b".getBytes(), "c".getBytes(), "d".getBytes());
-            
-            // Test sInterStore
-            Long storeResult = connection.setCommands().sInterStore(destKey.getBytes(), key1.getBytes(), key2.getBytes());
-            assertThat(storeResult).isEqualTo(2L); // Should store 2 elements: "b", "c"
-            
-            // Verify stored result
-            Set<byte[]> storedInter = connection.setCommands().sMembers(destKey.getBytes());
-            Set<String> storedInterStrings = storedInter.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toSet());
-            assertThat(storedInterStrings).containsExactlyInAnyOrder("b", "c");
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-            cleanupKey(destKey);
-        }
-    }
+			// Convert to strings for easier comparison
+			Set<String> memberStrings = members.stream().map(String::new).collect(java.util.stream.Collectors.toSet());
+			assertThat(memberStrings).containsExactlyInAnyOrder("member1", "member2", "member3");
 
-    @Test
-    void testSUnion() {
-        String key1 = "test:set:union:key1";
-        String key2 = "test:set:union:key2";
-        String key3 = "test:set:union:key3";
-        
-        try {
-            // Setup test sets
-            // key1: {a, b}
-            connection.setCommands().sAdd(key1.getBytes(), "a".getBytes(), "b".getBytes());
-            // key2: {b, c}
-            connection.setCommands().sAdd(key2.getBytes(), "b".getBytes(), "c".getBytes());
-            // key3: {c, d}
-            connection.setCommands().sAdd(key3.getBytes(), "c".getBytes(), "d".getBytes());
-            
-            // Test union of key1 and key2 (should be {a, b, c})
-            Set<byte[]> union1 = connection.setCommands().sUnion(key1.getBytes(), key2.getBytes());
-            Set<String> union1Strings = union1.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toSet());
-            assertThat(union1Strings).containsExactlyInAnyOrder("a", "b", "c");
-            
-            // Test union of all three (should be {a, b, c, d})
-            Set<byte[]> union2 = connection.setCommands().sUnion(key1.getBytes(), key2.getBytes(), key3.getBytes());
-            Set<String> union2Strings = union2.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toSet());
-            assertThat(union2Strings).containsExactlyInAnyOrder("a", "b", "c", "d");
-            
-            // Test union with non-existent key
-            String nonExistentKey = "test:set:union:nonexistent";
-            Set<byte[]> union3 = connection.setCommands().sUnion(key1.getBytes(), nonExistentKey.getBytes());
-            Set<String> union3Strings = union3.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toSet());
-            assertThat(union3Strings).containsExactlyInAnyOrder("a", "b");
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-            cleanupKey(key3);
-        }
-    }
+			// Test sIsMember for existing members
+			Boolean isMember1 = connection.setCommands().sIsMember(key.getBytes(), value1);
+			assertThat(isMember1).isTrue();
 
-    @Test
-    void testSUnionStore() {
-        String key1 = "test:set:unionstore:key1";
-        String key2 = "test:set:unionstore:key2";
-        String destKey = "test:set:unionstore:dest";
-        
-        try {
-            // Setup test sets
-            connection.setCommands().sAdd(key1.getBytes(), "a".getBytes(), "b".getBytes());
-            connection.setCommands().sAdd(key2.getBytes(), "b".getBytes(), "c".getBytes());
-            
-            // Test sUnionStore
-            Long storeResult = connection.setCommands().sUnionStore(destKey.getBytes(), key1.getBytes(), key2.getBytes());
-            assertThat(storeResult).isEqualTo(3L); // Should store 3 elements: "a", "b", "c"
-            
-            // Verify stored result
-            Set<byte[]> storedUnion = connection.setCommands().sMembers(destKey.getBytes());
-            Set<String> storedUnionStrings = storedUnion.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toSet());
-            assertThat(storedUnionStrings).containsExactlyInAnyOrder("a", "b", "c");
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-            cleanupKey(destKey);
-        }
-    }
+			Boolean isMember2 = connection.setCommands().sIsMember(key.getBytes(), value2);
+			assertThat(isMember2).isTrue();
 
-    // ==================== Set Scanning Operations ====================
+			// Test sIsMember for non-existing member
+			Boolean isNonMember = connection.setCommands().sIsMember(key.getBytes(), nonMember);
+			assertThat(isNonMember).isFalse();
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
 
-    @Test
-    void testSScan() {
-        String key = "test:set:scan:key";
-        
-        try {
-            // Setup test set with multiple members
-            for (int i = 0; i < 10; i++) {
-                connection.setCommands().sAdd(key.getBytes(), ("member" + i).getBytes());
-            }
-            
-            // Test basic scan
-            ScanOptions options = ScanOptions.scanOptions().build();
-            Cursor<byte[]> cursor = connection.setCommands().sScan(key.getBytes(), options);
-            
-            java.util.List<String> scannedMembers = new java.util.ArrayList<>();
-            while (cursor.hasNext()) {
-                scannedMembers.add(new String(cursor.next()));
-            }
-            cursor.close();
-            
-            // Should find all members
-            assertThat(scannedMembers).hasSize(10);
-            for (int i = 0; i < 10; i++) {
-                assertThat(scannedMembers).contains("member" + i);
-            }
-            
-            // Test scan with pattern
-            ScanOptions patternOptions = ScanOptions.scanOptions().match("member[1-3]").build();
-            Cursor<byte[]> patternCursor = connection.setCommands().sScan(key.getBytes(), patternOptions);
-            
-            java.util.List<String> patternMembers = new java.util.ArrayList<>();
-            while (patternCursor.hasNext()) {
-                patternMembers.add(new String(patternCursor.next()));
-            }
-            patternCursor.close();
-            
-            // Should find fewer members due to pattern filter
-            assertThat(patternMembers.size()).isLessThanOrEqualTo(3);
-            
-            // Test scan with count
-            ScanOptions countOptions = ScanOptions.scanOptions().count(2).build();
-            Cursor<byte[]> countCursor = connection.setCommands().sScan(key.getBytes(), countOptions);
-            
-            java.util.List<String> countMembers = new java.util.ArrayList<>();
-            while (countCursor.hasNext()) {
-                countMembers.add(new String(countCursor.next()));
-            }
-            countCursor.close();
-            
-            // Should still find all members, but in smaller batches
-            assertThat(countMembers).hasSize(10);
-        } finally {
-            cleanupKey(key);
-        }
-    }
+	@Test
+	void testSMIsMember() {
+		String key = "test:set:mismember:key";
+		byte[] value1 = "member1".getBytes();
+		byte[] value2 = "member2".getBytes();
+		byte[] value3 = "member3".getBytes();
+		byte[] nonMember = "nonmember".getBytes();
 
-    // ==================== Error Handling and Edge Cases ====================
+		try {
+			// Add some members
+			connection.setCommands().sAdd(key.getBytes(), value1, value2);
 
-    @Test
-    void testSetOperationsErrorHandling() {
-        // Test operations on null keys (should throw IllegalArgumentException)
-        assertThatThrownBy(() -> connection.setCommands().sAdd(null, "value".getBytes()))
-            .isInstanceOf(IllegalArgumentException.class);
-        
-        assertThatThrownBy(() -> connection.setCommands().sRem(null, "value".getBytes()))
-            .isInstanceOf(IllegalArgumentException.class);
-        
-        assertThatThrownBy(() -> connection.setCommands().sCard(null))
-            .isInstanceOf(IllegalArgumentException.class);
-        
-        // Test operations on empty keys (should throw IllegalArgumentException)
-        // assertThatThrownBy(() -> connection.setCommands().sAdd(new byte[0], "value".getBytes()))
-        //     .isInstanceOf(IllegalArgumentException.class);
-        
-        // assertThatThrownBy(() -> connection.setCommands().sRem(new byte[0], "value".getBytes()))
-        //     .isInstanceOf(IllegalArgumentException.class);
-        
-        // assertThatThrownBy(() -> connection.setCommands().sCard(new byte[0]))
-        //     .isInstanceOf(IllegalArgumentException.class);
-        
-        // Test operations with null values
-        assertThatThrownBy(() -> connection.setCommands().sAdd("key".getBytes(), (byte[]) null))
-            .isInstanceOf(IllegalArgumentException.class);
-        
-        assertThatThrownBy(() -> connection.setCommands().sRem("key".getBytes(), (byte[]) null))
-            .isInstanceOf(IllegalArgumentException.class);
-        
-        assertThatThrownBy(() -> connection.setCommands().sIsMember("key".getBytes(), null))
-            .isInstanceOf(IllegalArgumentException.class);
-    }
+			// Test sMIsMember with mixed existing and non-existing members
+			List<Boolean> results = connection.setCommands()
+				.sMIsMember(key.getBytes(), value1, value2, value3, nonMember);
 
-    @Test
-    void testSetOperationsEdgeCases() {
-        String key = "test:set:edge:key";
-        
-        try {
-            // Test operations on very large values
-            byte[] largeValue = new byte[1024 * 10]; // 10KB value
-            java.util.Arrays.fill(largeValue, (byte) 'A');
-            
-            Long addLarge = connection.setCommands().sAdd(key.getBytes(), largeValue);
-            assertThat(addLarge).isEqualTo(1L);
-            
-            Boolean isLargeMember = connection.setCommands().sIsMember(key.getBytes(), largeValue);
-            assertThat(isLargeMember).isTrue();
-            
-            Long remLarge = connection.setCommands().sRem(key.getBytes(), largeValue);
-            assertThat(remLarge).isEqualTo(1L);
-            
-            // Test with empty value
-            byte[] emptyValue = new byte[0];
-            Long addEmpty = connection.setCommands().sAdd(key.getBytes(), emptyValue);
-            assertThat(addEmpty).isEqualTo(1L);
-            
-            Boolean isEmptyMember = connection.setCommands().sIsMember(key.getBytes(), emptyValue);
-            assertThat(isEmptyMember).isTrue();
-            
-            // Test with binary values
-            byte[] binaryValue = {0x00, (byte) 0xFF, 0x7F, (byte) 0x80, 0x01};
-            Long addBinary = connection.setCommands().sAdd(key.getBytes(), binaryValue);
-            assertThat(addBinary).isEqualTo(1L);
-            
-            Boolean isBinaryMember = connection.setCommands().sIsMember(key.getBytes(), binaryValue);
-            assertThat(isBinaryMember).isTrue();
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			assertThat(results).hasSize(4);
+			assertThat(results.get(0)).isTrue(); // member1 exists
+			assertThat(results.get(1)).isTrue(); // member2 exists
+			assertThat(results.get(2)).isFalse(); // member3 doesn't exist
+			assertThat(results.get(3)).isFalse(); // nonmember doesn't exist
 
-    @Test
-    void testSetAlgebraEdgeCases() {
-        String key1 = "test:set:algebra:edge:key1";
-        String key2 = "test:set:algebra:edge:key2";
-        String destKey = "test:set:algebra:edge:dest";
-        
-        try {
-            // Test operations with empty sets
-            Set<byte[]> emptyDiff = connection.setCommands().sDiff(key1.getBytes(), key2.getBytes());
-            assertThat(emptyDiff).isEmpty();
-            
-            Set<byte[]> emptyInter = connection.setCommands().sInter(key1.getBytes(), key2.getBytes());
-            assertThat(emptyInter).isEmpty();
-            
-            Set<byte[]> emptyUnion = connection.setCommands().sUnion(key1.getBytes(), key2.getBytes());
-            assertThat(emptyUnion).isEmpty();
-            
-            // Test store operations with empty results
-            Long diffStore = connection.setCommands().sDiffStore(destKey.getBytes(), key1.getBytes(), key2.getBytes());
-            assertThat(diffStore).isEqualTo(0L);
-            
-            Long interStore = connection.setCommands().sInterStore(destKey.getBytes(), key1.getBytes(), key2.getBytes());
-            assertThat(interStore).isEqualTo(0L);
-            
-            Long unionStore = connection.setCommands().sUnionStore(destKey.getBytes(), key1.getBytes(), key2.getBytes());
-            assertThat(unionStore).isEqualTo(0L);
-            
-            // Test with single set having data
-            connection.setCommands().sAdd(key1.getBytes(), "a".getBytes(), "b".getBytes());
-            
-            Set<byte[]> diffSingle = connection.setCommands().sDiff(key1.getBytes(), key2.getBytes());
-            assertThat(diffSingle).hasSize(2);
-            
-            Set<byte[]> unionSingle = connection.setCommands().sUnion(key1.getBytes(), key2.getBytes());
-            assertThat(unionSingle).hasSize(2);
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-            cleanupKey(destKey);
-        }
-    }
+			// Test on empty set
+			String emptyKey = "test:set:mismember:empty";
+			List<Boolean> emptyResults = connection.setCommands().sMIsMember(emptyKey.getBytes(), value1, value2);
+			assertThat(emptyResults).containsOnly(false, false);
+		}
+		finally {
+			cleanupKey(key);
+			cleanupKey("test:set:mismember:empty");
+		}
+	}
 
-    // ==================== Pipeline Mode Tests ====================
+	@Test
+	void testSRem() {
+		String key = "test:set:rem:key";
+		byte[] value1 = "member1".getBytes();
+		byte[] value2 = "member2".getBytes();
+		byte[] value3 = "member3".getBytes();
+		byte[] nonMember = "nonmember".getBytes();
 
-    @Test
-    void testSetOperationsInPipelineMode() {
-        String key1 = "test:set:pipeline:key1";
-        String key2 = "test:set:pipeline:key2";
-        String destKey = "test:set:pipeline:dest";
-        
-        try {
-            // Setup initial data
-            connection.setCommands().sAdd(key1.getBytes(), "a".getBytes(), "b".getBytes(), "c".getBytes());
-            connection.setCommands().sAdd(key2.getBytes(), "b".getBytes(), "c".getBytes(), "d".getBytes());
-            
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Execute commands in pipeline - all should return null
-            Long sAddResult = connection.setCommands().sAdd(key1.getBytes(), "e".getBytes());
-            assertThat(sAddResult).isNull();
-            
-            Long sRemResult = connection.setCommands().sRem(key1.getBytes(), "a".getBytes());
-            assertThat(sRemResult).isNull();
-            
-            Long sCardResult = connection.setCommands().sCard(key1.getBytes());
-            assertThat(sCardResult).isNull();
-            
-            Boolean sIsMemberResult = connection.setCommands().sIsMember(key1.getBytes(), "b".getBytes());
-            assertThat(sIsMemberResult).isNull();
-            
-            Set<byte[]> sMembersResult = connection.setCommands().sMembers(key1.getBytes());
-            assertThat(sMembersResult).isNull();
-            
-            Set<byte[]> sDiffResult = connection.setCommands().sDiff(key1.getBytes(), key2.getBytes());
-            assertThat(sDiffResult).isNull();
-            
-            Long sDiffStoreResult = connection.setCommands().sDiffStore(destKey.getBytes(), key1.getBytes(), key2.getBytes());
-            assertThat(sDiffStoreResult).isNull();
-            
-            // Close pipeline and get results
-            List<Object> results = connection.closePipeline();
-            
-            // Verify pipeline results in order
-            assertThat(results).hasSize(7);
-            assertThat((Long) results.get(0)).isEqualTo(1L);  // sAdd added 1 element
-            assertThat((Long) results.get(1)).isEqualTo(1L);  // sRem removed 1 element
-            assertThat((Long) results.get(2)).isEqualTo(3L);  // sCard: b, c, e (a removed, e added)
-            assertThat((Boolean) results.get(3)).isTrue();    // sIsMember: b exists
-            
-            // Verify sMembers result
-            @SuppressWarnings("unchecked")
-            Set<byte[]> membersResult = (Set<byte[]>) results.get(4);
-            Set<String> memberStrings = membersResult.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toSet());
-            assertThat(memberStrings).containsExactlyInAnyOrder("b", "c", "e");
-            
-            // Verify sDiff result
-            @SuppressWarnings("unchecked")
-            Set<byte[]> diffResult = (Set<byte[]>) results.get(5);
-            Set<String> diffStrings = diffResult.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toSet());
-            assertThat(diffStrings).containsExactlyInAnyOrder("e");  // {b,c,e} - {b,c,d} = {e}
-            
-            assertThat((Long) results.get(6)).isEqualTo(1L);  // sDiffStore stored 1 element
-            
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-            cleanupKey(destKey);
-        }
-    }
+		try {
+			// Add some members
+			connection.setCommands().sAdd(key.getBytes(), value1, value2, value3);
 
-    @Test
-    void testSetOperationsWithMultipleValuesPipeline() {
-        String key = "test:set:pipeline:multi:key";
-        
-        try {
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Test commands with multiple values in pipeline
-            Long sAddResult = connection.setCommands().sAdd(key.getBytes(), "a".getBytes(), "b".getBytes(), "c".getBytes());
-            assertThat(sAddResult).isNull();
-            
-            List<Boolean> sMIsMemberResult = connection.setCommands().sMIsMember(key.getBytes(), 
-                "a".getBytes(), "b".getBytes(), "d".getBytes());
-            assertThat(sMIsMemberResult).isNull();
-            
-            Long sRemResult = connection.setCommands().sRem(key.getBytes(), "a".getBytes(), "b".getBytes());
-            assertThat(sRemResult).isNull();
-            
-            // Close pipeline and get results
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(3);
-            assertThat((Long) results.get(0)).isEqualTo(3L);  // sAdd added 3 elements
-            
-            @SuppressWarnings("unchecked")
-            List<Boolean> multiMemberResult = (List<Boolean>) results.get(1);
-            assertThat(multiMemberResult).containsExactly(true, true, false);  // a, b exist; d doesn't
-            
-            assertThat((Long) results.get(2)).isEqualTo(2L);  // sRem removed 2 elements
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test removing single member
+			Long remResult1 = connection.setCommands().sRem(key.getBytes(), value1);
+			assertThat(remResult1).isEqualTo(1L);
 
-    @Test
-    void testSetRandomOperationsPipeline() {
-        String key = "test:set:pipeline:random:key";
-        
-        try {
-            // Setup initial data
-            connection.setCommands().sAdd(key.getBytes(), "a".getBytes(), "b".getBytes(), "c".getBytes());
-            
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Test random operations in pipeline
-            byte[] sRandMemberResult = connection.setCommands().sRandMember(key.getBytes());
-            assertThat(sRandMemberResult).isNull();
-            
-            List<byte[]> sRandMemberMultiResult = connection.setCommands().sRandMember(key.getBytes(), 2);
-            assertThat(sRandMemberMultiResult).isNull();
-            
-            byte[] sPopResult = connection.setCommands().sPop(key.getBytes());
-            assertThat(sPopResult).isNull();
-            
-            List<byte[]> sPopMultiResult = connection.setCommands().sPop(key.getBytes(), 1);
-            assertThat(sPopMultiResult).isNull();
-            
-            // Close pipeline and get results
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(4);
-            
-            // sRandMember single result
-            byte[] randMember = (byte[]) results.get(0);
-            assertThat(randMember).isNotNull();
-            String randMemberStr = new String(randMember);
-            assertThat(randMemberStr).isIn("a", "b", "c");
-            
-            // sRandMember multiple result
-            @SuppressWarnings("unchecked")
-            List<byte[]> randMembers = (List<byte[]>) results.get(1);
-            assertThat(randMembers).hasSize(2);
-            
-            // sPop single result
-            byte[] poppedMember = (byte[]) results.get(2);
-            assertThat(poppedMember).isNotNull();
-            String poppedStr = new String(poppedMember);
-            assertThat(poppedStr).isIn("a", "b", "c");
-            
-            // sPop multiple result
-            @SuppressWarnings("unchecked")
-            List<byte[]> poppedMembers = (List<byte[]>) results.get(3);
-            assertThat(poppedMembers).hasSize(1);
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Verify member was removed
+			Boolean isMember = connection.setCommands().sIsMember(key.getBytes(), value1);
+			assertThat(isMember).isFalse();
 
-    // ==================== Transaction Mode Tests ====================
+			// Test removing multiple members
+			Long remResult2 = connection.setCommands().sRem(key.getBytes(), value2, value3);
+			assertThat(remResult2).isEqualTo(2L);
 
-    @Test
-    void testSetOperationsInTransactionMode() {
-        String key1 = "test:set:tx:key1";
-        String key2 = "test:set:tx:key2";
-        String destKey = "test:set:tx:dest";
-        
-        try {
-            // Setup initial data
-            connection.setCommands().sAdd(key1.getBytes(), "a".getBytes(), "b".getBytes(), "c".getBytes());
-            connection.setCommands().sAdd(key2.getBytes(), "b".getBytes(), "c".getBytes(), "d".getBytes());
-            
-            // Start transaction
-            connection.multi();
-            
-            // Execute commands in transaction - all should return null
-            Long sAddResult = connection.setCommands().sAdd(key1.getBytes(), "e".getBytes());
-            assertThat(sAddResult).isNull();
-            
-            Long sRemResult = connection.setCommands().sRem(key1.getBytes(), "a".getBytes());
-            assertThat(sRemResult).isNull();
-            
-            Long sCardResult = connection.setCommands().sCard(key1.getBytes());
-            assertThat(sCardResult).isNull();
-            
-            Boolean sIsMemberResult = connection.setCommands().sIsMember(key1.getBytes(), "b".getBytes());
-            assertThat(sIsMemberResult).isNull();
-            
-            Set<byte[]> sMembersResult = connection.setCommands().sMembers(key1.getBytes());
-            assertThat(sMembersResult).isNull();
-            
-            Set<byte[]> sInterResult = connection.setCommands().sInter(key1.getBytes(), key2.getBytes());
-            assertThat(sInterResult).isNull();
-            
-            Long sInterStoreResult = connection.setCommands().sInterStore(destKey.getBytes(), key1.getBytes(), key2.getBytes());
-            assertThat(sInterStoreResult).isNull();
-            
-            // Execute transaction and get results
-            List<Object> results = connection.exec();
-            
-            // Verify transaction results in order
-            assertThat(results).hasSize(7);
-            assertThat((Long) results.get(0)).isEqualTo(1L);  // sAdd added 1 element
-            assertThat((Long) results.get(1)).isEqualTo(1L);  // sRem removed 1 element
-            assertThat((Long) results.get(2)).isEqualTo(3L);  // sCard: b, c, e (a removed, e added)
-            assertThat((Boolean) results.get(3)).isTrue();    // sIsMember: b exists
-            
-            // Verify sMembers result
-            @SuppressWarnings("unchecked")
-            Set<byte[]> membersResult = (Set<byte[]>) results.get(4);
-            Set<String> memberStrings = membersResult.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toSet());
-            assertThat(memberStrings).containsExactlyInAnyOrder("b", "c", "e");
-            
-            // Verify sInter result
-            @SuppressWarnings("unchecked")
-            Set<byte[]> interResult = (Set<byte[]>) results.get(5);
-            Set<String> interStrings = interResult.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toSet());
-            assertThat(interStrings).containsExactlyInAnyOrder("b", "c");  // {b,c,e} ∩ {b,c,d} = {b,c}
-            
-            assertThat((Long) results.get(6)).isEqualTo(2L);  // sInterStore stored 2 elements
-            
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-            cleanupKey(destKey);
-        }
-    }
+			// Test removing non-existing member
+			Long remNonExist = connection.setCommands().sRem(key.getBytes(), nonMember);
+			assertThat(remNonExist).isEqualTo(0L);
 
-    @Test
-    void testSetAlgebraOperationsTransaction() {
-        String key1 = "test:set:tx:algebra:key1";
-        String key2 = "test:set:tx:algebra:key2";
-        String key3 = "test:set:tx:algebra:key3";
-        String diffDest = "test:set:tx:algebra:diff:dest";
-        String unionDest = "test:set:tx:algebra:union:dest";
-        
-        try {
-            // Setup initial data
-            connection.setCommands().sAdd(key1.getBytes(), "a".getBytes(), "b".getBytes());
-            connection.setCommands().sAdd(key2.getBytes(), "b".getBytes(), "c".getBytes());
-            connection.setCommands().sAdd(key3.getBytes(), "c".getBytes(), "d".getBytes());
-            
-            // Start transaction
-            connection.multi();
-            
-            // Test set algebra operations in transaction
-            Set<byte[]> sDiffResult = connection.setCommands().sDiff(key1.getBytes(), key2.getBytes());
-            assertThat(sDiffResult).isNull();
-            
-            Set<byte[]> sUnionResult = connection.setCommands().sUnion(key1.getBytes(), key2.getBytes(), key3.getBytes());
-            assertThat(sUnionResult).isNull();
-            
-            Long sDiffStoreResult = connection.setCommands().sDiffStore(diffDest.getBytes(), key1.getBytes(), key2.getBytes());
-            assertThat(sDiffStoreResult).isNull();
-            
-            Long sUnionStoreResult = connection.setCommands().sUnionStore(unionDest.getBytes(), key1.getBytes(), key2.getBytes(), key3.getBytes());
-            assertThat(sUnionStoreResult).isNull();
-            
-            // Execute transaction and get results
-            List<Object> results = connection.exec();
-            
-            // Verify results
-            assertThat(results).hasSize(4);
-            
-            // Verify sDiff result
-            @SuppressWarnings("unchecked")
-            Set<byte[]> diffResult = (Set<byte[]>) results.get(0);
-            Set<String> diffStrings = diffResult.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toSet());
-            assertThat(diffStrings).containsExactlyInAnyOrder("a");  // {a,b} - {b,c} = {a}
-            
-            // Verify sUnion result
-            @SuppressWarnings("unchecked")
-            Set<byte[]> unionResult = (Set<byte[]>) results.get(1);
-            Set<String> unionStrings = unionResult.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toSet());
-            assertThat(unionStrings).containsExactlyInAnyOrder("a", "b", "c", "d");  // {a,b} ∪ {b,c} ∪ {c,d}
-            
-            assertThat((Long) results.get(2)).isEqualTo(1L);  // sDiffStore stored 1 element
-            assertThat((Long) results.get(3)).isEqualTo(4L);  // sUnionStore stored 4 elements
-            
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-            cleanupKey(key3);
-            cleanupKey(diffDest);
-            cleanupKey(unionDest);
-        }
-    }
+			// Verify set is empty
+			Long card = connection.setCommands().sCard(key.getBytes());
+			assertThat(card).isEqualTo(0L);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
 
-    @Test
-    void testSetMoveOperationTransaction() {
-        String srcKey = "test:set:tx:move:src";
-        String destKey = "test:set:tx:move:dest";
-        
-        try {
-            // Setup initial data
-            connection.setCommands().sAdd(srcKey.getBytes(), "a".getBytes(), "b".getBytes(), "c".getBytes());
-            connection.setCommands().sAdd(destKey.getBytes(), "x".getBytes(), "y".getBytes());
-            
-            // Start transaction
-            connection.multi();
-            
-            // Test sMove operations in transaction
-            Boolean sMoveResult1 = connection.setCommands().sMove(srcKey.getBytes(), destKey.getBytes(), "a".getBytes());
-            assertThat(sMoveResult1).isNull();
-            
-            Boolean sMoveResult2 = connection.setCommands().sMove(srcKey.getBytes(), destKey.getBytes(), "nonexistent".getBytes());
-            assertThat(sMoveResult2).isNull();
-            
-            Long srcCardResult = connection.setCommands().sCard(srcKey.getBytes());
-            assertThat(srcCardResult).isNull();
-            
-            Long destCardResult = connection.setCommands().sCard(destKey.getBytes());
-            assertThat(destCardResult).isNull();
-            
-            // Execute transaction and get results
-            List<Object> results = connection.exec();
-            
-            // Verify results
-            assertThat(results).hasSize(4);
-            assertThat((Boolean) results.get(0)).isTrue();   // sMove successful
-            assertThat((Boolean) results.get(1)).isFalse();  // sMove failed (nonexistent element)
-            assertThat((Long) results.get(2)).isEqualTo(2L); // srcCard: b, c (a moved out)
-            assertThat((Long) results.get(3)).isEqualTo(3L); // destCard: x, y, a (a moved in)
-            
-        } finally {
-            cleanupKey(srcKey);
-            cleanupKey(destKey);
-        }
-    }
+	// ==================== Random Operations ====================
 
-    // ==================== Command-Response Index Correlation Tests ====================
+	@Test
+	void testSRandMember() {
+		String key = "test:set:randmember:key";
+		byte[] value1 = "member1".getBytes();
+		byte[] value2 = "member2".getBytes();
+		byte[] value3 = "member3".getBytes();
 
-    @Test
-    void testMixedSetOperationsPipelineIndexCorrelation() {
-        String key1 = "test:set:pipeline:mixed:key1";
-        String key2 = "test:set:pipeline:mixed:key2";
-        
-        try {
-            // Setup initial data
-            connection.setCommands().sAdd(key1.getBytes(), "a".getBytes(), "b".getBytes());
-            
-            // Start pipeline with mixed operations
-            connection.openPipeline();
-            
-            // Mix of different operation types to test index correlation
-            Long addResult = connection.setCommands().sAdd(key1.getBytes(), "c".getBytes());       // Index 0: Long
-            Boolean memberResult = connection.setCommands().sIsMember(key1.getBytes(), "b".getBytes()); // Index 1: Boolean
-            Set<byte[]> membersResult = connection.setCommands().sMembers(key1.getBytes());        // Index 2: Set<byte[]>
-            Long cardResult = connection.setCommands().sCard(key1.getBytes());                     // Index 3: Long
-            List<Boolean> multiMemberResult = connection.setCommands().sMIsMember(key1.getBytes(), 
-                "a".getBytes(), "d".getBytes());                                                   // Index 4: List<Boolean>
-            byte[] popResult = connection.setCommands().sPop(key1.getBytes());                     // Index 5: byte[]
-            Long remResult = connection.setCommands().sRem(key1.getBytes(), "b".getBytes());       // Index 6: Long
-            
-            // All should be null during pipeline
-            assertThat(addResult).isNull();
-            assertThat(memberResult).isNull();
-            assertThat(membersResult).isNull();
-            assertThat(cardResult).isNull();
-            assertThat(multiMemberResult).isNull();
-            assertThat(popResult).isNull();
-            assertThat(remResult).isNull();
-            
-            // Close pipeline and verify exact index correlation
-            List<Object> results = connection.closePipeline();
-            
-            assertThat(results).hasSize(7);
-            
-            // Index 0: sAdd result
-            assertThat((Long) results.get(0)).isEqualTo(1L);
-            
-            // Index 1: sIsMember result
-            assertThat((Boolean) results.get(1)).isTrue();
-            
-            // Index 2: sMembers result
-            @SuppressWarnings("unchecked")
-            Set<byte[]> members = (Set<byte[]>) results.get(2);
-            assertThat(members).hasSize(3); // a, b, c
-            
-            // Index 3: sCard result
-            assertThat((Long) results.get(3)).isEqualTo(3L);
-            
-            // Index 4: sMIsMember result
-            @SuppressWarnings("unchecked")
-            List<Boolean> multiMember = (List<Boolean>) results.get(4);
-            assertThat(multiMember).containsExactly(true, false); // a exists, d doesn't
-            
-            // Index 5: sPop result
-            byte[] popped = (byte[]) results.get(5);
-            assertThat(popped).isNotNull();
-            String poppedStr = new String(popped);
-            assertThat(poppedStr).isIn("a", "b", "c");
-            
-            // Index 6: sRem result (may be 0 or 1 depending on what was popped)
-            Long removed = (Long) results.get(6);
-            assertThat(removed).isBetween(0L, 1L);
-            
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-        }
-    }
+		try {
+			// Test sRandMember on empty set
+			byte[] emptyRand = connection.setCommands().sRandMember(key.getBytes());
+			assertThat(emptyRand).isNull();
 
-    @Test
-    void testComplexSetOperationsTransactionIndexCorrelation() {
-        String baseKey = "test:set:tx:complex:";
-        
-        try {
-            // Setup multiple keys with initial data
-            for (int i = 1; i <= 3; i++) {
-                connection.setCommands().sAdd((baseKey + i).getBytes(), 
-                    ("member" + i).getBytes(), "common".getBytes());
-            }
-            
-            // Start transaction with complex operations
-            connection.multi();
-            
-            // Create a complex sequence of operations to test exact index correlation
-            Long add1 = connection.setCommands().sAdd((baseKey + "1").getBytes(), "new1".getBytes());    // Index 0
-            Long add2 = connection.setCommands().sAdd((baseKey + "2").getBytes(), "new2".getBytes());    // Index 1
-            Long add3 = connection.setCommands().sAdd((baseKey + "3").getBytes(), "new3".getBytes());    // Index 2
-            
-            Set<byte[]> diff12 = connection.setCommands().sDiff((baseKey + "1").getBytes(), (baseKey + "2").getBytes()); // Index 3
-            Set<byte[]> inter123 = connection.setCommands().sInter((baseKey + "1").getBytes(), 
-                (baseKey + "2").getBytes(), (baseKey + "3").getBytes());                               // Index 4
-            Set<byte[]> union12 = connection.setCommands().sUnion((baseKey + "1").getBytes(), (baseKey + "2").getBytes()); // Index 5
-            
-            Long diffStore = connection.setCommands().sDiffStore((baseKey + "diff").getBytes(), 
-                (baseKey + "1").getBytes(), (baseKey + "3").getBytes());                               // Index 6
-            Long unionStore = connection.setCommands().sUnionStore((baseKey + "union").getBytes(), 
-                (baseKey + "1").getBytes(), (baseKey + "2").getBytes(), (baseKey + "3").getBytes());  // Index 7
-            
-            // All should be null during transaction
-            assertThat(add1).isNull();
-            assertThat(add2).isNull();
-            assertThat(add3).isNull();
-            assertThat(diff12).isNull();
-            assertThat(inter123).isNull();
-            assertThat(union12).isNull();
-            assertThat(diffStore).isNull();
-            assertThat(unionStore).isNull();
-            
-            // Execute transaction and verify exact index correlation
-            List<Object> results = connection.exec();
-            
-            assertThat(results).hasSize(8);
-            
-            // Verify each result at its exact index
-            assertThat((Long) results.get(0)).isEqualTo(1L);  // add1
-            assertThat((Long) results.get(1)).isEqualTo(1L);  // add2
-            assertThat((Long) results.get(2)).isEqualTo(1L);  // add3
-            
-            // Verify set operation results
-            @SuppressWarnings("unchecked")
-            Set<byte[]> diffResult = (Set<byte[]>) results.get(3);
-            Set<String> diffStrings = diffResult.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toSet());
-            assertThat(diffStrings).contains("member1", "new1"); // Elements unique to key1
-            
-            @SuppressWarnings("unchecked")
-            Set<byte[]> interResult = (Set<byte[]>) results.get(4);
-            Set<String> interStrings = interResult.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toSet());
-            assertThat(interStrings).containsExactly("common"); // Only common element
-            
-            @SuppressWarnings("unchecked")
-            Set<byte[]> unionResult = (Set<byte[]>) results.get(5);
-            assertThat(unionResult).hasSizeGreaterThanOrEqualTo(4); // At least: member1, member2, common, new1, new2
-            
-            assertThat((Long) results.get(6)).isGreaterThanOrEqualTo(1L);  // diffStore
-            assertThat((Long) results.get(7)).isGreaterThanOrEqualTo(5L);  // unionStore
-            
-        } finally {
-            for (int i = 1; i <= 3; i++) {
-                cleanupKey(baseKey + i);
-            }
-            cleanupKey(baseKey + "diff");
-            cleanupKey(baseKey + "union");
-        }
-    }
+			// Add members
+			connection.setCommands().sAdd(key.getBytes(), value1, value2, value3);
 
-    // ==================== Additional Pipeline Mode Tests for Complete Coverage ====================
+			// Test single random member
+			byte[] randomMember = connection.setCommands().sRandMember(key.getBytes());
+			assertThat(randomMember).isNotNull();
 
-    @Test
-    void testSetMoveAndAlgebraOperationsPipeline() {
-        String srcKey = "test:set:pipeline:move:src";
-        String destKey = "test:set:pipeline:move:dest";
-        String key1 = "test:set:pipeline:algebra:key1";
-        String key2 = "test:set:pipeline:algebra:key2";
-        String interDest = "test:set:pipeline:algebra:inter:dest";
-        String unionDest = "test:set:pipeline:algebra:union:dest";
-        
-        try {
-            // Setup initial data
-            connection.setCommands().sAdd(srcKey.getBytes(), "a".getBytes(), "b".getBytes());
-            connection.setCommands().sAdd(key1.getBytes(), "x".getBytes(), "y".getBytes());
-            connection.setCommands().sAdd(key2.getBytes(), "y".getBytes(), "z".getBytes());
-            
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Test sMove in pipeline
-            Boolean sMoveResult = connection.setCommands().sMove(srcKey.getBytes(), destKey.getBytes(), "a".getBytes());
-            assertThat(sMoveResult).isNull();
-            
-            // Test set algebra operations in pipeline
-            Set<byte[]> sInterResult = connection.setCommands().sInter(key1.getBytes(), key2.getBytes());
-            assertThat(sInterResult).isNull();
-            
-            Long sInterStoreResult = connection.setCommands().sInterStore(interDest.getBytes(), key1.getBytes(), key2.getBytes());
-            assertThat(sInterStoreResult).isNull();
-            
-            Set<byte[]> sUnionResult = connection.setCommands().sUnion(key1.getBytes(), key2.getBytes());
-            assertThat(sUnionResult).isNull();
-            
-            Long sUnionStoreResult = connection.setCommands().sUnionStore(unionDest.getBytes(), key1.getBytes(), key2.getBytes());
-            assertThat(sUnionStoreResult).isNull();
-            
-            // Close pipeline and get results
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(5);
-            assertThat((Boolean) results.get(0)).isTrue();  // sMove successful
-            
-            // Verify sInter result
-            @SuppressWarnings("unchecked")
-            Set<byte[]> interResult = (Set<byte[]>) results.get(1);
-            Set<String> interStrings = interResult.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toSet());
-            assertThat(interStrings).containsExactlyInAnyOrder("y");
-            
-            assertThat((Long) results.get(2)).isEqualTo(1L);  // sInterStore stored 1 element
-            
-            // Verify sUnion result
-            @SuppressWarnings("unchecked")
-            Set<byte[]> unionResult = (Set<byte[]>) results.get(3);
-            Set<String> unionStrings = unionResult.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toSet());
-            assertThat(unionStrings).containsExactlyInAnyOrder("x", "y", "z");
-            
-            assertThat((Long) results.get(4)).isEqualTo(3L);  // sUnionStore stored 3 elements
-            
-        } finally {
-            cleanupKey(srcKey);
-            cleanupKey(destKey);
-            cleanupKey(key1);
-            cleanupKey(key2);
-            cleanupKey(interDest);
-            cleanupKey(unionDest);
-        }
-    }
+			String randomMemberStr = new String(randomMember);
+			assertThat(randomMemberStr).isIn("member1", "member2", "member3");
 
-    @Test
-    void testSetScanOperationPipeline() {
-        String key = "test:set:pipeline:scan:key";
-        
-        try {
-            // Setup test set
-            for (int i = 0; i < 5; i++) {
-                connection.setCommands().sAdd(key.getBytes(), ("scan" + i).getBytes());
-            }
-            
-            // Note: sScan returns a Cursor which doesn't work in pipeline mode
-            // This test verifies that sScan operates correctly after pipeline operations
-            connection.openPipeline();
-            
-            // Execute other operations in pipeline
-            Long sCardResult = connection.setCommands().sCard(key.getBytes());
-            assertThat(sCardResult).isNull();
-            
-            // Close pipeline first
-            List<Object> results = connection.closePipeline();
-            assertThat(results).hasSize(1);
-            assertThat((Long) results.get(0)).isEqualTo(5L);
-            
-            // Now test sScan in immediate mode (sScan doesn't support pipeline/transaction modes)
-            ScanOptions options = ScanOptions.scanOptions().build();
-            Cursor<byte[]> cursor = connection.setCommands().sScan(key.getBytes(), options);
-            
-            java.util.List<String> scannedMembers = new java.util.ArrayList<>();
-            while (cursor.hasNext()) {
-                scannedMembers.add(new String(cursor.next()));
-            }
-            cursor.close();
-            
-            assertThat(scannedMembers).hasSize(5);
-            for (int i = 0; i < 5; i++) {
-                assertThat(scannedMembers).contains("scan" + i);
-            }
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test multiple random members
+			List<byte[]> randomMembers = connection.setCommands().sRandMember(key.getBytes(), 2);
+			assertThat(randomMembers).hasSize(2);
 
-    // ==================== Additional Transaction Mode Tests for Complete Coverage ====================
+			// Convert to strings for verification
+			List<String> randomMemberStrs = randomMembers.stream()
+				.map(String::new)
+				.collect(java.util.stream.Collectors.toList());
 
-    @Test
-    void testSetPopAndRandomOperationsTransaction() {
-        String popKey = "test:set:tx:pop:key";
-        String randKey = "test:set:tx:rand:key";
-        
-        try {
-            // Setup initial data
-            connection.setCommands().sAdd(popKey.getBytes(), "pop1".getBytes(), "pop2".getBytes(), "pop3".getBytes());
-            connection.setCommands().sAdd(randKey.getBytes(), "rand1".getBytes(), "rand2".getBytes(), "rand3".getBytes());
-            
-            // Start transaction
-            connection.multi();
-            
-            // Test sPop operations in transaction
-            byte[] sPopResult = connection.setCommands().sPop(popKey.getBytes());
-            assertThat(sPopResult).isNull();
-            
-            List<byte[]> sPopMultiResult = connection.setCommands().sPop(popKey.getBytes(), 1);
-            assertThat(sPopMultiResult).isNull();
-            
-            // Test sRandMember operations in transaction
-            byte[] sRandMemberResult = connection.setCommands().sRandMember(randKey.getBytes());
-            assertThat(sRandMemberResult).isNull();
-            
-            List<byte[]> sRandMemberMultiResult = connection.setCommands().sRandMember(randKey.getBytes(), 2);
-            assertThat(sRandMemberMultiResult).isNull();
-            
-            // Test sMIsMember in transaction
-            List<Boolean> sMIsMemberResult = connection.setCommands().sMIsMember(randKey.getBytes(), 
-                "rand1".getBytes(), "rand2".getBytes(), "nonexistent".getBytes());
-            assertThat(sMIsMemberResult).isNull();
-            
-            // Execute transaction and get results
-            List<Object> results = connection.exec();
-            
-            // Verify results
-            assertThat(results).hasSize(5);
-            
-            // sPop single result
-            byte[] poppedSingle = (byte[]) results.get(0);
-            assertThat(poppedSingle).isNotNull();
-            String poppedStr = new String(poppedSingle);
-            assertThat(poppedStr).isIn("pop1", "pop2", "pop3");
-            
-            // sPop multiple result
-            @SuppressWarnings("unchecked")
-            List<byte[]> poppedMulti = (List<byte[]>) results.get(1);
-            assertThat(poppedMulti).hasSize(1);
-            
-            // sRandMember single result
-            byte[] randSingle = (byte[]) results.get(2);
-            assertThat(randSingle).isNotNull();
-            String randStr = new String(randSingle);
-            assertThat(randStr).isIn("rand1", "rand2", "rand3");
-            
-            // sRandMember multiple result
-            @SuppressWarnings("unchecked")
-            List<byte[]> randMulti = (List<byte[]>) results.get(3);
-            assertThat(randMulti).hasSize(2);
-            
-            // sMIsMember result
-            @SuppressWarnings("unchecked")
-            List<Boolean> multiMemberResult = (List<Boolean>) results.get(4);
-            assertThat(multiMemberResult).containsExactly(true, true, false);
-            
-        } finally {
-            cleanupKey(popKey);
-            cleanupKey(randKey);
-        }
-    }
+			// All returned members should be valid
+			for (String member : randomMemberStrs) {
+				assertThat(member).isIn("member1", "member2", "member3");
+			}
 
-    @Test 
-    void testSetScanOperationTransaction() {
-        String key = "test:set:tx:scan:key";
-        
-        try {
-            // Setup test set
-            for (int i = 0; i < 5; i++) {
-                connection.setCommands().sAdd(key.getBytes(), ("txscan" + i).getBytes());
-            }
-            
-            // Note: sScan returns a Cursor which doesn't work in transaction mode
-            // This test verifies that sScan operates correctly after transaction operations
-            connection.multi();
-            
-            // Execute other operations in transaction
-            Long sCardResult = connection.setCommands().sCard(key.getBytes());
-            assertThat(sCardResult).isNull();
-            
-            // Execute transaction first
-            List<Object> results = connection.exec();
-            assertThat(results).hasSize(1);
-            assertThat((Long) results.get(0)).isEqualTo(5L);
-            
-            // Now test sScan in immediate mode (sScan doesn't support pipeline/transaction modes)
-            ScanOptions options = ScanOptions.scanOptions().build();
-            Cursor<byte[]> cursor = connection.setCommands().sScan(key.getBytes(), options);
-            
-            java.util.List<String> scannedMembers = new java.util.ArrayList<>();
-            while (cursor.hasNext()) {
-                scannedMembers.add(new String(cursor.next()));
-            }
-            cursor.close();
-            
-            assertThat(scannedMembers).hasSize(5);
-            for (int i = 0; i < 5; i++) {
-                assertThat(scannedMembers).contains("txscan" + i);
-            }
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test with count larger than set size
+			List<byte[]> moreMembers = connection.setCommands().sRandMember(key.getBytes(), 5);
+			assertThat(moreMembers).hasSizeLessThanOrEqualTo(3); // Should not exceed set
+																	// size
 
-    // ==================== Coverage Validation Test ====================
+			// Test with negative count (allows duplicates)
+			List<byte[]> negativeCount = connection.setCommands().sRandMember(key.getBytes(), -5);
+			assertThat(negativeCount).hasSize(5); // Should return exactly 5 elements
+													// (with possible duplicates)
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
 
-    @Test
-    void testCompleteValkeySetCommandsCoverage() {
-        // This test serves as documentation and validation that all 18 ValkeySetCommands methods
-        // are covered across all three invocation modes (immediate, pipeline, transaction)
-        
-        String key = "test:set:coverage:key";
-        
-        try {
-            // Verify all methods exist and are callable in immediate mode
-            connection.setCommands().sAdd(key.getBytes(), "test".getBytes());
-            connection.setCommands().sRem(key.getBytes(), "test".getBytes());
-            connection.setCommands().sAdd(key.getBytes(), "a".getBytes(), "b".getBytes(), "c".getBytes());
-            
-            // Single return methods
-            connection.setCommands().sPop(key.getBytes());
-            connection.setCommands().sRandMember(key.getBytes());
-            connection.setCommands().sCard(key.getBytes());
-            connection.setCommands().sIsMember(key.getBytes(), "a".getBytes());
-            
-            // Collection return methods  
-            connection.setCommands().sPop(key.getBytes(), 1);
-            connection.setCommands().sRandMember(key.getBytes(), 2);
-            connection.setCommands().sMIsMember(key.getBytes(), "a".getBytes(), "b".getBytes());
-            connection.setCommands().sMembers(key.getBytes());
-            
-            // Set algebra methods
-            connection.setCommands().sDiff(key.getBytes());
-            connection.setCommands().sInter(key.getBytes());
-            connection.setCommands().sUnion(key.getBytes());
-            
-            // Store methods
-            String destKey = "test:set:coverage:dest";
-            connection.setCommands().sDiffStore(destKey.getBytes(), key.getBytes());
-            connection.setCommands().sInterStore(destKey.getBytes(), key.getBytes());
-            connection.setCommands().sUnionStore(destKey.getBytes(), key.getBytes());
-            
-            // Move method
-            connection.setCommands().sMove(key.getBytes(), destKey.getBytes(), "a".getBytes());
-            
-            // Scan method
-            ScanOptions options = ScanOptions.scanOptions().build();
-            Cursor<byte[]> cursor = connection.setCommands().sScan(key.getBytes(), options);
-            cursor.close();
-            
-            // If we reach here, all 18 methods are implemented and callable
-            assertThat(true).isTrue(); // Coverage validation passed
-            
-            cleanupKey(destKey);
-        } finally {
-            cleanupKey(key);
-        }
-    }
+	@Test
+	void testSPop() {
+		String key = "test:set:pop:key";
+		byte[] value1 = "member1".getBytes();
+		byte[] value2 = "member2".getBytes();
+		byte[] value3 = "member3".getBytes();
 
-    // ==================== SINTERCARD Tests ====================
+		try {
+			// Test sPop on empty set
+			byte[] emptyPop = connection.setCommands().sPop(key.getBytes());
+			assertThat(emptyPop).isNull();
 
-    @Test
-    @EnabledOnCommand("SINTERCARD")
-    void testSInterCard() {
-        String key1 = "test:set:sintercard:key1";
-        String key2 = "test:set:sintercard:key2";
-        String key3 = "test:set:sintercard:key3";
+			// Add members
+			connection.setCommands().sAdd(key.getBytes(), value1, value2, value3);
 
-        try {
-            // Set up test data
-            connection.setCommands().sAdd(key1.getBytes(), "a".getBytes(), "b".getBytes(), "c".getBytes());
-            connection.setCommands().sAdd(key2.getBytes(), "b".getBytes(), "c".getBytes(), "d".getBytes());
-            connection.setCommands().sAdd(key3.getBytes(), "c".getBytes(), "d".getBytes(), "e".getBytes());
+			// Test single pop
+			byte[] poppedMember = connection.setCommands().sPop(key.getBytes());
+			assertThat(poppedMember).isNotNull();
 
-            // Test intersection cardinality of two keys
-            Long card2 = connection.setCommands().sInterCard(key1.getBytes(), key2.getBytes());
-            assertThat(card2).isEqualTo(2L); // b, c
+			String poppedStr = new String(poppedMember);
+			assertThat(poppedStr).isIn("member1", "member2", "member3");
 
-            // Test intersection cardinality of three keys
-            Long card3 = connection.setCommands().sInterCard(key1.getBytes(), key2.getBytes(), key3.getBytes());
-            assertThat(card3).isEqualTo(1L); // c
+			// Verify member was removed
+			Boolean stillMember = connection.setCommands().sIsMember(key.getBytes(), poppedMember);
+			assertThat(stillMember).isFalse();
 
-            // Test intersection with non-existent key
-            Long cardEmpty = connection.setCommands().sInterCard(key1.getBytes(), "non:existent".getBytes());
-            assertThat(cardEmpty).isEqualTo(0L);
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-            cleanupKey(key3);
-        }
-    }
+			// Verify cardinality decreased
+			Long card = connection.setCommands().sCard(key.getBytes());
+			assertThat(card).isEqualTo(2L);
+
+			// Test multiple pop
+			List<byte[]> poppedMembers = connection.setCommands().sPop(key.getBytes(), 2);
+			assertThat(poppedMembers).hasSize(2);
+
+			// Verify all were removed
+			Long finalCard = connection.setCommands().sCard(key.getBytes());
+			assertThat(finalCard).isEqualTo(0L);
+
+			// Test pop more than available
+			connection.setCommands().sAdd(key.getBytes(), value1);
+			List<byte[]> overPop = connection.setCommands().sPop(key.getBytes(), 5);
+			assertThat(overPop).hasSize(1); // Should only return what's available
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== Set Movement Operations ====================
+
+	@Test
+	void testSMove() {
+		String srcKey = "test:set:move:src";
+		String destKey = "test:set:move:dest";
+		byte[] value1 = "member1".getBytes();
+		byte[] value2 = "member2".getBytes();
+		byte[] nonMember = "nonmember".getBytes();
+
+		try {
+			// Setup source set
+			connection.setCommands().sAdd(srcKey.getBytes(), value1, value2);
+
+			// Test moving existing member
+			Boolean moveResult1 = connection.setCommands().sMove(srcKey.getBytes(), destKey.getBytes(), value1);
+			assertThat(moveResult1).isTrue();
+
+			// Verify member was removed from source
+			Boolean inSrc = connection.setCommands().sIsMember(srcKey.getBytes(), value1);
+			assertThat(inSrc).isFalse();
+
+			// Verify member was added to destination
+			Boolean inDest = connection.setCommands().sIsMember(destKey.getBytes(), value1);
+			assertThat(inDest).isTrue();
+
+			// Test moving non-existing member
+			Boolean moveResult2 = connection.setCommands().sMove(srcKey.getBytes(), destKey.getBytes(), nonMember);
+			assertThat(moveResult2).isFalse();
+
+			// Test moving from non-existing set
+			String nonExistentKey = "test:set:move:nonexistent";
+			Boolean moveResult3 = connection.setCommands().sMove(nonExistentKey.getBytes(), destKey.getBytes(), value2);
+			assertThat(moveResult3).isFalse();
+		}
+		finally {
+			cleanupKey(srcKey);
+			cleanupKey(destKey);
+			cleanupKey("test:set:move:nonexistent");
+		}
+	}
+
+	// ==================== Set Algebra Operations ====================
+
+	@Test
+	void testSDiff() {
+		String key1 = "test:set:diff:key1";
+		String key2 = "test:set:diff:key2";
+		String key3 = "test:set:diff:key3";
+
+		try {
+			// Setup test sets
+			// key1: {a, b, c, d}
+			connection.setCommands()
+				.sAdd(key1.getBytes(), "a".getBytes(), "b".getBytes(), "c".getBytes(), "d".getBytes());
+			// key2: {b, c, e}
+			connection.setCommands().sAdd(key2.getBytes(), "b".getBytes(), "c".getBytes(), "e".getBytes());
+			// key3: {d, f}
+			connection.setCommands().sAdd(key3.getBytes(), "d".getBytes(), "f".getBytes());
+
+			// Test diff of key1 - key2 (should be {a, d})
+			Set<byte[]> diff1 = connection.setCommands().sDiff(key1.getBytes(), key2.getBytes());
+			Set<String> diff1Strings = diff1.stream().map(String::new).collect(java.util.stream.Collectors.toSet());
+			assertThat(diff1Strings).containsExactlyInAnyOrder("a", "d");
+
+			// Test diff of key1 - key2 - key3 (should be {a})
+			Set<byte[]> diff2 = connection.setCommands().sDiff(key1.getBytes(), key2.getBytes(), key3.getBytes());
+			Set<String> diff2Strings = diff2.stream().map(String::new).collect(java.util.stream.Collectors.toSet());
+			assertThat(diff2Strings).containsExactlyInAnyOrder("a");
+
+			// Test diff with non-existent key
+			String nonExistentKey = "test:set:diff:nonexistent";
+			Set<byte[]> diff3 = connection.setCommands().sDiff(key1.getBytes(), nonExistentKey.getBytes());
+			Set<String> diff3Strings = diff3.stream().map(String::new).collect(java.util.stream.Collectors.toSet());
+			assertThat(diff3Strings).containsExactlyInAnyOrder("a", "b", "c", "d");
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+			cleanupKey(key3);
+		}
+	}
+
+	@Test
+	void testSDiffStore() {
+		String key1 = "test:set:diffstore:key1";
+		String key2 = "test:set:diffstore:key2";
+		String destKey = "test:set:diffstore:dest";
+
+		try {
+			// Setup test sets
+			connection.setCommands().sAdd(key1.getBytes(), "a".getBytes(), "b".getBytes(), "c".getBytes());
+			connection.setCommands().sAdd(key2.getBytes(), "b".getBytes(), "c".getBytes(), "d".getBytes());
+
+			// Test sDiffStore
+			Long storeResult = connection.setCommands()
+				.sDiffStore(destKey.getBytes(), key1.getBytes(), key2.getBytes());
+			assertThat(storeResult).isEqualTo(1L); // Should store 1 element: "a"
+
+			// Verify stored result
+			Set<byte[]> storedDiff = connection.setCommands().sMembers(destKey.getBytes());
+			Set<String> storedDiffStrings = storedDiff.stream()
+				.map(String::new)
+				.collect(java.util.stream.Collectors.toSet());
+			assertThat(storedDiffStrings).containsExactlyInAnyOrder("a");
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+			cleanupKey(destKey);
+		}
+	}
+
+	@Test
+	void testSInter() {
+		String key1 = "test:set:inter:key1";
+		String key2 = "test:set:inter:key2";
+		String key3 = "test:set:inter:key3";
+
+		try {
+			// Setup test sets
+			// key1: {a, b, c}
+			connection.setCommands().sAdd(key1.getBytes(), "a".getBytes(), "b".getBytes(), "c".getBytes());
+			// key2: {b, c, d}
+			connection.setCommands().sAdd(key2.getBytes(), "b".getBytes(), "c".getBytes(), "d".getBytes());
+			// key3: {c, d, e}
+			connection.setCommands().sAdd(key3.getBytes(), "c".getBytes(), "d".getBytes(), "e".getBytes());
+
+			// Test intersection of key1 and key2 (should be {b, c})
+			Set<byte[]> inter1 = connection.setCommands().sInter(key1.getBytes(), key2.getBytes());
+			Set<String> inter1Strings = inter1.stream().map(String::new).collect(java.util.stream.Collectors.toSet());
+			assertThat(inter1Strings).containsExactlyInAnyOrder("b", "c");
+
+			// Test intersection of all three (should be {c})
+			Set<byte[]> inter2 = connection.setCommands().sInter(key1.getBytes(), key2.getBytes(), key3.getBytes());
+			Set<String> inter2Strings = inter2.stream().map(String::new).collect(java.util.stream.Collectors.toSet());
+			assertThat(inter2Strings).containsExactlyInAnyOrder("c");
+
+			// Test intersection with non-existent key (should be empty)
+			String nonExistentKey = "test:set:inter:nonexistent";
+			Set<byte[]> inter3 = connection.setCommands().sInter(key1.getBytes(), nonExistentKey.getBytes());
+			assertThat(inter3).isEmpty();
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+			cleanupKey(key3);
+		}
+	}
+
+	@Test
+	void testSInterStore() {
+		String key1 = "test:set:interstore:key1";
+		String key2 = "test:set:interstore:key2";
+		String destKey = "test:set:interstore:dest";
+
+		try {
+			// Setup test sets
+			connection.setCommands().sAdd(key1.getBytes(), "a".getBytes(), "b".getBytes(), "c".getBytes());
+			connection.setCommands().sAdd(key2.getBytes(), "b".getBytes(), "c".getBytes(), "d".getBytes());
+
+			// Test sInterStore
+			Long storeResult = connection.setCommands()
+				.sInterStore(destKey.getBytes(), key1.getBytes(), key2.getBytes());
+			assertThat(storeResult).isEqualTo(2L); // Should store 2 elements: "b", "c"
+
+			// Verify stored result
+			Set<byte[]> storedInter = connection.setCommands().sMembers(destKey.getBytes());
+			Set<String> storedInterStrings = storedInter.stream()
+				.map(String::new)
+				.collect(java.util.stream.Collectors.toSet());
+			assertThat(storedInterStrings).containsExactlyInAnyOrder("b", "c");
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+			cleanupKey(destKey);
+		}
+	}
+
+	@Test
+	void testSUnion() {
+		String key1 = "test:set:union:key1";
+		String key2 = "test:set:union:key2";
+		String key3 = "test:set:union:key3";
+
+		try {
+			// Setup test sets
+			// key1: {a, b}
+			connection.setCommands().sAdd(key1.getBytes(), "a".getBytes(), "b".getBytes());
+			// key2: {b, c}
+			connection.setCommands().sAdd(key2.getBytes(), "b".getBytes(), "c".getBytes());
+			// key3: {c, d}
+			connection.setCommands().sAdd(key3.getBytes(), "c".getBytes(), "d".getBytes());
+
+			// Test union of key1 and key2 (should be {a, b, c})
+			Set<byte[]> union1 = connection.setCommands().sUnion(key1.getBytes(), key2.getBytes());
+			Set<String> union1Strings = union1.stream().map(String::new).collect(java.util.stream.Collectors.toSet());
+			assertThat(union1Strings).containsExactlyInAnyOrder("a", "b", "c");
+
+			// Test union of all three (should be {a, b, c, d})
+			Set<byte[]> union2 = connection.setCommands().sUnion(key1.getBytes(), key2.getBytes(), key3.getBytes());
+			Set<String> union2Strings = union2.stream().map(String::new).collect(java.util.stream.Collectors.toSet());
+			assertThat(union2Strings).containsExactlyInAnyOrder("a", "b", "c", "d");
+
+			// Test union with non-existent key
+			String nonExistentKey = "test:set:union:nonexistent";
+			Set<byte[]> union3 = connection.setCommands().sUnion(key1.getBytes(), nonExistentKey.getBytes());
+			Set<String> union3Strings = union3.stream().map(String::new).collect(java.util.stream.Collectors.toSet());
+			assertThat(union3Strings).containsExactlyInAnyOrder("a", "b");
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+			cleanupKey(key3);
+		}
+	}
+
+	@Test
+	void testSUnionStore() {
+		String key1 = "test:set:unionstore:key1";
+		String key2 = "test:set:unionstore:key2";
+		String destKey = "test:set:unionstore:dest";
+
+		try {
+			// Setup test sets
+			connection.setCommands().sAdd(key1.getBytes(), "a".getBytes(), "b".getBytes());
+			connection.setCommands().sAdd(key2.getBytes(), "b".getBytes(), "c".getBytes());
+
+			// Test sUnionStore
+			Long storeResult = connection.setCommands()
+				.sUnionStore(destKey.getBytes(), key1.getBytes(), key2.getBytes());
+			assertThat(storeResult).isEqualTo(3L); // Should store 3 elements: "a", "b",
+													// "c"
+
+			// Verify stored result
+			Set<byte[]> storedUnion = connection.setCommands().sMembers(destKey.getBytes());
+			Set<String> storedUnionStrings = storedUnion.stream()
+				.map(String::new)
+				.collect(java.util.stream.Collectors.toSet());
+			assertThat(storedUnionStrings).containsExactlyInAnyOrder("a", "b", "c");
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+			cleanupKey(destKey);
+		}
+	}
+
+	// ==================== Set Scanning Operations ====================
+
+	@Test
+	void testSScan() {
+		String key = "test:set:scan:key";
+
+		try {
+			// Setup test set with multiple members
+			for (int i = 0; i < 10; i++) {
+				connection.setCommands().sAdd(key.getBytes(), ("member" + i).getBytes());
+			}
+
+			// Test basic scan
+			ScanOptions options = ScanOptions.scanOptions().build();
+			Cursor<byte[]> cursor = connection.setCommands().sScan(key.getBytes(), options);
+
+			java.util.List<String> scannedMembers = new java.util.ArrayList<>();
+			while (cursor.hasNext()) {
+				scannedMembers.add(new String(cursor.next()));
+			}
+			cursor.close();
+
+			// Should find all members
+			assertThat(scannedMembers).hasSize(10);
+			for (int i = 0; i < 10; i++) {
+				assertThat(scannedMembers).contains("member" + i);
+			}
+
+			// Test scan with pattern
+			ScanOptions patternOptions = ScanOptions.scanOptions().match("member[1-3]").build();
+			Cursor<byte[]> patternCursor = connection.setCommands().sScan(key.getBytes(), patternOptions);
+
+			java.util.List<String> patternMembers = new java.util.ArrayList<>();
+			while (patternCursor.hasNext()) {
+				patternMembers.add(new String(patternCursor.next()));
+			}
+			patternCursor.close();
+
+			// Should find fewer members due to pattern filter
+			assertThat(patternMembers.size()).isLessThanOrEqualTo(3);
+
+			// Test scan with count
+			ScanOptions countOptions = ScanOptions.scanOptions().count(2).build();
+			Cursor<byte[]> countCursor = connection.setCommands().sScan(key.getBytes(), countOptions);
+
+			java.util.List<String> countMembers = new java.util.ArrayList<>();
+			while (countCursor.hasNext()) {
+				countMembers.add(new String(countCursor.next()));
+			}
+			countCursor.close();
+
+			// Should still find all members, but in smaller batches
+			assertThat(countMembers).hasSize(10);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== Error Handling and Edge Cases ====================
+
+	@Test
+	void testSetOperationsErrorHandling() {
+		// Test operations on null keys (should throw IllegalArgumentException)
+		assertThatThrownBy(() -> connection.setCommands().sAdd(null, "value".getBytes()))
+			.isInstanceOf(IllegalArgumentException.class);
+
+		assertThatThrownBy(() -> connection.setCommands().sRem(null, "value".getBytes()))
+			.isInstanceOf(IllegalArgumentException.class);
+
+		assertThatThrownBy(() -> connection.setCommands().sCard(null)).isInstanceOf(IllegalArgumentException.class);
+
+		// Test operations on empty keys (should throw IllegalArgumentException)
+		// assertThatThrownBy(() -> connection.setCommands().sAdd(new byte[0],
+		// "value".getBytes()))
+		// .isInstanceOf(IllegalArgumentException.class);
+
+		// assertThatThrownBy(() -> connection.setCommands().sRem(new byte[0],
+		// "value".getBytes()))
+		// .isInstanceOf(IllegalArgumentException.class);
+
+		// assertThatThrownBy(() -> connection.setCommands().sCard(new byte[0]))
+		// .isInstanceOf(IllegalArgumentException.class);
+
+		// Test operations with null values
+		assertThatThrownBy(() -> connection.setCommands().sAdd("key".getBytes(), (byte[]) null))
+			.isInstanceOf(IllegalArgumentException.class);
+
+		assertThatThrownBy(() -> connection.setCommands().sRem("key".getBytes(), (byte[]) null))
+			.isInstanceOf(IllegalArgumentException.class);
+
+		assertThatThrownBy(() -> connection.setCommands().sIsMember("key".getBytes(), null))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	void testSetOperationsEdgeCases() {
+		String key = "test:set:edge:key";
+
+		try {
+			// Test operations on very large values
+			byte[] largeValue = new byte[1024 * 10]; // 10KB value
+			java.util.Arrays.fill(largeValue, (byte) 'A');
+
+			Long addLarge = connection.setCommands().sAdd(key.getBytes(), largeValue);
+			assertThat(addLarge).isEqualTo(1L);
+
+			Boolean isLargeMember = connection.setCommands().sIsMember(key.getBytes(), largeValue);
+			assertThat(isLargeMember).isTrue();
+
+			Long remLarge = connection.setCommands().sRem(key.getBytes(), largeValue);
+			assertThat(remLarge).isEqualTo(1L);
+
+			// Test with empty value
+			byte[] emptyValue = new byte[0];
+			Long addEmpty = connection.setCommands().sAdd(key.getBytes(), emptyValue);
+			assertThat(addEmpty).isEqualTo(1L);
+
+			Boolean isEmptyMember = connection.setCommands().sIsMember(key.getBytes(), emptyValue);
+			assertThat(isEmptyMember).isTrue();
+
+			// Test with binary values
+			byte[] binaryValue = { 0x00, (byte) 0xFF, 0x7F, (byte) 0x80, 0x01 };
+			Long addBinary = connection.setCommands().sAdd(key.getBytes(), binaryValue);
+			assertThat(addBinary).isEqualTo(1L);
+
+			Boolean isBinaryMember = connection.setCommands().sIsMember(key.getBytes(), binaryValue);
+			assertThat(isBinaryMember).isTrue();
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testSetAlgebraEdgeCases() {
+		String key1 = "test:set:algebra:edge:key1";
+		String key2 = "test:set:algebra:edge:key2";
+		String destKey = "test:set:algebra:edge:dest";
+
+		try {
+			// Test operations with empty sets
+			Set<byte[]> emptyDiff = connection.setCommands().sDiff(key1.getBytes(), key2.getBytes());
+			assertThat(emptyDiff).isEmpty();
+
+			Set<byte[]> emptyInter = connection.setCommands().sInter(key1.getBytes(), key2.getBytes());
+			assertThat(emptyInter).isEmpty();
+
+			Set<byte[]> emptyUnion = connection.setCommands().sUnion(key1.getBytes(), key2.getBytes());
+			assertThat(emptyUnion).isEmpty();
+
+			// Test store operations with empty results
+			Long diffStore = connection.setCommands().sDiffStore(destKey.getBytes(), key1.getBytes(), key2.getBytes());
+			assertThat(diffStore).isEqualTo(0L);
+
+			Long interStore = connection.setCommands()
+				.sInterStore(destKey.getBytes(), key1.getBytes(), key2.getBytes());
+			assertThat(interStore).isEqualTo(0L);
+
+			Long unionStore = connection.setCommands()
+				.sUnionStore(destKey.getBytes(), key1.getBytes(), key2.getBytes());
+			assertThat(unionStore).isEqualTo(0L);
+
+			// Test with single set having data
+			connection.setCommands().sAdd(key1.getBytes(), "a".getBytes(), "b".getBytes());
+
+			Set<byte[]> diffSingle = connection.setCommands().sDiff(key1.getBytes(), key2.getBytes());
+			assertThat(diffSingle).hasSize(2);
+
+			Set<byte[]> unionSingle = connection.setCommands().sUnion(key1.getBytes(), key2.getBytes());
+			assertThat(unionSingle).hasSize(2);
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+			cleanupKey(destKey);
+		}
+	}
+
+	// ==================== Pipeline Mode Tests ====================
+
+	@Test
+	void testSetOperationsInPipelineMode() {
+		String key1 = "test:set:pipeline:key1";
+		String key2 = "test:set:pipeline:key2";
+		String destKey = "test:set:pipeline:dest";
+
+		try {
+			// Setup initial data
+			connection.setCommands().sAdd(key1.getBytes(), "a".getBytes(), "b".getBytes(), "c".getBytes());
+			connection.setCommands().sAdd(key2.getBytes(), "b".getBytes(), "c".getBytes(), "d".getBytes());
+
+			// Start pipeline
+			connection.openPipeline();
+
+			// Execute commands in pipeline - all should return null
+			Long sAddResult = connection.setCommands().sAdd(key1.getBytes(), "e".getBytes());
+			assertThat(sAddResult).isNull();
+
+			Long sRemResult = connection.setCommands().sRem(key1.getBytes(), "a".getBytes());
+			assertThat(sRemResult).isNull();
+
+			Long sCardResult = connection.setCommands().sCard(key1.getBytes());
+			assertThat(sCardResult).isNull();
+
+			Boolean sIsMemberResult = connection.setCommands().sIsMember(key1.getBytes(), "b".getBytes());
+			assertThat(sIsMemberResult).isNull();
+
+			Set<byte[]> sMembersResult = connection.setCommands().sMembers(key1.getBytes());
+			assertThat(sMembersResult).isNull();
+
+			Set<byte[]> sDiffResult = connection.setCommands().sDiff(key1.getBytes(), key2.getBytes());
+			assertThat(sDiffResult).isNull();
+
+			Long sDiffStoreResult = connection.setCommands()
+				.sDiffStore(destKey.getBytes(), key1.getBytes(), key2.getBytes());
+			assertThat(sDiffStoreResult).isNull();
+
+			// Close pipeline and get results
+			List<Object> results = connection.closePipeline();
+
+			// Verify pipeline results in order
+			assertThat(results).hasSize(7);
+			assertThat((Long) results.get(0)).isEqualTo(1L); // sAdd added 1 element
+			assertThat((Long) results.get(1)).isEqualTo(1L); // sRem removed 1 element
+			assertThat((Long) results.get(2)).isEqualTo(3L); // sCard: b, c, e (a removed,
+																// e added)
+			assertThat((Boolean) results.get(3)).isTrue(); // sIsMember: b exists
+
+			// Verify sMembers result
+			@SuppressWarnings("unchecked")
+			Set<byte[]> membersResult = (Set<byte[]>) results.get(4);
+			Set<String> memberStrings = membersResult.stream()
+				.map(String::new)
+				.collect(java.util.stream.Collectors.toSet());
+			assertThat(memberStrings).containsExactlyInAnyOrder("b", "c", "e");
+
+			// Verify sDiff result
+			@SuppressWarnings("unchecked")
+			Set<byte[]> diffResult = (Set<byte[]>) results.get(5);
+			Set<String> diffStrings = diffResult.stream().map(String::new).collect(java.util.stream.Collectors.toSet());
+			assertThat(diffStrings).containsExactlyInAnyOrder("e"); // {b,c,e} - {b,c,d} =
+																	// {e}
+
+			assertThat((Long) results.get(6)).isEqualTo(1L); // sDiffStore stored 1
+																// element
+
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+			cleanupKey(destKey);
+		}
+	}
+
+	@Test
+	void testSetOperationsWithMultipleValuesPipeline() {
+		String key = "test:set:pipeline:multi:key";
+
+		try {
+			// Start pipeline
+			connection.openPipeline();
+
+			// Test commands with multiple values in pipeline
+			Long sAddResult = connection.setCommands()
+				.sAdd(key.getBytes(), "a".getBytes(), "b".getBytes(), "c".getBytes());
+			assertThat(sAddResult).isNull();
+
+			List<Boolean> sMIsMemberResult = connection.setCommands()
+				.sMIsMember(key.getBytes(), "a".getBytes(), "b".getBytes(), "d".getBytes());
+			assertThat(sMIsMemberResult).isNull();
+
+			Long sRemResult = connection.setCommands().sRem(key.getBytes(), "a".getBytes(), "b".getBytes());
+			assertThat(sRemResult).isNull();
+
+			// Close pipeline and get results
+			List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(3);
+			assertThat((Long) results.get(0)).isEqualTo(3L); // sAdd added 3 elements
+
+			@SuppressWarnings("unchecked")
+			List<Boolean> multiMemberResult = (List<Boolean>) results.get(1);
+			assertThat(multiMemberResult).containsExactly(true, true, false); // a, b
+																				// exist;
+																				// d
+																				// doesn't
+
+			assertThat((Long) results.get(2)).isEqualTo(2L); // sRem removed 2 elements
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testSetRandomOperationsPipeline() {
+		String key = "test:set:pipeline:random:key";
+
+		try {
+			// Setup initial data
+			connection.setCommands().sAdd(key.getBytes(), "a".getBytes(), "b".getBytes(), "c".getBytes());
+
+			// Start pipeline
+			connection.openPipeline();
+
+			// Test random operations in pipeline
+			byte[] sRandMemberResult = connection.setCommands().sRandMember(key.getBytes());
+			assertThat(sRandMemberResult).isNull();
+
+			List<byte[]> sRandMemberMultiResult = connection.setCommands().sRandMember(key.getBytes(), 2);
+			assertThat(sRandMemberMultiResult).isNull();
+
+			byte[] sPopResult = connection.setCommands().sPop(key.getBytes());
+			assertThat(sPopResult).isNull();
+
+			List<byte[]> sPopMultiResult = connection.setCommands().sPop(key.getBytes(), 1);
+			assertThat(sPopMultiResult).isNull();
+
+			// Close pipeline and get results
+			List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(4);
+
+			// sRandMember single result
+			byte[] randMember = (byte[]) results.get(0);
+			assertThat(randMember).isNotNull();
+			String randMemberStr = new String(randMember);
+			assertThat(randMemberStr).isIn("a", "b", "c");
+
+			// sRandMember multiple result
+			@SuppressWarnings("unchecked")
+			List<byte[]> randMembers = (List<byte[]>) results.get(1);
+			assertThat(randMembers).hasSize(2);
+
+			// sPop single result
+			byte[] poppedMember = (byte[]) results.get(2);
+			assertThat(poppedMember).isNotNull();
+			String poppedStr = new String(poppedMember);
+			assertThat(poppedStr).isIn("a", "b", "c");
+
+			// sPop multiple result
+			@SuppressWarnings("unchecked")
+			List<byte[]> poppedMembers = (List<byte[]>) results.get(3);
+			assertThat(poppedMembers).hasSize(1);
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== Transaction Mode Tests ====================
+
+	@Test
+	void testSetOperationsInTransactionMode() {
+		String key1 = "test:set:tx:key1";
+		String key2 = "test:set:tx:key2";
+		String destKey = "test:set:tx:dest";
+
+		try {
+			// Setup initial data
+			connection.setCommands().sAdd(key1.getBytes(), "a".getBytes(), "b".getBytes(), "c".getBytes());
+			connection.setCommands().sAdd(key2.getBytes(), "b".getBytes(), "c".getBytes(), "d".getBytes());
+
+			// Start transaction
+			connection.multi();
+
+			// Execute commands in transaction - all should return null
+			Long sAddResult = connection.setCommands().sAdd(key1.getBytes(), "e".getBytes());
+			assertThat(sAddResult).isNull();
+
+			Long sRemResult = connection.setCommands().sRem(key1.getBytes(), "a".getBytes());
+			assertThat(sRemResult).isNull();
+
+			Long sCardResult = connection.setCommands().sCard(key1.getBytes());
+			assertThat(sCardResult).isNull();
+
+			Boolean sIsMemberResult = connection.setCommands().sIsMember(key1.getBytes(), "b".getBytes());
+			assertThat(sIsMemberResult).isNull();
+
+			Set<byte[]> sMembersResult = connection.setCommands().sMembers(key1.getBytes());
+			assertThat(sMembersResult).isNull();
+
+			Set<byte[]> sInterResult = connection.setCommands().sInter(key1.getBytes(), key2.getBytes());
+			assertThat(sInterResult).isNull();
+
+			Long sInterStoreResult = connection.setCommands()
+				.sInterStore(destKey.getBytes(), key1.getBytes(), key2.getBytes());
+			assertThat(sInterStoreResult).isNull();
+
+			// Execute transaction and get results
+			List<Object> results = connection.exec();
+
+			// Verify transaction results in order
+			assertThat(results).hasSize(7);
+			assertThat((Long) results.get(0)).isEqualTo(1L); // sAdd added 1 element
+			assertThat((Long) results.get(1)).isEqualTo(1L); // sRem removed 1 element
+			assertThat((Long) results.get(2)).isEqualTo(3L); // sCard: b, c, e (a removed,
+																// e added)
+			assertThat((Boolean) results.get(3)).isTrue(); // sIsMember: b exists
+
+			// Verify sMembers result
+			@SuppressWarnings("unchecked")
+			Set<byte[]> membersResult = (Set<byte[]>) results.get(4);
+			Set<String> memberStrings = membersResult.stream()
+				.map(String::new)
+				.collect(java.util.stream.Collectors.toSet());
+			assertThat(memberStrings).containsExactlyInAnyOrder("b", "c", "e");
+
+			// Verify sInter result
+			@SuppressWarnings("unchecked")
+			Set<byte[]> interResult = (Set<byte[]>) results.get(5);
+			Set<String> interStrings = interResult.stream()
+				.map(String::new)
+				.collect(java.util.stream.Collectors.toSet());
+			assertThat(interStrings).containsExactlyInAnyOrder("b", "c"); // {b,c,e} ∩
+																			// {b,c,d} =
+																			// {b,c}
+
+			assertThat((Long) results.get(6)).isEqualTo(2L); // sInterStore stored 2
+																// elements
+
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+			cleanupKey(destKey);
+		}
+	}
+
+	@Test
+	void testSetAlgebraOperationsTransaction() {
+		String key1 = "test:set:tx:algebra:key1";
+		String key2 = "test:set:tx:algebra:key2";
+		String key3 = "test:set:tx:algebra:key3";
+		String diffDest = "test:set:tx:algebra:diff:dest";
+		String unionDest = "test:set:tx:algebra:union:dest";
+
+		try {
+			// Setup initial data
+			connection.setCommands().sAdd(key1.getBytes(), "a".getBytes(), "b".getBytes());
+			connection.setCommands().sAdd(key2.getBytes(), "b".getBytes(), "c".getBytes());
+			connection.setCommands().sAdd(key3.getBytes(), "c".getBytes(), "d".getBytes());
+
+			// Start transaction
+			connection.multi();
+
+			// Test set algebra operations in transaction
+			Set<byte[]> sDiffResult = connection.setCommands().sDiff(key1.getBytes(), key2.getBytes());
+			assertThat(sDiffResult).isNull();
+
+			Set<byte[]> sUnionResult = connection.setCommands()
+				.sUnion(key1.getBytes(), key2.getBytes(), key3.getBytes());
+			assertThat(sUnionResult).isNull();
+
+			Long sDiffStoreResult = connection.setCommands()
+				.sDiffStore(diffDest.getBytes(), key1.getBytes(), key2.getBytes());
+			assertThat(sDiffStoreResult).isNull();
+
+			Long sUnionStoreResult = connection.setCommands()
+				.sUnionStore(unionDest.getBytes(), key1.getBytes(), key2.getBytes(), key3.getBytes());
+			assertThat(sUnionStoreResult).isNull();
+
+			// Execute transaction and get results
+			List<Object> results = connection.exec();
+
+			// Verify results
+			assertThat(results).hasSize(4);
+
+			// Verify sDiff result
+			@SuppressWarnings("unchecked")
+			Set<byte[]> diffResult = (Set<byte[]>) results.get(0);
+			Set<String> diffStrings = diffResult.stream().map(String::new).collect(java.util.stream.Collectors.toSet());
+			assertThat(diffStrings).containsExactlyInAnyOrder("a"); // {a,b} - {b,c} = {a}
+
+			// Verify sUnion result
+			@SuppressWarnings("unchecked")
+			Set<byte[]> unionResult = (Set<byte[]>) results.get(1);
+			Set<String> unionStrings = unionResult.stream()
+				.map(String::new)
+				.collect(java.util.stream.Collectors.toSet());
+			assertThat(unionStrings).containsExactlyInAnyOrder("a", "b", "c", "d"); // {a,b}
+																					// ∪
+																					// {b,c}
+																					// ∪
+																					// {c,d}
+
+			assertThat((Long) results.get(2)).isEqualTo(1L); // sDiffStore stored 1
+																// element
+			assertThat((Long) results.get(3)).isEqualTo(4L); // sUnionStore stored 4
+																// elements
+
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+			cleanupKey(key3);
+			cleanupKey(diffDest);
+			cleanupKey(unionDest);
+		}
+	}
+
+	@Test
+	void testSetMoveOperationTransaction() {
+		String srcKey = "test:set:tx:move:src";
+		String destKey = "test:set:tx:move:dest";
+
+		try {
+			// Setup initial data
+			connection.setCommands().sAdd(srcKey.getBytes(), "a".getBytes(), "b".getBytes(), "c".getBytes());
+			connection.setCommands().sAdd(destKey.getBytes(), "x".getBytes(), "y".getBytes());
+
+			// Start transaction
+			connection.multi();
+
+			// Test sMove operations in transaction
+			Boolean sMoveResult1 = connection.setCommands()
+				.sMove(srcKey.getBytes(), destKey.getBytes(), "a".getBytes());
+			assertThat(sMoveResult1).isNull();
+
+			Boolean sMoveResult2 = connection.setCommands()
+				.sMove(srcKey.getBytes(), destKey.getBytes(), "nonexistent".getBytes());
+			assertThat(sMoveResult2).isNull();
+
+			Long srcCardResult = connection.setCommands().sCard(srcKey.getBytes());
+			assertThat(srcCardResult).isNull();
+
+			Long destCardResult = connection.setCommands().sCard(destKey.getBytes());
+			assertThat(destCardResult).isNull();
+
+			// Execute transaction and get results
+			List<Object> results = connection.exec();
+
+			// Verify results
+			assertThat(results).hasSize(4);
+			assertThat((Boolean) results.get(0)).isTrue(); // sMove successful
+			assertThat((Boolean) results.get(1)).isFalse(); // sMove failed (nonexistent
+															// element)
+			assertThat((Long) results.get(2)).isEqualTo(2L); // srcCard: b, c (a moved
+																// out)
+			assertThat((Long) results.get(3)).isEqualTo(3L); // destCard: x, y, a (a moved
+																// in)
+
+		}
+		finally {
+			cleanupKey(srcKey);
+			cleanupKey(destKey);
+		}
+	}
+
+	// ==================== Command-Response Index Correlation Tests ====================
+
+	@Test
+	void testMixedSetOperationsPipelineIndexCorrelation() {
+		String key1 = "test:set:pipeline:mixed:key1";
+		String key2 = "test:set:pipeline:mixed:key2";
+
+		try {
+			// Setup initial data
+			connection.setCommands().sAdd(key1.getBytes(), "a".getBytes(), "b".getBytes());
+
+			// Start pipeline with mixed operations
+			connection.openPipeline();
+
+			// Mix of different operation types to test index correlation
+			Long addResult = connection.setCommands().sAdd(key1.getBytes(), "c".getBytes()); // Index
+																								// 0:
+																								// Long
+			Boolean memberResult = connection.setCommands().sIsMember(key1.getBytes(), "b".getBytes()); // Index
+																										// 1:
+																										// Boolean
+			Set<byte[]> membersResult = connection.setCommands().sMembers(key1.getBytes()); // Index
+																							// 2:
+																							// Set<byte[]>
+			Long cardResult = connection.setCommands().sCard(key1.getBytes()); // Index 3:
+																				// Long
+			List<Boolean> multiMemberResult = connection.setCommands()
+				.sMIsMember(key1.getBytes(), "a".getBytes(), "d".getBytes()); // Index 4:
+																				// List<Boolean>
+			byte[] popResult = connection.setCommands().sPop(key1.getBytes()); // Index 5:
+																				// byte[]
+			Long remResult = connection.setCommands().sRem(key1.getBytes(), "b".getBytes()); // Index
+																								// 6:
+																								// Long
+
+			// All should be null during pipeline
+			assertThat(addResult).isNull();
+			assertThat(memberResult).isNull();
+			assertThat(membersResult).isNull();
+			assertThat(cardResult).isNull();
+			assertThat(multiMemberResult).isNull();
+			assertThat(popResult).isNull();
+			assertThat(remResult).isNull();
+
+			// Close pipeline and verify exact index correlation
+			List<Object> results = connection.closePipeline();
+
+			assertThat(results).hasSize(7);
+
+			// Index 0: sAdd result
+			assertThat((Long) results.get(0)).isEqualTo(1L);
+
+			// Index 1: sIsMember result
+			assertThat((Boolean) results.get(1)).isTrue();
+
+			// Index 2: sMembers result
+			@SuppressWarnings("unchecked")
+			Set<byte[]> members = (Set<byte[]>) results.get(2);
+			assertThat(members).hasSize(3); // a, b, c
+
+			// Index 3: sCard result
+			assertThat((Long) results.get(3)).isEqualTo(3L);
+
+			// Index 4: sMIsMember result
+			@SuppressWarnings("unchecked")
+			List<Boolean> multiMember = (List<Boolean>) results.get(4);
+			assertThat(multiMember).containsExactly(true, false); // a exists, d doesn't
+
+			// Index 5: sPop result
+			byte[] popped = (byte[]) results.get(5);
+			assertThat(popped).isNotNull();
+			String poppedStr = new String(popped);
+			assertThat(poppedStr).isIn("a", "b", "c");
+
+			// Index 6: sRem result (may be 0 or 1 depending on what was popped)
+			Long removed = (Long) results.get(6);
+			assertThat(removed).isBetween(0L, 1L);
+
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+		}
+	}
+
+	@Test
+	void testComplexSetOperationsTransactionIndexCorrelation() {
+		String baseKey = "test:set:tx:complex:";
+
+		try {
+			// Setup multiple keys with initial data
+			for (int i = 1; i <= 3; i++) {
+				connection.setCommands().sAdd((baseKey + i).getBytes(), ("member" + i).getBytes(), "common".getBytes());
+			}
+
+			// Start transaction with complex operations
+			connection.multi();
+
+			// Create a complex sequence of operations to test exact index correlation
+			Long add1 = connection.setCommands().sAdd((baseKey + "1").getBytes(), "new1".getBytes()); // Index
+																										// 0
+			Long add2 = connection.setCommands().sAdd((baseKey + "2").getBytes(), "new2".getBytes()); // Index
+																										// 1
+			Long add3 = connection.setCommands().sAdd((baseKey + "3").getBytes(), "new3".getBytes()); // Index
+																										// 2
+
+			Set<byte[]> diff12 = connection.setCommands().sDiff((baseKey + "1").getBytes(), (baseKey + "2").getBytes()); // Index
+																															// 3
+			Set<byte[]> inter123 = connection.setCommands()
+				.sInter((baseKey + "1").getBytes(), (baseKey + "2").getBytes(), (baseKey + "3").getBytes()); // Index
+																												// 4
+			Set<byte[]> union12 = connection.setCommands()
+				.sUnion((baseKey + "1").getBytes(), (baseKey + "2").getBytes()); // Index
+																					// 5
+
+			Long diffStore = connection.setCommands()
+				.sDiffStore((baseKey + "diff").getBytes(), (baseKey + "1").getBytes(), (baseKey + "3").getBytes()); // Index
+																													// 6
+			Long unionStore = connection.setCommands()
+				.sUnionStore((baseKey + "union").getBytes(), (baseKey + "1").getBytes(), (baseKey + "2").getBytes(),
+						(baseKey + "3").getBytes()); // Index 7
+
+			// All should be null during transaction
+			assertThat(add1).isNull();
+			assertThat(add2).isNull();
+			assertThat(add3).isNull();
+			assertThat(diff12).isNull();
+			assertThat(inter123).isNull();
+			assertThat(union12).isNull();
+			assertThat(diffStore).isNull();
+			assertThat(unionStore).isNull();
+
+			// Execute transaction and verify exact index correlation
+			List<Object> results = connection.exec();
+
+			assertThat(results).hasSize(8);
+
+			// Verify each result at its exact index
+			assertThat((Long) results.get(0)).isEqualTo(1L); // add1
+			assertThat((Long) results.get(1)).isEqualTo(1L); // add2
+			assertThat((Long) results.get(2)).isEqualTo(1L); // add3
+
+			// Verify set operation results
+			@SuppressWarnings("unchecked")
+			Set<byte[]> diffResult = (Set<byte[]>) results.get(3);
+			Set<String> diffStrings = diffResult.stream().map(String::new).collect(java.util.stream.Collectors.toSet());
+			assertThat(diffStrings).contains("member1", "new1"); // Elements unique to
+																	// key1
+
+			@SuppressWarnings("unchecked")
+			Set<byte[]> interResult = (Set<byte[]>) results.get(4);
+			Set<String> interStrings = interResult.stream()
+				.map(String::new)
+				.collect(java.util.stream.Collectors.toSet());
+			assertThat(interStrings).containsExactly("common"); // Only common element
+
+			@SuppressWarnings("unchecked")
+			Set<byte[]> unionResult = (Set<byte[]>) results.get(5);
+			assertThat(unionResult).hasSizeGreaterThanOrEqualTo(4); // At least: member1,
+																	// member2, common,
+																	// new1, new2
+
+			assertThat((Long) results.get(6)).isGreaterThanOrEqualTo(1L); // diffStore
+			assertThat((Long) results.get(7)).isGreaterThanOrEqualTo(5L); // unionStore
+
+		}
+		finally {
+			for (int i = 1; i <= 3; i++) {
+				cleanupKey(baseKey + i);
+			}
+			cleanupKey(baseKey + "diff");
+			cleanupKey(baseKey + "union");
+		}
+	}
+
+	// ==================== Additional Pipeline Mode Tests for Complete Coverage
+	// ====================
+
+	@Test
+	void testSetMoveAndAlgebraOperationsPipeline() {
+		String srcKey = "test:set:pipeline:move:src";
+		String destKey = "test:set:pipeline:move:dest";
+		String key1 = "test:set:pipeline:algebra:key1";
+		String key2 = "test:set:pipeline:algebra:key2";
+		String interDest = "test:set:pipeline:algebra:inter:dest";
+		String unionDest = "test:set:pipeline:algebra:union:dest";
+
+		try {
+			// Setup initial data
+			connection.setCommands().sAdd(srcKey.getBytes(), "a".getBytes(), "b".getBytes());
+			connection.setCommands().sAdd(key1.getBytes(), "x".getBytes(), "y".getBytes());
+			connection.setCommands().sAdd(key2.getBytes(), "y".getBytes(), "z".getBytes());
+
+			// Start pipeline
+			connection.openPipeline();
+
+			// Test sMove in pipeline
+			Boolean sMoveResult = connection.setCommands().sMove(srcKey.getBytes(), destKey.getBytes(), "a".getBytes());
+			assertThat(sMoveResult).isNull();
+
+			// Test set algebra operations in pipeline
+			Set<byte[]> sInterResult = connection.setCommands().sInter(key1.getBytes(), key2.getBytes());
+			assertThat(sInterResult).isNull();
+
+			Long sInterStoreResult = connection.setCommands()
+				.sInterStore(interDest.getBytes(), key1.getBytes(), key2.getBytes());
+			assertThat(sInterStoreResult).isNull();
+
+			Set<byte[]> sUnionResult = connection.setCommands().sUnion(key1.getBytes(), key2.getBytes());
+			assertThat(sUnionResult).isNull();
+
+			Long sUnionStoreResult = connection.setCommands()
+				.sUnionStore(unionDest.getBytes(), key1.getBytes(), key2.getBytes());
+			assertThat(sUnionStoreResult).isNull();
+
+			// Close pipeline and get results
+			List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(5);
+			assertThat((Boolean) results.get(0)).isTrue(); // sMove successful
+
+			// Verify sInter result
+			@SuppressWarnings("unchecked")
+			Set<byte[]> interResult = (Set<byte[]>) results.get(1);
+			Set<String> interStrings = interResult.stream()
+				.map(String::new)
+				.collect(java.util.stream.Collectors.toSet());
+			assertThat(interStrings).containsExactlyInAnyOrder("y");
+
+			assertThat((Long) results.get(2)).isEqualTo(1L); // sInterStore stored 1
+																// element
+
+			// Verify sUnion result
+			@SuppressWarnings("unchecked")
+			Set<byte[]> unionResult = (Set<byte[]>) results.get(3);
+			Set<String> unionStrings = unionResult.stream()
+				.map(String::new)
+				.collect(java.util.stream.Collectors.toSet());
+			assertThat(unionStrings).containsExactlyInAnyOrder("x", "y", "z");
+
+			assertThat((Long) results.get(4)).isEqualTo(3L); // sUnionStore stored 3
+																// elements
+
+		}
+		finally {
+			cleanupKey(srcKey);
+			cleanupKey(destKey);
+			cleanupKey(key1);
+			cleanupKey(key2);
+			cleanupKey(interDest);
+			cleanupKey(unionDest);
+		}
+	}
+
+	@Test
+	void testSetScanOperationPipeline() {
+		String key = "test:set:pipeline:scan:key";
+
+		try {
+			// Setup test set
+			for (int i = 0; i < 5; i++) {
+				connection.setCommands().sAdd(key.getBytes(), ("scan" + i).getBytes());
+			}
+
+			// Note: sScan returns a Cursor which doesn't work in pipeline mode
+			// This test verifies that sScan operates correctly after pipeline operations
+			connection.openPipeline();
+
+			// Execute other operations in pipeline
+			Long sCardResult = connection.setCommands().sCard(key.getBytes());
+			assertThat(sCardResult).isNull();
+
+			// Close pipeline first
+			List<Object> results = connection.closePipeline();
+			assertThat(results).hasSize(1);
+			assertThat((Long) results.get(0)).isEqualTo(5L);
+
+			// Now test sScan in immediate mode (sScan doesn't support
+			// pipeline/transaction modes)
+			ScanOptions options = ScanOptions.scanOptions().build();
+			Cursor<byte[]> cursor = connection.setCommands().sScan(key.getBytes(), options);
+
+			java.util.List<String> scannedMembers = new java.util.ArrayList<>();
+			while (cursor.hasNext()) {
+				scannedMembers.add(new String(cursor.next()));
+			}
+			cursor.close();
+
+			assertThat(scannedMembers).hasSize(5);
+			for (int i = 0; i < 5; i++) {
+				assertThat(scannedMembers).contains("scan" + i);
+			}
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== Additional Transaction Mode Tests for Complete Coverage
+	// ====================
+
+	@Test
+	void testSetPopAndRandomOperationsTransaction() {
+		String popKey = "test:set:tx:pop:key";
+		String randKey = "test:set:tx:rand:key";
+
+		try {
+			// Setup initial data
+			connection.setCommands().sAdd(popKey.getBytes(), "pop1".getBytes(), "pop2".getBytes(), "pop3".getBytes());
+			connection.setCommands()
+				.sAdd(randKey.getBytes(), "rand1".getBytes(), "rand2".getBytes(), "rand3".getBytes());
+
+			// Start transaction
+			connection.multi();
+
+			// Test sPop operations in transaction
+			byte[] sPopResult = connection.setCommands().sPop(popKey.getBytes());
+			assertThat(sPopResult).isNull();
+
+			List<byte[]> sPopMultiResult = connection.setCommands().sPop(popKey.getBytes(), 1);
+			assertThat(sPopMultiResult).isNull();
+
+			// Test sRandMember operations in transaction
+			byte[] sRandMemberResult = connection.setCommands().sRandMember(randKey.getBytes());
+			assertThat(sRandMemberResult).isNull();
+
+			List<byte[]> sRandMemberMultiResult = connection.setCommands().sRandMember(randKey.getBytes(), 2);
+			assertThat(sRandMemberMultiResult).isNull();
+
+			// Test sMIsMember in transaction
+			List<Boolean> sMIsMemberResult = connection.setCommands()
+				.sMIsMember(randKey.getBytes(), "rand1".getBytes(), "rand2".getBytes(), "nonexistent".getBytes());
+			assertThat(sMIsMemberResult).isNull();
+
+			// Execute transaction and get results
+			List<Object> results = connection.exec();
+
+			// Verify results
+			assertThat(results).hasSize(5);
+
+			// sPop single result
+			byte[] poppedSingle = (byte[]) results.get(0);
+			assertThat(poppedSingle).isNotNull();
+			String poppedStr = new String(poppedSingle);
+			assertThat(poppedStr).isIn("pop1", "pop2", "pop3");
+
+			// sPop multiple result
+			@SuppressWarnings("unchecked")
+			List<byte[]> poppedMulti = (List<byte[]>) results.get(1);
+			assertThat(poppedMulti).hasSize(1);
+
+			// sRandMember single result
+			byte[] randSingle = (byte[]) results.get(2);
+			assertThat(randSingle).isNotNull();
+			String randStr = new String(randSingle);
+			assertThat(randStr).isIn("rand1", "rand2", "rand3");
+
+			// sRandMember multiple result
+			@SuppressWarnings("unchecked")
+			List<byte[]> randMulti = (List<byte[]>) results.get(3);
+			assertThat(randMulti).hasSize(2);
+
+			// sMIsMember result
+			@SuppressWarnings("unchecked")
+			List<Boolean> multiMemberResult = (List<Boolean>) results.get(4);
+			assertThat(multiMemberResult).containsExactly(true, true, false);
+
+		}
+		finally {
+			cleanupKey(popKey);
+			cleanupKey(randKey);
+		}
+	}
+
+	@Test
+	void testSetScanOperationTransaction() {
+		String key = "test:set:tx:scan:key";
+
+		try {
+			// Setup test set
+			for (int i = 0; i < 5; i++) {
+				connection.setCommands().sAdd(key.getBytes(), ("txscan" + i).getBytes());
+			}
+
+			// Note: sScan returns a Cursor which doesn't work in transaction mode
+			// This test verifies that sScan operates correctly after transaction
+			// operations
+			connection.multi();
+
+			// Execute other operations in transaction
+			Long sCardResult = connection.setCommands().sCard(key.getBytes());
+			assertThat(sCardResult).isNull();
+
+			// Execute transaction first
+			List<Object> results = connection.exec();
+			assertThat(results).hasSize(1);
+			assertThat((Long) results.get(0)).isEqualTo(5L);
+
+			// Now test sScan in immediate mode (sScan doesn't support
+			// pipeline/transaction modes)
+			ScanOptions options = ScanOptions.scanOptions().build();
+			Cursor<byte[]> cursor = connection.setCommands().sScan(key.getBytes(), options);
+
+			java.util.List<String> scannedMembers = new java.util.ArrayList<>();
+			while (cursor.hasNext()) {
+				scannedMembers.add(new String(cursor.next()));
+			}
+			cursor.close();
+
+			assertThat(scannedMembers).hasSize(5);
+			for (int i = 0; i < 5; i++) {
+				assertThat(scannedMembers).contains("txscan" + i);
+			}
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== Coverage Validation Test ====================
+
+	@Test
+	void testCompleteValkeySetCommandsCoverage() {
+		// This test serves as documentation and validation that all 18 ValkeySetCommands
+		// methods
+		// are covered across all three invocation modes (immediate, pipeline,
+		// transaction)
+
+		String key = "test:set:coverage:key";
+
+		try {
+			// Verify all methods exist and are callable in immediate mode
+			connection.setCommands().sAdd(key.getBytes(), "test".getBytes());
+			connection.setCommands().sRem(key.getBytes(), "test".getBytes());
+			connection.setCommands().sAdd(key.getBytes(), "a".getBytes(), "b".getBytes(), "c".getBytes());
+
+			// Single return methods
+			connection.setCommands().sPop(key.getBytes());
+			connection.setCommands().sRandMember(key.getBytes());
+			connection.setCommands().sCard(key.getBytes());
+			connection.setCommands().sIsMember(key.getBytes(), "a".getBytes());
+
+			// Collection return methods
+			connection.setCommands().sPop(key.getBytes(), 1);
+			connection.setCommands().sRandMember(key.getBytes(), 2);
+			connection.setCommands().sMIsMember(key.getBytes(), "a".getBytes(), "b".getBytes());
+			connection.setCommands().sMembers(key.getBytes());
+
+			// Set algebra methods
+			connection.setCommands().sDiff(key.getBytes());
+			connection.setCommands().sInter(key.getBytes());
+			connection.setCommands().sUnion(key.getBytes());
+
+			// Store methods
+			String destKey = "test:set:coverage:dest";
+			connection.setCommands().sDiffStore(destKey.getBytes(), key.getBytes());
+			connection.setCommands().sInterStore(destKey.getBytes(), key.getBytes());
+			connection.setCommands().sUnionStore(destKey.getBytes(), key.getBytes());
+
+			// Move method
+			connection.setCommands().sMove(key.getBytes(), destKey.getBytes(), "a".getBytes());
+
+			// Scan method
+			ScanOptions options = ScanOptions.scanOptions().build();
+			Cursor<byte[]> cursor = connection.setCommands().sScan(key.getBytes(), options);
+			cursor.close();
+
+			// If we reach here, all 18 methods are implemented and callable
+			assertThat(true).isTrue(); // Coverage validation passed
+
+			cleanupKey(destKey);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== SINTERCARD Tests ====================
+
+	@Test
+	@EnabledOnCommand("SINTERCARD")
+	void testSInterCard() {
+		String key1 = "test:set:sintercard:key1";
+		String key2 = "test:set:sintercard:key2";
+		String key3 = "test:set:sintercard:key3";
+
+		try {
+			// Set up test data
+			connection.setCommands().sAdd(key1.getBytes(), "a".getBytes(), "b".getBytes(), "c".getBytes());
+			connection.setCommands().sAdd(key2.getBytes(), "b".getBytes(), "c".getBytes(), "d".getBytes());
+			connection.setCommands().sAdd(key3.getBytes(), "c".getBytes(), "d".getBytes(), "e".getBytes());
+
+			// Test intersection cardinality of two keys
+			Long card2 = connection.setCommands().sInterCard(key1.getBytes(), key2.getBytes());
+			assertThat(card2).isEqualTo(2L); // b, c
+
+			// Test intersection cardinality of three keys
+			Long card3 = connection.setCommands().sInterCard(key1.getBytes(), key2.getBytes(), key3.getBytes());
+			assertThat(card3).isEqualTo(1L); // c
+
+			// Test intersection with non-existent key
+			Long cardEmpty = connection.setCommands().sInterCard(key1.getBytes(), "non:existent".getBytes());
+			assertThat(cardEmpty).isEqualTo(0L);
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+			cleanupKey(key3);
+		}
+	}
 
 }

--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionStreamCommandsIntegrationTests.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionStreamCommandsIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,1821 +41,1810 @@ import io.valkey.springframework.data.valkey.ValkeySystemException;
 import io.valkey.springframework.data.valkey.test.condition.EnabledOnCommand;
 
 /**
- * Comprehensive low-level integration tests for {@link ValkeyGlideConnection} 
- * stream functionality using the ValkeyStreamCommands interface directly.
- * 
- * These tests systematically validate all ValkeyStreamCommands methods in three modes:
- * 1. IMMEDIATE MODE - Direct command execution
- * 2. PIPELINE MODE - Batched command execution
+ * Comprehensive low-level integration tests for {@link ValkeyGlideConnection} stream
+ * functionality using the ValkeyStreamCommands interface directly.
+ *
+ * These tests systematically validate all ValkeyStreamCommands methods in three modes: 1.
+ * IMMEDIATE MODE - Direct command execution 2. PIPELINE MODE - Batched command execution
  * 3. TRANSACTION MODE - Atomic command execution
- * 
- * Stream Commands Coverage:
- * - Basic operations: xAdd, xDel, xLen, xTrim
- * - Range queries: xRange, xRevRange  
- * - Stream reading: xRead, xReadGroup
- * - Consumer groups: xGroupCreate, xGroupDestroy, xGroupDelConsumer
- * - Acknowledgements: xAck
- * - Message claiming: xClaim, xClaimJustId
- * - Pending messages: xPending (summary and detailed)
- * - Stream information: xInfo, xInfoGroups, xInfoConsumers
- * - Error handling and edge cases
+ *
+ * Stream Commands Coverage: - Basic operations: xAdd, xDel, xLen, xTrim - Range queries:
+ * xRange, xRevRange - Stream reading: xRead, xReadGroup - Consumer groups: xGroupCreate,
+ * xGroupDestroy, xGroupDelConsumer - Acknowledgements: xAck - Message claiming: xClaim,
+ * xClaimJustId - Pending messages: xPending (summary and detailed) - Stream information:
+ * xInfo, xInfoGroups, xInfoConsumers - Error handling and edge cases
  *
  * @author Ilia Kolominsky
  * @since 2.0
  */
 public class ValkeyGlideConnectionStreamCommandsIntegrationTests extends AbstractValkeyGlideIntegrationTests {
-    
-    // Helper method to safely get value from byte array map by key content
-    private byte[] getValueByKeyContent(Map<byte[], byte[]> map, String keyContent) {
-        return map.entrySet().stream()
-            .filter(entry -> java.util.Arrays.equals(entry.getKey(), keyContent.getBytes()))
-            .map(Map.Entry::getValue)
-            .findFirst()
-            .orElse(null);
-    }
-
-    @Override
-    protected String[] getTestKeyPatterns() {
-        return new String[]{
-            "test:stream:basic", "test:stream:group", "test:stream:consumer",
-            "test:stream:read", "test:stream:claim", "test:stream:pending",
-            "test:stream:info", "test:stream:range", "test:stream:trim",
-            "test:stream:validation", "test:stream:pipeline", "test:stream:transaction",
-            "test:stream:edge", "test:stream:multi*", "test:stream:source*", "test:stream:target*"
-        };
-    }
-
-    // ==================== Basic Stream Operations ====================
-
-    @Test
-    void testStreamBasicOperations() {
-        String streamKey = "test:stream:basic";
-        
-        try {
-            // Test adding records
-            Map<byte[], byte[]> fields1 = Map.of(
-                "field1".getBytes(), "value1".getBytes(),
-                "field2".getBytes(), "value2".getBytes()
-            );
-            
-            MapRecord<byte[], byte[], byte[]> record1 = StreamRecords.newRecord()
-                .in(streamKey.getBytes())
-                .ofMap(fields1);
-            
-            RecordId id1 = connection.streamCommands().xAdd(record1);
-            assertThat(id1).isNotNull();
-            assertThat(id1.getValue()).isNotEmpty();
-            
-            // Test stream length
-            Long length = connection.streamCommands().xLen(streamKey.getBytes());
-            assertThat(length).isEqualTo(1L);
-            
-            // Add another record with auto-generated ID (avoid potential ID conflicts)
-            Map<byte[], byte[]> fields2 = Map.of(
-                "field3".getBytes(), "value3".getBytes()
-            );
-            
-            MapRecord<byte[], byte[], byte[]> record2 = StreamRecords.newRecord()
-                .in(streamKey.getBytes())
-                .ofMap(fields2);
-            
-            RecordId id2 = connection.streamCommands().xAdd(record2);
-            assertThat(id2).isNotNull();
-            assertThat(id2.getValue()).isNotEmpty();
-            
-            // Test stream length after second record
-            length = connection.streamCommands().xLen(streamKey.getBytes());
-            assertThat(length).isEqualTo(2L);
-            
-            // Test deleting a record
-            Long deletedCount = connection.streamCommands().xDel(streamKey.getBytes(), id1);
-            assertThat(deletedCount).isEqualTo(1L);
-            
-            // Verify length after deletion
-            length = connection.streamCommands().xLen(streamKey.getBytes());
-            assertThat(length).isEqualTo(1L);
-            
-            // Test deleting non-existent record
-            RecordId nonExistentId = RecordId.of("9999-0");
-            deletedCount = connection.streamCommands().xDel(streamKey.getBytes(), nonExistentId);
-            assertThat(deletedCount).isEqualTo(0L);
-            
-        } finally {
-            cleanupKey(streamKey);
-        }
-    }
-
-    @Test
-    void testStreamWithOptions() {
-        String streamKey = "test:stream:options";
-        
-        try {
-            Map<byte[], byte[]> fields = Map.of(
-                "field1".getBytes(), "value1".getBytes()
-            );
-            
-            // Test with MAXLEN option
-            MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
-                .in(streamKey.getBytes())
-                .ofMap(fields);
-            
-            ValkeyStreamCommands.XAddOptions options = ValkeyStreamCommands.XAddOptions.maxlen(5);
-            RecordId id = connection.streamCommands().xAdd(record, options);
-            assertThat(id).isNotNull();
-            
-            // Test with approximation trimming
-            ValkeyStreamCommands.XAddOptions approxOptions = ValkeyStreamCommands.XAddOptions.maxlen(10)
-                .approximateTrimming(true);
-            
-            RecordId id2 = connection.streamCommands().xAdd(record, approxOptions);
-            assertThat(id2).isNotNull();
-            
-        } finally {
-            cleanupKey(streamKey);
-        }
-    }
-
-    // ==================== Range Operations ====================
-
-    @Test
-    void testStreamRangeOperations() {
-        String streamKey = "test:stream:range";
-        
-        try {
-            // Add multiple records
-            for (int i = 0; i < 5; i++) {
-                Map<byte[], byte[]> fields = Map.of(
-                    "index".getBytes(), String.valueOf(i).getBytes(),
-                    "data".getBytes(), ("data" + i).getBytes()
-                );
-                
-                MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
-                    .in(streamKey.getBytes())
-                    .ofMap(fields);
-                
-                connection.streamCommands().xAdd(record);
-            }
-            
-            // Test reading all records
-            List<ByteRecord> allRecords = connection.streamCommands()
-                .xRange(streamKey.getBytes(), Range.unbounded(), Limit.unlimited());
-            
-            assertThat(allRecords).hasSize(5);
-            
-            // Check if any key in the first record's value matches "index" content
-            boolean hasIndexKey = allRecords.get(0).getValue().keySet().stream()
-                .anyMatch(key -> java.util.Arrays.equals(key, "index".getBytes()));
-            assertThat(hasIndexKey).isTrue();
-            
-            // Test with limit
-            List<ByteRecord> limitedRecords = connection.streamCommands()
-                .xRange(streamKey.getBytes(), Range.unbounded(), Limit.limit().count(3));
-            
-            assertThat(limitedRecords).hasSize(3);
-            
-            // Test reverse range
-            List<ByteRecord> reverseRecords = connection.streamCommands()
-                .xRevRange(streamKey.getBytes(), Range.unbounded(), Limit.unlimited());
-            
-            assertThat(reverseRecords).hasSize(5);
-            // First record in reverse should be the last one added
-            byte[] indexValue = getValueByKeyContent(reverseRecords.get(0).getValue(), "index");
-            assertThat(indexValue).isNotNull();
-            assertThat(new String(indexValue)).isEqualTo("4");
-            
-        } finally {
-            cleanupKey(streamKey);
-        }
-    }
-
-    @Test
-    void testStreamRangeBoundaryOperations() {
-        String streamKey = "test:stream:boundary";
-        
-        try {
-            // Add exactly 3 records to have clear boundaries for testing
-            List<RecordId> recordIds = new ArrayList<>();
-            for (int i = 0; i < 3; i++) {
-                Map<byte[], byte[]> fields = Map.of(
-                    "index".getBytes(), String.valueOf(i).getBytes(),
-                    "data".getBytes(), ("record" + i).getBytes()
-                );
-                
-                MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
-                    .in(streamKey.getBytes())
-                    .ofMap(fields);
-                
-                RecordId recordId = connection.streamCommands().xAdd(record);
-                recordIds.add(recordId);
-            }
-            
-            // Verify we have 3 records total
-            assertThat(recordIds).hasSize(3);
-            
-            RecordId firstId = recordIds.get(0);
-            RecordId middleId = recordIds.get(1);
-            RecordId lastId = recordIds.get(2);
-            
-            // Test inclusive range - should include both boundary records
-            List<ByteRecord> inclusiveRange = connection.streamCommands().xRange(
-                streamKey.getBytes(),
-                Range.from(Range.Bound.inclusive(firstId.getValue())).to(Range.Bound.inclusive(middleId.getValue())),
-                Limit.unlimited()
-            );
-            assertThat(inclusiveRange).hasSize(2);
-            assertThat(inclusiveRange.get(0).getId()).isEqualTo(firstId);
-            assertThat(inclusiveRange.get(1).getId()).isEqualTo(middleId);
-            
-            // Test exclusive lower bound - should exclude first record, include middle
-            List<ByteRecord> exclusiveLowerRange = connection.streamCommands().xRange(
-                streamKey.getBytes(),
-                Range.from(Range.Bound.exclusive(firstId.getValue())).to(Range.Bound.inclusive(middleId.getValue())),
-                Limit.unlimited()
-            );
-            assertThat(exclusiveLowerRange).hasSize(1);
-            assertThat(exclusiveLowerRange.get(0).getId()).isEqualTo(middleId);
-            
-            // Test exclusive upper bound - should include first record, exclude middle  
-            List<ByteRecord> exclusiveUpperRange = connection.streamCommands().xRange(
-                streamKey.getBytes(),
-                Range.from(Range.Bound.inclusive(firstId.getValue())).to(Range.Bound.exclusive(middleId.getValue())),
-                Limit.unlimited()
-            );
-            assertThat(exclusiveUpperRange).hasSize(1);
-            assertThat(exclusiveUpperRange.get(0).getId()).isEqualTo(firstId);
-            
-            // Test both bounds exclusive - should return no records (only first and middle are in range)
-            List<ByteRecord> bothExclusiveRange = connection.streamCommands().xRange(
-                streamKey.getBytes(),
-                Range.from(Range.Bound.exclusive(firstId.getValue())).to(Range.Bound.exclusive(middleId.getValue())),
-                Limit.unlimited()
-            );
-            assertThat(bothExclusiveRange).hasSize(0);
-            
-            // Test reverse range with boundaries
-            // Inclusive reverse range - should include both boundary records in reverse order
-            List<ByteRecord> inclusiveRevRange = connection.streamCommands().xRevRange(
-                streamKey.getBytes(),
-                Range.from(Range.Bound.inclusive(firstId.getValue())).to(Range.Bound.inclusive(lastId.getValue())),
-                Limit.unlimited()
-            );
-            assertThat(inclusiveRevRange).hasSize(3);
-            assertThat(inclusiveRevRange.get(0).getId()).isEqualTo(lastId);   // Last record first in reverse
-            assertThat(inclusiveRevRange.get(1).getId()).isEqualTo(middleId); // Middle record
-            assertThat(inclusiveRevRange.get(2).getId()).isEqualTo(firstId);  // First record last in reverse
-            
-            // Exclusive reverse range - exclude first record
-            List<ByteRecord> exclusiveRevRange = connection.streamCommands().xRevRange(
-                streamKey.getBytes(),
-                Range.from(Range.Bound.exclusive(firstId.getValue())).to(Range.Bound.inclusive(lastId.getValue())),
-                Limit.unlimited()
-            );
-            assertThat(exclusiveRevRange).hasSize(2);
-            assertThat(exclusiveRevRange.get(0).getId()).isEqualTo(lastId);   // Last record first
-            assertThat(exclusiveRevRange.get(1).getId()).isEqualTo(middleId); // Middle record second
-            
-            // Exclusive reverse range - exclude last record  
-            List<ByteRecord> exclusiveUpperRevRange = connection.streamCommands().xRevRange(
-                streamKey.getBytes(),
-                Range.from(Range.Bound.inclusive(firstId.getValue())).to(Range.Bound.exclusive(lastId.getValue())),
-                Limit.unlimited()
-            );
-            assertThat(exclusiveUpperRevRange).hasSize(2);
-            assertThat(exclusiveUpperRevRange.get(0).getId()).isEqualTo(middleId); // Middle record first in reverse
-            assertThat(exclusiveUpperRevRange.get(1).getId()).isEqualTo(firstId);  // First record second in reverse
-            
-        } finally {
-            cleanupKey(streamKey);
-        }
-    }
-
-    // ==================== Consumer Group Operations ====================
-
-    @Test
-    void testConsumerGroupOperations() {
-        String streamKey = "test:stream:group";
-        String groupName = "test-group";
-        String consumerName = "test-consumer";
-        
-        try {
-            // Add some records first
-            Map<byte[], byte[]> fields = Map.of(
-                "field1".getBytes(), "value1".getBytes()
-            );
-            
-            MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
-                .in(streamKey.getBytes())
-                .ofMap(fields);
-            
-            connection.streamCommands().xAdd(record);
-            
-            // Create consumer group using MKSTREAM to avoid "key doesn't exist" error
-            String result = connection.streamCommands()
-                .xGroupCreate(streamKey.getBytes(), groupName, ReadOffset.from("0"), true);
-            assertThat(result).isEqualTo("OK");
-            
-            // Test destroying consumer group
-            Boolean destroyed = connection.streamCommands()
-                .xGroupDestroy(streamKey.getBytes(), groupName);
-            assertThat(destroyed).isTrue();
-            
-            // Try to destroy non-existent group
-            Boolean notDestroyed = connection.streamCommands()
-                .xGroupDestroy(streamKey.getBytes(), "non-existent");
-            assertThat(notDestroyed).isFalse();
-            
-            // Create group again with MKSTREAM option
-            String streamKey2 = "test:stream:group:mkstream";
-            try {
-                String result2 = connection.streamCommands()
-                    .xGroupCreate(streamKey2.getBytes(), groupName, ReadOffset.latest(), true);
-                assertThat(result2).isEqualTo("OK");
-                
-                // Verify stream was created
-                Long length = connection.streamCommands().xLen(streamKey2.getBytes());
-                assertThat(length).isEqualTo(0L);
-                
-            } finally {
-                try {
-                    connection.streamCommands().xGroupDestroy(streamKey2.getBytes(), groupName);
-                } catch (Exception ignored) {}
-                cleanupKey(streamKey2);
-            }
-            
-        } finally {
-            try {
-                connection.streamCommands().xGroupDestroy(streamKey.getBytes(), groupName);
-            } catch (Exception ignored) {}
-            cleanupKey(streamKey);
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    void testConsumerManagement() {
-        String streamKey = "test:stream:consumer";
-        String groupName = "test-group";
-        String consumerName = "test-consumer";
-        
-        try {
-            // Add record and create group
-            Map<byte[], byte[]> fields = Map.of("field1".getBytes(), "value1".getBytes());
-            MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
-                .in(streamKey.getBytes())
-                .ofMap(fields);
-            
-            connection.streamCommands().xAdd(record);
-            connection.streamCommands().xGroupCreate(streamKey.getBytes(), groupName, ReadOffset.from("0"));
-            
-            Consumer consumer = Consumer.from(groupName, consumerName);
-            
-            // Read a message to create the consumer
-            List<ByteRecord> records = connection.streamCommands().xReadGroup(
-                consumer,
-                StreamReadOptions.empty(),
-                StreamOffset.create(streamKey.getBytes(), ReadOffset.lastConsumed())
-            );
-            
-            if (!records.isEmpty()) {
-            // Delete the consumer - should return true for existing consumer with pending messages
-            Boolean deleted = connection.streamCommands()
-                .xGroupDelConsumer(streamKey.getBytes(), consumer);
-            assertThat(deleted).isTrue();
-        }
-        
-        // Try to delete non-existent consumer - should return false
-        Consumer nonExistentConsumer = Consumer.from(groupName, "non-existent");
-        Boolean notDeleted = connection.streamCommands()
-            .xGroupDelConsumer(streamKey.getBytes(), nonExistentConsumer);
-        assertThat(notDeleted).isFalse();
-            
-        } finally {
-            try {
-                connection.streamCommands().xGroupDestroy(streamKey.getBytes(), groupName);
-            } catch (Exception ignored) {}
-            cleanupKey(streamKey);
-        }
-    }
-
-    // ==================== Stream Reading Operations ====================
-
-    @SuppressWarnings("unchecked")
-    @Test
-    void testStreamReading() {
-        String streamKey = "test:stream:read";
-        
-        try {
-            // Add some test records
-            for (int i = 0; i < 3; i++) {
-                Map<byte[], byte[]> fields = Map.of(
-                    "index".getBytes(), String.valueOf(i).getBytes()
-                );
-                
-                MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
-                    .in(streamKey.getBytes())
-                    .ofMap(fields);
-                
-                connection.streamCommands().xAdd(record);
-            }
-            
-            // Test reading from beginning
-            List<ByteRecord> records = connection.streamCommands().xRead(
-                StreamReadOptions.empty(),
-                StreamOffset.create(streamKey.getBytes(), ReadOffset.from("0"))
-            );
-            
-            assertThat(records).hasSize(3);
-            
-            // Test reading with count limit
-            List<ByteRecord> limitedRecords = connection.streamCommands().xRead(
-                StreamReadOptions.empty().count(2),
-                StreamOffset.create(streamKey.getBytes(), ReadOffset.from("0"))
-            );
-            
-            assertThat(limitedRecords).hasSize(2);
-            
-        } finally {
-            cleanupKey(streamKey);
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    void testStreamGroupReading() {
-        String streamKey = "test:stream:groupread";
-        String groupName = "test-group";
-        String consumerName = "test-consumer";
-        
-        try {
-            // Add test record
-            Map<byte[], byte[]> fields = Map.of("data".getBytes(), "test-value".getBytes());
-            MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
-                .in(streamKey.getBytes())
-                .ofMap(fields);
-            
-            RecordId addedId = connection.streamCommands().xAdd(record);
-            assertThat(addedId).isNotNull();
-            
-            // Create consumer group
-            connection.streamCommands().xGroupCreate(streamKey.getBytes(), groupName, ReadOffset.from("0"));
-            
-            Consumer consumer = Consumer.from(groupName, consumerName);
-            
-            // Read from group
-            List<ByteRecord> records = connection.streamCommands().xReadGroup(
-                consumer,
-                StreamReadOptions.empty(),
-                StreamOffset.create(streamKey.getBytes(), ReadOffset.lastConsumed())
-            );
-            
-            assertThat(records).isNotEmpty();
-            
-            // Test acknowledgement
-            if (!records.isEmpty()) {
-                RecordId recordId = records.get(0).getId();
-                Long ackCount = connection.streamCommands().xAck(streamKey.getBytes(), groupName, recordId);
-                assertThat(ackCount).isEqualTo(1L);
-                
-                // Try to ack the same message again
-                Long ackCount2 = connection.streamCommands().xAck(streamKey.getBytes(), groupName, recordId);
-                assertThat(ackCount2).isEqualTo(0L);
-            }
-            
-        } finally {
-            try {
-                connection.streamCommands().xGroupDestroy(streamKey.getBytes(), groupName);
-            } catch (Exception ignored) {}
-            cleanupKey(streamKey);
-        }
-    }
-
-    // ==================== Pending Messages Operations ====================
-
-    @SuppressWarnings("unchecked")
-    @Test
-    void testPendingMessages() {
-        String streamKey = "test:stream:pending";
-        String groupName = "test-group";
-        String consumerName = "test-consumer";
-        
-        try {
-            // Add test record
-            Map<byte[], byte[]> fields = Map.of("data".getBytes(), "pending-test".getBytes());
-            MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
-                .in(streamKey.getBytes())
-                .ofMap(fields);
-            
-            connection.streamCommands().xAdd(record);
-            
-            // Create consumer group and read message (making it pending)
-            connection.streamCommands().xGroupCreate(streamKey.getBytes(), groupName, ReadOffset.from("0"));
-            
-            Consumer consumer = Consumer.from(groupName, consumerName);
-            List<ByteRecord> records = connection.streamCommands().xReadGroup(
-                consumer,
-                StreamReadOptions.empty(),
-                StreamOffset.create(streamKey.getBytes(), ReadOffset.lastConsumed())
-            );
-            
-            if (!records.isEmpty()) {
-                // Test pending messages summary
-                PendingMessagesSummary summary = connection.streamCommands()
-                    .xPending(streamKey.getBytes(), groupName);
-                assertThat(summary).isNotNull();
-                assertThat(summary.getTotalPendingMessages()).isEqualTo(1L);
-                assertThat(summary.getGroupName()).isEmpty(); // Default group name is empty in summary
-                
-                // Test detailed pending messages
-                PendingMessages pending = connection.streamCommands()
-                    .xPending(streamKey.getBytes(), groupName, consumerName);
-                assertThat(pending).isNotNull();
-                assertThat(pending.isEmpty()).isFalse();
-                assertThat(pending.size()).isEqualTo(1);
-                assertThat(pending.getGroupName()).isEqualTo(groupName);
-                
-                // Verify the pending message details
-                PendingMessage pendingMsg = pending.get(0);
-                assertThat(pendingMsg).isNotNull();
-                assertThat(pendingMsg.getConsumer().getName()).isEqualTo(consumerName);
-                assertThat(pendingMsg.getConsumer().getGroup()).isEqualTo(groupName);
-                assertThat(pendingMsg.getTotalDeliveryCount()).isEqualTo(1L);
-                
-                // Test pending with range and count
-                PendingMessages pendingWithOptions = connection.streamCommands()
-                    .xPending(streamKey.getBytes(), groupName, 
-                        ValkeyStreamCommands.XPendingOptions.range(Range.unbounded(), 10L));
-                assertThat(pendingWithOptions).isNotNull();
-                assertThat(pendingWithOptions.isEmpty()).isFalse();
-                assertThat(pendingWithOptions.size()).isEqualTo(1);
-            }
-            
-        } finally {
-            try {
-                connection.streamCommands().xGroupDestroy(streamKey.getBytes(), groupName);
-            } catch (Exception ignored) {}
-            cleanupKey(streamKey);
-        }
-    }
-
-    // ==================== Message Claiming Operations ====================
-
-    @SuppressWarnings("unchecked")
-    @Test
-    void testMessageClaiming() {
-        String streamKey = "test:stream:claim";
-        String groupName = "test-group";
-        String consumer1 = "consumer1";
-        String consumer2 = "consumer2";
-        
-        try {
-            // Add test record
-            Map<byte[], byte[]> fields = Map.of("data".getBytes(), "claim-test".getBytes());
-            MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
-                .in(streamKey.getBytes())
-                .ofMap(fields);
-            
-            connection.streamCommands().xAdd(record);
-            
-            // Create consumer group and make message pending
-            connection.streamCommands().xGroupCreate(streamKey.getBytes(), groupName, ReadOffset.from("0"));
-            
-            List<ByteRecord> records = connection.streamCommands().xReadGroup(
-                Consumer.from(groupName, consumer1),
-                StreamReadOptions.empty(),
-                StreamOffset.create(streamKey.getBytes(), ReadOffset.lastConsumed())
-            );
-            
-            if (!records.isEmpty()) {
-                RecordId pendingId = records.get(0).getId();
-                
-                // Test claiming message
-                ValkeyStreamCommands.XClaimOptions claimOptions = 
-                    ValkeyStreamCommands.XClaimOptions.minIdle(Duration.ofMillis(0)).ids(pendingId);
-                
-                List<ByteRecord> claimedRecords = connection.streamCommands()
-                    .xClaim(streamKey.getBytes(), groupName, consumer2, claimOptions);
-                assertThat(claimedRecords).isNotEmpty();
-                assertThat(claimedRecords).hasSize(1);
-                
-                // Verify the claimed record has the expected content
-                ByteRecord claimedRecord = claimedRecords.get(0);
-                assertThat(claimedRecord.getId()).isEqualTo(pendingId);
-                byte[] claimedData = getValueByKeyContent(claimedRecord.getValue(), "data");
-                assertThat(claimedData).isNotNull();
-                assertThat(new String(claimedData)).isEqualTo("claim-test");
-                
-                // Test claiming with just IDs
-                List<RecordId> claimedIds = connection.streamCommands()
-                    .xClaimJustId(streamKey.getBytes(), groupName, consumer2, claimOptions);
-                assertThat(claimedIds).isNotEmpty();
-                assertThat(claimedIds).hasSize(1);
-                assertThat(claimedIds.get(0)).isEqualTo(pendingId);
-            }
-            
-        } finally {
-            try {
-                connection.streamCommands().xGroupDestroy(streamKey.getBytes(), groupName);
-            } catch (Exception ignored) {}
-            cleanupKey(streamKey);
-        }
-    }
-
-    // ==================== Stream Information Operations ====================
-
-    @SuppressWarnings("unchecked")
-    @Test
-    void testStreamInformation() {
-        String streamKey = "test:stream:info";
-        String groupName = "test-group";
-        String consumerName = "test-consumer";
-        
-        try {
-            // Add test record
-            Map<byte[], byte[]> fields = Map.of("info".getBytes(), "test".getBytes());
-            MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
-                .in(streamKey.getBytes())
-                .ofMap(fields);
-            
-            RecordId addedRecordId = connection.streamCommands().xAdd(record);
-            assertThat(addedRecordId).isNotNull();
-
-            // Test stream info - verify actual content
-            XInfoStream streamInfo = connection.streamCommands().xInfo(streamKey.getBytes());
-            assertThat(streamInfo).isNotNull();
-            assertThat(streamInfo.streamLength()).isEqualTo(1L);
-            assertThat(streamInfo.getFirstEntry()).isNotNull();
-            assertThat(streamInfo.getLastEntry()).isNotNull();
-
-            // Create consumer group and test group info - verify actual content
-            String createResult = connection.streamCommands().xGroupCreate(streamKey.getBytes(), groupName, ReadOffset.from("0"));
-            assertThat(createResult).isEqualTo("OK");
-
-            XInfoGroups groupsInfo = connection.streamCommands().xInfoGroups(streamKey.getBytes());
-            assertThat(groupsInfo).isNotNull();
-            assertThat(groupsInfo.isEmpty()).isFalse();
-            assertThat(groupsInfo.size()).isEqualTo(1);
-            
-            // Verify group details
-            StreamInfo.XInfoGroup groupInfo = groupsInfo.iterator().next();
-            assertThat(groupInfo).isNotNull();
-            assertThat(groupInfo.groupName()).isEqualTo(groupName);
-            assertThat(groupInfo.consumerCount()).isEqualTo(0L); // No consumers yet
-            assertThat(groupInfo.pendingCount()).isEqualTo(0L); // No pending messages yet
-            
-            // Make consumer active and test consumer info - verify actual content
-            List<ByteRecord> records = connection.streamCommands().xReadGroup(
-                Consumer.from(groupName, consumerName),
-                StreamReadOptions.empty(),
-                StreamOffset.create(streamKey.getBytes(), ReadOffset.lastConsumed())
-            );
-            
-            assertThat(records).isNotEmpty();
-            assertThat(records).hasSize(1);
-            
-            // Verify the record content
-            ByteRecord readRecord = records.get(0);
-            assertThat(readRecord).isNotNull();
-            assertThat(readRecord.getId()).isNotNull();
-            byte[] infoValue = getValueByKeyContent(readRecord.getValue(), "info");
-            assertThat(infoValue).isNotNull();
-            assertThat(new String(infoValue)).isEqualTo("test");
-            
-            // Test consumer info - verify actual content
-            XInfoConsumers consumersInfo = connection.streamCommands()
-                .xInfoConsumers(streamKey.getBytes(), groupName);
-            assertThat(consumersInfo).isNotNull();
-            assertThat(consumersInfo.isEmpty()).isFalse();
-            assertThat(consumersInfo.size()).isEqualTo(1);
-            
-            // Verify consumer details
-            StreamInfo.XInfoConsumer consumerInfo = consumersInfo.iterator().next();
-            assertThat(consumerInfo).isNotNull();
-            assertThat(consumerInfo.consumerName()).isEqualTo(consumerName);
-            assertThat(consumerInfo.pendingCount()).isEqualTo(1L); // One pending message
-            assertThat(consumerInfo.idleTimeMs()).isGreaterThanOrEqualTo(0L);
-            
-            // Verify group info is updated after consumer activity
-            XInfoGroups updatedGroupsInfo = connection.streamCommands().xInfoGroups(streamKey.getBytes());
-            StreamInfo.XInfoGroup updatedGroupInfo = updatedGroupsInfo.iterator().next();
-            assertThat(updatedGroupInfo.consumerCount()).isEqualTo(1L); // Now has one consumer
-            assertThat(updatedGroupInfo.pendingCount()).isEqualTo(1L); // One pending message
-            
-        } finally {
-            try {
-                connection.streamCommands().xGroupDestroy(streamKey.getBytes(), groupName);
-            } catch (Exception ignored) {}
-            cleanupKey(streamKey);
-        }
-    }
-
-    // ==================== Stream Trimming Operations ====================
-
-    @Test
-    void testStreamTrimming() {
-        String streamKey = "test:stream:trim";
-        
-        try {
-            // Add multiple records
-            for (int i = 0; i < 10; i++) {
-                Map<byte[], byte[]> fields = Map.of(
-                    "index".getBytes(), String.valueOf(i).getBytes()
-                );
-                
-                MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
-                    .in(streamKey.getBytes())
-                    .ofMap(fields);
-                
-                connection.streamCommands().xAdd(record);
-            }
-            
-            // Verify initial length
-            Long initialLength = connection.streamCommands().xLen(streamKey.getBytes());
-            assertThat(initialLength).isEqualTo(10L);
-            
-            // Test exact trimming
-            Long trimmed = connection.streamCommands().xTrim(streamKey.getBytes(), 5);
-            assertThat(trimmed).isGreaterThan(0L);
-            
-            Long newLength = connection.streamCommands().xLen(streamKey.getBytes());
-            assertThat(newLength).isLessThanOrEqualTo(5L);
-            
-            // Test approximate trimming
-            for (int i = 0; i < 5; i++) {
-                Map<byte[], byte[]> fields = Map.of(
-                    "extra".getBytes(), String.valueOf(i).getBytes()
-                );
-                
-                MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
-                    .in(streamKey.getBytes())
-                    .ofMap(fields);
-                
-                connection.streamCommands().xAdd(record);
-            }
-            
-            Long approximateTrimmed = connection.streamCommands().xTrim(streamKey.getBytes(), 3, true);
-            assertThat(approximateTrimmed).isNotNull();
-            
-        } finally {
-            cleanupKey(streamKey);
-        }
-    }
-
-    // ==================== Error Handling and Validation ====================
-
-    @SuppressWarnings({ "unchecked", "unchecked" })
-    @Test
-    void testErrorHandling() {
-        String streamKey = "test:stream:validation";
-        
-        try {
-            // Test null parameter validation
-            assertThatThrownBy(() -> connection.streamCommands().xLen(null))
-                .isInstanceOf(IllegalArgumentException.class);
-                
-            assertThatThrownBy(() -> connection.streamCommands().xAdd(null))
-                .isInstanceOf(IllegalArgumentException.class);
-                
-            assertThatThrownBy(() -> connection.streamCommands().xDel(null, RecordId.of("1-0")))
-                .isInstanceOf(IllegalArgumentException.class);
-                
-            assertThatThrownBy(() -> connection.streamCommands()
-                .xGroupCreate(null, "group", ReadOffset.latest()))
-                .isInstanceOf(IllegalArgumentException.class);
-                
-            assertThatThrownBy(() -> connection.streamCommands()
-                .xAck(streamKey.getBytes(), null, RecordId.of("1-0")))
-                .isInstanceOf(IllegalArgumentException.class);
-            
-            // Test operations on non-existent stream
-            Long length = connection.streamCommands().xLen("non:existent".getBytes());
-            assertThat(length).isEqualTo(0L);
-            
-            // Test reading from non-existent stream
-            @SuppressWarnings("unchecked")
-            List<ByteRecord> records = connection.streamCommands().xRead(
-                StreamReadOptions.empty(),
-                StreamOffset.create("non:existent".getBytes(), ReadOffset.from("0"))
-            );
-            assertThat(records).isEmpty();
-            
-            // Test xReadGroup on non-existent consumer group - should throw exception
-            assertThatThrownBy(() -> connection.streamCommands().xReadGroup(
-                Consumer.from("non-existent-group", "consumer"),
-                StreamReadOptions.empty(),
-                StreamOffset.create("non:existent".getBytes(), ReadOffset.from("0"))
-            ))
-            .isInstanceOf(ValkeySystemException.class)
-            .hasMessageContaining("NOGROUP");
-            
-            // Test xRange on non-existent stream  
-            List<ByteRecord> rangeRecords = connection.streamCommands()
-                .xRange("non:existent".getBytes(), Range.unbounded(), Limit.unlimited());
-            assertThat(rangeRecords).isEmpty();
-            
-            // Test xRevRange on non-existent stream
-            List<ByteRecord> revRangeRecords = connection.streamCommands()
-                .xRevRange("non:existent".getBytes(), Range.unbounded(), Limit.unlimited());
-            assertThat(revRangeRecords).isEmpty();
-            
-            // Test xClaim on non-existent consumer group - should throw exception
-            assertThatThrownBy(() -> connection.streamCommands()
-                .xClaim("non:existent".getBytes(), "group", "consumer", 
-                    ValkeyStreamCommands.XClaimOptions.minIdle(Duration.ofMillis(0)).ids(RecordId.of("0-0"))))
-            .isInstanceOf(ValkeySystemException.class)
-            .hasMessageContaining("NOGROUP");
-            
-            // Test xClaimJustId on non-existent consumer group - should throw exception
-            assertThatThrownBy(() -> connection.streamCommands()
-                .xClaimJustId("non:existent".getBytes(), "group", "consumer",
-                    ValkeyStreamCommands.XClaimOptions.minIdle(Duration.ofMillis(0)).ids(RecordId.of("0-0"))))
-            .isInstanceOf(ValkeySystemException.class)
-            .hasMessageContaining("NOGROUP");
-            
-        } finally {
-            cleanupKey(streamKey);
-        }
-    }
-
-    // ==================== Comprehensive Pipeline Mode Tests ====================
-
-    @Test
-    void testStreamBasicOperationsPipeline() {
-        String streamKey = "test:stream:pipeline:basic";
-        
-        try {
-            connection.openPipeline();
-            
-            // Test xAdd and xLen in pipeline
-            Map<byte[], byte[]> fields1 = Map.of("field1".getBytes(), "value1".getBytes());
-            MapRecord<byte[], byte[], byte[]> record1 = StreamRecords.newRecord()
-                .in(streamKey.getBytes())
-                .ofMap(fields1);
-            
-            // Pipeline commands should return null
-            RecordId addResult1 = connection.streamCommands().xAdd(record1);
-            assertThat(addResult1).isNull();
-            
-            Long lenResult1 = connection.streamCommands().xLen(streamKey.getBytes());
-            assertThat(lenResult1).isNull();
-            
-            Map<byte[], byte[]> fields2 = Map.of("field2".getBytes(), "value2".getBytes());
-            MapRecord<byte[], byte[], byte[]> record2 = StreamRecords.newRecord()
-                .in(streamKey.getBytes())
-                .ofMap(fields2);
-            
-            RecordId addResult2 = connection.streamCommands().xAdd(record2);
-            assertThat(addResult2).isNull();
-            
-            Long lenResult2 = connection.streamCommands().xLen(streamKey.getBytes());
-            assertThat(lenResult2).isNull();
-            
-            List<Object> results = connection.closePipeline();
-            assertThat(results).hasSize(4);
-            
-            // First xAdd result should be a record ID
-            assertThat(results.get(0)).isNotNull();
-            // First xLen result should be 1
-            assertThat(((Number) results.get(1)).longValue()).isEqualTo(1L);
-            // Second xAdd result should be a record ID
-            assertThat(results.get(2)).isNotNull();
-            // Second xLen result should be 2
-            assertThat(((Number) results.get(3)).longValue()).isEqualTo(2L);
-            
-        } finally {
-            if (connection.isPipelined()) {
-                connection.closePipeline();
-            }
-            cleanupKey(streamKey);
-        }
-    }
-
-    @Test
-    void testStreamRangeOperationsPipeline() {
-        String streamKey = "test:stream:pipeline:range";
-        
-        try {
-            // Setup data first
-            for (int i = 0; i < 5; i++) {
-                Map<byte[], byte[]> fields = Map.of("index".getBytes(), String.valueOf(i).getBytes());
-                MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
-                    .in(streamKey.getBytes())
-                    .ofMap(fields);
-                connection.streamCommands().xAdd(record);
-            }
-            
-            connection.openPipeline();
-            
-            // Test range operations in pipeline - pipeline commands should return null
-            List<ByteRecord> rangeResult = connection.streamCommands().xRange(streamKey.getBytes(), Range.unbounded(), Limit.unlimited());
-            assertThat(rangeResult).isNull();
-            
-            List<ByteRecord> revRangeResult = connection.streamCommands().xRevRange(streamKey.getBytes(), Range.unbounded(), Limit.limit().count(3));
-            assertThat(revRangeResult).isNull();
-            
-            Long lenResult = connection.streamCommands().xLen(streamKey.getBytes());
-            assertThat(lenResult).isNull();
-            
-            List<Object> results = connection.closePipeline();
-            assertThat(results).hasSize(3);
-            
-            // First result should be all 5 records
-            @SuppressWarnings("unchecked")
-            List<ByteRecord> rangeRecords = (List<ByteRecord>) results.get(0);
-            assertThat(rangeRecords).hasSize(5);
-            
-            // Second result should be 3 records in reverse order
-            @SuppressWarnings("unchecked")
-            List<ByteRecord> revRangeRecords = (List<ByteRecord>) results.get(1);
-            assertThat(revRangeRecords).hasSize(3);
-            
-            // Third result should be length 5
-            assertThat(((Number) results.get(2)).longValue()).isEqualTo(5L);
-            
-        } finally {
-            if (connection.isPipelined()) {
-                connection.closePipeline();
-            }
-            cleanupKey(streamKey);
-        }
-    }
-
-    @Test
-    void testStreamGroupOperationsPipeline() {
-        String streamKey = "test:stream:pipeline:group";
-        String groupName = "test-group";
-        
-        try {
-            // Setup data first
-            Map<byte[], byte[]> fields = Map.of("data".getBytes(), "test".getBytes());
-            MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
-                .in(streamKey.getBytes())
-                .ofMap(fields);
-            connection.streamCommands().xAdd(record);
-            
-            connection.openPipeline();
-            
-            // Test group operations in pipeline - pipeline commands should return null
-            String createResult = connection.streamCommands().xGroupCreate(streamKey.getBytes(), groupName, ReadOffset.from("0"));
-            assertThat(createResult).isNull();
-            
-            XInfoGroups groupsResult = connection.streamCommands().xInfoGroups(streamKey.getBytes());
-            assertThat(groupsResult).isNull();
-            
-            Boolean destroyResult = connection.streamCommands().xGroupDestroy(streamKey.getBytes(), groupName);
-            assertThat(destroyResult).isNull();
-            
-            List<Object> results = connection.closePipeline();
-            assertThat(results).hasSize(3);
-            
-            // First result should be "OK"
-            assertThat(results.get(0)).isEqualTo("OK");
-            
-            // Second result should be groups info
-            assertThat(results.get(1)).isInstanceOf(XInfoGroups.class);
-            XInfoGroups groupsInfo = (XInfoGroups) results.get(1);
-            assertThat(groupsInfo.size()).isEqualTo(1);
-            
-            // Third result should be true (group destroyed)
-            assertThat(results.get(2)).isEqualTo(true);
-            
-        } finally {
-            if (connection.isPipelined()) {
-                connection.closePipeline();
-            }
-            try {
-                connection.streamCommands().xGroupDestroy(streamKey.getBytes(), groupName);
-            } catch (Exception ignored) {}
-            cleanupKey(streamKey);
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    void testStreamReadOperationsPipeline() {
-        String streamKey = "test:stream:pipeline:read";
-        
-        try {
-            // Setup data first
-            for (int i = 0; i < 3; i++) {
-                Map<byte[], byte[]> fields = Map.of("index".getBytes(), String.valueOf(i).getBytes());
-                MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
-                    .in(streamKey.getBytes())
-                    .ofMap(fields);
-                connection.streamCommands().xAdd(record);
-            }
-            
-            connection.openPipeline();
-            
-            // Test read operations in pipeline
-            connection.streamCommands().xRead(
-                StreamReadOptions.empty(),
-                StreamOffset.create(streamKey.getBytes(), ReadOffset.from("0"))
-            );
-            connection.streamCommands().xRead(
-                StreamReadOptions.empty().count(2),
-                StreamOffset.create(streamKey.getBytes(), ReadOffset.from("0"))
-            );
-            connection.streamCommands().xLen(streamKey.getBytes());
-            
-            List<Object> results = connection.closePipeline();
-            assertThat(results).hasSize(3);
-            
-            // First result should be all 3 records
-            List<ByteRecord> allRecords = (List<ByteRecord>) results.get(0);
-            assertThat(allRecords).hasSize(3);
-            
-            // Second result should be 2 records
-            List<ByteRecord> limitedRecords = (List<ByteRecord>) results.get(1);
-            assertThat(limitedRecords).hasSize(2);
-            
-            // Third result should be length 3
-            assertThat(((Number) results.get(2)).longValue()).isEqualTo(3L);
-            
-        } finally {
-            if (connection.isPipelined()) {
-                connection.closePipeline();
-            }
-            cleanupKey(streamKey);
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    void testStreamInfoOperationsPipeline() {
-        String streamKey = "test:stream:pipeline:info";
-        String groupName = "test-group";
-        String consumerName = "test-consumer";
-        
-        try {
-            // Setup data first
-            Map<byte[], byte[]> fields = Map.of("info".getBytes(), "test".getBytes());
-            MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
-                .in(streamKey.getBytes())
-                .ofMap(fields);
-            connection.streamCommands().xAdd(record);
-            
-            // Create group and consumer with pending message
-            connection.streamCommands().xGroupCreate(streamKey.getBytes(), groupName, ReadOffset.from("0"));
-            connection.streamCommands().xReadGroup(
-                Consumer.from(groupName, consumerName),
-                StreamReadOptions.empty(),
-                StreamOffset.create(streamKey.getBytes(), ReadOffset.lastConsumed())
-            );
-            
-            connection.openPipeline();
-            
-            // Test info operations in pipeline
-            connection.streamCommands().xInfo(streamKey.getBytes());
-            connection.streamCommands().xInfoGroups(streamKey.getBytes());
-            connection.streamCommands().xInfoConsumers(streamKey.getBytes(), groupName);
-            connection.streamCommands().xPending(streamKey.getBytes(), groupName);
-            
-            List<Object> results = connection.closePipeline();
-            assertThat(results).hasSize(4);
-            
-            // Verify stream info
-            assertThat(results.get(0)).isInstanceOf(XInfoStream.class);
-            XInfoStream streamInfo = (XInfoStream) results.get(0);
-            assertThat(streamInfo.streamLength()).isEqualTo(1L);
-            
-            // Verify groups info
-            assertThat(results.get(1)).isInstanceOf(XInfoGroups.class);
-            XInfoGroups groupsInfo = (XInfoGroups) results.get(1);
-            assertThat(groupsInfo.size()).isEqualTo(1);
-            
-            // Verify consumers info
-            assertThat(results.get(2)).isInstanceOf(XInfoConsumers.class);
-            XInfoConsumers consumersInfo = (XInfoConsumers) results.get(2);
-            assertThat(consumersInfo.size()).isEqualTo(1);
-            
-            // Verify pending messages
-            assertThat(results.get(3)).isInstanceOf(PendingMessagesSummary.class);
-            PendingMessagesSummary pendingSummary = (PendingMessagesSummary) results.get(3);
-            assertThat(pendingSummary.getTotalPendingMessages()).isEqualTo(1L);
-            
-        } finally {
-            if (connection.isPipelined()) {
-                connection.closePipeline();
-            }
-            try {
-                connection.streamCommands().xGroupDestroy(streamKey.getBytes(), groupName);
-            } catch (Exception ignored) {}
-            cleanupKey(streamKey);
-        }
-    }
-
-    // ==================== Comprehensive Transaction Mode Tests ====================
-
-    @Test
-    void testStreamBasicOperationsTransaction() {
-        String streamKey = "test:stream:transaction:basic";
-        
-        try {
-            connection.multi();
-            
-            // Test xAdd and xLen in transaction
-            Map<byte[], byte[]> fields1 = Map.of("field1".getBytes(), "value1".getBytes());
-            MapRecord<byte[], byte[], byte[]> record1 = StreamRecords.newRecord()
-                .in(streamKey.getBytes())
-                .ofMap(fields1);
-            
-            // Transaction commands should return null
-            RecordId addResult1 = connection.streamCommands().xAdd(record1);
-            assertThat(addResult1).isNull();
-            
-            Long lenResult1 = connection.streamCommands().xLen(streamKey.getBytes());
-            assertThat(lenResult1).isNull();
-            
-            Map<byte[], byte[]> fields2 = Map.of("field2".getBytes(), "value2".getBytes());
-            MapRecord<byte[], byte[], byte[]> record2 = StreamRecords.newRecord()
-                .in(streamKey.getBytes())
-                .ofMap(fields2);
-            
-            RecordId addResult2 = connection.streamCommands().xAdd(record2);
-            assertThat(addResult2).isNull();
-            
-            Long lenResult2 = connection.streamCommands().xLen(streamKey.getBytes());
-            assertThat(lenResult2).isNull();
-            
-            List<Object> results = connection.exec();
-            assertThat(results).hasSize(4);
-            
-            // First xAdd result should be a record ID
-            assertThat(results.get(0)).isNotNull();
-            // First xLen result should be 1
-            assertThat(((Number) results.get(1)).longValue()).isEqualTo(1L);
-            // Second xAdd result should be a record ID
-            assertThat(results.get(2)).isNotNull();
-            // Second xLen result should be 2
-            assertThat(((Number) results.get(3)).longValue()).isEqualTo(2L);
-            
-        } finally {
-            if (connection.isQueueing()) {
-                connection.discard();
-            }
-            cleanupKey(streamKey);
-        }
-    }
-
-    @Test
-    void testStreamRangeOperationsTransaction() {
-        String streamKey = "test:stream:transaction:range";
-        
-        try {
-            // Setup data first
-            for (int i = 0; i < 5; i++) {
-                Map<byte[], byte[]> fields = Map.of("index".getBytes(), String.valueOf(i).getBytes());
-                MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
-                    .in(streamKey.getBytes())
-                    .ofMap(fields);
-                connection.streamCommands().xAdd(record);
-            }
-            
-            connection.multi();
-            
-            // Test range operations in transaction
-            connection.streamCommands().xRange(streamKey.getBytes(), Range.unbounded(), Limit.unlimited());
-            connection.streamCommands().xRevRange(streamKey.getBytes(), Range.unbounded(), Limit.limit().count(3));
-            connection.streamCommands().xLen(streamKey.getBytes());
-            
-            List<Object> results = connection.exec();
-            assertThat(results).hasSize(3);
-            
-            // First result should be all 5 records
-            @SuppressWarnings("unchecked")
-            List<ByteRecord> rangeRecords = (List<ByteRecord>) results.get(0);
-            assertThat(rangeRecords).hasSize(5);
-            
-            // Second result should be 3 records in reverse order
-            @SuppressWarnings("unchecked")
-            List<ByteRecord> revRangeRecords = (List<ByteRecord>) results.get(1);
-            assertThat(revRangeRecords).hasSize(3);
-            
-            // Third result should be length 5
-            assertThat(((Number) results.get(2)).longValue()).isEqualTo(5L);
-            
-        } finally {
-            if (connection.isQueueing()) {
-                connection.discard();
-            }
-            cleanupKey(streamKey);
-        }
-    }
-
-    @Test
-    void testStreamGroupOperationsTransaction() {
-        String streamKey = "test:stream:transaction:group";
-        String groupName = "test-group";
-        
-        try {
-            // Setup data first
-            Map<byte[], byte[]> fields = Map.of("data".getBytes(), "test".getBytes());
-            MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
-                .in(streamKey.getBytes())
-                .ofMap(fields);
-            connection.streamCommands().xAdd(record);
-            
-            connection.multi();
-            
-            // Test group operations in transaction
-            connection.streamCommands().xGroupCreate(streamKey.getBytes(), groupName, ReadOffset.from("0"));
-            connection.streamCommands().xInfoGroups(streamKey.getBytes());
-            
-            List<Object> results = connection.exec();
-            assertThat(results).hasSize(2);
-            
-            // First result should be "OK"
-            assertThat(results.get(0)).isEqualTo("OK");
-            
-            // Second result should be groups info
-            assertThat(results.get(1)).isInstanceOf(XInfoGroups.class);
-            XInfoGroups groupsInfo = (XInfoGroups) results.get(1);
-            assertThat(groupsInfo.size()).isEqualTo(1);
-            
-        } finally {
-            if (connection.isQueueing()) {
-                connection.discard();
-            }
-            try {
-                connection.streamCommands().xGroupDestroy(streamKey.getBytes(), groupName);
-            } catch (Exception ignored) {}
-            cleanupKey(streamKey);
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    void testStreamReadOperationsTransaction() {
-        String streamKey = "test:stream:transaction:read";
-        
-        try {
-            // Setup data first
-            for (int i = 0; i < 3; i++) {
-                Map<byte[], byte[]> fields = Map.of("index".getBytes(), String.valueOf(i).getBytes());
-                MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
-                    .in(streamKey.getBytes())
-                    .ofMap(fields);
-                connection.streamCommands().xAdd(record);
-            }
-            
-            connection.multi();
-            
-            // Test read operations in transaction
-            connection.streamCommands().xRead(
-                StreamReadOptions.empty(),
-                StreamOffset.create(streamKey.getBytes(), ReadOffset.from("0"))
-            );
-            connection.streamCommands().xRead(
-                StreamReadOptions.empty().count(2),
-                StreamOffset.create(streamKey.getBytes(), ReadOffset.from("0"))
-            );
-            connection.streamCommands().xLen(streamKey.getBytes());
-            
-            List<Object> results = connection.exec();
-            assertThat(results).hasSize(3);
-            
-            // First result should be all 3 records
-            List<ByteRecord> allRecords = (List<ByteRecord>) results.get(0);
-            assertThat(allRecords).hasSize(3);
-            
-            // Second result should be 2 records
-            List<ByteRecord> limitedRecords = (List<ByteRecord>) results.get(1);
-            assertThat(limitedRecords).hasSize(2);
-            
-            // Third result should be length 3
-            assertThat(((Number) results.get(2)).longValue()).isEqualTo(3L);
-            
-        } finally {
-            if (connection.isQueueing()) {
-                connection.discard();
-            }
-            cleanupKey(streamKey);
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    void testStreamInfoOperationsTransaction() {
-        String streamKey = "test:stream:transaction:info";
-        String groupName = "test-group";
-        String consumerName = "test-consumer";
-        
-        try {
-            // Setup data first
-            Map<byte[], byte[]> fields = Map.of("info".getBytes(), "test".getBytes());
-            MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
-                .in(streamKey.getBytes())
-                .ofMap(fields);
-            connection.streamCommands().xAdd(record);
-            
-            // Create group and consumer with pending message
-            connection.streamCommands().xGroupCreate(streamKey.getBytes(), groupName, ReadOffset.from("0"));
-            connection.streamCommands().xReadGroup(
-                Consumer.from(groupName, consumerName),
-                StreamReadOptions.empty(),
-                StreamOffset.create(streamKey.getBytes(), ReadOffset.lastConsumed())
-            );
-            
-            connection.multi();
-            
-            // Test info operations in transaction
-            connection.streamCommands().xInfo(streamKey.getBytes());
-            connection.streamCommands().xInfoGroups(streamKey.getBytes());
-            connection.streamCommands().xInfoConsumers(streamKey.getBytes(), groupName);
-            connection.streamCommands().xPending(streamKey.getBytes(), groupName);
-            
-            List<Object> results = connection.exec();
-            assertThat(results).hasSize(4);
-            
-            // Verify stream info
-            assertThat(results.get(0)).isInstanceOf(XInfoStream.class);
-            XInfoStream streamInfo = (XInfoStream) results.get(0);
-            assertThat(streamInfo.streamLength()).isEqualTo(1L);
-            
-            // Verify groups info
-            assertThat(results.get(1)).isInstanceOf(XInfoGroups.class);
-            XInfoGroups groupsInfo = (XInfoGroups) results.get(1);
-            assertThat(groupsInfo.size()).isEqualTo(1);
-            
-            // Verify consumers info
-            assertThat(results.get(2)).isInstanceOf(XInfoConsumers.class);
-            XInfoConsumers consumersInfo = (XInfoConsumers) results.get(2);
-            assertThat(consumersInfo.size()).isEqualTo(1);
-            
-            // Verify pending messages
-            assertThat(results.get(3)).isInstanceOf(PendingMessagesSummary.class);
-            PendingMessagesSummary pendingSummary = (PendingMessagesSummary) results.get(3);
-            assertThat(pendingSummary.getTotalPendingMessages()).isEqualTo(1L);
-            
-        } finally {
-            if (connection.isQueueing()) {
-                connection.discard();
-            }
-            try {
-                connection.streamCommands().xGroupDestroy(streamKey.getBytes(), groupName);
-            } catch (Exception ignored) {}
-            cleanupKey(streamKey);
-        }
-    }
-
-    @Test
-    void testComplexStreamScenarioTransaction() {
-        String streamKey = "test:stream:transaction:complex";
-        String groupName = "test-group";
-        
-        try {
-            // Setup initial data
-            Map<byte[], byte[]> fields = Map.of("data".getBytes(), "initial".getBytes());
-            MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
-                .in(streamKey.getBytes())
-                .ofMap(fields);
-            connection.streamCommands().xAdd(record);
-            
-            connection.multi();
-            
-            // Complex scenario: add records, create group, read, acknowledge in one transaction
-            Map<byte[], byte[]> fields1 = Map.of("step".getBytes(), "1".getBytes());
-            MapRecord<byte[], byte[], byte[]> record1 = StreamRecords.newRecord()
-                .in(streamKey.getBytes())
-                .ofMap(fields1);
-            connection.streamCommands().xAdd(record1);
-            
-            connection.streamCommands().xGroupCreate(streamKey.getBytes(), groupName, ReadOffset.from("0"));
-            connection.streamCommands().xLen(streamKey.getBytes());
-            connection.streamCommands().xInfo(streamKey.getBytes());
-            
-            List<Object> results = connection.exec();
-            assertThat(results).hasSize(4);
-            
-            // Verify transaction results
-            assertThat(results.get(0)).isNotNull(); // Record ID from xAdd
-            assertThat(results.get(1)).isEqualTo("OK"); // Group create result
-            assertThat(((Number) results.get(2)).longValue()).isEqualTo(2L); // Stream length
-            assertThat(results.get(3)).isInstanceOf(XInfoStream.class); // Stream info
-            
-            XInfoStream streamInfo = (XInfoStream) results.get(3);
-            assertThat(streamInfo.streamLength()).isEqualTo(2L);
-            assertThat(streamInfo.groupCount()).isEqualTo(1L);
-            
-        } finally {
-            if (connection.isQueueing()) {
-                connection.discard();
-            }
-            try {
-                connection.streamCommands().xGroupDestroy(streamKey.getBytes(), groupName);
-            } catch (Exception ignored) {}
-            cleanupKey(streamKey);
-        }
-    }
-
-    // ==================== Edge Cases and Complex Scenarios ====================
-
-    @SuppressWarnings("unchecked")
-    @Test
-    void testComplexStreamScenario() {
-        String streamKey = "test:stream:edge";
-        String groupName = "edge-group";
-        String consumer1 = "consumer1";
-        String consumer2 = "consumer2";
-        
-        try {
-            // Create a complex scenario with multiple records, groups, and consumers
-            
-            // Add multiple records with different field structures
-            List<RecordId> addedIds = new ArrayList<>();
-            for (int i = 0; i < 5; i++) {
-                Map<byte[], byte[]> fields = new HashMap<>();
-                fields.put("id".getBytes(), String.valueOf(i).getBytes());
-                fields.put("data".getBytes(), ("value" + i).getBytes());
-                
-                if (i % 2 == 0) {
-                    fields.put("extra".getBytes(), ("extra" + i).getBytes());
-                }
-                
-                MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
-                    .in(streamKey.getBytes())
-                    .ofMap(fields);
-                
-                RecordId addedId = connection.streamCommands().xAdd(record);
-                assertThat(addedId).isNotNull();
-                assertThat(addedId.getValue()).isNotEmpty();
-                addedIds.add(addedId);
-            }
-            
-            // Verify stream length after adding all records
-            Long streamLength = connection.streamCommands().xLen(streamKey.getBytes());
-            assertThat(streamLength).isEqualTo(5L);
-            
-            // Create consumer group
-            String groupResult = connection.streamCommands().xGroupCreate(streamKey.getBytes(), groupName, ReadOffset.from("0"));
-            assertThat(groupResult).isEqualTo("OK");
-            
-            // Have multiple consumers read messages
-            List<ByteRecord> records1 = connection.streamCommands().xReadGroup(
-                Consumer.from(groupName, consumer1),
-                StreamReadOptions.empty().count(2),
-                StreamOffset.create(streamKey.getBytes(), ReadOffset.lastConsumed())
-            );
-            
-            List<ByteRecord> records2 = connection.streamCommands().xReadGroup(
-                Consumer.from(groupName, consumer2),
-                StreamReadOptions.empty().count(2),
-                StreamOffset.create(streamKey.getBytes(), ReadOffset.lastConsumed())
-            );
-            
-            // Verify each consumer got the expected number of records
-            assertThat(records1).hasSize(2);
-            assertThat(records2).hasSize(2);
-            
-            // Verify content of first consumer's first record
-            ByteRecord firstRecord = records1.get(0);
-            assertThat(firstRecord.getId()).isNotNull();
-            byte[] idValue = getValueByKeyContent(firstRecord.getValue(), "id");
-            assertThat(idValue).isNotNull();
-            String recordIndex = new String(idValue);
-            assertThat(recordIndex).matches("[0-4]"); // Should be one of the added record indices
-            
-            byte[] dataValue = getValueByKeyContent(firstRecord.getValue(), "data");
-            assertThat(dataValue).isNotNull();
-            assertThat(new String(dataValue)).isEqualTo("value" + recordIndex);
-            
-            // Verify pending messages before acknowledgment - both consumers should have pending messages
-            PendingMessagesSummary summaryBefore = connection.streamCommands().xPending(streamKey.getBytes(), groupName);
-            
-            assertThat(summaryBefore.getTotalPendingMessages()).isEqualTo(4L); // 2 from each consumer
-            
-            Map<String, Long> consumerMessageCountBefore = summaryBefore.getPendingMessagesPerConsumer();
-            assertThat(consumerMessageCountBefore).containsKey(consumer1);
-            assertThat(consumerMessageCountBefore).containsKey(consumer2);
-            assertThat(consumerMessageCountBefore.get(consumer1)).isEqualTo(2L);
-            assertThat(consumerMessageCountBefore.get(consumer2)).isEqualTo(2L);
-            
-            // Acknowledge 1 message from consumer1, leaving 1 pending for consumer1 and 2 for consumer2
-            Long ackCount = connection.streamCommands().xAck(streamKey.getBytes(), groupName, records1.get(0).getId());
-            assertThat(ackCount).isEqualTo(1L);
-            
-            // Verify pending messages after acknowledgment - consumer1: 1 pending, consumer2: 2 pending, total: 3 pending
-            PendingMessagesSummary summary = connection.streamCommands().xPending(streamKey.getBytes(), groupName);
-            assertThat(summary.getTotalPendingMessages()).isEqualTo(3L);
-            
-            // Verify consumer names in pending summary with exact counts
-            Map<String, Long> consumerMessageCount = summary.getPendingMessagesPerConsumer();
-            assertThat(consumerMessageCount).containsKey(consumer1);
-            assertThat(consumerMessageCount).containsKey(consumer2);
-            assertThat(consumerMessageCount.get(consumer1)).isEqualTo(1L); // Read 2, acked 1 = 1 pending
-            assertThat(consumerMessageCount.get(consumer2)).isEqualTo(2L); // Read 2, acked 0 = 2 pending
-            
-            // Test stream info with detailed validation
-            XInfoStream streamInfo = connection.streamCommands().xInfo(streamKey.getBytes());
-            assertThat(streamInfo).isNotNull();
-            assertThat(streamInfo.streamLength()).isEqualTo(5L);
-            assertThat(streamInfo.groupCount()).isEqualTo(1L);
-            assertThat(streamInfo.getFirstEntry()).isNotNull();
-            assertThat(streamInfo.getLastEntry()).isNotNull();
-            
-            // Test groups info with detailed validation
-            XInfoGroups groupsInfo = connection.streamCommands().xInfoGroups(streamKey.getBytes());
-            assertThat(groupsInfo).isNotNull();
-            assertThat(groupsInfo.isEmpty()).isFalse();
-            assertThat(groupsInfo.size()).isEqualTo(1);
-            
-            StreamInfo.XInfoGroup groupInfo = groupsInfo.iterator().next();
-            assertThat(groupInfo.groupName()).isEqualTo(groupName);
-            assertThat(groupInfo.consumerCount()).isEqualTo(2L); // Two consumers were active
-            assertThat(groupInfo.pendingCount()).isEqualTo(3L); // Total pending messages
-            
-            // Test consumers info with detailed validation
-            XInfoConsumers consumersInfo = connection.streamCommands()
-                .xInfoConsumers(streamKey.getBytes(), groupName);
-            assertThat(consumersInfo).isNotNull();
-            assertThat(consumersInfo.size()).isEqualTo(2);
-            
-            // Verify both consumers exist and have correct names
-            List<String> consumerNames = new ArrayList<>();
-            for (StreamInfo.XInfoConsumer consumerInfo : consumersInfo) {
-                consumerNames.add(consumerInfo.consumerName());
-                assertThat(consumerInfo.pendingCount()).isGreaterThanOrEqualTo(0L);
-                assertThat(consumerInfo.idleTimeMs()).isGreaterThanOrEqualTo(0L);
-            }
-            assertThat(consumerNames).containsExactlyInAnyOrder(consumer1, consumer2);
-            
-        } finally {
-            try {
-                connection.streamCommands().xGroupDestroy(streamKey.getBytes(), groupName);
-            } catch (Exception ignored) {}
-            cleanupKey(streamKey);
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    void testMultipleStreamsReading() {
-        String stream1 = "test:stream:multi1";
-        String stream2 = "test:stream:multi2";
-        
-        try {
-            // Add records to multiple streams
-            for (int i = 0; i < 3; i++) {
-                Map<byte[], byte[]> fields1 = Map.of(
-                    "stream".getBytes(), "1".getBytes(),
-                    "index".getBytes(), String.valueOf(i).getBytes()
-                );
-                
-                Map<byte[], byte[]> fields2 = Map.of(
-                    "stream".getBytes(), "2".getBytes(),
-                    "index".getBytes(), String.valueOf(i).getBytes()
-                );
-                
-                connection.streamCommands().xAdd(StreamRecords.newRecord()
-                    .in(stream1.getBytes())
-                    .ofMap(fields1));
-                    
-                connection.streamCommands().xAdd(StreamRecords.newRecord()
-                    .in(stream2.getBytes())
-                    .ofMap(fields2));
-            }
-            
-            // Read from multiple streams
-            List<ByteRecord> records = connection.streamCommands().xRead(
-                StreamReadOptions.empty(),
-                StreamOffset.create(stream1.getBytes(), ReadOffset.from("0")),
-                StreamOffset.create(stream2.getBytes(), ReadOffset.from("0"))
-            );
-            
-            assertThat(records).hasSize(6); // 3 from each stream
-            
-            // Verify records come from both streams
-            boolean hasStream1 = records.stream().anyMatch(r -> {
-                byte[] streamValue = getValueByKeyContent(r.getValue(), "stream");
-                return streamValue != null && "1".equals(new String(streamValue));
-            });
-            boolean hasStream2 = records.stream().anyMatch(r -> {
-                byte[] streamValue = getValueByKeyContent(r.getValue(), "stream");
-                return streamValue != null && "2".equals(new String(streamValue));
-            });
-                
-            assertThat(hasStream1).isTrue();
-            assertThat(hasStream2).isTrue();
-            
-        } finally {
-            cleanupKeys(stream1, stream2);
-        }
-    }
-
-    @Test
-    void testEmptyStreamOperations() {
-        String emptyStream = "test:stream:empty";
-        
-        try {
-            // Test operations on non-existent stream
-            Long length = connection.streamCommands().xLen(emptyStream.getBytes());
-            assertThat(length).isEqualTo(0L);
-            
-            // Test range operations on empty stream
-            List<ByteRecord> records = connection.streamCommands()
-                .xRange(emptyStream.getBytes(), Range.unbounded(), Limit.unlimited());
-            assertThat(records).isEmpty();
-            
-            // Test trim on empty stream
-            Long trimmed = connection.streamCommands().xTrim(emptyStream.getBytes(), 5);
-            assertThat(trimmed).isEqualTo(0L);
-            
-        } finally {
-            cleanupKey(emptyStream);
-        }
-    }
-
-    // ==================== XTRIM with XTrimOptions Tests ====================
-
-    @Test
-    @EnabledOnCommand("XTRIM")
-    void testXTrimWithXTrimOptionsMaxlen() {
-        String streamKey = "test:stream:xtrim:maxlen";
-
-        try {
-            // Add 10 records
-            for (int i = 0; i < 10; i++) {
-                Map<byte[], byte[]> fields = Map.of("index".getBytes(), String.valueOf(i).getBytes());
-                MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
-                    .in(streamKey.getBytes())
-                    .ofMap(fields);
-                connection.streamCommands().xAdd(record);
-            }
-
-            // Verify initial length
-            assertThat(connection.streamCommands().xLen(streamKey.getBytes())).isEqualTo(10L);
-
-            // Trim to 5 entries using XTrimOptions with MAXLEN
-            Long trimmed = connection.streamCommands().xTrim(streamKey.getBytes(),
-                    XTrimOptions.trim(TrimOptions.maxLen(5)));
-            assertThat(trimmed).isEqualTo(5L); // 5 entries removed
-
-            // Verify 5 entries remaining
-            assertThat(connection.streamCommands().xLen(streamKey.getBytes())).isEqualTo(5L);
-        } finally {
-            cleanupKey(streamKey);
-        }
-    }
-
-    @Test
-    @EnabledOnCommand("XTRIM")
-    void testXTrimWithXTrimOptionsMinId() {
-        String streamKey = "test:stream:xtrim:minid";
-
-        try {
-            // Add 5 records and capture their IDs
-            List<RecordId> ids = new ArrayList<>();
-            for (int i = 0; i < 5; i++) {
-                Map<byte[], byte[]> fields = Map.of("index".getBytes(), String.valueOf(i).getBytes());
-                MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
-                    .in(streamKey.getBytes())
-                    .ofMap(fields);
-                ids.add(connection.streamCommands().xAdd(record));
-            }
-
-            RecordId id3 = ids.get(2); // Get the 3rd ID
-
-            // Trim using MINID - keep only entries with ID >= id3
-            Long trimmed = connection.streamCommands().xTrim(streamKey.getBytes(),
-                    XTrimOptions.trim(TrimOptions.minId(id3)));
-            assertThat(trimmed).isEqualTo(2L); // 2 entries removed (id1, id2)
-
-            // 3 entries remaining (id3, id4, id5)
-            assertThat(connection.streamCommands().xLen(streamKey.getBytes())).isEqualTo(3L);
-        } finally {
-            cleanupKey(streamKey);
-        }
-    }
-
-    @Test
-    @EnabledOnCommand("XTRIM")
-    void testXTrimWithXTrimOptionsApproximate() {
-        String streamKey = "test:stream:xtrim:approx";
-
-        try {
-            // Add 100 records
-            for (int i = 0; i < 100; i++) {
-                Map<byte[], byte[]> fields = Map.of("index".getBytes(), String.valueOf(i).getBytes());
-                MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
-                    .in(streamKey.getBytes())
-                    .ofMap(fields);
-                connection.streamCommands().xAdd(record);
-            }
-
-            // Trim with approximate trimming
-            connection.streamCommands().xTrim(streamKey.getBytes(),
-                    XTrimOptions.trim(TrimOptions.maxLen(50).approximate()));
-
-            // With approximate trimming, the result may not be exact but should be around 50
-            Long remaining = connection.streamCommands().xLen(streamKey.getBytes());
-            assertThat(remaining).isGreaterThanOrEqualTo(50L).isLessThanOrEqualTo(100L);
-        } finally {
-            cleanupKey(streamKey);
-        }
-    }
-
-    // ==================== XDELEX Tests ====================
-
-    @Test
-    @EnabledOnCommand("XDELEX")
-    void testXDelExShouldDeleteEntries() {
-        String streamKey = "test:stream:xdelex";
-
-        try {
-            // Add records
-            Map<byte[], byte[]> fields = Map.of("data".getBytes(), "test".getBytes());
-            MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
-                .in(streamKey.getBytes())
-                .ofMap(fields);
-
-            RecordId id1 = connection.streamCommands().xAdd(record);
-            RecordId id2 = connection.streamCommands().xAdd(record);
-
-            // Verify 2 entries
-            assertThat(connection.streamCommands().xLen(streamKey.getBytes())).isEqualTo(2L);
-
-            // Delete using xDelEx with default options
-            XDelOptions options = XDelOptions.defaults();
-            List<StreamEntryDeletionResult> results = connection.streamCommands().xDelEx(
-                    streamKey.getBytes(), options, id1, id2);
-
-            assertThat(results).hasSize(2);
-            assertThat(results.get(0)).isEqualTo(StreamEntryDeletionResult.DELETED);
-            assertThat(results.get(1)).isEqualTo(StreamEntryDeletionResult.DELETED);
-
-            // Verify entries were deleted
-            assertThat(connection.streamCommands().xLen(streamKey.getBytes())).isEqualTo(0L);
-        } finally {
-            cleanupKey(streamKey);
-        }
-    }
-
-    @Test
-    @EnabledOnCommand("XDELEX")
-    void testXDelExNonExistentEntry() {
-        String streamKey = "test:stream:xdelex:notfound";
-
-        try {
-            // Add one record
-            Map<byte[], byte[]> fields = Map.of("data".getBytes(), "test".getBytes());
-            MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
-                .in(streamKey.getBytes())
-                .ofMap(fields);
-            connection.streamCommands().xAdd(record);
-
-            // Try to delete a non-existent entry
-            XDelOptions options = XDelOptions.defaults();
-            List<StreamEntryDeletionResult> results = connection.streamCommands().xDelEx(
-                    streamKey.getBytes(), options, RecordId.of("9999999-0"));
-
-            assertThat(results).hasSize(1);
-            assertThat(results.get(0)).isEqualTo(StreamEntryDeletionResult.NOT_FOUND);
-        } finally {
-            cleanupKey(streamKey);
-        }
-    }
-
-    // ==================== XACKDEL Tests ====================
-
-    @Test
-    @EnabledOnCommand("XACKDEL")
-    void testXAckDelShouldAcknowledgeAndDeleteEntries() {
-        String streamKey = "test:stream:xackdel";
-        String groupName = "test-group";
-
-        try {
-            // Add records
-            Map<byte[], byte[]> fields = Map.of("data".getBytes(), "test".getBytes());
-            MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
-                .in(streamKey.getBytes())
-                .ofMap(fields);
-
-            RecordId id1 = connection.streamCommands().xAdd(record);
-            RecordId id2 = connection.streamCommands().xAdd(record);
-
-            // Create a consumer group
-            connection.streamCommands().xGroupCreate(streamKey.getBytes(), groupName, ReadOffset.from("0"), true);
-
-            // Read messages from the group to make them pending
-            connection.streamCommands().xReadGroup(
-                Consumer.from(groupName, "my-consumer"),
-                StreamReadOptions.empty(),
-                StreamOffset.create(streamKey.getBytes(), ReadOffset.lastConsumed())
-            );
-
-            // Use xAckDel to acknowledge and delete
-            XDelOptions options = XDelOptions.deletionPolicy(StreamDeletionPolicy.removeAcknowledged());
-            List<StreamEntryDeletionResult> results = connection.streamCommands().xAckDel(
-                    streamKey.getBytes(), groupName, options, id1, id2);
-
-            assertThat(results).hasSize(2);
-            assertThat(results.get(0)).isEqualTo(StreamEntryDeletionResult.DELETED);
-            assertThat(results.get(1)).isEqualTo(StreamEntryDeletionResult.DELETED);
-        } finally {
-            try {
-                connection.streamCommands().xGroupDestroy(streamKey.getBytes(), groupName);
-            } catch (Exception ignored) {}
-            cleanupKey(streamKey);
-        }
-    }
+
+	// Helper method to safely get value from byte array map by key content
+	private byte[] getValueByKeyContent(Map<byte[], byte[]> map, String keyContent) {
+		return map.entrySet()
+			.stream()
+			.filter(entry -> java.util.Arrays.equals(entry.getKey(), keyContent.getBytes()))
+			.map(Map.Entry::getValue)
+			.findFirst()
+			.orElse(null);
+	}
+
+	@Override
+	protected String[] getTestKeyPatterns() {
+		return new String[] { "test:stream:basic", "test:stream:group", "test:stream:consumer", "test:stream:read",
+				"test:stream:claim", "test:stream:pending", "test:stream:info", "test:stream:range", "test:stream:trim",
+				"test:stream:validation", "test:stream:pipeline", "test:stream:transaction", "test:stream:edge",
+				"test:stream:multi*", "test:stream:source*", "test:stream:target*" };
+	}
+
+	// ==================== Basic Stream Operations ====================
+
+	@Test
+	void testStreamBasicOperations() {
+		String streamKey = "test:stream:basic";
+
+		try {
+			// Test adding records
+			Map<byte[], byte[]> fields1 = Map.of("field1".getBytes(), "value1".getBytes(), "field2".getBytes(),
+					"value2".getBytes());
+
+			MapRecord<byte[], byte[], byte[]> record1 = StreamRecords.newRecord()
+				.in(streamKey.getBytes())
+				.ofMap(fields1);
+
+			RecordId id1 = connection.streamCommands().xAdd(record1);
+			assertThat(id1).isNotNull();
+			assertThat(id1.getValue()).isNotEmpty();
+
+			// Test stream length
+			Long length = connection.streamCommands().xLen(streamKey.getBytes());
+			assertThat(length).isEqualTo(1L);
+
+			// Add another record with auto-generated ID (avoid potential ID conflicts)
+			Map<byte[], byte[]> fields2 = Map.of("field3".getBytes(), "value3".getBytes());
+
+			MapRecord<byte[], byte[], byte[]> record2 = StreamRecords.newRecord()
+				.in(streamKey.getBytes())
+				.ofMap(fields2);
+
+			RecordId id2 = connection.streamCommands().xAdd(record2);
+			assertThat(id2).isNotNull();
+			assertThat(id2.getValue()).isNotEmpty();
+
+			// Test stream length after second record
+			length = connection.streamCommands().xLen(streamKey.getBytes());
+			assertThat(length).isEqualTo(2L);
+
+			// Test deleting a record
+			Long deletedCount = connection.streamCommands().xDel(streamKey.getBytes(), id1);
+			assertThat(deletedCount).isEqualTo(1L);
+
+			// Verify length after deletion
+			length = connection.streamCommands().xLen(streamKey.getBytes());
+			assertThat(length).isEqualTo(1L);
+
+			// Test deleting non-existent record
+			RecordId nonExistentId = RecordId.of("9999-0");
+			deletedCount = connection.streamCommands().xDel(streamKey.getBytes(), nonExistentId);
+			assertThat(deletedCount).isEqualTo(0L);
+
+		}
+		finally {
+			cleanupKey(streamKey);
+		}
+	}
+
+	@Test
+	void testStreamWithOptions() {
+		String streamKey = "test:stream:options";
+
+		try {
+			Map<byte[], byte[]> fields = Map.of("field1".getBytes(), "value1".getBytes());
+
+			// Test with MAXLEN option
+			MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord().in(streamKey.getBytes()).ofMap(fields);
+
+			ValkeyStreamCommands.XAddOptions options = ValkeyStreamCommands.XAddOptions.maxlen(5);
+			RecordId id = connection.streamCommands().xAdd(record, options);
+			assertThat(id).isNotNull();
+
+			// Test with approximation trimming
+			ValkeyStreamCommands.XAddOptions approxOptions = ValkeyStreamCommands.XAddOptions.maxlen(10)
+				.approximateTrimming(true);
+
+			RecordId id2 = connection.streamCommands().xAdd(record, approxOptions);
+			assertThat(id2).isNotNull();
+
+		}
+		finally {
+			cleanupKey(streamKey);
+		}
+	}
+
+	// ==================== Range Operations ====================
+
+	@Test
+	void testStreamRangeOperations() {
+		String streamKey = "test:stream:range";
+
+		try {
+			// Add multiple records
+			for (int i = 0; i < 5; i++) {
+				Map<byte[], byte[]> fields = Map.of("index".getBytes(), String.valueOf(i).getBytes(), "data".getBytes(),
+						("data" + i).getBytes());
+
+				MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
+					.in(streamKey.getBytes())
+					.ofMap(fields);
+
+				connection.streamCommands().xAdd(record);
+			}
+
+			// Test reading all records
+			List<ByteRecord> allRecords = connection.streamCommands()
+				.xRange(streamKey.getBytes(), Range.unbounded(), Limit.unlimited());
+
+			assertThat(allRecords).hasSize(5);
+
+			// Check if any key in the first record's value matches "index" content
+			boolean hasIndexKey = allRecords.get(0)
+				.getValue()
+				.keySet()
+				.stream()
+				.anyMatch(key -> java.util.Arrays.equals(key, "index".getBytes()));
+			assertThat(hasIndexKey).isTrue();
+
+			// Test with limit
+			List<ByteRecord> limitedRecords = connection.streamCommands()
+				.xRange(streamKey.getBytes(), Range.unbounded(), Limit.limit().count(3));
+
+			assertThat(limitedRecords).hasSize(3);
+
+			// Test reverse range
+			List<ByteRecord> reverseRecords = connection.streamCommands()
+				.xRevRange(streamKey.getBytes(), Range.unbounded(), Limit.unlimited());
+
+			assertThat(reverseRecords).hasSize(5);
+			// First record in reverse should be the last one added
+			byte[] indexValue = getValueByKeyContent(reverseRecords.get(0).getValue(), "index");
+			assertThat(indexValue).isNotNull();
+			assertThat(new String(indexValue)).isEqualTo("4");
+
+		}
+		finally {
+			cleanupKey(streamKey);
+		}
+	}
+
+	@Test
+	void testStreamRangeBoundaryOperations() {
+		String streamKey = "test:stream:boundary";
+
+		try {
+			// Add exactly 3 records to have clear boundaries for testing
+			List<RecordId> recordIds = new ArrayList<>();
+			for (int i = 0; i < 3; i++) {
+				Map<byte[], byte[]> fields = Map.of("index".getBytes(), String.valueOf(i).getBytes(), "data".getBytes(),
+						("record" + i).getBytes());
+
+				MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
+					.in(streamKey.getBytes())
+					.ofMap(fields);
+
+				RecordId recordId = connection.streamCommands().xAdd(record);
+				recordIds.add(recordId);
+			}
+
+			// Verify we have 3 records total
+			assertThat(recordIds).hasSize(3);
+
+			RecordId firstId = recordIds.get(0);
+			RecordId middleId = recordIds.get(1);
+			RecordId lastId = recordIds.get(2);
+
+			// Test inclusive range - should include both boundary records
+			List<ByteRecord> inclusiveRange = connection.streamCommands()
+				.xRange(streamKey.getBytes(), Range.from(Range.Bound.inclusive(firstId.getValue()))
+					.to(Range.Bound.inclusive(middleId.getValue())), Limit.unlimited());
+			assertThat(inclusiveRange).hasSize(2);
+			assertThat(inclusiveRange.get(0).getId()).isEqualTo(firstId);
+			assertThat(inclusiveRange.get(1).getId()).isEqualTo(middleId);
+
+			// Test exclusive lower bound - should exclude first record, include middle
+			List<ByteRecord> exclusiveLowerRange = connection.streamCommands()
+				.xRange(streamKey.getBytes(), Range.from(Range.Bound.exclusive(firstId.getValue()))
+					.to(Range.Bound.inclusive(middleId.getValue())), Limit.unlimited());
+			assertThat(exclusiveLowerRange).hasSize(1);
+			assertThat(exclusiveLowerRange.get(0).getId()).isEqualTo(middleId);
+
+			// Test exclusive upper bound - should include first record, exclude middle
+			List<ByteRecord> exclusiveUpperRange = connection.streamCommands()
+				.xRange(streamKey.getBytes(), Range.from(Range.Bound.inclusive(firstId.getValue()))
+					.to(Range.Bound.exclusive(middleId.getValue())), Limit.unlimited());
+			assertThat(exclusiveUpperRange).hasSize(1);
+			assertThat(exclusiveUpperRange.get(0).getId()).isEqualTo(firstId);
+
+			// Test both bounds exclusive - should return no records (only first and
+			// middle are in range)
+			List<ByteRecord> bothExclusiveRange = connection.streamCommands()
+				.xRange(streamKey.getBytes(), Range.from(Range.Bound.exclusive(firstId.getValue()))
+					.to(Range.Bound.exclusive(middleId.getValue())), Limit.unlimited());
+			assertThat(bothExclusiveRange).hasSize(0);
+
+			// Test reverse range with boundaries
+			// Inclusive reverse range - should include both boundary records in reverse
+			// order
+			List<ByteRecord> inclusiveRevRange = connection.streamCommands()
+				.xRevRange(streamKey.getBytes(), Range.from(Range.Bound.inclusive(firstId.getValue()))
+					.to(Range.Bound.inclusive(lastId.getValue())), Limit.unlimited());
+			assertThat(inclusiveRevRange).hasSize(3);
+			assertThat(inclusiveRevRange.get(0).getId()).isEqualTo(lastId); // Last record
+																			// first in
+																			// reverse
+			assertThat(inclusiveRevRange.get(1).getId()).isEqualTo(middleId); // Middle
+																				// record
+			assertThat(inclusiveRevRange.get(2).getId()).isEqualTo(firstId); // First
+																				// record
+																				// last in
+																				// reverse
+
+			// Exclusive reverse range - exclude first record
+			List<ByteRecord> exclusiveRevRange = connection.streamCommands()
+				.xRevRange(streamKey.getBytes(), Range.from(Range.Bound.exclusive(firstId.getValue()))
+					.to(Range.Bound.inclusive(lastId.getValue())), Limit.unlimited());
+			assertThat(exclusiveRevRange).hasSize(2);
+			assertThat(exclusiveRevRange.get(0).getId()).isEqualTo(lastId); // Last record
+																			// first
+			assertThat(exclusiveRevRange.get(1).getId()).isEqualTo(middleId); // Middle
+																				// record
+																				// second
+
+			// Exclusive reverse range - exclude last record
+			List<ByteRecord> exclusiveUpperRevRange = connection.streamCommands()
+				.xRevRange(streamKey.getBytes(), Range.from(Range.Bound.inclusive(firstId.getValue()))
+					.to(Range.Bound.exclusive(lastId.getValue())), Limit.unlimited());
+			assertThat(exclusiveUpperRevRange).hasSize(2);
+			assertThat(exclusiveUpperRevRange.get(0).getId()).isEqualTo(middleId); // Middle
+																					// record
+																					// first
+																					// in
+																					// reverse
+			assertThat(exclusiveUpperRevRange.get(1).getId()).isEqualTo(firstId); // First
+																					// record
+																					// second
+																					// in
+																					// reverse
+
+		}
+		finally {
+			cleanupKey(streamKey);
+		}
+	}
+
+	// ==================== Consumer Group Operations ====================
+
+	@Test
+	void testConsumerGroupOperations() {
+		String streamKey = "test:stream:group";
+		String groupName = "test-group";
+		String consumerName = "test-consumer";
+
+		try {
+			// Add some records first
+			Map<byte[], byte[]> fields = Map.of("field1".getBytes(), "value1".getBytes());
+
+			MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord().in(streamKey.getBytes()).ofMap(fields);
+
+			connection.streamCommands().xAdd(record);
+
+			// Create consumer group using MKSTREAM to avoid "key doesn't exist" error
+			String result = connection.streamCommands()
+				.xGroupCreate(streamKey.getBytes(), groupName, ReadOffset.from("0"), true);
+			assertThat(result).isEqualTo("OK");
+
+			// Test destroying consumer group
+			Boolean destroyed = connection.streamCommands().xGroupDestroy(streamKey.getBytes(), groupName);
+			assertThat(destroyed).isTrue();
+
+			// Try to destroy non-existent group
+			Boolean notDestroyed = connection.streamCommands().xGroupDestroy(streamKey.getBytes(), "non-existent");
+			assertThat(notDestroyed).isFalse();
+
+			// Create group again with MKSTREAM option
+			String streamKey2 = "test:stream:group:mkstream";
+			try {
+				String result2 = connection.streamCommands()
+					.xGroupCreate(streamKey2.getBytes(), groupName, ReadOffset.latest(), true);
+				assertThat(result2).isEqualTo("OK");
+
+				// Verify stream was created
+				Long length = connection.streamCommands().xLen(streamKey2.getBytes());
+				assertThat(length).isEqualTo(0L);
+
+			}
+			finally {
+				try {
+					connection.streamCommands().xGroupDestroy(streamKey2.getBytes(), groupName);
+				}
+				catch (Exception ignored) {
+				}
+				cleanupKey(streamKey2);
+			}
+
+		}
+		finally {
+			try {
+				connection.streamCommands().xGroupDestroy(streamKey.getBytes(), groupName);
+			}
+			catch (Exception ignored) {
+			}
+			cleanupKey(streamKey);
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void testConsumerManagement() {
+		String streamKey = "test:stream:consumer";
+		String groupName = "test-group";
+		String consumerName = "test-consumer";
+
+		try {
+			// Add record and create group
+			Map<byte[], byte[]> fields = Map.of("field1".getBytes(), "value1".getBytes());
+			MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord().in(streamKey.getBytes()).ofMap(fields);
+
+			connection.streamCommands().xAdd(record);
+			connection.streamCommands().xGroupCreate(streamKey.getBytes(), groupName, ReadOffset.from("0"));
+
+			Consumer consumer = Consumer.from(groupName, consumerName);
+
+			// Read a message to create the consumer
+			List<ByteRecord> records = connection.streamCommands()
+				.xReadGroup(consumer, StreamReadOptions.empty(),
+						StreamOffset.create(streamKey.getBytes(), ReadOffset.lastConsumed()));
+
+			if (!records.isEmpty()) {
+				// Delete the consumer - should return true for existing consumer with
+				// pending messages
+				Boolean deleted = connection.streamCommands().xGroupDelConsumer(streamKey.getBytes(), consumer);
+				assertThat(deleted).isTrue();
+			}
+
+			// Try to delete non-existent consumer - should return false
+			Consumer nonExistentConsumer = Consumer.from(groupName, "non-existent");
+			Boolean notDeleted = connection.streamCommands()
+				.xGroupDelConsumer(streamKey.getBytes(), nonExistentConsumer);
+			assertThat(notDeleted).isFalse();
+
+		}
+		finally {
+			try {
+				connection.streamCommands().xGroupDestroy(streamKey.getBytes(), groupName);
+			}
+			catch (Exception ignored) {
+			}
+			cleanupKey(streamKey);
+		}
+	}
+
+	// ==================== Stream Reading Operations ====================
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void testStreamReading() {
+		String streamKey = "test:stream:read";
+
+		try {
+			// Add some test records
+			for (int i = 0; i < 3; i++) {
+				Map<byte[], byte[]> fields = Map.of("index".getBytes(), String.valueOf(i).getBytes());
+
+				MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
+					.in(streamKey.getBytes())
+					.ofMap(fields);
+
+				connection.streamCommands().xAdd(record);
+			}
+
+			// Test reading from beginning
+			List<ByteRecord> records = connection.streamCommands()
+				.xRead(StreamReadOptions.empty(), StreamOffset.create(streamKey.getBytes(), ReadOffset.from("0")));
+
+			assertThat(records).hasSize(3);
+
+			// Test reading with count limit
+			List<ByteRecord> limitedRecords = connection.streamCommands()
+				.xRead(StreamReadOptions.empty().count(2),
+						StreamOffset.create(streamKey.getBytes(), ReadOffset.from("0")));
+
+			assertThat(limitedRecords).hasSize(2);
+
+		}
+		finally {
+			cleanupKey(streamKey);
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void testStreamGroupReading() {
+		String streamKey = "test:stream:groupread";
+		String groupName = "test-group";
+		String consumerName = "test-consumer";
+
+		try {
+			// Add test record
+			Map<byte[], byte[]> fields = Map.of("data".getBytes(), "test-value".getBytes());
+			MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord().in(streamKey.getBytes()).ofMap(fields);
+
+			RecordId addedId = connection.streamCommands().xAdd(record);
+			assertThat(addedId).isNotNull();
+
+			// Create consumer group
+			connection.streamCommands().xGroupCreate(streamKey.getBytes(), groupName, ReadOffset.from("0"));
+
+			Consumer consumer = Consumer.from(groupName, consumerName);
+
+			// Read from group
+			List<ByteRecord> records = connection.streamCommands()
+				.xReadGroup(consumer, StreamReadOptions.empty(),
+						StreamOffset.create(streamKey.getBytes(), ReadOffset.lastConsumed()));
+
+			assertThat(records).isNotEmpty();
+
+			// Test acknowledgement
+			if (!records.isEmpty()) {
+				RecordId recordId = records.get(0).getId();
+				Long ackCount = connection.streamCommands().xAck(streamKey.getBytes(), groupName, recordId);
+				assertThat(ackCount).isEqualTo(1L);
+
+				// Try to ack the same message again
+				Long ackCount2 = connection.streamCommands().xAck(streamKey.getBytes(), groupName, recordId);
+				assertThat(ackCount2).isEqualTo(0L);
+			}
+
+		}
+		finally {
+			try {
+				connection.streamCommands().xGroupDestroy(streamKey.getBytes(), groupName);
+			}
+			catch (Exception ignored) {
+			}
+			cleanupKey(streamKey);
+		}
+	}
+
+	// ==================== Pending Messages Operations ====================
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void testPendingMessages() {
+		String streamKey = "test:stream:pending";
+		String groupName = "test-group";
+		String consumerName = "test-consumer";
+
+		try {
+			// Add test record
+			Map<byte[], byte[]> fields = Map.of("data".getBytes(), "pending-test".getBytes());
+			MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord().in(streamKey.getBytes()).ofMap(fields);
+
+			connection.streamCommands().xAdd(record);
+
+			// Create consumer group and read message (making it pending)
+			connection.streamCommands().xGroupCreate(streamKey.getBytes(), groupName, ReadOffset.from("0"));
+
+			Consumer consumer = Consumer.from(groupName, consumerName);
+			List<ByteRecord> records = connection.streamCommands()
+				.xReadGroup(consumer, StreamReadOptions.empty(),
+						StreamOffset.create(streamKey.getBytes(), ReadOffset.lastConsumed()));
+
+			if (!records.isEmpty()) {
+				// Test pending messages summary
+				PendingMessagesSummary summary = connection.streamCommands().xPending(streamKey.getBytes(), groupName);
+				assertThat(summary).isNotNull();
+				assertThat(summary.getTotalPendingMessages()).isEqualTo(1L);
+				assertThat(summary.getGroupName()).isEmpty(); // Default group name is
+																// empty in summary
+
+				// Test detailed pending messages
+				PendingMessages pending = connection.streamCommands()
+					.xPending(streamKey.getBytes(), groupName, consumerName);
+				assertThat(pending).isNotNull();
+				assertThat(pending.isEmpty()).isFalse();
+				assertThat(pending.size()).isEqualTo(1);
+				assertThat(pending.getGroupName()).isEqualTo(groupName);
+
+				// Verify the pending message details
+				PendingMessage pendingMsg = pending.get(0);
+				assertThat(pendingMsg).isNotNull();
+				assertThat(pendingMsg.getConsumer().getName()).isEqualTo(consumerName);
+				assertThat(pendingMsg.getConsumer().getGroup()).isEqualTo(groupName);
+				assertThat(pendingMsg.getTotalDeliveryCount()).isEqualTo(1L);
+
+				// Test pending with range and count
+				PendingMessages pendingWithOptions = connection.streamCommands()
+					.xPending(streamKey.getBytes(), groupName,
+							ValkeyStreamCommands.XPendingOptions.range(Range.unbounded(), 10L));
+				assertThat(pendingWithOptions).isNotNull();
+				assertThat(pendingWithOptions.isEmpty()).isFalse();
+				assertThat(pendingWithOptions.size()).isEqualTo(1);
+			}
+
+		}
+		finally {
+			try {
+				connection.streamCommands().xGroupDestroy(streamKey.getBytes(), groupName);
+			}
+			catch (Exception ignored) {
+			}
+			cleanupKey(streamKey);
+		}
+	}
+
+	// ==================== Message Claiming Operations ====================
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void testMessageClaiming() {
+		String streamKey = "test:stream:claim";
+		String groupName = "test-group";
+		String consumer1 = "consumer1";
+		String consumer2 = "consumer2";
+
+		try {
+			// Add test record
+			Map<byte[], byte[]> fields = Map.of("data".getBytes(), "claim-test".getBytes());
+			MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord().in(streamKey.getBytes()).ofMap(fields);
+
+			connection.streamCommands().xAdd(record);
+
+			// Create consumer group and make message pending
+			connection.streamCommands().xGroupCreate(streamKey.getBytes(), groupName, ReadOffset.from("0"));
+
+			List<ByteRecord> records = connection.streamCommands()
+				.xReadGroup(Consumer.from(groupName, consumer1), StreamReadOptions.empty(),
+						StreamOffset.create(streamKey.getBytes(), ReadOffset.lastConsumed()));
+
+			if (!records.isEmpty()) {
+				RecordId pendingId = records.get(0).getId();
+
+				// Test claiming message
+				ValkeyStreamCommands.XClaimOptions claimOptions = ValkeyStreamCommands.XClaimOptions
+					.minIdle(Duration.ofMillis(0))
+					.ids(pendingId);
+
+				List<ByteRecord> claimedRecords = connection.streamCommands()
+					.xClaim(streamKey.getBytes(), groupName, consumer2, claimOptions);
+				assertThat(claimedRecords).isNotEmpty();
+				assertThat(claimedRecords).hasSize(1);
+
+				// Verify the claimed record has the expected content
+				ByteRecord claimedRecord = claimedRecords.get(0);
+				assertThat(claimedRecord.getId()).isEqualTo(pendingId);
+				byte[] claimedData = getValueByKeyContent(claimedRecord.getValue(), "data");
+				assertThat(claimedData).isNotNull();
+				assertThat(new String(claimedData)).isEqualTo("claim-test");
+
+				// Test claiming with just IDs
+				List<RecordId> claimedIds = connection.streamCommands()
+					.xClaimJustId(streamKey.getBytes(), groupName, consumer2, claimOptions);
+				assertThat(claimedIds).isNotEmpty();
+				assertThat(claimedIds).hasSize(1);
+				assertThat(claimedIds.get(0)).isEqualTo(pendingId);
+			}
+
+		}
+		finally {
+			try {
+				connection.streamCommands().xGroupDestroy(streamKey.getBytes(), groupName);
+			}
+			catch (Exception ignored) {
+			}
+			cleanupKey(streamKey);
+		}
+	}
+
+	// ==================== Stream Information Operations ====================
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void testStreamInformation() {
+		String streamKey = "test:stream:info";
+		String groupName = "test-group";
+		String consumerName = "test-consumer";
+
+		try {
+			// Add test record
+			Map<byte[], byte[]> fields = Map.of("info".getBytes(), "test".getBytes());
+			MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord().in(streamKey.getBytes()).ofMap(fields);
+
+			RecordId addedRecordId = connection.streamCommands().xAdd(record);
+			assertThat(addedRecordId).isNotNull();
+
+			// Test stream info - verify actual content
+			XInfoStream streamInfo = connection.streamCommands().xInfo(streamKey.getBytes());
+			assertThat(streamInfo).isNotNull();
+			assertThat(streamInfo.streamLength()).isEqualTo(1L);
+			assertThat(streamInfo.getFirstEntry()).isNotNull();
+			assertThat(streamInfo.getLastEntry()).isNotNull();
+
+			// Create consumer group and test group info - verify actual content
+			String createResult = connection.streamCommands()
+				.xGroupCreate(streamKey.getBytes(), groupName, ReadOffset.from("0"));
+			assertThat(createResult).isEqualTo("OK");
+
+			XInfoGroups groupsInfo = connection.streamCommands().xInfoGroups(streamKey.getBytes());
+			assertThat(groupsInfo).isNotNull();
+			assertThat(groupsInfo.isEmpty()).isFalse();
+			assertThat(groupsInfo.size()).isEqualTo(1);
+
+			// Verify group details
+			StreamInfo.XInfoGroup groupInfo = groupsInfo.iterator().next();
+			assertThat(groupInfo).isNotNull();
+			assertThat(groupInfo.groupName()).isEqualTo(groupName);
+			assertThat(groupInfo.consumerCount()).isEqualTo(0L); // No consumers yet
+			assertThat(groupInfo.pendingCount()).isEqualTo(0L); // No pending messages yet
+
+			// Make consumer active and test consumer info - verify actual content
+			List<ByteRecord> records = connection.streamCommands()
+				.xReadGroup(Consumer.from(groupName, consumerName), StreamReadOptions.empty(),
+						StreamOffset.create(streamKey.getBytes(), ReadOffset.lastConsumed()));
+
+			assertThat(records).isNotEmpty();
+			assertThat(records).hasSize(1);
+
+			// Verify the record content
+			ByteRecord readRecord = records.get(0);
+			assertThat(readRecord).isNotNull();
+			assertThat(readRecord.getId()).isNotNull();
+			byte[] infoValue = getValueByKeyContent(readRecord.getValue(), "info");
+			assertThat(infoValue).isNotNull();
+			assertThat(new String(infoValue)).isEqualTo("test");
+
+			// Test consumer info - verify actual content
+			XInfoConsumers consumersInfo = connection.streamCommands().xInfoConsumers(streamKey.getBytes(), groupName);
+			assertThat(consumersInfo).isNotNull();
+			assertThat(consumersInfo.isEmpty()).isFalse();
+			assertThat(consumersInfo.size()).isEqualTo(1);
+
+			// Verify consumer details
+			StreamInfo.XInfoConsumer consumerInfo = consumersInfo.iterator().next();
+			assertThat(consumerInfo).isNotNull();
+			assertThat(consumerInfo.consumerName()).isEqualTo(consumerName);
+			assertThat(consumerInfo.pendingCount()).isEqualTo(1L); // One pending message
+			assertThat(consumerInfo.idleTimeMs()).isGreaterThanOrEqualTo(0L);
+
+			// Verify group info is updated after consumer activity
+			XInfoGroups updatedGroupsInfo = connection.streamCommands().xInfoGroups(streamKey.getBytes());
+			StreamInfo.XInfoGroup updatedGroupInfo = updatedGroupsInfo.iterator().next();
+			assertThat(updatedGroupInfo.consumerCount()).isEqualTo(1L); // Now has one
+																		// consumer
+			assertThat(updatedGroupInfo.pendingCount()).isEqualTo(1L); // One pending
+																		// message
+
+		}
+		finally {
+			try {
+				connection.streamCommands().xGroupDestroy(streamKey.getBytes(), groupName);
+			}
+			catch (Exception ignored) {
+			}
+			cleanupKey(streamKey);
+		}
+	}
+
+	// ==================== Stream Trimming Operations ====================
+
+	@Test
+	void testStreamTrimming() {
+		String streamKey = "test:stream:trim";
+
+		try {
+			// Add multiple records
+			for (int i = 0; i < 10; i++) {
+				Map<byte[], byte[]> fields = Map.of("index".getBytes(), String.valueOf(i).getBytes());
+
+				MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
+					.in(streamKey.getBytes())
+					.ofMap(fields);
+
+				connection.streamCommands().xAdd(record);
+			}
+
+			// Verify initial length
+			Long initialLength = connection.streamCommands().xLen(streamKey.getBytes());
+			assertThat(initialLength).isEqualTo(10L);
+
+			// Test exact trimming
+			Long trimmed = connection.streamCommands().xTrim(streamKey.getBytes(), 5);
+			assertThat(trimmed).isGreaterThan(0L);
+
+			Long newLength = connection.streamCommands().xLen(streamKey.getBytes());
+			assertThat(newLength).isLessThanOrEqualTo(5L);
+
+			// Test approximate trimming
+			for (int i = 0; i < 5; i++) {
+				Map<byte[], byte[]> fields = Map.of("extra".getBytes(), String.valueOf(i).getBytes());
+
+				MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
+					.in(streamKey.getBytes())
+					.ofMap(fields);
+
+				connection.streamCommands().xAdd(record);
+			}
+
+			Long approximateTrimmed = connection.streamCommands().xTrim(streamKey.getBytes(), 3, true);
+			assertThat(approximateTrimmed).isNotNull();
+
+		}
+		finally {
+			cleanupKey(streamKey);
+		}
+	}
+
+	// ==================== Error Handling and Validation ====================
+
+	@SuppressWarnings({ "unchecked", "unchecked" })
+	@Test
+	void testErrorHandling() {
+		String streamKey = "test:stream:validation";
+
+		try {
+			// Test null parameter validation
+			assertThatThrownBy(() -> connection.streamCommands().xLen(null))
+				.isInstanceOf(IllegalArgumentException.class);
+
+			assertThatThrownBy(() -> connection.streamCommands().xAdd(null))
+				.isInstanceOf(IllegalArgumentException.class);
+
+			assertThatThrownBy(() -> connection.streamCommands().xDel(null, RecordId.of("1-0")))
+				.isInstanceOf(IllegalArgumentException.class);
+
+			assertThatThrownBy(() -> connection.streamCommands().xGroupCreate(null, "group", ReadOffset.latest()))
+				.isInstanceOf(IllegalArgumentException.class);
+
+			assertThatThrownBy(() -> connection.streamCommands().xAck(streamKey.getBytes(), null, RecordId.of("1-0")))
+				.isInstanceOf(IllegalArgumentException.class);
+
+			// Test operations on non-existent stream
+			Long length = connection.streamCommands().xLen("non:existent".getBytes());
+			assertThat(length).isEqualTo(0L);
+
+			// Test reading from non-existent stream
+			@SuppressWarnings("unchecked")
+			List<ByteRecord> records = connection.streamCommands()
+				.xRead(StreamReadOptions.empty(), StreamOffset.create("non:existent".getBytes(), ReadOffset.from("0")));
+			assertThat(records).isEmpty();
+
+			// Test xReadGroup on non-existent consumer group - should throw exception
+			assertThatThrownBy(() -> connection.streamCommands()
+				.xReadGroup(Consumer.from("non-existent-group", "consumer"), StreamReadOptions.empty(),
+						StreamOffset.create("non:existent".getBytes(), ReadOffset.from("0"))))
+				.isInstanceOf(ValkeySystemException.class)
+				.hasMessageContaining("NOGROUP");
+
+			// Test xRange on non-existent stream
+			List<ByteRecord> rangeRecords = connection.streamCommands()
+				.xRange("non:existent".getBytes(), Range.unbounded(), Limit.unlimited());
+			assertThat(rangeRecords).isEmpty();
+
+			// Test xRevRange on non-existent stream
+			List<ByteRecord> revRangeRecords = connection.streamCommands()
+				.xRevRange("non:existent".getBytes(), Range.unbounded(), Limit.unlimited());
+			assertThat(revRangeRecords).isEmpty();
+
+			// Test xClaim on non-existent consumer group - should throw exception
+			assertThatThrownBy(() -> connection.streamCommands()
+				.xClaim("non:existent".getBytes(), "group", "consumer",
+						ValkeyStreamCommands.XClaimOptions.minIdle(Duration.ofMillis(0)).ids(RecordId.of("0-0"))))
+				.isInstanceOf(ValkeySystemException.class)
+				.hasMessageContaining("NOGROUP");
+
+			// Test xClaimJustId on non-existent consumer group - should throw exception
+			assertThatThrownBy(() -> connection.streamCommands()
+				.xClaimJustId("non:existent".getBytes(), "group", "consumer",
+						ValkeyStreamCommands.XClaimOptions.minIdle(Duration.ofMillis(0)).ids(RecordId.of("0-0"))))
+				.isInstanceOf(ValkeySystemException.class)
+				.hasMessageContaining("NOGROUP");
+
+		}
+		finally {
+			cleanupKey(streamKey);
+		}
+	}
+
+	// ==================== Comprehensive Pipeline Mode Tests ====================
+
+	@Test
+	void testStreamBasicOperationsPipeline() {
+		String streamKey = "test:stream:pipeline:basic";
+
+		try {
+			connection.openPipeline();
+
+			// Test xAdd and xLen in pipeline
+			Map<byte[], byte[]> fields1 = Map.of("field1".getBytes(), "value1".getBytes());
+			MapRecord<byte[], byte[], byte[]> record1 = StreamRecords.newRecord()
+				.in(streamKey.getBytes())
+				.ofMap(fields1);
+
+			// Pipeline commands should return null
+			RecordId addResult1 = connection.streamCommands().xAdd(record1);
+			assertThat(addResult1).isNull();
+
+			Long lenResult1 = connection.streamCommands().xLen(streamKey.getBytes());
+			assertThat(lenResult1).isNull();
+
+			Map<byte[], byte[]> fields2 = Map.of("field2".getBytes(), "value2".getBytes());
+			MapRecord<byte[], byte[], byte[]> record2 = StreamRecords.newRecord()
+				.in(streamKey.getBytes())
+				.ofMap(fields2);
+
+			RecordId addResult2 = connection.streamCommands().xAdd(record2);
+			assertThat(addResult2).isNull();
+
+			Long lenResult2 = connection.streamCommands().xLen(streamKey.getBytes());
+			assertThat(lenResult2).isNull();
+
+			List<Object> results = connection.closePipeline();
+			assertThat(results).hasSize(4);
+
+			// First xAdd result should be a record ID
+			assertThat(results.get(0)).isNotNull();
+			// First xLen result should be 1
+			assertThat(((Number) results.get(1)).longValue()).isEqualTo(1L);
+			// Second xAdd result should be a record ID
+			assertThat(results.get(2)).isNotNull();
+			// Second xLen result should be 2
+			assertThat(((Number) results.get(3)).longValue()).isEqualTo(2L);
+
+		}
+		finally {
+			if (connection.isPipelined()) {
+				connection.closePipeline();
+			}
+			cleanupKey(streamKey);
+		}
+	}
+
+	@Test
+	void testStreamRangeOperationsPipeline() {
+		String streamKey = "test:stream:pipeline:range";
+
+		try {
+			// Setup data first
+			for (int i = 0; i < 5; i++) {
+				Map<byte[], byte[]> fields = Map.of("index".getBytes(), String.valueOf(i).getBytes());
+				MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
+					.in(streamKey.getBytes())
+					.ofMap(fields);
+				connection.streamCommands().xAdd(record);
+			}
+
+			connection.openPipeline();
+
+			// Test range operations in pipeline - pipeline commands should return null
+			List<ByteRecord> rangeResult = connection.streamCommands()
+				.xRange(streamKey.getBytes(), Range.unbounded(), Limit.unlimited());
+			assertThat(rangeResult).isNull();
+
+			List<ByteRecord> revRangeResult = connection.streamCommands()
+				.xRevRange(streamKey.getBytes(), Range.unbounded(), Limit.limit().count(3));
+			assertThat(revRangeResult).isNull();
+
+			Long lenResult = connection.streamCommands().xLen(streamKey.getBytes());
+			assertThat(lenResult).isNull();
+
+			List<Object> results = connection.closePipeline();
+			assertThat(results).hasSize(3);
+
+			// First result should be all 5 records
+			@SuppressWarnings("unchecked")
+			List<ByteRecord> rangeRecords = (List<ByteRecord>) results.get(0);
+			assertThat(rangeRecords).hasSize(5);
+
+			// Second result should be 3 records in reverse order
+			@SuppressWarnings("unchecked")
+			List<ByteRecord> revRangeRecords = (List<ByteRecord>) results.get(1);
+			assertThat(revRangeRecords).hasSize(3);
+
+			// Third result should be length 5
+			assertThat(((Number) results.get(2)).longValue()).isEqualTo(5L);
+
+		}
+		finally {
+			if (connection.isPipelined()) {
+				connection.closePipeline();
+			}
+			cleanupKey(streamKey);
+		}
+	}
+
+	@Test
+	void testStreamGroupOperationsPipeline() {
+		String streamKey = "test:stream:pipeline:group";
+		String groupName = "test-group";
+
+		try {
+			// Setup data first
+			Map<byte[], byte[]> fields = Map.of("data".getBytes(), "test".getBytes());
+			MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord().in(streamKey.getBytes()).ofMap(fields);
+			connection.streamCommands().xAdd(record);
+
+			connection.openPipeline();
+
+			// Test group operations in pipeline - pipeline commands should return null
+			String createResult = connection.streamCommands()
+				.xGroupCreate(streamKey.getBytes(), groupName, ReadOffset.from("0"));
+			assertThat(createResult).isNull();
+
+			XInfoGroups groupsResult = connection.streamCommands().xInfoGroups(streamKey.getBytes());
+			assertThat(groupsResult).isNull();
+
+			Boolean destroyResult = connection.streamCommands().xGroupDestroy(streamKey.getBytes(), groupName);
+			assertThat(destroyResult).isNull();
+
+			List<Object> results = connection.closePipeline();
+			assertThat(results).hasSize(3);
+
+			// First result should be "OK"
+			assertThat(results.get(0)).isEqualTo("OK");
+
+			// Second result should be groups info
+			assertThat(results.get(1)).isInstanceOf(XInfoGroups.class);
+			XInfoGroups groupsInfo = (XInfoGroups) results.get(1);
+			assertThat(groupsInfo.size()).isEqualTo(1);
+
+			// Third result should be true (group destroyed)
+			assertThat(results.get(2)).isEqualTo(true);
+
+		}
+		finally {
+			if (connection.isPipelined()) {
+				connection.closePipeline();
+			}
+			try {
+				connection.streamCommands().xGroupDestroy(streamKey.getBytes(), groupName);
+			}
+			catch (Exception ignored) {
+			}
+			cleanupKey(streamKey);
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void testStreamReadOperationsPipeline() {
+		String streamKey = "test:stream:pipeline:read";
+
+		try {
+			// Setup data first
+			for (int i = 0; i < 3; i++) {
+				Map<byte[], byte[]> fields = Map.of("index".getBytes(), String.valueOf(i).getBytes());
+				MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
+					.in(streamKey.getBytes())
+					.ofMap(fields);
+				connection.streamCommands().xAdd(record);
+			}
+
+			connection.openPipeline();
+
+			// Test read operations in pipeline
+			connection.streamCommands()
+				.xRead(StreamReadOptions.empty(), StreamOffset.create(streamKey.getBytes(), ReadOffset.from("0")));
+			connection.streamCommands()
+				.xRead(StreamReadOptions.empty().count(2),
+						StreamOffset.create(streamKey.getBytes(), ReadOffset.from("0")));
+			connection.streamCommands().xLen(streamKey.getBytes());
+
+			List<Object> results = connection.closePipeline();
+			assertThat(results).hasSize(3);
+
+			// First result should be all 3 records
+			List<ByteRecord> allRecords = (List<ByteRecord>) results.get(0);
+			assertThat(allRecords).hasSize(3);
+
+			// Second result should be 2 records
+			List<ByteRecord> limitedRecords = (List<ByteRecord>) results.get(1);
+			assertThat(limitedRecords).hasSize(2);
+
+			// Third result should be length 3
+			assertThat(((Number) results.get(2)).longValue()).isEqualTo(3L);
+
+		}
+		finally {
+			if (connection.isPipelined()) {
+				connection.closePipeline();
+			}
+			cleanupKey(streamKey);
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void testStreamInfoOperationsPipeline() {
+		String streamKey = "test:stream:pipeline:info";
+		String groupName = "test-group";
+		String consumerName = "test-consumer";
+
+		try {
+			// Setup data first
+			Map<byte[], byte[]> fields = Map.of("info".getBytes(), "test".getBytes());
+			MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord().in(streamKey.getBytes()).ofMap(fields);
+			connection.streamCommands().xAdd(record);
+
+			// Create group and consumer with pending message
+			connection.streamCommands().xGroupCreate(streamKey.getBytes(), groupName, ReadOffset.from("0"));
+			connection.streamCommands()
+				.xReadGroup(Consumer.from(groupName, consumerName), StreamReadOptions.empty(),
+						StreamOffset.create(streamKey.getBytes(), ReadOffset.lastConsumed()));
+
+			connection.openPipeline();
+
+			// Test info operations in pipeline
+			connection.streamCommands().xInfo(streamKey.getBytes());
+			connection.streamCommands().xInfoGroups(streamKey.getBytes());
+			connection.streamCommands().xInfoConsumers(streamKey.getBytes(), groupName);
+			connection.streamCommands().xPending(streamKey.getBytes(), groupName);
+
+			List<Object> results = connection.closePipeline();
+			assertThat(results).hasSize(4);
+
+			// Verify stream info
+			assertThat(results.get(0)).isInstanceOf(XInfoStream.class);
+			XInfoStream streamInfo = (XInfoStream) results.get(0);
+			assertThat(streamInfo.streamLength()).isEqualTo(1L);
+
+			// Verify groups info
+			assertThat(results.get(1)).isInstanceOf(XInfoGroups.class);
+			XInfoGroups groupsInfo = (XInfoGroups) results.get(1);
+			assertThat(groupsInfo.size()).isEqualTo(1);
+
+			// Verify consumers info
+			assertThat(results.get(2)).isInstanceOf(XInfoConsumers.class);
+			XInfoConsumers consumersInfo = (XInfoConsumers) results.get(2);
+			assertThat(consumersInfo.size()).isEqualTo(1);
+
+			// Verify pending messages
+			assertThat(results.get(3)).isInstanceOf(PendingMessagesSummary.class);
+			PendingMessagesSummary pendingSummary = (PendingMessagesSummary) results.get(3);
+			assertThat(pendingSummary.getTotalPendingMessages()).isEqualTo(1L);
+
+		}
+		finally {
+			if (connection.isPipelined()) {
+				connection.closePipeline();
+			}
+			try {
+				connection.streamCommands().xGroupDestroy(streamKey.getBytes(), groupName);
+			}
+			catch (Exception ignored) {
+			}
+			cleanupKey(streamKey);
+		}
+	}
+
+	// ==================== Comprehensive Transaction Mode Tests ====================
+
+	@Test
+	void testStreamBasicOperationsTransaction() {
+		String streamKey = "test:stream:transaction:basic";
+
+		try {
+			connection.multi();
+
+			// Test xAdd and xLen in transaction
+			Map<byte[], byte[]> fields1 = Map.of("field1".getBytes(), "value1".getBytes());
+			MapRecord<byte[], byte[], byte[]> record1 = StreamRecords.newRecord()
+				.in(streamKey.getBytes())
+				.ofMap(fields1);
+
+			// Transaction commands should return null
+			RecordId addResult1 = connection.streamCommands().xAdd(record1);
+			assertThat(addResult1).isNull();
+
+			Long lenResult1 = connection.streamCommands().xLen(streamKey.getBytes());
+			assertThat(lenResult1).isNull();
+
+			Map<byte[], byte[]> fields2 = Map.of("field2".getBytes(), "value2".getBytes());
+			MapRecord<byte[], byte[], byte[]> record2 = StreamRecords.newRecord()
+				.in(streamKey.getBytes())
+				.ofMap(fields2);
+
+			RecordId addResult2 = connection.streamCommands().xAdd(record2);
+			assertThat(addResult2).isNull();
+
+			Long lenResult2 = connection.streamCommands().xLen(streamKey.getBytes());
+			assertThat(lenResult2).isNull();
+
+			List<Object> results = connection.exec();
+			assertThat(results).hasSize(4);
+
+			// First xAdd result should be a record ID
+			assertThat(results.get(0)).isNotNull();
+			// First xLen result should be 1
+			assertThat(((Number) results.get(1)).longValue()).isEqualTo(1L);
+			// Second xAdd result should be a record ID
+			assertThat(results.get(2)).isNotNull();
+			// Second xLen result should be 2
+			assertThat(((Number) results.get(3)).longValue()).isEqualTo(2L);
+
+		}
+		finally {
+			if (connection.isQueueing()) {
+				connection.discard();
+			}
+			cleanupKey(streamKey);
+		}
+	}
+
+	@Test
+	void testStreamRangeOperationsTransaction() {
+		String streamKey = "test:stream:transaction:range";
+
+		try {
+			// Setup data first
+			for (int i = 0; i < 5; i++) {
+				Map<byte[], byte[]> fields = Map.of("index".getBytes(), String.valueOf(i).getBytes());
+				MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
+					.in(streamKey.getBytes())
+					.ofMap(fields);
+				connection.streamCommands().xAdd(record);
+			}
+
+			connection.multi();
+
+			// Test range operations in transaction
+			connection.streamCommands().xRange(streamKey.getBytes(), Range.unbounded(), Limit.unlimited());
+			connection.streamCommands().xRevRange(streamKey.getBytes(), Range.unbounded(), Limit.limit().count(3));
+			connection.streamCommands().xLen(streamKey.getBytes());
+
+			List<Object> results = connection.exec();
+			assertThat(results).hasSize(3);
+
+			// First result should be all 5 records
+			@SuppressWarnings("unchecked")
+			List<ByteRecord> rangeRecords = (List<ByteRecord>) results.get(0);
+			assertThat(rangeRecords).hasSize(5);
+
+			// Second result should be 3 records in reverse order
+			@SuppressWarnings("unchecked")
+			List<ByteRecord> revRangeRecords = (List<ByteRecord>) results.get(1);
+			assertThat(revRangeRecords).hasSize(3);
+
+			// Third result should be length 5
+			assertThat(((Number) results.get(2)).longValue()).isEqualTo(5L);
+
+		}
+		finally {
+			if (connection.isQueueing()) {
+				connection.discard();
+			}
+			cleanupKey(streamKey);
+		}
+	}
+
+	@Test
+	void testStreamGroupOperationsTransaction() {
+		String streamKey = "test:stream:transaction:group";
+		String groupName = "test-group";
+
+		try {
+			// Setup data first
+			Map<byte[], byte[]> fields = Map.of("data".getBytes(), "test".getBytes());
+			MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord().in(streamKey.getBytes()).ofMap(fields);
+			connection.streamCommands().xAdd(record);
+
+			connection.multi();
+
+			// Test group operations in transaction
+			connection.streamCommands().xGroupCreate(streamKey.getBytes(), groupName, ReadOffset.from("0"));
+			connection.streamCommands().xInfoGroups(streamKey.getBytes());
+
+			List<Object> results = connection.exec();
+			assertThat(results).hasSize(2);
+
+			// First result should be "OK"
+			assertThat(results.get(0)).isEqualTo("OK");
+
+			// Second result should be groups info
+			assertThat(results.get(1)).isInstanceOf(XInfoGroups.class);
+			XInfoGroups groupsInfo = (XInfoGroups) results.get(1);
+			assertThat(groupsInfo.size()).isEqualTo(1);
+
+		}
+		finally {
+			if (connection.isQueueing()) {
+				connection.discard();
+			}
+			try {
+				connection.streamCommands().xGroupDestroy(streamKey.getBytes(), groupName);
+			}
+			catch (Exception ignored) {
+			}
+			cleanupKey(streamKey);
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void testStreamReadOperationsTransaction() {
+		String streamKey = "test:stream:transaction:read";
+
+		try {
+			// Setup data first
+			for (int i = 0; i < 3; i++) {
+				Map<byte[], byte[]> fields = Map.of("index".getBytes(), String.valueOf(i).getBytes());
+				MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
+					.in(streamKey.getBytes())
+					.ofMap(fields);
+				connection.streamCommands().xAdd(record);
+			}
+
+			connection.multi();
+
+			// Test read operations in transaction
+			connection.streamCommands()
+				.xRead(StreamReadOptions.empty(), StreamOffset.create(streamKey.getBytes(), ReadOffset.from("0")));
+			connection.streamCommands()
+				.xRead(StreamReadOptions.empty().count(2),
+						StreamOffset.create(streamKey.getBytes(), ReadOffset.from("0")));
+			connection.streamCommands().xLen(streamKey.getBytes());
+
+			List<Object> results = connection.exec();
+			assertThat(results).hasSize(3);
+
+			// First result should be all 3 records
+			List<ByteRecord> allRecords = (List<ByteRecord>) results.get(0);
+			assertThat(allRecords).hasSize(3);
+
+			// Second result should be 2 records
+			List<ByteRecord> limitedRecords = (List<ByteRecord>) results.get(1);
+			assertThat(limitedRecords).hasSize(2);
+
+			// Third result should be length 3
+			assertThat(((Number) results.get(2)).longValue()).isEqualTo(3L);
+
+		}
+		finally {
+			if (connection.isQueueing()) {
+				connection.discard();
+			}
+			cleanupKey(streamKey);
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void testStreamInfoOperationsTransaction() {
+		String streamKey = "test:stream:transaction:info";
+		String groupName = "test-group";
+		String consumerName = "test-consumer";
+
+		try {
+			// Setup data first
+			Map<byte[], byte[]> fields = Map.of("info".getBytes(), "test".getBytes());
+			MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord().in(streamKey.getBytes()).ofMap(fields);
+			connection.streamCommands().xAdd(record);
+
+			// Create group and consumer with pending message
+			connection.streamCommands().xGroupCreate(streamKey.getBytes(), groupName, ReadOffset.from("0"));
+			connection.streamCommands()
+				.xReadGroup(Consumer.from(groupName, consumerName), StreamReadOptions.empty(),
+						StreamOffset.create(streamKey.getBytes(), ReadOffset.lastConsumed()));
+
+			connection.multi();
+
+			// Test info operations in transaction
+			connection.streamCommands().xInfo(streamKey.getBytes());
+			connection.streamCommands().xInfoGroups(streamKey.getBytes());
+			connection.streamCommands().xInfoConsumers(streamKey.getBytes(), groupName);
+			connection.streamCommands().xPending(streamKey.getBytes(), groupName);
+
+			List<Object> results = connection.exec();
+			assertThat(results).hasSize(4);
+
+			// Verify stream info
+			assertThat(results.get(0)).isInstanceOf(XInfoStream.class);
+			XInfoStream streamInfo = (XInfoStream) results.get(0);
+			assertThat(streamInfo.streamLength()).isEqualTo(1L);
+
+			// Verify groups info
+			assertThat(results.get(1)).isInstanceOf(XInfoGroups.class);
+			XInfoGroups groupsInfo = (XInfoGroups) results.get(1);
+			assertThat(groupsInfo.size()).isEqualTo(1);
+
+			// Verify consumers info
+			assertThat(results.get(2)).isInstanceOf(XInfoConsumers.class);
+			XInfoConsumers consumersInfo = (XInfoConsumers) results.get(2);
+			assertThat(consumersInfo.size()).isEqualTo(1);
+
+			// Verify pending messages
+			assertThat(results.get(3)).isInstanceOf(PendingMessagesSummary.class);
+			PendingMessagesSummary pendingSummary = (PendingMessagesSummary) results.get(3);
+			assertThat(pendingSummary.getTotalPendingMessages()).isEqualTo(1L);
+
+		}
+		finally {
+			if (connection.isQueueing()) {
+				connection.discard();
+			}
+			try {
+				connection.streamCommands().xGroupDestroy(streamKey.getBytes(), groupName);
+			}
+			catch (Exception ignored) {
+			}
+			cleanupKey(streamKey);
+		}
+	}
+
+	@Test
+	void testComplexStreamScenarioTransaction() {
+		String streamKey = "test:stream:transaction:complex";
+		String groupName = "test-group";
+
+		try {
+			// Setup initial data
+			Map<byte[], byte[]> fields = Map.of("data".getBytes(), "initial".getBytes());
+			MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord().in(streamKey.getBytes()).ofMap(fields);
+			connection.streamCommands().xAdd(record);
+
+			connection.multi();
+
+			// Complex scenario: add records, create group, read, acknowledge in one
+			// transaction
+			Map<byte[], byte[]> fields1 = Map.of("step".getBytes(), "1".getBytes());
+			MapRecord<byte[], byte[], byte[]> record1 = StreamRecords.newRecord()
+				.in(streamKey.getBytes())
+				.ofMap(fields1);
+			connection.streamCommands().xAdd(record1);
+
+			connection.streamCommands().xGroupCreate(streamKey.getBytes(), groupName, ReadOffset.from("0"));
+			connection.streamCommands().xLen(streamKey.getBytes());
+			connection.streamCommands().xInfo(streamKey.getBytes());
+
+			List<Object> results = connection.exec();
+			assertThat(results).hasSize(4);
+
+			// Verify transaction results
+			assertThat(results.get(0)).isNotNull(); // Record ID from xAdd
+			assertThat(results.get(1)).isEqualTo("OK"); // Group create result
+			assertThat(((Number) results.get(2)).longValue()).isEqualTo(2L); // Stream
+																				// length
+			assertThat(results.get(3)).isInstanceOf(XInfoStream.class); // Stream info
+
+			XInfoStream streamInfo = (XInfoStream) results.get(3);
+			assertThat(streamInfo.streamLength()).isEqualTo(2L);
+			assertThat(streamInfo.groupCount()).isEqualTo(1L);
+
+		}
+		finally {
+			if (connection.isQueueing()) {
+				connection.discard();
+			}
+			try {
+				connection.streamCommands().xGroupDestroy(streamKey.getBytes(), groupName);
+			}
+			catch (Exception ignored) {
+			}
+			cleanupKey(streamKey);
+		}
+	}
+
+	// ==================== Edge Cases and Complex Scenarios ====================
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void testComplexStreamScenario() {
+		String streamKey = "test:stream:edge";
+		String groupName = "edge-group";
+		String consumer1 = "consumer1";
+		String consumer2 = "consumer2";
+
+		try {
+			// Create a complex scenario with multiple records, groups, and consumers
+
+			// Add multiple records with different field structures
+			List<RecordId> addedIds = new ArrayList<>();
+			for (int i = 0; i < 5; i++) {
+				Map<byte[], byte[]> fields = new HashMap<>();
+				fields.put("id".getBytes(), String.valueOf(i).getBytes());
+				fields.put("data".getBytes(), ("value" + i).getBytes());
+
+				if (i % 2 == 0) {
+					fields.put("extra".getBytes(), ("extra" + i).getBytes());
+				}
+
+				MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
+					.in(streamKey.getBytes())
+					.ofMap(fields);
+
+				RecordId addedId = connection.streamCommands().xAdd(record);
+				assertThat(addedId).isNotNull();
+				assertThat(addedId.getValue()).isNotEmpty();
+				addedIds.add(addedId);
+			}
+
+			// Verify stream length after adding all records
+			Long streamLength = connection.streamCommands().xLen(streamKey.getBytes());
+			assertThat(streamLength).isEqualTo(5L);
+
+			// Create consumer group
+			String groupResult = connection.streamCommands()
+				.xGroupCreate(streamKey.getBytes(), groupName, ReadOffset.from("0"));
+			assertThat(groupResult).isEqualTo("OK");
+
+			// Have multiple consumers read messages
+			List<ByteRecord> records1 = connection.streamCommands()
+				.xReadGroup(Consumer.from(groupName, consumer1), StreamReadOptions.empty().count(2),
+						StreamOffset.create(streamKey.getBytes(), ReadOffset.lastConsumed()));
+
+			List<ByteRecord> records2 = connection.streamCommands()
+				.xReadGroup(Consumer.from(groupName, consumer2), StreamReadOptions.empty().count(2),
+						StreamOffset.create(streamKey.getBytes(), ReadOffset.lastConsumed()));
+
+			// Verify each consumer got the expected number of records
+			assertThat(records1).hasSize(2);
+			assertThat(records2).hasSize(2);
+
+			// Verify content of first consumer's first record
+			ByteRecord firstRecord = records1.get(0);
+			assertThat(firstRecord.getId()).isNotNull();
+			byte[] idValue = getValueByKeyContent(firstRecord.getValue(), "id");
+			assertThat(idValue).isNotNull();
+			String recordIndex = new String(idValue);
+			assertThat(recordIndex).matches("[0-4]"); // Should be one of the added record
+														// indices
+
+			byte[] dataValue = getValueByKeyContent(firstRecord.getValue(), "data");
+			assertThat(dataValue).isNotNull();
+			assertThat(new String(dataValue)).isEqualTo("value" + recordIndex);
+
+			// Verify pending messages before acknowledgment - both consumers should have
+			// pending messages
+			PendingMessagesSummary summaryBefore = connection.streamCommands()
+				.xPending(streamKey.getBytes(), groupName);
+
+			assertThat(summaryBefore.getTotalPendingMessages()).isEqualTo(4L); // 2 from
+																				// each
+																				// consumer
+
+			Map<String, Long> consumerMessageCountBefore = summaryBefore.getPendingMessagesPerConsumer();
+			assertThat(consumerMessageCountBefore).containsKey(consumer1);
+			assertThat(consumerMessageCountBefore).containsKey(consumer2);
+			assertThat(consumerMessageCountBefore.get(consumer1)).isEqualTo(2L);
+			assertThat(consumerMessageCountBefore.get(consumer2)).isEqualTo(2L);
+
+			// Acknowledge 1 message from consumer1, leaving 1 pending for consumer1 and 2
+			// for consumer2
+			Long ackCount = connection.streamCommands().xAck(streamKey.getBytes(), groupName, records1.get(0).getId());
+			assertThat(ackCount).isEqualTo(1L);
+
+			// Verify pending messages after acknowledgment - consumer1: 1 pending,
+			// consumer2: 2 pending, total: 3 pending
+			PendingMessagesSummary summary = connection.streamCommands().xPending(streamKey.getBytes(), groupName);
+			assertThat(summary.getTotalPendingMessages()).isEqualTo(3L);
+
+			// Verify consumer names in pending summary with exact counts
+			Map<String, Long> consumerMessageCount = summary.getPendingMessagesPerConsumer();
+			assertThat(consumerMessageCount).containsKey(consumer1);
+			assertThat(consumerMessageCount).containsKey(consumer2);
+			assertThat(consumerMessageCount.get(consumer1)).isEqualTo(1L); // Read 2,
+																			// acked 1 = 1
+																			// pending
+			assertThat(consumerMessageCount.get(consumer2)).isEqualTo(2L); // Read 2,
+																			// acked 0 = 2
+																			// pending
+
+			// Test stream info with detailed validation
+			XInfoStream streamInfo = connection.streamCommands().xInfo(streamKey.getBytes());
+			assertThat(streamInfo).isNotNull();
+			assertThat(streamInfo.streamLength()).isEqualTo(5L);
+			assertThat(streamInfo.groupCount()).isEqualTo(1L);
+			assertThat(streamInfo.getFirstEntry()).isNotNull();
+			assertThat(streamInfo.getLastEntry()).isNotNull();
+
+			// Test groups info with detailed validation
+			XInfoGroups groupsInfo = connection.streamCommands().xInfoGroups(streamKey.getBytes());
+			assertThat(groupsInfo).isNotNull();
+			assertThat(groupsInfo.isEmpty()).isFalse();
+			assertThat(groupsInfo.size()).isEqualTo(1);
+
+			StreamInfo.XInfoGroup groupInfo = groupsInfo.iterator().next();
+			assertThat(groupInfo.groupName()).isEqualTo(groupName);
+			assertThat(groupInfo.consumerCount()).isEqualTo(2L); // Two consumers were
+																	// active
+			assertThat(groupInfo.pendingCount()).isEqualTo(3L); // Total pending messages
+
+			// Test consumers info with detailed validation
+			XInfoConsumers consumersInfo = connection.streamCommands().xInfoConsumers(streamKey.getBytes(), groupName);
+			assertThat(consumersInfo).isNotNull();
+			assertThat(consumersInfo.size()).isEqualTo(2);
+
+			// Verify both consumers exist and have correct names
+			List<String> consumerNames = new ArrayList<>();
+			for (StreamInfo.XInfoConsumer consumerInfo : consumersInfo) {
+				consumerNames.add(consumerInfo.consumerName());
+				assertThat(consumerInfo.pendingCount()).isGreaterThanOrEqualTo(0L);
+				assertThat(consumerInfo.idleTimeMs()).isGreaterThanOrEqualTo(0L);
+			}
+			assertThat(consumerNames).containsExactlyInAnyOrder(consumer1, consumer2);
+
+		}
+		finally {
+			try {
+				connection.streamCommands().xGroupDestroy(streamKey.getBytes(), groupName);
+			}
+			catch (Exception ignored) {
+			}
+			cleanupKey(streamKey);
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void testMultipleStreamsReading() {
+		String stream1 = "test:stream:multi1";
+		String stream2 = "test:stream:multi2";
+
+		try {
+			// Add records to multiple streams
+			for (int i = 0; i < 3; i++) {
+				Map<byte[], byte[]> fields1 = Map.of("stream".getBytes(), "1".getBytes(), "index".getBytes(),
+						String.valueOf(i).getBytes());
+
+				Map<byte[], byte[]> fields2 = Map.of("stream".getBytes(), "2".getBytes(), "index".getBytes(),
+						String.valueOf(i).getBytes());
+
+				connection.streamCommands().xAdd(StreamRecords.newRecord().in(stream1.getBytes()).ofMap(fields1));
+
+				connection.streamCommands().xAdd(StreamRecords.newRecord().in(stream2.getBytes()).ofMap(fields2));
+			}
+
+			// Read from multiple streams
+			List<ByteRecord> records = connection.streamCommands()
+				.xRead(StreamReadOptions.empty(), StreamOffset.create(stream1.getBytes(), ReadOffset.from("0")),
+						StreamOffset.create(stream2.getBytes(), ReadOffset.from("0")));
+
+			assertThat(records).hasSize(6); // 3 from each stream
+
+			// Verify records come from both streams
+			boolean hasStream1 = records.stream().anyMatch(r -> {
+				byte[] streamValue = getValueByKeyContent(r.getValue(), "stream");
+				return streamValue != null && "1".equals(new String(streamValue));
+			});
+			boolean hasStream2 = records.stream().anyMatch(r -> {
+				byte[] streamValue = getValueByKeyContent(r.getValue(), "stream");
+				return streamValue != null && "2".equals(new String(streamValue));
+			});
+
+			assertThat(hasStream1).isTrue();
+			assertThat(hasStream2).isTrue();
+
+		}
+		finally {
+			cleanupKeys(stream1, stream2);
+		}
+	}
+
+	@Test
+	void testEmptyStreamOperations() {
+		String emptyStream = "test:stream:empty";
+
+		try {
+			// Test operations on non-existent stream
+			Long length = connection.streamCommands().xLen(emptyStream.getBytes());
+			assertThat(length).isEqualTo(0L);
+
+			// Test range operations on empty stream
+			List<ByteRecord> records = connection.streamCommands()
+				.xRange(emptyStream.getBytes(), Range.unbounded(), Limit.unlimited());
+			assertThat(records).isEmpty();
+
+			// Test trim on empty stream
+			Long trimmed = connection.streamCommands().xTrim(emptyStream.getBytes(), 5);
+			assertThat(trimmed).isEqualTo(0L);
+
+		}
+		finally {
+			cleanupKey(emptyStream);
+		}
+	}
+
+	// ==================== XTRIM with XTrimOptions Tests ====================
+
+	@Test
+	@EnabledOnCommand("XTRIM")
+	void testXTrimWithXTrimOptionsMaxlen() {
+		String streamKey = "test:stream:xtrim:maxlen";
+
+		try {
+			// Add 10 records
+			for (int i = 0; i < 10; i++) {
+				Map<byte[], byte[]> fields = Map.of("index".getBytes(), String.valueOf(i).getBytes());
+				MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
+					.in(streamKey.getBytes())
+					.ofMap(fields);
+				connection.streamCommands().xAdd(record);
+			}
+
+			// Verify initial length
+			assertThat(connection.streamCommands().xLen(streamKey.getBytes())).isEqualTo(10L);
+
+			// Trim to 5 entries using XTrimOptions with MAXLEN
+			Long trimmed = connection.streamCommands()
+				.xTrim(streamKey.getBytes(), XTrimOptions.trim(TrimOptions.maxLen(5)));
+			assertThat(trimmed).isEqualTo(5L); // 5 entries removed
+
+			// Verify 5 entries remaining
+			assertThat(connection.streamCommands().xLen(streamKey.getBytes())).isEqualTo(5L);
+		}
+		finally {
+			cleanupKey(streamKey);
+		}
+	}
+
+	@Test
+	@EnabledOnCommand("XTRIM")
+	void testXTrimWithXTrimOptionsMinId() {
+		String streamKey = "test:stream:xtrim:minid";
+
+		try {
+			// Add 5 records and capture their IDs
+			List<RecordId> ids = new ArrayList<>();
+			for (int i = 0; i < 5; i++) {
+				Map<byte[], byte[]> fields = Map.of("index".getBytes(), String.valueOf(i).getBytes());
+				MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
+					.in(streamKey.getBytes())
+					.ofMap(fields);
+				ids.add(connection.streamCommands().xAdd(record));
+			}
+
+			RecordId id3 = ids.get(2); // Get the 3rd ID
+
+			// Trim using MINID - keep only entries with ID >= id3
+			Long trimmed = connection.streamCommands()
+				.xTrim(streamKey.getBytes(), XTrimOptions.trim(TrimOptions.minId(id3)));
+			assertThat(trimmed).isEqualTo(2L); // 2 entries removed (id1, id2)
+
+			// 3 entries remaining (id3, id4, id5)
+			assertThat(connection.streamCommands().xLen(streamKey.getBytes())).isEqualTo(3L);
+		}
+		finally {
+			cleanupKey(streamKey);
+		}
+	}
+
+	@Test
+	@EnabledOnCommand("XTRIM")
+	void testXTrimWithXTrimOptionsApproximate() {
+		String streamKey = "test:stream:xtrim:approx";
+
+		try {
+			// Add 100 records
+			for (int i = 0; i < 100; i++) {
+				Map<byte[], byte[]> fields = Map.of("index".getBytes(), String.valueOf(i).getBytes());
+				MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord()
+					.in(streamKey.getBytes())
+					.ofMap(fields);
+				connection.streamCommands().xAdd(record);
+			}
+
+			// Trim with approximate trimming
+			connection.streamCommands()
+				.xTrim(streamKey.getBytes(), XTrimOptions.trim(TrimOptions.maxLen(50).approximate()));
+
+			// With approximate trimming, the result may not be exact but should be around
+			// 50
+			Long remaining = connection.streamCommands().xLen(streamKey.getBytes());
+			assertThat(remaining).isGreaterThanOrEqualTo(50L).isLessThanOrEqualTo(100L);
+		}
+		finally {
+			cleanupKey(streamKey);
+		}
+	}
+
+	// ==================== XDELEX Tests ====================
+
+	@Test
+	@EnabledOnCommand("XDELEX")
+	void testXDelExShouldDeleteEntries() {
+		String streamKey = "test:stream:xdelex";
+
+		try {
+			// Add records
+			Map<byte[], byte[]> fields = Map.of("data".getBytes(), "test".getBytes());
+			MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord().in(streamKey.getBytes()).ofMap(fields);
+
+			RecordId id1 = connection.streamCommands().xAdd(record);
+			RecordId id2 = connection.streamCommands().xAdd(record);
+
+			// Verify 2 entries
+			assertThat(connection.streamCommands().xLen(streamKey.getBytes())).isEqualTo(2L);
+
+			// Delete using xDelEx with default options
+			XDelOptions options = XDelOptions.defaults();
+			List<StreamEntryDeletionResult> results = connection.streamCommands()
+				.xDelEx(streamKey.getBytes(), options, id1, id2);
+
+			assertThat(results).hasSize(2);
+			assertThat(results.get(0)).isEqualTo(StreamEntryDeletionResult.DELETED);
+			assertThat(results.get(1)).isEqualTo(StreamEntryDeletionResult.DELETED);
+
+			// Verify entries were deleted
+			assertThat(connection.streamCommands().xLen(streamKey.getBytes())).isEqualTo(0L);
+		}
+		finally {
+			cleanupKey(streamKey);
+		}
+	}
+
+	@Test
+	@EnabledOnCommand("XDELEX")
+	void testXDelExNonExistentEntry() {
+		String streamKey = "test:stream:xdelex:notfound";
+
+		try {
+			// Add one record
+			Map<byte[], byte[]> fields = Map.of("data".getBytes(), "test".getBytes());
+			MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord().in(streamKey.getBytes()).ofMap(fields);
+			connection.streamCommands().xAdd(record);
+
+			// Try to delete a non-existent entry
+			XDelOptions options = XDelOptions.defaults();
+			List<StreamEntryDeletionResult> results = connection.streamCommands()
+				.xDelEx(streamKey.getBytes(), options, RecordId.of("9999999-0"));
+
+			assertThat(results).hasSize(1);
+			assertThat(results.get(0)).isEqualTo(StreamEntryDeletionResult.NOT_FOUND);
+		}
+		finally {
+			cleanupKey(streamKey);
+		}
+	}
+
+	// ==================== XACKDEL Tests ====================
+
+	@Test
+	@EnabledOnCommand("XACKDEL")
+	void testXAckDelShouldAcknowledgeAndDeleteEntries() {
+		String streamKey = "test:stream:xackdel";
+		String groupName = "test-group";
+
+		try {
+			// Add records
+			Map<byte[], byte[]> fields = Map.of("data".getBytes(), "test".getBytes());
+			MapRecord<byte[], byte[], byte[]> record = StreamRecords.newRecord().in(streamKey.getBytes()).ofMap(fields);
+
+			RecordId id1 = connection.streamCommands().xAdd(record);
+			RecordId id2 = connection.streamCommands().xAdd(record);
+
+			// Create a consumer group
+			connection.streamCommands().xGroupCreate(streamKey.getBytes(), groupName, ReadOffset.from("0"), true);
+
+			// Read messages from the group to make them pending
+			connection.streamCommands()
+				.xReadGroup(Consumer.from(groupName, "my-consumer"), StreamReadOptions.empty(),
+						StreamOffset.create(streamKey.getBytes(), ReadOffset.lastConsumed()));
+
+			// Use xAckDel to acknowledge and delete
+			XDelOptions options = XDelOptions.deletionPolicy(StreamDeletionPolicy.removeAcknowledged());
+			List<StreamEntryDeletionResult> results = connection.streamCommands()
+				.xAckDel(streamKey.getBytes(), groupName, options, id1, id2);
+
+			assertThat(results).hasSize(2);
+			assertThat(results.get(0)).isEqualTo(StreamEntryDeletionResult.DELETED);
+			assertThat(results.get(1)).isEqualTo(StreamEntryDeletionResult.DELETED);
+		}
+		finally {
+			try {
+				connection.streamCommands().xGroupDestroy(streamKey.getBytes(), groupName);
+			}
+			catch (Exception ignored) {
+			}
+			cleanupKey(streamKey);
+		}
+	}
+
 }

--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionStringCommandsIntegrationTests.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionStringCommandsIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,1452 +32,1574 @@ import io.valkey.springframework.data.valkey.connection.ValkeyStringCommands.Set
 import io.valkey.springframework.data.valkey.core.types.Expiration;
 
 /**
- * Comprehensive low-level integration tests for {@link ValkeyGlideConnection} 
- * string functionality using the ValkeyStringCommands interface directly.
- * 
- * These tests validate the implementation of all ValkeyStringCommands methods:
- * - Basic string operations (get, set, getSet, etc.)
- * - Multi-key operations (mGet, mSet, mSetNX)
- * - Expiration-related operations (setEx, pSetEx, getEx, getDel)
- * - Increment/decrement operations (incr, incrBy, decr, decrBy)
- * - String manipulation (append, getRange, setRange, strLen)
- * - Bit operations (getBit, setBit, bitCount, bitField, bitOp, bitPos)
+ * Comprehensive low-level integration tests for {@link ValkeyGlideConnection} string
+ * functionality using the ValkeyStringCommands interface directly.
+ *
+ * These tests validate the implementation of all ValkeyStringCommands methods: - Basic
+ * string operations (get, set, getSet, etc.) - Multi-key operations (mGet, mSet, mSetNX)
+ * - Expiration-related operations (setEx, pSetEx, getEx, getDel) - Increment/decrement
+ * operations (incr, incrBy, decr, decrBy) - String manipulation (append, getRange,
+ * setRange, strLen) - Bit operations (getBit, setBit, bitCount, bitField, bitOp, bitPos)
  *
  * @author Ilia Kolominsky
  * @since 2.0
  */
 public class ValkeyGlideConnectionStringCommandsIntegrationTests extends AbstractValkeyGlideIntegrationTests {
 
-    @Override
-    protected String[] getTestKeyPatterns() {
-        return new String[]{
-            "test:string:getset", "test:string:getset:old", "new:key",
-            "test:string:getdel", "test:string:getex", "test:string:setoptions",
-            "test:string:setget", "test:string:setex", "test:string:psetex",
-            "test:string:mget:key1", "test:string:mget:key2", "test:string:mget:key3",
-            "test:string:msetnx:key1", "test:string:msetnx:key2", "test:string:msetnx:existing",
-            "test:string:msetnx:new1", "test:string:msetnx:new2",
-            "test:string:incrdecr", "test:string:incrby:int", "test:string:incrby:float",
-            "test:string:append", "test:string:range", "test:string:bit", 
-            "test:string:bitcount", "test:string:bitpos", 
-            "test:string:bitop:key1", "test:string:bitop:key2", "test:string:bitop:dest",
-            "test:string:bitfield", "test:string:error:list", "test:string:empty"
-        };
-    }
+	@Override
+	protected String[] getTestKeyPatterns() {
+		return new String[] { "test:string:getset", "test:string:getset:old", "new:key", "test:string:getdel",
+				"test:string:getex", "test:string:setoptions", "test:string:setget", "test:string:setex",
+				"test:string:psetex", "test:string:mget:key1", "test:string:mget:key2", "test:string:mget:key3",
+				"test:string:msetnx:key1", "test:string:msetnx:key2", "test:string:msetnx:existing",
+				"test:string:msetnx:new1", "test:string:msetnx:new2", "test:string:incrdecr", "test:string:incrby:int",
+				"test:string:incrby:float", "test:string:append", "test:string:range", "test:string:bit",
+				"test:string:bitcount", "test:string:bitpos", "test:string:bitop:key1", "test:string:bitop:key2",
+				"test:string:bitop:dest", "test:string:bitfield", "test:string:error:list", "test:string:empty" };
+	}
 
-    // ==================== Basic String Operations ====================
+	// ==================== Basic String Operations ====================
 
-    @Test
-    void testGetSet() {
-        String key = "test:string:getset";
-        byte[] keyBytes = key.getBytes();
-        byte[] value = "test_value".getBytes();
-        
-        try {
-            // Set initial value
-            Boolean setResult = connection.stringCommands().set(keyBytes, value);
-            assertThat(setResult).isTrue();
-            
-            // Get the value
-            byte[] retrievedValue = connection.stringCommands().get(keyBytes);
-            assertThat(retrievedValue).isEqualTo(value);
-            
-            // Test non-existent key
-            byte[] nonExistentValue = connection.stringCommands().get("non:existent:key".getBytes());
-            assertThat(nonExistentValue).isNull();
-        } finally {
-            cleanupKey(key);
-        }
-    }
+	@Test
+	void testGetSet() {
+		String key = "test:string:getset";
+		byte[] keyBytes = key.getBytes();
+		byte[] value = "test_value".getBytes();
 
-    @Test
-    void testGetSetWithOldValue() {
-        String key = "test:string:getset:old";
-        byte[] keyBytes = key.getBytes();
-        byte[] initialValue = "initial".getBytes();
-        byte[] newValue = "new_value".getBytes();
-        
-        try {
-            // Set initial value
-            connection.stringCommands().set(keyBytes, initialValue);
-            
-            // Get and set new value
-            byte[] oldValue = connection.stringCommands().getSet(keyBytes, newValue);
-            assertThat(oldValue).isEqualTo(initialValue);
-            
-            // Verify new value is set
-            byte[] currentValue = connection.stringCommands().get(keyBytes);
-            assertThat(currentValue).isEqualTo(newValue);
-            
-            // Test getSet on non-existent key
-            byte[] nonExistentOld = connection.stringCommands().getSet("new:key".getBytes(), "value".getBytes());
-            assertThat(nonExistentOld).isNull();
-        } finally {
-            cleanupKey(key);
-            cleanupKey("new:key");
-        }
-    }
+		try {
+			// Set initial value
+			Boolean setResult = connection.stringCommands().set(keyBytes, value);
+			assertThat(setResult).isTrue();
 
-    @Test
-    void testGetDelAndGetEx() {
-        String key1 = "test:string:getdel";
-        String key2 = "test:string:getex";
-        byte[] value = "test_value".getBytes();
-        
-        try {
-            // Test getDel
-            connection.stringCommands().set(key1.getBytes(), value);
-            byte[] retrievedValue = connection.stringCommands().getDel(key1.getBytes());
-            assertThat(retrievedValue).isEqualTo(value);
-            
-            // Verify key is deleted
-            byte[] deletedValue = connection.stringCommands().get(key1.getBytes());
-            assertThat(deletedValue).isNull();
-            
-            // Test getEx with expiration
-            connection.stringCommands().set(key2.getBytes(), value);
-            byte[] exValue = connection.stringCommands().getEx(key2.getBytes(), Expiration.seconds(1));
-            assertThat(exValue).isEqualTo(value);
-            
-            // Wait for expiration and verify
-            Thread.sleep(1100);
-            byte[] expiredValue = connection.stringCommands().get(key2.getBytes());
-            assertThat(expiredValue).isNull();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-        }
-    }
+			// Get the value
+			byte[] retrievedValue = connection.stringCommands().get(keyBytes);
+			assertThat(retrievedValue).isEqualTo(value);
 
-    @Test
-    void testGetExPersistent() {
-        String key = "test:string:getex:persistent";
-        byte[] value = "persistent_value".getBytes();
-        
-        try {
-            // Set key with expiration first
-            connection.stringCommands().set(key.getBytes(), value, Expiration.seconds(60), SetOption.upsert());
-            
-            // Verify key has expiration
-            Long ttlBefore = connection.keyCommands().ttl(key.getBytes());
-            assertThat(ttlBefore).isGreaterThan(0);
-            
-            // Test getEx with persistent expiration (should remove expiration)
-            byte[] retrievedValue = connection.stringCommands().getEx(key.getBytes(), Expiration.persistent());
-            assertThat(retrievedValue).isEqualTo(value);
-            
-            // Verify key no longer has expiration
-            Long ttlAfter = connection.keyCommands().ttl(key.getBytes());
-            assertThat(ttlAfter).isEqualTo(-1L); // -1 means no expiration
-            
-            // Verify value is still accessible
-            byte[] finalValue = connection.stringCommands().get(key.getBytes());
-            assertThat(finalValue).isEqualTo(value);
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test non-existent key
+			byte[] nonExistentValue = connection.stringCommands().get("non:existent:key".getBytes());
+			assertThat(nonExistentValue).isNull();
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
 
-    @Test
-    void testGetExKeepTtl() {
-        String key = "test:string:getex:keepttl";
-        byte[] value = "keepttl_value".getBytes();
-        
-        try {
-            // Set key with expiration first
-            connection.stringCommands().set(key.getBytes(), value, Expiration.seconds(60), SetOption.upsert());
-            
-            // Get initial TTL
-            Long ttlBefore = connection.keyCommands().ttl(key.getBytes());
-            assertThat(ttlBefore).isGreaterThan(0);
-            
-            // Test getEx with keepTtl expiration (should preserve existing expiration)
-            byte[] retrievedValue = connection.stringCommands().getEx(key.getBytes(), Expiration.keepTtl());
-            assertThat(retrievedValue).isEqualTo(value);
-            
-            // Verify key still has similar expiration
-            Long ttlAfter = connection.keyCommands().ttl(key.getBytes());
-            assertThat(ttlAfter).isGreaterThan(0);
-            assertThat(ttlAfter).isLessThanOrEqualTo(ttlBefore); // Should be same or slightly less due to time passage
-            
-            // Verify value is still accessible
-            byte[] finalValue = connection.stringCommands().get(key.getBytes());
-            assertThat(finalValue).isEqualTo(value);
-        } finally {
-            cleanupKey(key);
-        }
-    }
+	@Test
+	void testGetSetWithOldValue() {
+		String key = "test:string:getset:old";
+		byte[] keyBytes = key.getBytes();
+		byte[] initialValue = "initial".getBytes();
+		byte[] newValue = "new_value".getBytes();
 
-    @Test
-    void testSetWithOptions() {
-        String key = "test:string:setoptions";
-        byte[] keyBytes = key.getBytes();
-        byte[] value1 = "value1".getBytes();
-        byte[] value2 = "value2".getBytes();
-        
-        try {
-            // Test setNX (set if not exists)
-            Boolean setNXResult1 = connection.stringCommands().setNX(keyBytes, value1);
-            assertThat(setNXResult1).isTrue();
-            
-            // Try setNX again - should fail
-            Boolean setNXResult2 = connection.stringCommands().setNX(keyBytes, value2);
-            assertThat(setNXResult2).isFalse();
-            
-            // Verify original value remains
-            assertThat(connection.stringCommands().get(keyBytes)).isEqualTo(value1);
-            
-            // Test set with SetOption.IF_PRESENT
-            Boolean setIfPresent = connection.stringCommands().set(keyBytes, value2, 
-                Expiration.persistent(), SetOption.ifPresent());
-            assertThat(setIfPresent).isTrue();
-            assertThat(connection.stringCommands().get(keyBytes)).isEqualTo(value2);
-            
-            // Test set with SetOption.IF_ABSENT on existing key
-            Boolean setIfAbsent = connection.stringCommands().set(keyBytes, value1, 
-                Expiration.persistent(), SetOption.ifAbsent());
-            assertThat(setIfAbsent).isFalse();
-            assertThat(connection.stringCommands().get(keyBytes)).isEqualTo(value2);
-        } finally {
-            cleanupKey(key);
-        }
-    }
+		try {
+			// Set initial value
+			connection.stringCommands().set(keyBytes, initialValue);
 
-    @Test
-    void testSetGet() {
-        String key = "test:string:setget";
-        byte[] keyBytes = key.getBytes();
-        byte[] value1 = "initial".getBytes();
-        byte[] value2 = "updated".getBytes();
-        
-        try {
-            // Test setGet on non-existing key
-            byte[] oldValue1 = connection.stringCommands().setGet(keyBytes, value1, 
-                Expiration.persistent(), SetOption.upsert());
-            assertThat(oldValue1).isNull();
-            assertThat(connection.stringCommands().get(keyBytes)).isEqualTo(value1);
-            
-            // Test setGet on existing key
-            byte[] oldValue2 = connection.stringCommands().setGet(keyBytes, value2, 
-                Expiration.persistent(), SetOption.upsert());
-            assertThat(oldValue2).isEqualTo(value1);
-            assertThat(connection.stringCommands().get(keyBytes)).isEqualTo(value2);
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Get and set new value
+			byte[] oldValue = connection.stringCommands().getSet(keyBytes, newValue);
+			assertThat(oldValue).isEqualTo(initialValue);
 
-    @Test
-    void testSetWithExpiration() {
-        String key1 = "test:string:setex";
-        String key2 = "test:string:psetex";
-        byte[] value = "expiring_value".getBytes();
-        
-        try {
-            // Test setEx (seconds)
-            Boolean setExResult = connection.stringCommands().setEx(key1.getBytes(), 1, value);
-            assertThat(setExResult).isTrue();
-            assertThat(connection.stringCommands().get(key1.getBytes())).isEqualTo(value);
-            
-            // Test pSetEx (milliseconds)
-            Boolean pSetExResult = connection.stringCommands().pSetEx(key2.getBytes(), 1000, value);
-            assertThat(pSetExResult).isTrue();
-            assertThat(connection.stringCommands().get(key2.getBytes())).isEqualTo(value);
-            
-            // Wait for expiration
-            Thread.sleep(1100);
-            assertThat(connection.stringCommands().get(key1.getBytes())).isNull();
-            assertThat(connection.stringCommands().get(key2.getBytes())).isNull();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-        }
-    }
+			// Verify new value is set
+			byte[] currentValue = connection.stringCommands().get(keyBytes);
+			assertThat(currentValue).isEqualTo(newValue);
 
-    // ==================== Multi-Key Operations ====================
+			// Test getSet on non-existent key
+			byte[] nonExistentOld = connection.stringCommands().getSet("new:key".getBytes(), "value".getBytes());
+			assertThat(nonExistentOld).isNull();
+		}
+		finally {
+			cleanupKey(key);
+			cleanupKey("new:key");
+		}
+	}
 
-    @Test
-    void testMGetMSet() {
-        String key1 = "test:string:mget:key1";
-        String key2 = "test:string:mget:key2";
-        String key3 = "test:string:mget:key3";
-        
-        try {
-            // Set up test data
-            Map<byte[], byte[]> keyValues = new HashMap<>();
-            keyValues.put(key1.getBytes(), "value1".getBytes());
-            keyValues.put(key2.getBytes(), "value2".getBytes());
-            keyValues.put(key3.getBytes(), "value3".getBytes());
-            
-            // Test mSet
-            Boolean mSetResult = connection.stringCommands().mSet(keyValues);
-            assertThat(mSetResult).isTrue();
-            
-            // Test mGet
-            List<byte[]> values = connection.stringCommands().mGet(
-                key1.getBytes(), key2.getBytes(), key3.getBytes(), "non:existent".getBytes());
-            
-            assertThat(values).hasSize(4);
-            assertThat(values.get(0)).isEqualTo("value1".getBytes());
-            assertThat(values.get(1)).isEqualTo("value2".getBytes());
-            assertThat(values.get(2)).isEqualTo("value3".getBytes());
-            assertThat(values.get(3)).isNull(); // non-existent key
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-            cleanupKey(key3);
-        }
-    }
+	@Test
+	void testGetDelAndGetEx() {
+		String key1 = "test:string:getdel";
+		String key2 = "test:string:getex";
+		byte[] value = "test_value".getBytes();
 
-    @Test
-    void testMSetNX() {
-        String key1 = "test:string:msetnx:key1";
-        String key2 = "test:string:msetnx:key2";
-        String key3 = "test:string:msetnx:existing";
-        String key4 = "test:string:msetnx:new1";
-        String key5 = "test:string:msetnx:new2";
-        
-        try {
-            // Set one key first
-            connection.stringCommands().set(key3.getBytes(), "existing_value".getBytes());
-            
-            // Try mSetNX with mix of new and existing keys
-            Map<byte[], byte[]> keyValues = new HashMap<>();
-            keyValues.put(key1.getBytes(), "value1".getBytes());
-            keyValues.put(key2.getBytes(), "value2".getBytes());
-            keyValues.put(key3.getBytes(), "new_value".getBytes()); // existing key
-            
-            Boolean mSetNXResult = connection.stringCommands().mSetNX(keyValues);
-            assertThat(mSetNXResult).isFalse(); // Should fail due to existing key
-            
-            // Verify none of the keys were set
-            assertThat(connection.stringCommands().get(key1.getBytes())).isNull();
-            assertThat(connection.stringCommands().get(key2.getBytes())).isNull();
-            assertThat(connection.stringCommands().get(key3.getBytes())).isEqualTo("existing_value".getBytes());
-            
-            // Test successful mSetNX with all new keys (using different keys)
-            Map<byte[], byte[]> newKeyValues = new HashMap<>();
-            newKeyValues.put(key4.getBytes(), "newvalue1".getBytes());
-            newKeyValues.put(key5.getBytes(), "newvalue2".getBytes());
-            Boolean successfulMSetNX = connection.stringCommands().mSetNX(newKeyValues);
-            assertThat(successfulMSetNX).isTrue();
-            
-            assertThat(connection.stringCommands().get(key4.getBytes())).isEqualTo("newvalue1".getBytes());
-            assertThat(connection.stringCommands().get(key5.getBytes())).isEqualTo("newvalue2".getBytes());
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-            cleanupKey(key3);
-            cleanupKey(key4);
-            cleanupKey(key5);
-        }
-    }
+		try {
+			// Test getDel
+			connection.stringCommands().set(key1.getBytes(), value);
+			byte[] retrievedValue = connection.stringCommands().getDel(key1.getBytes());
+			assertThat(retrievedValue).isEqualTo(value);
 
-    // ==================== Increment/Decrement Operations ====================
+			// Verify key is deleted
+			byte[] deletedValue = connection.stringCommands().get(key1.getBytes());
+			assertThat(deletedValue).isNull();
 
-    @Test
-    void testIncrDecr() {
-        String key = "test:string:incrdecr";
-        byte[] keyBytes = key.getBytes();
-        
-        try {
-            // Test incr on non-existent key (should start from 0)
-            Long incrResult1 = connection.stringCommands().incr(keyBytes);
-            assertThat(incrResult1).isEqualTo(1L);
-            
-            // Test multiple increments
-            Long incrResult2 = connection.stringCommands().incr(keyBytes);
-            assertThat(incrResult2).isEqualTo(2L);
-            
-            // Test decr
-            Long decrResult1 = connection.stringCommands().decr(keyBytes);
-            assertThat(decrResult1).isEqualTo(1L);
-            
-            // Test decr to negative
-            Long decrResult2 = connection.stringCommands().decr(keyBytes);
-            Long decrResult3 = connection.stringCommands().decr(keyBytes);
-            assertThat(decrResult2).isEqualTo(0L);
-            assertThat(decrResult3).isEqualTo(-1L);
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test getEx with expiration
+			connection.stringCommands().set(key2.getBytes(), value);
+			byte[] exValue = connection.stringCommands().getEx(key2.getBytes(), Expiration.seconds(1));
+			assertThat(exValue).isEqualTo(value);
 
-    @Test
-    void testIncrByDecrBy() {
-        String intKey = "test:string:incrby:int";
-        String floatKey = "test:string:incrby:float";
-        
-        try {
-            // Test incrBy with integers
-            Long incrByResult1 = connection.stringCommands().incrBy(intKey.getBytes(), 5L);
-            assertThat(incrByResult1).isEqualTo(5L);
-            
-            Long incrByResult2 = connection.stringCommands().incrBy(intKey.getBytes(), 10L);
-            assertThat(incrByResult2).isEqualTo(15L);
-            
-            // Test decrBy
-            Long decrByResult = connection.stringCommands().decrBy(intKey.getBytes(), 7L);
-            assertThat(decrByResult).isEqualTo(8L);
-            
-            // Test incrBy with floats
-            Double floatIncrResult1 = connection.stringCommands().incrBy(floatKey.getBytes(), 3.14);
-            assertThat(floatIncrResult1).isEqualTo(3.14);
-            
-            Double floatIncrResult2 = connection.stringCommands().incrBy(floatKey.getBytes(), 2.86);
-            assertThat(floatIncrResult2).isEqualTo(6.0);
-            
-            // Test negative increment (effectively decrement)
-            Double floatDecrResult = connection.stringCommands().incrBy(floatKey.getBytes(), -1.5);
-            assertThat(floatDecrResult).isEqualTo(4.5);
-        } finally {
-            cleanupKey(intKey);
-            cleanupKey(floatKey);
-        }
-    }
+			// Wait for expiration and verify
+			Thread.sleep(1100);
+			byte[] expiredValue = connection.stringCommands().get(key2.getBytes());
+			assertThat(expiredValue).isNull();
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+		}
+	}
 
-    // ==================== String Manipulation ====================
+	@Test
+	void testGetExPersistent() {
+		String key = "test:string:getex:persistent";
+		byte[] value = "persistent_value".getBytes();
 
-    @Test
-    void testAppendAndStrLen() {
-        String key = "test:string:append";
-        byte[] keyBytes = key.getBytes();
-        
-        try {
-            // Test append to non-existent key
-            Long appendResult1 = connection.stringCommands().append(keyBytes, "Hello".getBytes());
-            assertThat(appendResult1).isEqualTo(5L); // Length of "Hello"
-            
-            // Test string length
-            Long strLenResult1 = connection.stringCommands().strLen(keyBytes);
-            assertThat(strLenResult1).isEqualTo(5L);
-            
-            // Test append to existing key
-            Long appendResult2 = connection.stringCommands().append(keyBytes, " World".getBytes());
-            assertThat(appendResult2).isEqualTo(11L); // Length of "Hello World"
-            
-            // Verify final value
-            byte[] finalValue = connection.stringCommands().get(keyBytes);
-            assertThat(finalValue).isEqualTo("Hello World".getBytes());
-            
-            Long strLenResult2 = connection.stringCommands().strLen(keyBytes);
-            assertThat(strLenResult2).isEqualTo(11L);
-        } finally {
-            cleanupKey(key);
-        }
-    }
+		try {
+			// Set key with expiration first
+			connection.stringCommands().set(key.getBytes(), value, Expiration.seconds(60), SetOption.upsert());
 
-    @Test
-    void testGetRangeSetRange() {
-        String key = "test:string:range";
-        byte[] keyBytes = key.getBytes();
-        String originalValue = "Hello World";
-        
-        try {
-            // Set initial value
-            connection.stringCommands().set(keyBytes, originalValue.getBytes());
-            
-            // Test getRange
-            byte[] range1 = connection.stringCommands().getRange(keyBytes, 0, 4);
-            assertThat(range1).isEqualTo("Hello".getBytes());
-            
-            byte[] range2 = connection.stringCommands().getRange(keyBytes, 6, -1);
-            assertThat(range2).isEqualTo("World".getBytes());
-            
-            byte[] range3 = connection.stringCommands().getRange(keyBytes, -5, -1);
-            assertThat(range3).isEqualTo("World".getBytes());
-            
-            // Test setRange
-            connection.stringCommands().setRange(keyBytes, "Valkey".getBytes(), 6);
-            byte[] modifiedValue = connection.stringCommands().get(keyBytes);
-            assertThat(modifiedValue).isEqualTo("Hello Valkey".getBytes());
-            
-            // Test setRange beyond string length (should pad with zeros)
-            connection.stringCommands().setRange(keyBytes, "!".getBytes(), 20);
-            byte[] paddedValue = connection.stringCommands().get(keyBytes);
-            assertThat(paddedValue).hasSize(21);
-            assertThat(paddedValue[20]).isEqualTo((byte) '!');
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Verify key has expiration
+			Long ttlBefore = connection.keyCommands().ttl(key.getBytes());
+			assertThat(ttlBefore).isGreaterThan(0);
 
-    // ==================== Bit Operations ====================
+			// Test getEx with persistent expiration (should remove expiration)
+			byte[] retrievedValue = connection.stringCommands().getEx(key.getBytes(), Expiration.persistent());
+			assertThat(retrievedValue).isEqualTo(value);
 
-    @Test
-    void testGetBitSetBit() {
-        String key = "test:string:bit";
-        byte[] keyBytes = key.getBytes();
-        
-        try {
-            // Test getBit on non-existent key
-            Boolean bit1 = connection.stringCommands().getBit(keyBytes, 0);
-            assertThat(bit1).isFalse(); // Non-existent keys return 0
-            
-            // Test setBit
-            Boolean oldBit1 = connection.stringCommands().setBit(keyBytes, 7, true);
-            assertThat(oldBit1).isFalse(); // Previous value was 0
-            
-            // Test getBit after setBit
-            Boolean bit2 = connection.stringCommands().getBit(keyBytes, 7);
-            assertThat(bit2).isTrue();
-            
-            // Test setting bit to false
-            Boolean oldBit2 = connection.stringCommands().setBit(keyBytes, 7, false);
-            assertThat(oldBit2).isTrue(); // Previous value was 1
-            
-            Boolean bit3 = connection.stringCommands().getBit(keyBytes, 7);
-            assertThat(bit3).isFalse();
-            
-            // Set multiple bits
-            connection.stringCommands().setBit(keyBytes, 0, true);
-            connection.stringCommands().setBit(keyBytes, 4, true);
-            connection.stringCommands().setBit(keyBytes, 8, true);
-            
-            // Verify individual bits
-            assertThat(connection.stringCommands().getBit(keyBytes, 0)).isTrue();
-            assertThat(connection.stringCommands().getBit(keyBytes, 4)).isTrue();
-            assertThat(connection.stringCommands().getBit(keyBytes, 8)).isTrue();
-            assertThat(connection.stringCommands().getBit(keyBytes, 1)).isFalse();
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Verify key no longer has expiration
+			Long ttlAfter = connection.keyCommands().ttl(key.getBytes());
+			assertThat(ttlAfter).isEqualTo(-1L); // -1 means no expiration
 
-    @Test
-    void testBitCount() {
-        String key = "test:string:bitcount";
-        byte[] keyBytes = key.getBytes();
-        
-        try {
-            // Set some bits
-            connection.stringCommands().setBit(keyBytes, 0, true);
-            connection.stringCommands().setBit(keyBytes, 4, true);
-            connection.stringCommands().setBit(keyBytes, 8, true);
-            connection.stringCommands().setBit(keyBytes, 16, true);
-            
-            // Test bitCount for entire string
-            Long bitCount1 = connection.stringCommands().bitCount(keyBytes);
-            assertThat(bitCount1).isEqualTo(4L);
-            
-            // Test bitCount with range (first byte only)
-            Long bitCount2 = connection.stringCommands().bitCount(keyBytes, 0, 0);
-            assertThat(bitCount2).isEqualTo(2L); // bits 0 and 4 are in first byte
-            
-            // Test bitCount with range (second byte)
-            Long bitCount3 = connection.stringCommands().bitCount(keyBytes, 1, 1);
-            assertThat(bitCount3).isEqualTo(1L); // bit 8 is in second byte
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Verify value is still accessible
+			byte[] finalValue = connection.stringCommands().get(key.getBytes());
+			assertThat(finalValue).isEqualTo(value);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
 
-    @Test
-    void testBitPos() {
-        String key = "test:string:bitpos";
-        byte[] keyBytes = key.getBytes();
-        
-        try {
-            // Set bits: 11110000 (0xF0)
-            connection.stringCommands().set(keyBytes, new byte[]{(byte) 0xF0});
-            
-            // Find first 1 bit
-            Long pos1 = connection.stringCommands().bitPos(keyBytes, true);
-            assertThat(pos1).isEqualTo(0L);
-            
-            // Find first 0 bit
-            Long pos0 = connection.stringCommands().bitPos(keyBytes, false);
-            assertThat(pos0).isEqualTo(4L);
-            
-            // Test with range
-            Long pos1Range = connection.stringCommands().bitPos(keyBytes, true, Range.closed(0L, 0L));
-            assertThat(pos1Range).isEqualTo(0L);
-            
-            Long pos0Range = connection.stringCommands().bitPos(keyBytes, false, Range.closed(0L, 0L));
-            assertThat(pos0Range).isEqualTo(4L);
-        } finally {
-            cleanupKey(key);
-        }
-    }
+	@Test
+	void testGetExKeepTtl() {
+		String key = "test:string:getex:keepttl";
+		byte[] value = "keepttl_value".getBytes();
 
-    @Test
-    void testBitOp() {
-        String key1 = "test:string:bitop:key1";
-        String key2 = "test:string:bitop:key2";
-        String destKey = "test:string:bitop:dest";
-        
-        try {
-            // Set up test data
-            connection.stringCommands().set(key1.getBytes(), new byte[]{(byte) 0xF0}); // 11110000
-            connection.stringCommands().set(key2.getBytes(), new byte[]{(byte) 0x0F}); // 00001111
-            
-            // Test AND operation
-            Long andResult = connection.stringCommands().bitOp(BitOperation.AND, destKey.getBytes(), 
-                key1.getBytes(), key2.getBytes());
-            assertThat(andResult).isEqualTo(1L); // 1 byte processed
-            
-            byte[] andValue = connection.stringCommands().get(destKey.getBytes());
-            assertThat(andValue[0]).isEqualTo((byte) 0x00); // 11110000 AND 00001111 = 00000000
-            
-            // Test OR operation  
-            Long orResult = connection.stringCommands().bitOp(BitOperation.OR, destKey.getBytes(), 
-                key1.getBytes(), key2.getBytes());
-            assertThat(orResult).isEqualTo(1L);
-            
-            byte[] orValue = connection.stringCommands().get(destKey.getBytes());
-            assertThat(orValue[0]).isEqualTo((byte) 0xFF); // 11110000 OR 00001111 = 11111111
-            
-            // Test XOR operation
-            Long xorResult = connection.stringCommands().bitOp(BitOperation.XOR, destKey.getBytes(), 
-                key1.getBytes(), key2.getBytes());
-            assertThat(xorResult).isEqualTo(1L);
-            
-            byte[] xorValue = connection.stringCommands().get(destKey.getBytes());
-            assertThat(xorValue[0]).isEqualTo((byte) 0xFF); // 11110000 XOR 00001111 = 11111111
-            
-            // Test NOT operation (single key)
-            Long notResult = connection.stringCommands().bitOp(BitOperation.NOT, destKey.getBytes(), 
-                key1.getBytes());
-            assertThat(notResult).isEqualTo(1L);
-            
-            byte[] notValue = connection.stringCommands().get(destKey.getBytes());
-            assertThat(notValue[0]).isEqualTo((byte) 0x0F); // NOT 11110000 = 00001111
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-            cleanupKey(destKey);
-        }
-    }
+		try {
+			// Set key with expiration first
+			connection.stringCommands().set(key.getBytes(), value, Expiration.seconds(60), SetOption.upsert());
 
-    @Test
-    void testBitField() {
-        String key = "test:string:bitfield";
-        byte[] keyBytes = key.getBytes();
-        
-        try {
-            BitFieldSubCommands subCommands = BitFieldSubCommands.create()
-                .set(BitFieldSubCommands.BitFieldType.unsigned(8)).valueAt(0).to(255)
-                .get(BitFieldSubCommands.BitFieldType.unsigned(8)).valueAt(0);
-            
-            // Test that bitField executes without throwing exception
-            // Note: ValkeyGlide implementation may return Object[] instead of List<Long>
-            List<Long> results = connection.stringCommands().bitField(keyBytes, subCommands);
-            
-            // Basic verification that some result is returned
-            assertThat(results).isNotNull();
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Get initial TTL
+			Long ttlBefore = connection.keyCommands().ttl(key.getBytes());
+			assertThat(ttlBefore).isGreaterThan(0);
 
-    @Test
-    void testBitFieldWithOverflowWrap() {
-        String key = "test:string:bitfield:wrap";
-        byte[] keyBytes = key.getBytes();
-        
-        try {
-            // Test OVERFLOW WRAP behavior (default)
-            // Increment u2 (max value 3) from 0 to 3, then wrap to 0
-            BitFieldSubCommands subCommands = BitFieldSubCommands.create()
-                .incr(BitFieldSubCommands.BitFieldType.unsigned(2)).valueAt(100).overflow(BitFieldSubCommands.BitFieldIncrBy.Overflow.WRAP).by(1)
-                .incr(BitFieldSubCommands.BitFieldType.unsigned(2)).valueAt(100).overflow(BitFieldSubCommands.BitFieldIncrBy.Overflow.WRAP).by(1)
-                .incr(BitFieldSubCommands.BitFieldType.unsigned(2)).valueAt(100).overflow(BitFieldSubCommands.BitFieldIncrBy.Overflow.WRAP).by(1)
-                .incr(BitFieldSubCommands.BitFieldType.unsigned(2)).valueAt(100).overflow(BitFieldSubCommands.BitFieldIncrBy.Overflow.WRAP).by(1);
-            
-            List<Long> results = connection.stringCommands().bitField(keyBytes, subCommands);
-            
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(4);
-            assertThat(results.get(0)).isEqualTo(1L); // 0 + 1 = 1
-            assertThat(results.get(1)).isEqualTo(2L); // 1 + 1 = 2
-            assertThat(results.get(2)).isEqualTo(3L); // 2 + 1 = 3 (max value)
-            assertThat(results.get(3)).isEqualTo(0L); // 3 + 1 wraps to 0
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test getEx with keepTtl expiration (should preserve existing expiration)
+			byte[] retrievedValue = connection.stringCommands().getEx(key.getBytes(), Expiration.keepTtl());
+			assertThat(retrievedValue).isEqualTo(value);
 
-    @Test
-    void testBitFieldWithOverflowSat() {
-        String key = "test:string:bitfield:sat";
-        byte[] keyBytes = key.getBytes();
-        
-        try {
-            // Test OVERFLOW SAT behavior (saturate at max/min)
-            // Increment u2 (max value 3) from 0 to 3, then saturate at 3
-            BitFieldSubCommands subCommands = BitFieldSubCommands.create()
-                .incr(BitFieldSubCommands.BitFieldType.unsigned(2)).valueAt(102).overflow(BitFieldSubCommands.BitFieldIncrBy.Overflow.SAT).by(1)
-                .incr(BitFieldSubCommands.BitFieldType.unsigned(2)).valueAt(102).overflow(BitFieldSubCommands.BitFieldIncrBy.Overflow.SAT).by(1)
-                .incr(BitFieldSubCommands.BitFieldType.unsigned(2)).valueAt(102).overflow(BitFieldSubCommands.BitFieldIncrBy.Overflow.SAT).by(1)
-                .incr(BitFieldSubCommands.BitFieldType.unsigned(2)).valueAt(102).overflow(BitFieldSubCommands.BitFieldIncrBy.Overflow.SAT).by(1);
-            
-            List<Long> results = connection.stringCommands().bitField(keyBytes, subCommands);
-            
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(4);
-            assertThat(results.get(0)).isEqualTo(1L); // 0 + 1 = 1
-            assertThat(results.get(1)).isEqualTo(2L); // 1 + 1 = 2
-            assertThat(results.get(2)).isEqualTo(3L); // 2 + 1 = 3 (max value)
-            assertThat(results.get(3)).isEqualTo(3L); // 3 + 1 saturates at 3
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Verify key still has similar expiration
+			Long ttlAfter = connection.keyCommands().ttl(key.getBytes());
+			assertThat(ttlAfter).isGreaterThan(0);
+			assertThat(ttlAfter).isLessThanOrEqualTo(ttlBefore); // Should be same or
+																	// slightly less due
+																	// to time passage
 
-    @Test
-    void testBitFieldWithOverflowFail() {
-        String key = "test:string:bitfield:fail";
-        byte[] keyBytes = key.getBytes();
-        
-        try {
-            // Test OVERFLOW FAIL behavior (return null on overflow)
-            // Increment u2 (max value 3) from 0 to 3, then fail and return null
-            BitFieldSubCommands subCommands = BitFieldSubCommands.create()
-                .incr(BitFieldSubCommands.BitFieldType.unsigned(2)).valueAt(102).overflow(BitFieldSubCommands.BitFieldIncrBy.Overflow.FAIL).by(1)
-                .incr(BitFieldSubCommands.BitFieldType.unsigned(2)).valueAt(102).overflow(BitFieldSubCommands.BitFieldIncrBy.Overflow.FAIL).by(1)
-                .incr(BitFieldSubCommands.BitFieldType.unsigned(2)).valueAt(102).overflow(BitFieldSubCommands.BitFieldIncrBy.Overflow.FAIL).by(1)
-                .incr(BitFieldSubCommands.BitFieldType.unsigned(2)).valueAt(102).overflow(BitFieldSubCommands.BitFieldIncrBy.Overflow.FAIL).by(1);
-            
-            List<Long> results = connection.stringCommands().bitField(keyBytes, subCommands);
-            
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(4);
-            assertThat(results.get(0)).isEqualTo(1L); // 0 + 1 = 1
-            assertThat(results.get(1)).isEqualTo(2L); // 1 + 1 = 2
-            assertThat(results.get(2)).isEqualTo(3L); // 2 + 1 = 3 (max value)
-            assertThat(results.get(3)).isNull(); // 3 + 1 fails and returns null
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Verify value is still accessible
+			byte[] finalValue = connection.stringCommands().get(key.getBytes());
+			assertThat(finalValue).isEqualTo(value);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
 
-    @Test
-    void testBitFieldMixedOverflowModes() {
-        String key = "test:string:bitfield:mixed";
-        byte[] keyBytes = key.getBytes();
-        
-        try {
-            // Test multiple overflow modes in single command
-            // Each OVERFLOW command affects subsequent operations until next OVERFLOW
-            BitFieldSubCommands subCommands = BitFieldSubCommands.create()
-                // Set initial values
-                .set(BitFieldSubCommands.BitFieldType.unsigned(2)).valueAt(100).to(3)
-                .set(BitFieldSubCommands.BitFieldType.unsigned(2)).valueAt(104).to(3)
-                .set(BitFieldSubCommands.BitFieldType.unsigned(2)).valueAt(108).to(3)
-                // Test WRAP overflow
-                .incr(BitFieldSubCommands.BitFieldType.unsigned(2)).valueAt(100).overflow(BitFieldSubCommands.BitFieldIncrBy.Overflow.WRAP).by(1)
-                // Test SAT overflow
-                .incr(BitFieldSubCommands.BitFieldType.unsigned(2)).valueAt(104).overflow(BitFieldSubCommands.BitFieldIncrBy.Overflow.SAT).by(1)
-                // Test FAIL overflow
-                .incr(BitFieldSubCommands.BitFieldType.unsigned(2)).valueAt(108).overflow(BitFieldSubCommands.BitFieldIncrBy.Overflow.FAIL).by(1);
-            
-            List<Long> results = connection.stringCommands().bitField(keyBytes, subCommands);
-            
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(6);
-            assertThat(results.get(0)).isEqualTo(0L); // SET returns old value (0)
-            assertThat(results.get(1)).isEqualTo(0L); // SET returns old value (0)
-            assertThat(results.get(2)).isEqualTo(0L); // SET returns old value (0)
-            assertThat(results.get(3)).isEqualTo(0L); // WRAP: 3 + 1 = 0
-            assertThat(results.get(4)).isEqualTo(3L); // SAT: 3 + 1 = 3 (saturated)
-            assertThat(results.get(5)).isNull(); // FAIL: 3 + 1 = null (overflow detected)
-        } finally {
-            cleanupKey(key);
-        }
-    }
+	@Test
+	void testSetWithOptions() {
+		String key = "test:string:setoptions";
+		byte[] keyBytes = key.getBytes();
+		byte[] value1 = "value1".getBytes();
+		byte[] value2 = "value2".getBytes();
 
-    @Test
-    void testBitFieldWithNonZeroBasedOffset() {
-        String key = "test:string:bitfield:nonzero";
-        byte[] keyBytes = key.getBytes();
-        
-        try {
-            // Test type-based (non-zero-based) offsets using multipliedByTypeLength()
-            // Type-based offsets are prefixed with "#" in Valkey and multiplied by the type width
-            // For INT_8 (8 bits = 1 byte), offset #1 means byte offset 1
-            BitFieldSubCommands subCommands = BitFieldSubCommands.create()
-                .set(BitFieldSubCommands.BitFieldType.signed(8))
-                    .valueAt(BitFieldSubCommands.Offset.offset(0L).multipliedByTypeLength()).to(100L)
-                .set(BitFieldSubCommands.BitFieldType.signed(8))
-                    .valueAt(BitFieldSubCommands.Offset.offset(1L).multipliedByTypeLength()).to(200L);
-            
-            List<Long> setResults = connection.stringCommands().bitField(keyBytes, subCommands);
-            
-            assertThat(setResults).isNotNull();
-            assertThat(setResults).hasSize(2);
-            assertThat(setResults).containsExactly(0L, 0L); // Both SET operations return old value (0)
-            
-            // Now get the values back using type-based offsets
-            BitFieldSubCommands getCommands = BitFieldSubCommands.create()
-                .get(BitFieldSubCommands.BitFieldType.signed(8))
-                    .valueAt(BitFieldSubCommands.Offset.offset(0L).multipliedByTypeLength())
-                .get(BitFieldSubCommands.BitFieldType.signed(8))
-                    .valueAt(BitFieldSubCommands.Offset.offset(1L).multipliedByTypeLength());
-            
-            List<Long> getResults = connection.stringCommands().bitField(keyBytes, getCommands);
-            
-            assertThat(getResults).isNotNull();
-            assertThat(getResults).hasSize(2);
-            assertThat(getResults.get(0)).isEqualTo(100L);
-            assertThat(getResults.get(1)).isEqualTo(-56L); // 200 as signed i8 wraps to -56
-        } finally {
-            cleanupKey(key);
-        }
-    }
+		try {
+			// Test setNX (set if not exists)
+			Boolean setNXResult1 = connection.stringCommands().setNX(keyBytes, value1);
+			assertThat(setNXResult1).isTrue();
 
-    // ==================== Error Handling and Edge Cases ====================
+			// Try setNX again - should fail
+			Boolean setNXResult2 = connection.stringCommands().setNX(keyBytes, value2);
+			assertThat(setNXResult2).isFalse();
 
-    @Test
-    void testStringOperationsOnNonStringTypes() {
-        String listKey = "test:string:error:list";
-        
-        try {
-            // Create a list
-            connection.listCommands().lPush(listKey.getBytes(), "item".getBytes());
-            
-            // Try string operations on list key - should fail or return appropriate response
-            assertThatThrownBy(() -> connection.stringCommands().incr(listKey.getBytes()))
-                .isInstanceOf(DataAccessException.class);
-        } finally {
-            cleanupKey(listKey);
-        }
-    }
+			// Verify original value remains
+			assertThat(connection.stringCommands().get(keyBytes)).isEqualTo(value1);
 
-    @Test
-    void testEmptyStringOperations() {
-        String key = "test:string:empty";
-        byte[] keyBytes = key.getBytes();
-        byte[] emptyValue = new byte[0];
-        
-        try {
-            // Set empty string
-            Boolean setResult = connection.stringCommands().set(keyBytes, emptyValue);
-            assertThat(setResult).isTrue();
-            
-            // Get empty string
-            byte[] retrievedValue = connection.stringCommands().get(keyBytes);
-            assertThat(retrievedValue).isEqualTo(emptyValue);
-            
-            // String length should be 0
-            Long strLen = connection.stringCommands().strLen(keyBytes);
-            assertThat(strLen).isEqualTo(0L);
-            
-            // Append to empty string
-            Long appendResult = connection.stringCommands().append(keyBytes, "appended".getBytes());
-            assertThat(appendResult).isEqualTo(8L); // "appended" is 8 characters
-            
-            byte[] finalValue = connection.stringCommands().get(keyBytes);
-            assertThat(finalValue).isEqualTo("appended".getBytes());
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test set with SetOption.IF_PRESENT
+			Boolean setIfPresent = connection.stringCommands()
+				.set(keyBytes, value2, Expiration.persistent(), SetOption.ifPresent());
+			assertThat(setIfPresent).isTrue();
+			assertThat(connection.stringCommands().get(keyBytes)).isEqualTo(value2);
 
-    // ==================== Pipeline Mode Tests ====================
+			// Test set with SetOption.IF_ABSENT on existing key
+			Boolean setIfAbsent = connection.stringCommands()
+				.set(keyBytes, value1, Expiration.persistent(), SetOption.ifAbsent());
+			assertThat(setIfAbsent).isFalse();
+			assertThat(connection.stringCommands().get(keyBytes)).isEqualTo(value2);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
 
-    @Test
-    void testBasicStringOperationsInPipelineMode() {
-        String key1 = "test:pipeline:basic1";
-        String key2 = "test:pipeline:basic2";
-        String key3 = "test:pipeline:basic3";
-        String key4 = "test:pipeline:basic4";
-        
-        try {
-            // Open pipeline
-            connection.openPipeline();
-            
-            // Queue basic string operations - assert they return null in pipeline mode
-            assertThat(connection.stringCommands().set(key1.getBytes(), "value1".getBytes())).isNull();
-            assertThat(connection.stringCommands().setNX(key2.getBytes(), "value2".getBytes())).isNull();
-            assertThat(connection.stringCommands().get(key1.getBytes())).isNull();
-            assertThat(connection.stringCommands().getSet(key1.getBytes(), "newvalue1".getBytes())).isNull();
-            assertThat(connection.stringCommands().getDel(key1.getBytes())).isNull();
-            assertThat(connection.stringCommands().setEx(key3.getBytes(), 60, "expiring".getBytes())).isNull();
-            assertThat(connection.stringCommands().pSetEx(key4.getBytes(), 60000, "expiring_ms".getBytes())).isNull();
-            
-            // Execute pipeline
-            java.util.List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(7);
-            assertThat(results.get(0)).isEqualTo(true); // SET result
-            assertThat(results.get(1)).isEqualTo(true); // SETNX result
-            assertThat(results.get(2)).isEqualTo("value1".getBytes()); // GET result
-            assertThat(results.get(3)).isEqualTo("value1".getBytes()); // GETSET result
-            assertThat(results.get(4)).isEqualTo("newvalue1".getBytes()); // GETDEL result
-            assertThat(results.get(5)).isEqualTo(true); // SETEX result
-            assertThat(results.get(6)).isEqualTo(true); // PSETEX result
-            
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-            cleanupKey(key3);
-            cleanupKey(key4);
-        }
-    }
+	@Test
+	void testSetGet() {
+		String key = "test:string:setget";
+		byte[] keyBytes = key.getBytes();
+		byte[] value1 = "initial".getBytes();
+		byte[] value2 = "updated".getBytes();
 
-    @Test
-    void testMultiKeyOperationsInPipelineMode() {
-        String key1 = "test:pipeline:mkey1";
-        String key2 = "test:pipeline:mkey2";
-        String key3 = "test:pipeline:mkey3";
-        String key4 = "test:pipeline:mkey4";
-        String key5 = "test:pipeline:mkey5";
-        
-        try {
-            // Set up initial data
-            connection.stringCommands().set(key1.getBytes(), "initial1".getBytes());
-            connection.stringCommands().set(key2.getBytes(), "initial2".getBytes());
-            
-            connection.openPipeline();
-            
-            // Queue multi-key operations - assert they return null in pipeline mode
-            assertThat(connection.stringCommands().mGet(key1.getBytes(), key2.getBytes(), key3.getBytes())).isNull();
-            
-            Map<byte[], byte[]> msetData = new HashMap<>();
-            msetData.put(key4.getBytes(), "msetvalue1".getBytes());
-            msetData.put(key5.getBytes(), "msetvalue2".getBytes());
-            assertThat(connection.stringCommands().mSet(msetData)).isNull();
-            
-            Map<byte[], byte[]> msetnxData = new HashMap<>();
-            msetnxData.put("new1".getBytes(), "msetnxvalue1".getBytes());
-            msetnxData.put("new2".getBytes(), "msetnxvalue2".getBytes());
-            assertThat(connection.stringCommands().mSetNX(msetnxData)).isNull();
-            
-            assertThat(connection.stringCommands().mGet(key4.getBytes(), key5.getBytes())).isNull();
-            
-            java.util.List<Object> results = connection.closePipeline();
-            
-            assertThat(results).hasSize(4);
-            
-            // mGet result
-            @SuppressWarnings("unchecked")
-            java.util.List<byte[]> mgetResult1 = (java.util.List<byte[]>) results.get(0);
-            assertThat(mgetResult1).hasSize(3);
-            assertThat(mgetResult1.get(0)).isEqualTo("initial1".getBytes());
-            assertThat(mgetResult1.get(1)).isEqualTo("initial2".getBytes());
-            assertThat(mgetResult1.get(2)).isNull(); // key3 doesn't exist
-            
-            assertThat(results.get(1)).isEqualTo(true); // MSET result
-            assertThat(results.get(2)).isEqualTo(true); // MSETNX result
-            
-            // Second mGet result
-            @SuppressWarnings("unchecked")
-            java.util.List<byte[]> mgetResult2 = (java.util.List<byte[]>) results.get(3);
-            assertThat(mgetResult2).hasSize(2);
-            assertThat(mgetResult2.get(0)).isEqualTo("msetvalue1".getBytes());
-            assertThat(mgetResult2.get(1)).isEqualTo("msetvalue2".getBytes());
-            
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-            cleanupKey(key3);
-            cleanupKey(key4);
-            cleanupKey(key5);
-            cleanupKey("new1");
-            cleanupKey("new2");
-        }
-    }
+		try {
+			// Test setGet on non-existing key
+			byte[] oldValue1 = connection.stringCommands()
+				.setGet(keyBytes, value1, Expiration.persistent(), SetOption.upsert());
+			assertThat(oldValue1).isNull();
+			assertThat(connection.stringCommands().get(keyBytes)).isEqualTo(value1);
 
-    @Test
-    void testArithmeticOperationsInPipelineMode() {
-        String intKey = "test:pipeline:int";
-        String floatKey = "test:pipeline:float";
-        String decrKey = "test:pipeline:decr";
-        
-        try {
-            connection.openPipeline();
-            
-            // Queue arithmetic operations - assert they return null in pipeline mode
-            assertThat(connection.stringCommands().incr(intKey.getBytes())).isNull();
-            assertThat(connection.stringCommands().incrBy(intKey.getBytes(), 5L)).isNull();
-            assertThat(connection.stringCommands().incrBy(floatKey.getBytes(), 3.14)).isNull();
-            assertThat(connection.stringCommands().incrBy(floatKey.getBytes(), -1.14)).isNull();
-            assertThat(connection.stringCommands().decr(decrKey.getBytes())).isNull();
-            assertThat(connection.stringCommands().decrBy(decrKey.getBytes(), 3L)).isNull();
-            
-            java.util.List<Object> results = connection.closePipeline();
-            
-            assertThat(results).hasSize(6);
-            assertThat(results.get(0)).isEqualTo(1L); // INCR result
-            assertThat(results.get(1)).isEqualTo(6L); // INCRBY result
-            assertThat(results.get(2)).isEqualTo(3.14); // INCRBYFLOAT result
-            assertThat(results.get(3)).isEqualTo(2.0); // INCRBYFLOAT result
-            assertThat(results.get(4)).isEqualTo(-1L); // DECR result
-            assertThat(results.get(5)).isEqualTo(-4L); // DECRBY result
-            
-        } finally {
-            cleanupKey(intKey);
-            cleanupKey(floatKey);
-            cleanupKey(decrKey);
-        }
-    }
+			// Test setGet on existing key
+			byte[] oldValue2 = connection.stringCommands()
+				.setGet(keyBytes, value2, Expiration.persistent(), SetOption.upsert());
+			assertThat(oldValue2).isEqualTo(value1);
+			assertThat(connection.stringCommands().get(keyBytes)).isEqualTo(value2);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
 
-    @Test
-    void testStringManipulationInPipelineMode() {
-        String key1 = "test:pipeline:manip1";
-        String key2 = "test:pipeline:manip2";
-        
-        try {
-            // Set up initial data
-            connection.stringCommands().set(key1.getBytes(), "Hello".getBytes());
-            connection.stringCommands().set(key2.getBytes(), "Valkey World".getBytes());
-            
-            connection.openPipeline();
-            
-            // Queue string manipulation operations - assert they return null in pipeline mode
-            assertThat(connection.stringCommands().append(key1.getBytes(), " World".getBytes())).isNull();
-            assertThat(connection.stringCommands().strLen(key1.getBytes())).isNull();
-            assertThat(connection.stringCommands().getRange(key2.getBytes(), 0, 5)).isNull();
-            connection.stringCommands().setRange(key2.getBytes(), "Valkey".getBytes(), 7); // void method
-            assertThat(connection.stringCommands().get(key2.getBytes())).isNull();
-            
-            java.util.List<Object> results = connection.closePipeline();
-            
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(5);
-            assertThat(results.get(0)).isEqualTo(11L); // APPEND result (length)
-            assertThat(results.get(1)).isEqualTo(11L); // STRLEN result
-            assertThat(results.get(2)).isEqualTo("Valkey".getBytes()); // GETRANGE result
-            assertThat(results.get(3)).isEqualTo(13L); // SETRANGE result (new length)
-            assertThat(results.get(4)).isEqualTo("Valkey Valkey".getBytes()); // GET result after setrange
-            
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-        }
-    }
+	@Test
+	void testSetWithExpiration() {
+		String key1 = "test:string:setex";
+		String key2 = "test:string:psetex";
+		byte[] value = "expiring_value".getBytes();
 
-    @Test
-    void testBitOperationsInPipelineMode() {
-        String key1 = "test:pipeline:bit1";
-        String key2 = "test:pipeline:bit2";
-        String destKey = "test:pipeline:bitop";
-        
-        try {
-            // Set up initial data
-            connection.stringCommands().set(key1.getBytes(), new byte[]{(byte) 0xF0}); // 11110000
-            connection.stringCommands().set(key2.getBytes(), new byte[]{(byte) 0x0F}); // 00001111
-            
-            connection.openPipeline();
-            
-            // Queue bit operations - assert they return null in pipeline mode
-            assertThat(connection.stringCommands().getBit(key1.getBytes(), 0)).isNull();
-            assertThat(connection.stringCommands().setBit(key1.getBytes(), 4, false)).isNull();
-            assertThat(connection.stringCommands().bitCount(key1.getBytes())).isNull();
-            assertThat(connection.stringCommands().bitCount(key2.getBytes(), 0, 0)).isNull();
-            assertThat(connection.stringCommands().bitOp(BitOperation.AND, destKey.getBytes(), key1.getBytes(), key2.getBytes())).isNull();
-            assertThat(connection.stringCommands().bitPos(key1.getBytes(), true)).isNull();
-            
-            java.util.List<Object> results = connection.closePipeline();
-            
-            assertThat(results).hasSize(6);
-            assertThat(results.get(0)).isEqualTo(true); // GETBIT result
-            assertThat(results.get(1)).isEqualTo(false); // SETBIT result (old value was 0)
-            assertThat(results.get(2)).isEqualTo(4L); // 4 bits still set
-            assertThat(results.get(3)).isEqualTo(4L); // BITCOUNT result with range
-            assertThat(results.get(4)).isEqualTo(1L); // BITOP result (1 byte processed)
-            assertThat(results.get(5)).isEqualTo(0L); // BITPOS result
-            
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-            cleanupKey(destKey);
-        }
-    }
+		try {
+			// Test setEx (seconds)
+			Boolean setExResult = connection.stringCommands().setEx(key1.getBytes(), 1, value);
+			assertThat(setExResult).isTrue();
+			assertThat(connection.stringCommands().get(key1.getBytes())).isEqualTo(value);
 
-    @Test
-    void testAdvancedStringOperationsInPipelineMode() {
-        String key1 = "test:pipeline:advanced1";
-        String key2 = "test:pipeline:advanced2";
-        
-        try {
-            connection.openPipeline();
-            
-            // Queue advanced operations - assert they return null in pipeline mode
-            assertThat(connection.stringCommands().set(key1.getBytes(), "test".getBytes(),
-                Expiration.seconds(60), SetOption.ifAbsent())).isNull();
-            assertThat(connection.stringCommands().setGet(key2.getBytes(), "newvalue".getBytes(),
-                Expiration.persistent(), SetOption.upsert())).isNull();
-            
-            // BitField operations
-            BitFieldSubCommands subCommands = BitFieldSubCommands.create()
-                .set(BitFieldSubCommands.BitFieldType.unsigned(8)).valueAt(0).to(255)
-                .get(BitFieldSubCommands.BitFieldType.unsigned(8)).valueAt(0);
-            assertThat(connection.stringCommands().bitField(key1.getBytes(), subCommands)).isNull();
-            
-            java.util.List<Object> results = connection.closePipeline();
-            
-            assertThat(results).hasSize(3);
-            assertThat(results.get(0)).isEqualTo(true); // SET with options result
-            assertThat(results.get(1)).isNull(); // SETGET result (no previous value)
-            
-            // BitField results
-            @SuppressWarnings("unchecked")
-            java.util.List<Long> bitFieldResults = (java.util.List<Long>) results.get(2);
-            assertThat(bitFieldResults).isNotNull();
-            
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-        }
-    }
+			// Test pSetEx (milliseconds)
+			Boolean pSetExResult = connection.stringCommands().pSetEx(key2.getBytes(), 1000, value);
+			assertThat(pSetExResult).isTrue();
+			assertThat(connection.stringCommands().get(key2.getBytes())).isEqualTo(value);
 
-    // ==================== Transaction Mode Tests ====================
+			// Wait for expiration
+			Thread.sleep(1100);
+			assertThat(connection.stringCommands().get(key1.getBytes())).isNull();
+			assertThat(connection.stringCommands().get(key2.getBytes())).isNull();
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+		}
+	}
 
-    @Test
-    void testBasicStringOperationsInTransactionMode() {
-        String key1 = "test:tx:basic1";
-        String key2 = "test:tx:basic2";
-        String key3 = "test:tx:basic3";
-        String key4 = "test:tx:basic4";
-        
-        try {
-            // Start transaction
-            connection.multi();
-            
-            // Queue basic string operations - assert they return null in transaction mode
-            assertThat(connection.stringCommands().set(key1.getBytes(), "txvalue1".getBytes())).isNull();
-            assertThat(connection.stringCommands().setNX(key2.getBytes(), "txvalue2".getBytes())).isNull();
-            assertThat(connection.stringCommands().get(key1.getBytes())).isNull();
-            assertThat(connection.stringCommands().getSet(key1.getBytes(), "newtxvalue1".getBytes())).isNull();
-            assertThat(connection.stringCommands().getDel(key1.getBytes())).isNull();
-            assertThat(connection.stringCommands().setEx(key3.getBytes(), 60, "expiring".getBytes())).isNull();
-            assertThat(connection.stringCommands().pSetEx(key4.getBytes(), 60000, "expiring_ms".getBytes())).isNull();
-            
-            // Execute transaction
-            java.util.List<Object> results = connection.exec();
-            
-            // Verify results
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(7);
-            assertThat(results.get(0)).isEqualTo(true); // SET result
-            assertThat(results.get(1)).isEqualTo(true); // SETNX result
-            assertThat(results.get(2)).isEqualTo("txvalue1".getBytes()); // GET result
-            assertThat(results.get(3)).isEqualTo("txvalue1".getBytes()); // GETSET result
-            assertThat(results.get(4)).isEqualTo("newtxvalue1".getBytes()); // GETDEL result
-            assertThat(results.get(5)).isEqualTo(true); // SETEX result
-            assertThat(results.get(6)).isEqualTo(true); // PSETEX result
-            
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-            cleanupKey(key3);
-            cleanupKey(key4);
-        }
-    }
+	// ==================== Multi-Key Operations ====================
 
-    @Test
-    void testMultiKeyOperationsInTransactionMode() {
-        String key1 = "test:tx:mkey1";
-        String key2 = "test:tx:mkey2";
-        String key3 = "test:tx:mkey3";
-        String key4 = "test:tx:mkey4";
-        String key5 = "test:tx:mkey5";
-        
-        try {
-            // Set up initial data
-            connection.stringCommands().set(key1.getBytes(), "txinitial1".getBytes());
-            connection.stringCommands().set(key2.getBytes(), "txinitial2".getBytes());
-            
-            connection.multi();
-            
-            // Queue multi-key operations - assert they return null in transaction mode
-            assertThat(connection.stringCommands().mGet(key1.getBytes(), key2.getBytes(), key3.getBytes())).isNull();
-            
-            Map<byte[], byte[]> msetData = new HashMap<>();
-            msetData.put(key4.getBytes(), "txmsetvalue1".getBytes());
-            msetData.put(key5.getBytes(), "txmsetvalue2".getBytes());
-            assertThat(connection.stringCommands().mSet(msetData)).isNull();
-            
-            Map<byte[], byte[]> msetnxData = new HashMap<>();
-            msetnxData.put("txnew1".getBytes(), "txmsetnxvalue1".getBytes());
-            msetnxData.put("txnew2".getBytes(), "txmsetnxvalue2".getBytes());
-            assertThat(connection.stringCommands().mSetNX(msetnxData)).isNull();
-            
-            assertThat(connection.stringCommands().mGet(key4.getBytes(), key5.getBytes())).isNull();
-            
-            java.util.List<Object> results = connection.exec();
-            
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(4);
-            
-            // mGet result
-            @SuppressWarnings("unchecked")
-            java.util.List<byte[]> mgetResult1 = (java.util.List<byte[]>) results.get(0);
-            assertThat(mgetResult1).hasSize(3);
-            assertThat(mgetResult1.get(0)).isEqualTo("txinitial1".getBytes());
-            assertThat(mgetResult1.get(1)).isEqualTo("txinitial2".getBytes());
-            assertThat(mgetResult1.get(2)).isNull(); // key3 doesn't exist
-            
-            assertThat(results.get(1)).isEqualTo(true); // MSET result
-            assertThat(results.get(2)).isEqualTo(true); // MSETNX result
-            
-            // Second mGet result
-            @SuppressWarnings("unchecked")
-            java.util.List<byte[]> mgetResult2 = (java.util.List<byte[]>) results.get(3);
-            assertThat(mgetResult2).hasSize(2);
-            assertThat(mgetResult2.get(0)).isEqualTo("txmsetvalue1".getBytes());
-            assertThat(mgetResult2.get(1)).isEqualTo("txmsetvalue2".getBytes());
-            
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-            cleanupKey(key3);
-            cleanupKey(key4);
-            cleanupKey(key5);
-            cleanupKey("txnew1");
-            cleanupKey("txnew2");
-        }
-    }
+	@Test
+	void testMGetMSet() {
+		String key1 = "test:string:mget:key1";
+		String key2 = "test:string:mget:key2";
+		String key3 = "test:string:mget:key3";
 
-    @Test
-    void testArithmeticOperationsInTransactionMode() {
-        String intKey = "test:tx:int";
-        String floatKey = "test:tx:float";
-        String decrKey = "test:tx:decr";
-        
-        try {
-            connection.multi();
-            
-            // Queue arithmetic operations - assert they return null in transaction mode
-            assertThat(connection.stringCommands().incr(intKey.getBytes())).isNull();
-            assertThat(connection.stringCommands().incrBy(intKey.getBytes(), 5L)).isNull();
-            assertThat(connection.stringCommands().incrBy(floatKey.getBytes(), 3.14)).isNull();
-            assertThat(connection.stringCommands().incrBy(floatKey.getBytes(), -1.14)).isNull();
-            assertThat(connection.stringCommands().decr(decrKey.getBytes())).isNull();
-            assertThat(connection.stringCommands().decrBy(decrKey.getBytes(), 3L)).isNull();
-            
-            java.util.List<Object> results = connection.exec();
-            
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(6);
-            assertThat(results.get(0)).isEqualTo(1L); // INCR result
-            assertThat(results.get(1)).isEqualTo(6L); // INCRBY result
-            assertThat(results.get(2)).isEqualTo(3.14); // INCRBYFLOAT result
-            assertThat(results.get(3)).isEqualTo(2.0); // INCRBYFLOAT result
-            assertThat(results.get(4)).isEqualTo(-1L); // DECR result
-            assertThat(results.get(5)).isEqualTo(-4L); // DECRBY result
-            
-        } finally {
-            cleanupKey(intKey);
-            cleanupKey(floatKey);
-            cleanupKey(decrKey);
-        }
-    }
+		try {
+			// Set up test data
+			Map<byte[], byte[]> keyValues = new HashMap<>();
+			keyValues.put(key1.getBytes(), "value1".getBytes());
+			keyValues.put(key2.getBytes(), "value2".getBytes());
+			keyValues.put(key3.getBytes(), "value3".getBytes());
 
-    @Test
-    void testStringManipulationInTransactionMode() {
-        String key1 = "test:tx:manip1";
-        String key2 = "test:tx:manip2";
-        
-        try {
-            // Set up initial data
-            connection.stringCommands().set(key1.getBytes(), "TxHello".getBytes());
-            connection.stringCommands().set(key2.getBytes(), "TxValkey World".getBytes());
-            
-            connection.multi();
-            
-            // Queue string manipulation operations - assert they return null in transaction mode
-            assertThat(connection.stringCommands().append(key1.getBytes(), " World".getBytes())).isNull();
-            assertThat(connection.stringCommands().strLen(key1.getBytes())).isNull();
-            assertThat(connection.stringCommands().getRange(key2.getBytes(), 0, 7)).isNull();
-            connection.stringCommands().setRange(key2.getBytes(), "Valkey".getBytes(), 9); // void method
-            assertThat(connection.stringCommands().get(key2.getBytes())).isNull();
-            
-            java.util.List<Object> results = connection.exec();
-            
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(5);
-            assertThat(results.get(0)).isEqualTo(13L); // APPEND result (length)
-            assertThat(results.get(1)).isEqualTo(13L); // STRLEN result
-            assertThat(results.get(2)).isEqualTo("TxValkey".getBytes()); // GETRANGE result
-            assertThat(results.get(3)).isEqualTo(15L); // SETRANGE result (new length)
-            assertThat(results.get(4)).isEqualTo("TxValkey Valkey".getBytes()); // GET result after setrange
-            
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-        }
-    }
+			// Test mSet
+			Boolean mSetResult = connection.stringCommands().mSet(keyValues);
+			assertThat(mSetResult).isTrue();
 
-    @Test
-    void testBitOperationsInTransactionMode() {
-        String key1 = "test:tx:bit1";
-        String key2 = "test:tx:bit2";
-        String destKey = "test:tx:bitop";
-        
-        try {
-            // Set up initial data
-            connection.stringCommands().set(key1.getBytes(), new byte[]{(byte) 0xF0}); // 11110000
-            connection.stringCommands().set(key2.getBytes(), new byte[]{(byte) 0x0F}); // 00001111
-            
-            connection.multi();
-            
-            // Queue bit operations - assert they return null in transaction mode
-            assertThat(connection.stringCommands().getBit(key1.getBytes(), 0)).isNull();
-            assertThat(connection.stringCommands().setBit(key1.getBytes(), 4, false)).isNull();
-            assertThat(connection.stringCommands().bitCount(key1.getBytes())).isNull();
-            assertThat(connection.stringCommands().bitCount(key2.getBytes(), 0, 0)).isNull();
-            assertThat(connection.stringCommands().bitOp(BitOperation.OR, destKey.getBytes(), key1.getBytes(), key2.getBytes())).isNull();
-            assertThat(connection.stringCommands().bitPos(key1.getBytes(), true)).isNull();
-            
-            java.util.List<Object> results = connection.exec();
-            
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(6);
-            assertThat(results.get(0)).isEqualTo(true); // GETBIT result
-            assertThat(results.get(1)).isEqualTo(false); // SETBIT resut (old value was 0)
-            assertThat(results.get(2)).isEqualTo(4L); // 4 bits still set
-            assertThat(results.get(3)).isEqualTo(4L); // BITCOUNT result with range
-            assertThat(results.get(4)).isEqualTo(1L); // BITOP result (1 byte processed)
-            assertThat(results.get(5)).isEqualTo(0L); // BITPOS result
-            
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-            cleanupKey(destKey);
-        }
-    }
+			// Test mGet
+			List<byte[]> values = connection.stringCommands()
+				.mGet(key1.getBytes(), key2.getBytes(), key3.getBytes(), "non:existent".getBytes());
 
-    @Test
-    void testAdvancedStringOperationsInTransactionMode() {
-        String key1 = "test:tx:advanced1";
-        String key2 = "test:tx:advanced2";
-        
-        try {
-            connection.multi();
-            
-            // Queue advanced operations - assert they return null in transaction mode
-            assertThat(connection.stringCommands().set(key1.getBytes(), "txtest".getBytes(),
-                Expiration.seconds(60), SetOption.ifAbsent())).isNull();
-            assertThat(connection.stringCommands().setGet(key2.getBytes(), "txnewvalue".getBytes(),
-                Expiration.persistent(), SetOption.upsert())).isNull();
-            
-            // BitField operations
-            BitFieldSubCommands subCommands = BitFieldSubCommands.create()
-                .set(BitFieldSubCommands.BitFieldType.unsigned(8)).valueAt(0).to(200)
-                .get(BitFieldSubCommands.BitFieldType.unsigned(8)).valueAt(0);
-            assertThat(connection.stringCommands().bitField(key1.getBytes(), subCommands)).isNull();
-            
-            java.util.List<Object> results = connection.exec();
-            
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(3);
-            assertThat(results.get(0)).isEqualTo(true); // SET with options result
-            assertThat(results.get(1)).isNull(); // SETGET result (no previous value)
-            
-            // BitField results
-            @SuppressWarnings("unchecked")
-            java.util.List<Long> bitFieldResults = (java.util.List<Long>) results.get(2);
-            assertThat(bitFieldResults).isNotNull();
-            
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-        }
-    }
+			assertThat(values).hasSize(4);
+			assertThat(values.get(0)).isEqualTo("value1".getBytes());
+			assertThat(values.get(1)).isEqualTo("value2".getBytes());
+			assertThat(values.get(2)).isEqualTo("value3".getBytes());
+			assertThat(values.get(3)).isNull(); // non-existent key
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+			cleanupKey(key3);
+		}
+	}
 
-    @Test
-    void testTransactionWithWatchedKeys() {
-        String watchedKey = "test:tx:watched";
-        String valueKey = "test:tx:value";
-        
-        try {
-            // Set initial value
-            connection.stringCommands().set(watchedKey.getBytes(), "initial".getBytes());
-            
-            // Watch the key
-            connection.watch(watchedKey.getBytes());
-            
-            // Start transaction
-            connection.multi();
-            connection.stringCommands().set(valueKey.getBytes(), "conditional_set".getBytes());
-            
-            // Execute transaction (should succeed since key wasn't modified)
-            java.util.List<Object> results = connection.exec();
-            
-            assertThat(results).hasSize(1);
-            assertThat(results.get(0)).isEqualTo(true);
-            
-            // Verify the conditional set worked
-            assertThat(connection.stringCommands().get(valueKey.getBytes())).isEqualTo("conditional_set".getBytes());
-        } finally {
-            cleanupKey(watchedKey);
-            cleanupKey(valueKey);
-        }
-    }
+	@Test
+	void testMSetNX() {
+		String key1 = "test:string:msetnx:key1";
+		String key2 = "test:string:msetnx:key2";
+		String key3 = "test:string:msetnx:existing";
+		String key4 = "test:string:msetnx:new1";
+		String key5 = "test:string:msetnx:new2";
 
-    @Test
-    void testTransactionAbortWithWatchConflict() {
-        String watchedKey = "test:tx:conflict";
-        String valueKey = "test:tx:aborted";
-        
-        try {
-            // Set initial value
-            connection.stringCommands().set(watchedKey.getBytes(), "initial".getBytes());
-            
-            // Watch the key
-            connection.watch(watchedKey.getBytes());
-            
-            // Modify the watched key from outside the transaction to simulate conflict
-            // In a real scenario, this would happen from another connection
-            connection.stringCommands().set(watchedKey.getBytes(), "modified".getBytes());
-            
-            // Start transaction
-            connection.multi();
-            connection.stringCommands().set(valueKey.getBytes(), "should_not_be_set".getBytes());
-            
-            // Execute transaction (should be aborted due to watch conflict)
-            // Valkey specification: aborted transactions return empty list
-            java.util.List<Object> results = connection.exec();
-            
-            // Transaction should be aborted - expect empty list (not null or exception)
-            assertThat(results).isNotNull().isEmpty();
-            
-            // Verify the conditional set was NOT executed
-            byte[] result = connection.stringCommands().get(valueKey.getBytes());
-            assertThat(result).isNull(); // Key should not exist
-        } finally {
-            cleanupKey(watchedKey);
-            cleanupKey(valueKey);
-        }
-    }
+		try {
+			// Set one key first
+			connection.stringCommands().set(key3.getBytes(), "existing_value".getBytes());
 
-    @Test
-    void testMixedStringOperationsInTransaction() {
-        String baseKey = "test:tx:mixed";
-        
-        try {
-            connection.multi();
-            
-            // Mix of different string operations
-            connection.stringCommands().set((baseKey + ":1").getBytes(), "100".getBytes());
-            connection.stringCommands().incr((baseKey + ":1").getBytes());
-            connection.stringCommands().append((baseKey + ":1").getBytes(), ".5".getBytes());
-            connection.stringCommands().strLen((baseKey + ":1").getBytes());
-            connection.stringCommands().setNX((baseKey + ":2").getBytes(), "new_value".getBytes());
-            
-            java.util.List<Object> results = connection.exec();
-            
-            assertThat(results).hasSize(5);
-            assertThat(results.get(0)).isEqualTo(true); // SET
-            assertThat(results.get(1)).isEqualTo(101L); // INCR
-            assertThat(results.get(2)).isEqualTo(5L); // APPEND (length after append)
-            assertThat(results.get(3)).isEqualTo(5L); // STRLEN
-            assertThat(results.get(4)).isEqualTo(true); // SETNX
-            
-            // Verify final state
-            assertThat(connection.stringCommands().get((baseKey + ":1").getBytes())).isEqualTo("101.5".getBytes());
-            assertThat(connection.stringCommands().get((baseKey + ":2").getBytes())).isEqualTo("new_value".getBytes());
-        } finally {
-            cleanupKey(baseKey + ":1");
-            cleanupKey(baseKey + ":2");
-        }
-    }
+			// Try mSetNX with mix of new and existing keys
+			Map<byte[], byte[]> keyValues = new HashMap<>();
+			keyValues.put(key1.getBytes(), "value1".getBytes());
+			keyValues.put(key2.getBytes(), "value2".getBytes());
+			keyValues.put(key3.getBytes(), "new_value".getBytes()); // existing key
+
+			Boolean mSetNXResult = connection.stringCommands().mSetNX(keyValues);
+			assertThat(mSetNXResult).isFalse(); // Should fail due to existing key
+
+			// Verify none of the keys were set
+			assertThat(connection.stringCommands().get(key1.getBytes())).isNull();
+			assertThat(connection.stringCommands().get(key2.getBytes())).isNull();
+			assertThat(connection.stringCommands().get(key3.getBytes())).isEqualTo("existing_value".getBytes());
+
+			// Test successful mSetNX with all new keys (using different keys)
+			Map<byte[], byte[]> newKeyValues = new HashMap<>();
+			newKeyValues.put(key4.getBytes(), "newvalue1".getBytes());
+			newKeyValues.put(key5.getBytes(), "newvalue2".getBytes());
+			Boolean successfulMSetNX = connection.stringCommands().mSetNX(newKeyValues);
+			assertThat(successfulMSetNX).isTrue();
+
+			assertThat(connection.stringCommands().get(key4.getBytes())).isEqualTo("newvalue1".getBytes());
+			assertThat(connection.stringCommands().get(key5.getBytes())).isEqualTo("newvalue2".getBytes());
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+			cleanupKey(key3);
+			cleanupKey(key4);
+			cleanupKey(key5);
+		}
+	}
+
+	// ==================== Increment/Decrement Operations ====================
+
+	@Test
+	void testIncrDecr() {
+		String key = "test:string:incrdecr";
+		byte[] keyBytes = key.getBytes();
+
+		try {
+			// Test incr on non-existent key (should start from 0)
+			Long incrResult1 = connection.stringCommands().incr(keyBytes);
+			assertThat(incrResult1).isEqualTo(1L);
+
+			// Test multiple increments
+			Long incrResult2 = connection.stringCommands().incr(keyBytes);
+			assertThat(incrResult2).isEqualTo(2L);
+
+			// Test decr
+			Long decrResult1 = connection.stringCommands().decr(keyBytes);
+			assertThat(decrResult1).isEqualTo(1L);
+
+			// Test decr to negative
+			Long decrResult2 = connection.stringCommands().decr(keyBytes);
+			Long decrResult3 = connection.stringCommands().decr(keyBytes);
+			assertThat(decrResult2).isEqualTo(0L);
+			assertThat(decrResult3).isEqualTo(-1L);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testIncrByDecrBy() {
+		String intKey = "test:string:incrby:int";
+		String floatKey = "test:string:incrby:float";
+
+		try {
+			// Test incrBy with integers
+			Long incrByResult1 = connection.stringCommands().incrBy(intKey.getBytes(), 5L);
+			assertThat(incrByResult1).isEqualTo(5L);
+
+			Long incrByResult2 = connection.stringCommands().incrBy(intKey.getBytes(), 10L);
+			assertThat(incrByResult2).isEqualTo(15L);
+
+			// Test decrBy
+			Long decrByResult = connection.stringCommands().decrBy(intKey.getBytes(), 7L);
+			assertThat(decrByResult).isEqualTo(8L);
+
+			// Test incrBy with floats
+			Double floatIncrResult1 = connection.stringCommands().incrBy(floatKey.getBytes(), 3.14);
+			assertThat(floatIncrResult1).isEqualTo(3.14);
+
+			Double floatIncrResult2 = connection.stringCommands().incrBy(floatKey.getBytes(), 2.86);
+			assertThat(floatIncrResult2).isEqualTo(6.0);
+
+			// Test negative increment (effectively decrement)
+			Double floatDecrResult = connection.stringCommands().incrBy(floatKey.getBytes(), -1.5);
+			assertThat(floatDecrResult).isEqualTo(4.5);
+		}
+		finally {
+			cleanupKey(intKey);
+			cleanupKey(floatKey);
+		}
+	}
+
+	// ==================== String Manipulation ====================
+
+	@Test
+	void testAppendAndStrLen() {
+		String key = "test:string:append";
+		byte[] keyBytes = key.getBytes();
+
+		try {
+			// Test append to non-existent key
+			Long appendResult1 = connection.stringCommands().append(keyBytes, "Hello".getBytes());
+			assertThat(appendResult1).isEqualTo(5L); // Length of "Hello"
+
+			// Test string length
+			Long strLenResult1 = connection.stringCommands().strLen(keyBytes);
+			assertThat(strLenResult1).isEqualTo(5L);
+
+			// Test append to existing key
+			Long appendResult2 = connection.stringCommands().append(keyBytes, " World".getBytes());
+			assertThat(appendResult2).isEqualTo(11L); // Length of "Hello World"
+
+			// Verify final value
+			byte[] finalValue = connection.stringCommands().get(keyBytes);
+			assertThat(finalValue).isEqualTo("Hello World".getBytes());
+
+			Long strLenResult2 = connection.stringCommands().strLen(keyBytes);
+			assertThat(strLenResult2).isEqualTo(11L);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testGetRangeSetRange() {
+		String key = "test:string:range";
+		byte[] keyBytes = key.getBytes();
+		String originalValue = "Hello World";
+
+		try {
+			// Set initial value
+			connection.stringCommands().set(keyBytes, originalValue.getBytes());
+
+			// Test getRange
+			byte[] range1 = connection.stringCommands().getRange(keyBytes, 0, 4);
+			assertThat(range1).isEqualTo("Hello".getBytes());
+
+			byte[] range2 = connection.stringCommands().getRange(keyBytes, 6, -1);
+			assertThat(range2).isEqualTo("World".getBytes());
+
+			byte[] range3 = connection.stringCommands().getRange(keyBytes, -5, -1);
+			assertThat(range3).isEqualTo("World".getBytes());
+
+			// Test setRange
+			connection.stringCommands().setRange(keyBytes, "Valkey".getBytes(), 6);
+			byte[] modifiedValue = connection.stringCommands().get(keyBytes);
+			assertThat(modifiedValue).isEqualTo("Hello Valkey".getBytes());
+
+			// Test setRange beyond string length (should pad with zeros)
+			connection.stringCommands().setRange(keyBytes, "!".getBytes(), 20);
+			byte[] paddedValue = connection.stringCommands().get(keyBytes);
+			assertThat(paddedValue).hasSize(21);
+			assertThat(paddedValue[20]).isEqualTo((byte) '!');
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== Bit Operations ====================
+
+	@Test
+	void testGetBitSetBit() {
+		String key = "test:string:bit";
+		byte[] keyBytes = key.getBytes();
+
+		try {
+			// Test getBit on non-existent key
+			Boolean bit1 = connection.stringCommands().getBit(keyBytes, 0);
+			assertThat(bit1).isFalse(); // Non-existent keys return 0
+
+			// Test setBit
+			Boolean oldBit1 = connection.stringCommands().setBit(keyBytes, 7, true);
+			assertThat(oldBit1).isFalse(); // Previous value was 0
+
+			// Test getBit after setBit
+			Boolean bit2 = connection.stringCommands().getBit(keyBytes, 7);
+			assertThat(bit2).isTrue();
+
+			// Test setting bit to false
+			Boolean oldBit2 = connection.stringCommands().setBit(keyBytes, 7, false);
+			assertThat(oldBit2).isTrue(); // Previous value was 1
+
+			Boolean bit3 = connection.stringCommands().getBit(keyBytes, 7);
+			assertThat(bit3).isFalse();
+
+			// Set multiple bits
+			connection.stringCommands().setBit(keyBytes, 0, true);
+			connection.stringCommands().setBit(keyBytes, 4, true);
+			connection.stringCommands().setBit(keyBytes, 8, true);
+
+			// Verify individual bits
+			assertThat(connection.stringCommands().getBit(keyBytes, 0)).isTrue();
+			assertThat(connection.stringCommands().getBit(keyBytes, 4)).isTrue();
+			assertThat(connection.stringCommands().getBit(keyBytes, 8)).isTrue();
+			assertThat(connection.stringCommands().getBit(keyBytes, 1)).isFalse();
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testBitCount() {
+		String key = "test:string:bitcount";
+		byte[] keyBytes = key.getBytes();
+
+		try {
+			// Set some bits
+			connection.stringCommands().setBit(keyBytes, 0, true);
+			connection.stringCommands().setBit(keyBytes, 4, true);
+			connection.stringCommands().setBit(keyBytes, 8, true);
+			connection.stringCommands().setBit(keyBytes, 16, true);
+
+			// Test bitCount for entire string
+			Long bitCount1 = connection.stringCommands().bitCount(keyBytes);
+			assertThat(bitCount1).isEqualTo(4L);
+
+			// Test bitCount with range (first byte only)
+			Long bitCount2 = connection.stringCommands().bitCount(keyBytes, 0, 0);
+			assertThat(bitCount2).isEqualTo(2L); // bits 0 and 4 are in first byte
+
+			// Test bitCount with range (second byte)
+			Long bitCount3 = connection.stringCommands().bitCount(keyBytes, 1, 1);
+			assertThat(bitCount3).isEqualTo(1L); // bit 8 is in second byte
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testBitPos() {
+		String key = "test:string:bitpos";
+		byte[] keyBytes = key.getBytes();
+
+		try {
+			// Set bits: 11110000 (0xF0)
+			connection.stringCommands().set(keyBytes, new byte[] { (byte) 0xF0 });
+
+			// Find first 1 bit
+			Long pos1 = connection.stringCommands().bitPos(keyBytes, true);
+			assertThat(pos1).isEqualTo(0L);
+
+			// Find first 0 bit
+			Long pos0 = connection.stringCommands().bitPos(keyBytes, false);
+			assertThat(pos0).isEqualTo(4L);
+
+			// Test with range
+			Long pos1Range = connection.stringCommands().bitPos(keyBytes, true, Range.closed(0L, 0L));
+			assertThat(pos1Range).isEqualTo(0L);
+
+			Long pos0Range = connection.stringCommands().bitPos(keyBytes, false, Range.closed(0L, 0L));
+			assertThat(pos0Range).isEqualTo(4L);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testBitOp() {
+		String key1 = "test:string:bitop:key1";
+		String key2 = "test:string:bitop:key2";
+		String destKey = "test:string:bitop:dest";
+
+		try {
+			// Set up test data
+			connection.stringCommands().set(key1.getBytes(), new byte[] { (byte) 0xF0 }); // 11110000
+			connection.stringCommands().set(key2.getBytes(), new byte[] { (byte) 0x0F }); // 00001111
+
+			// Test AND operation
+			Long andResult = connection.stringCommands()
+				.bitOp(BitOperation.AND, destKey.getBytes(), key1.getBytes(), key2.getBytes());
+			assertThat(andResult).isEqualTo(1L); // 1 byte processed
+
+			byte[] andValue = connection.stringCommands().get(destKey.getBytes());
+			assertThat(andValue[0]).isEqualTo((byte) 0x00); // 11110000 AND 00001111 =
+															// 00000000
+
+			// Test OR operation
+			Long orResult = connection.stringCommands()
+				.bitOp(BitOperation.OR, destKey.getBytes(), key1.getBytes(), key2.getBytes());
+			assertThat(orResult).isEqualTo(1L);
+
+			byte[] orValue = connection.stringCommands().get(destKey.getBytes());
+			assertThat(orValue[0]).isEqualTo((byte) 0xFF); // 11110000 OR 00001111 =
+															// 11111111
+
+			// Test XOR operation
+			Long xorResult = connection.stringCommands()
+				.bitOp(BitOperation.XOR, destKey.getBytes(), key1.getBytes(), key2.getBytes());
+			assertThat(xorResult).isEqualTo(1L);
+
+			byte[] xorValue = connection.stringCommands().get(destKey.getBytes());
+			assertThat(xorValue[0]).isEqualTo((byte) 0xFF); // 11110000 XOR 00001111 =
+															// 11111111
+
+			// Test NOT operation (single key)
+			Long notResult = connection.stringCommands().bitOp(BitOperation.NOT, destKey.getBytes(), key1.getBytes());
+			assertThat(notResult).isEqualTo(1L);
+
+			byte[] notValue = connection.stringCommands().get(destKey.getBytes());
+			assertThat(notValue[0]).isEqualTo((byte) 0x0F); // NOT 11110000 = 00001111
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+			cleanupKey(destKey);
+		}
+	}
+
+	@Test
+	void testBitField() {
+		String key = "test:string:bitfield";
+		byte[] keyBytes = key.getBytes();
+
+		try {
+			BitFieldSubCommands subCommands = BitFieldSubCommands.create()
+				.set(BitFieldSubCommands.BitFieldType.unsigned(8))
+				.valueAt(0)
+				.to(255)
+				.get(BitFieldSubCommands.BitFieldType.unsigned(8))
+				.valueAt(0);
+
+			// Test that bitField executes without throwing exception
+			// Note: ValkeyGlide implementation may return Object[] instead of List<Long>
+			List<Long> results = connection.stringCommands().bitField(keyBytes, subCommands);
+
+			// Basic verification that some result is returned
+			assertThat(results).isNotNull();
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testBitFieldWithOverflowWrap() {
+		String key = "test:string:bitfield:wrap";
+		byte[] keyBytes = key.getBytes();
+
+		try {
+			// Test OVERFLOW WRAP behavior (default)
+			// Increment u2 (max value 3) from 0 to 3, then wrap to 0
+			BitFieldSubCommands subCommands = BitFieldSubCommands.create()
+				.incr(BitFieldSubCommands.BitFieldType.unsigned(2))
+				.valueAt(100)
+				.overflow(BitFieldSubCommands.BitFieldIncrBy.Overflow.WRAP)
+				.by(1)
+				.incr(BitFieldSubCommands.BitFieldType.unsigned(2))
+				.valueAt(100)
+				.overflow(BitFieldSubCommands.BitFieldIncrBy.Overflow.WRAP)
+				.by(1)
+				.incr(BitFieldSubCommands.BitFieldType.unsigned(2))
+				.valueAt(100)
+				.overflow(BitFieldSubCommands.BitFieldIncrBy.Overflow.WRAP)
+				.by(1)
+				.incr(BitFieldSubCommands.BitFieldType.unsigned(2))
+				.valueAt(100)
+				.overflow(BitFieldSubCommands.BitFieldIncrBy.Overflow.WRAP)
+				.by(1);
+
+			List<Long> results = connection.stringCommands().bitField(keyBytes, subCommands);
+
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(4);
+			assertThat(results.get(0)).isEqualTo(1L); // 0 + 1 = 1
+			assertThat(results.get(1)).isEqualTo(2L); // 1 + 1 = 2
+			assertThat(results.get(2)).isEqualTo(3L); // 2 + 1 = 3 (max value)
+			assertThat(results.get(3)).isEqualTo(0L); // 3 + 1 wraps to 0
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testBitFieldWithOverflowSat() {
+		String key = "test:string:bitfield:sat";
+		byte[] keyBytes = key.getBytes();
+
+		try {
+			// Test OVERFLOW SAT behavior (saturate at max/min)
+			// Increment u2 (max value 3) from 0 to 3, then saturate at 3
+			BitFieldSubCommands subCommands = BitFieldSubCommands.create()
+				.incr(BitFieldSubCommands.BitFieldType.unsigned(2))
+				.valueAt(102)
+				.overflow(BitFieldSubCommands.BitFieldIncrBy.Overflow.SAT)
+				.by(1)
+				.incr(BitFieldSubCommands.BitFieldType.unsigned(2))
+				.valueAt(102)
+				.overflow(BitFieldSubCommands.BitFieldIncrBy.Overflow.SAT)
+				.by(1)
+				.incr(BitFieldSubCommands.BitFieldType.unsigned(2))
+				.valueAt(102)
+				.overflow(BitFieldSubCommands.BitFieldIncrBy.Overflow.SAT)
+				.by(1)
+				.incr(BitFieldSubCommands.BitFieldType.unsigned(2))
+				.valueAt(102)
+				.overflow(BitFieldSubCommands.BitFieldIncrBy.Overflow.SAT)
+				.by(1);
+
+			List<Long> results = connection.stringCommands().bitField(keyBytes, subCommands);
+
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(4);
+			assertThat(results.get(0)).isEqualTo(1L); // 0 + 1 = 1
+			assertThat(results.get(1)).isEqualTo(2L); // 1 + 1 = 2
+			assertThat(results.get(2)).isEqualTo(3L); // 2 + 1 = 3 (max value)
+			assertThat(results.get(3)).isEqualTo(3L); // 3 + 1 saturates at 3
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testBitFieldWithOverflowFail() {
+		String key = "test:string:bitfield:fail";
+		byte[] keyBytes = key.getBytes();
+
+		try {
+			// Test OVERFLOW FAIL behavior (return null on overflow)
+			// Increment u2 (max value 3) from 0 to 3, then fail and return null
+			BitFieldSubCommands subCommands = BitFieldSubCommands.create()
+				.incr(BitFieldSubCommands.BitFieldType.unsigned(2))
+				.valueAt(102)
+				.overflow(BitFieldSubCommands.BitFieldIncrBy.Overflow.FAIL)
+				.by(1)
+				.incr(BitFieldSubCommands.BitFieldType.unsigned(2))
+				.valueAt(102)
+				.overflow(BitFieldSubCommands.BitFieldIncrBy.Overflow.FAIL)
+				.by(1)
+				.incr(BitFieldSubCommands.BitFieldType.unsigned(2))
+				.valueAt(102)
+				.overflow(BitFieldSubCommands.BitFieldIncrBy.Overflow.FAIL)
+				.by(1)
+				.incr(BitFieldSubCommands.BitFieldType.unsigned(2))
+				.valueAt(102)
+				.overflow(BitFieldSubCommands.BitFieldIncrBy.Overflow.FAIL)
+				.by(1);
+
+			List<Long> results = connection.stringCommands().bitField(keyBytes, subCommands);
+
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(4);
+			assertThat(results.get(0)).isEqualTo(1L); // 0 + 1 = 1
+			assertThat(results.get(1)).isEqualTo(2L); // 1 + 1 = 2
+			assertThat(results.get(2)).isEqualTo(3L); // 2 + 1 = 3 (max value)
+			assertThat(results.get(3)).isNull(); // 3 + 1 fails and returns null
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testBitFieldMixedOverflowModes() {
+		String key = "test:string:bitfield:mixed";
+		byte[] keyBytes = key.getBytes();
+
+		try {
+			// Test multiple overflow modes in single command
+			// Each OVERFLOW command affects subsequent operations until next OVERFLOW
+			BitFieldSubCommands subCommands = BitFieldSubCommands.create()
+				// Set initial values
+				.set(BitFieldSubCommands.BitFieldType.unsigned(2))
+				.valueAt(100)
+				.to(3)
+				.set(BitFieldSubCommands.BitFieldType.unsigned(2))
+				.valueAt(104)
+				.to(3)
+				.set(BitFieldSubCommands.BitFieldType.unsigned(2))
+				.valueAt(108)
+				.to(3)
+				// Test WRAP overflow
+				.incr(BitFieldSubCommands.BitFieldType.unsigned(2))
+				.valueAt(100)
+				.overflow(BitFieldSubCommands.BitFieldIncrBy.Overflow.WRAP)
+				.by(1)
+				// Test SAT overflow
+				.incr(BitFieldSubCommands.BitFieldType.unsigned(2))
+				.valueAt(104)
+				.overflow(BitFieldSubCommands.BitFieldIncrBy.Overflow.SAT)
+				.by(1)
+				// Test FAIL overflow
+				.incr(BitFieldSubCommands.BitFieldType.unsigned(2))
+				.valueAt(108)
+				.overflow(BitFieldSubCommands.BitFieldIncrBy.Overflow.FAIL)
+				.by(1);
+
+			List<Long> results = connection.stringCommands().bitField(keyBytes, subCommands);
+
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(6);
+			assertThat(results.get(0)).isEqualTo(0L); // SET returns old value (0)
+			assertThat(results.get(1)).isEqualTo(0L); // SET returns old value (0)
+			assertThat(results.get(2)).isEqualTo(0L); // SET returns old value (0)
+			assertThat(results.get(3)).isEqualTo(0L); // WRAP: 3 + 1 = 0
+			assertThat(results.get(4)).isEqualTo(3L); // SAT: 3 + 1 = 3 (saturated)
+			assertThat(results.get(5)).isNull(); // FAIL: 3 + 1 = null (overflow detected)
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testBitFieldWithNonZeroBasedOffset() {
+		String key = "test:string:bitfield:nonzero";
+		byte[] keyBytes = key.getBytes();
+
+		try {
+			// Test type-based (non-zero-based) offsets using multipliedByTypeLength()
+			// Type-based offsets are prefixed with "#" in Valkey and multiplied by the
+			// type width
+			// For INT_8 (8 bits = 1 byte), offset #1 means byte offset 1
+			BitFieldSubCommands subCommands = BitFieldSubCommands.create()
+				.set(BitFieldSubCommands.BitFieldType.signed(8))
+				.valueAt(BitFieldSubCommands.Offset.offset(0L).multipliedByTypeLength())
+				.to(100L)
+				.set(BitFieldSubCommands.BitFieldType.signed(8))
+				.valueAt(BitFieldSubCommands.Offset.offset(1L).multipliedByTypeLength())
+				.to(200L);
+
+			List<Long> setResults = connection.stringCommands().bitField(keyBytes, subCommands);
+
+			assertThat(setResults).isNotNull();
+			assertThat(setResults).hasSize(2);
+			assertThat(setResults).containsExactly(0L, 0L); // Both SET operations return
+															// old value (0)
+
+			// Now get the values back using type-based offsets
+			BitFieldSubCommands getCommands = BitFieldSubCommands.create()
+				.get(BitFieldSubCommands.BitFieldType.signed(8))
+				.valueAt(BitFieldSubCommands.Offset.offset(0L).multipliedByTypeLength())
+				.get(BitFieldSubCommands.BitFieldType.signed(8))
+				.valueAt(BitFieldSubCommands.Offset.offset(1L).multipliedByTypeLength());
+
+			List<Long> getResults = connection.stringCommands().bitField(keyBytes, getCommands);
+
+			assertThat(getResults).isNotNull();
+			assertThat(getResults).hasSize(2);
+			assertThat(getResults.get(0)).isEqualTo(100L);
+			assertThat(getResults.get(1)).isEqualTo(-56L); // 200 as signed i8 wraps to
+															// -56
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== Error Handling and Edge Cases ====================
+
+	@Test
+	void testStringOperationsOnNonStringTypes() {
+		String listKey = "test:string:error:list";
+
+		try {
+			// Create a list
+			connection.listCommands().lPush(listKey.getBytes(), "item".getBytes());
+
+			// Try string operations on list key - should fail or return appropriate
+			// response
+			assertThatThrownBy(() -> connection.stringCommands().incr(listKey.getBytes()))
+				.isInstanceOf(DataAccessException.class);
+		}
+		finally {
+			cleanupKey(listKey);
+		}
+	}
+
+	@Test
+	void testEmptyStringOperations() {
+		String key = "test:string:empty";
+		byte[] keyBytes = key.getBytes();
+		byte[] emptyValue = new byte[0];
+
+		try {
+			// Set empty string
+			Boolean setResult = connection.stringCommands().set(keyBytes, emptyValue);
+			assertThat(setResult).isTrue();
+
+			// Get empty string
+			byte[] retrievedValue = connection.stringCommands().get(keyBytes);
+			assertThat(retrievedValue).isEqualTo(emptyValue);
+
+			// String length should be 0
+			Long strLen = connection.stringCommands().strLen(keyBytes);
+			assertThat(strLen).isEqualTo(0L);
+
+			// Append to empty string
+			Long appendResult = connection.stringCommands().append(keyBytes, "appended".getBytes());
+			assertThat(appendResult).isEqualTo(8L); // "appended" is 8 characters
+
+			byte[] finalValue = connection.stringCommands().get(keyBytes);
+			assertThat(finalValue).isEqualTo("appended".getBytes());
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== Pipeline Mode Tests ====================
+
+	@Test
+	void testBasicStringOperationsInPipelineMode() {
+		String key1 = "test:pipeline:basic1";
+		String key2 = "test:pipeline:basic2";
+		String key3 = "test:pipeline:basic3";
+		String key4 = "test:pipeline:basic4";
+
+		try {
+			// Open pipeline
+			connection.openPipeline();
+
+			// Queue basic string operations - assert they return null in pipeline mode
+			assertThat(connection.stringCommands().set(key1.getBytes(), "value1".getBytes())).isNull();
+			assertThat(connection.stringCommands().setNX(key2.getBytes(), "value2".getBytes())).isNull();
+			assertThat(connection.stringCommands().get(key1.getBytes())).isNull();
+			assertThat(connection.stringCommands().getSet(key1.getBytes(), "newvalue1".getBytes())).isNull();
+			assertThat(connection.stringCommands().getDel(key1.getBytes())).isNull();
+			assertThat(connection.stringCommands().setEx(key3.getBytes(), 60, "expiring".getBytes())).isNull();
+			assertThat(connection.stringCommands().pSetEx(key4.getBytes(), 60000, "expiring_ms".getBytes())).isNull();
+
+			// Execute pipeline
+			java.util.List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(7);
+			assertThat(results.get(0)).isEqualTo(true); // SET result
+			assertThat(results.get(1)).isEqualTo(true); // SETNX result
+			assertThat(results.get(2)).isEqualTo("value1".getBytes()); // GET result
+			assertThat(results.get(3)).isEqualTo("value1".getBytes()); // GETSET result
+			assertThat(results.get(4)).isEqualTo("newvalue1".getBytes()); // GETDEL result
+			assertThat(results.get(5)).isEqualTo(true); // SETEX result
+			assertThat(results.get(6)).isEqualTo(true); // PSETEX result
+
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+			cleanupKey(key3);
+			cleanupKey(key4);
+		}
+	}
+
+	@Test
+	void testMultiKeyOperationsInPipelineMode() {
+		String key1 = "test:pipeline:mkey1";
+		String key2 = "test:pipeline:mkey2";
+		String key3 = "test:pipeline:mkey3";
+		String key4 = "test:pipeline:mkey4";
+		String key5 = "test:pipeline:mkey5";
+
+		try {
+			// Set up initial data
+			connection.stringCommands().set(key1.getBytes(), "initial1".getBytes());
+			connection.stringCommands().set(key2.getBytes(), "initial2".getBytes());
+
+			connection.openPipeline();
+
+			// Queue multi-key operations - assert they return null in pipeline mode
+			assertThat(connection.stringCommands().mGet(key1.getBytes(), key2.getBytes(), key3.getBytes())).isNull();
+
+			Map<byte[], byte[]> msetData = new HashMap<>();
+			msetData.put(key4.getBytes(), "msetvalue1".getBytes());
+			msetData.put(key5.getBytes(), "msetvalue2".getBytes());
+			assertThat(connection.stringCommands().mSet(msetData)).isNull();
+
+			Map<byte[], byte[]> msetnxData = new HashMap<>();
+			msetnxData.put("new1".getBytes(), "msetnxvalue1".getBytes());
+			msetnxData.put("new2".getBytes(), "msetnxvalue2".getBytes());
+			assertThat(connection.stringCommands().mSetNX(msetnxData)).isNull();
+
+			assertThat(connection.stringCommands().mGet(key4.getBytes(), key5.getBytes())).isNull();
+
+			java.util.List<Object> results = connection.closePipeline();
+
+			assertThat(results).hasSize(4);
+
+			// mGet result
+			@SuppressWarnings("unchecked")
+			java.util.List<byte[]> mgetResult1 = (java.util.List<byte[]>) results.get(0);
+			assertThat(mgetResult1).hasSize(3);
+			assertThat(mgetResult1.get(0)).isEqualTo("initial1".getBytes());
+			assertThat(mgetResult1.get(1)).isEqualTo("initial2".getBytes());
+			assertThat(mgetResult1.get(2)).isNull(); // key3 doesn't exist
+
+			assertThat(results.get(1)).isEqualTo(true); // MSET result
+			assertThat(results.get(2)).isEqualTo(true); // MSETNX result
+
+			// Second mGet result
+			@SuppressWarnings("unchecked")
+			java.util.List<byte[]> mgetResult2 = (java.util.List<byte[]>) results.get(3);
+			assertThat(mgetResult2).hasSize(2);
+			assertThat(mgetResult2.get(0)).isEqualTo("msetvalue1".getBytes());
+			assertThat(mgetResult2.get(1)).isEqualTo("msetvalue2".getBytes());
+
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+			cleanupKey(key3);
+			cleanupKey(key4);
+			cleanupKey(key5);
+			cleanupKey("new1");
+			cleanupKey("new2");
+		}
+	}
+
+	@Test
+	void testArithmeticOperationsInPipelineMode() {
+		String intKey = "test:pipeline:int";
+		String floatKey = "test:pipeline:float";
+		String decrKey = "test:pipeline:decr";
+
+		try {
+			connection.openPipeline();
+
+			// Queue arithmetic operations - assert they return null in pipeline mode
+			assertThat(connection.stringCommands().incr(intKey.getBytes())).isNull();
+			assertThat(connection.stringCommands().incrBy(intKey.getBytes(), 5L)).isNull();
+			assertThat(connection.stringCommands().incrBy(floatKey.getBytes(), 3.14)).isNull();
+			assertThat(connection.stringCommands().incrBy(floatKey.getBytes(), -1.14)).isNull();
+			assertThat(connection.stringCommands().decr(decrKey.getBytes())).isNull();
+			assertThat(connection.stringCommands().decrBy(decrKey.getBytes(), 3L)).isNull();
+
+			java.util.List<Object> results = connection.closePipeline();
+
+			assertThat(results).hasSize(6);
+			assertThat(results.get(0)).isEqualTo(1L); // INCR result
+			assertThat(results.get(1)).isEqualTo(6L); // INCRBY result
+			assertThat(results.get(2)).isEqualTo(3.14); // INCRBYFLOAT result
+			assertThat(results.get(3)).isEqualTo(2.0); // INCRBYFLOAT result
+			assertThat(results.get(4)).isEqualTo(-1L); // DECR result
+			assertThat(results.get(5)).isEqualTo(-4L); // DECRBY result
+
+		}
+		finally {
+			cleanupKey(intKey);
+			cleanupKey(floatKey);
+			cleanupKey(decrKey);
+		}
+	}
+
+	@Test
+	void testStringManipulationInPipelineMode() {
+		String key1 = "test:pipeline:manip1";
+		String key2 = "test:pipeline:manip2";
+
+		try {
+			// Set up initial data
+			connection.stringCommands().set(key1.getBytes(), "Hello".getBytes());
+			connection.stringCommands().set(key2.getBytes(), "Valkey World".getBytes());
+
+			connection.openPipeline();
+
+			// Queue string manipulation operations - assert they return null in pipeline
+			// mode
+			assertThat(connection.stringCommands().append(key1.getBytes(), " World".getBytes())).isNull();
+			assertThat(connection.stringCommands().strLen(key1.getBytes())).isNull();
+			assertThat(connection.stringCommands().getRange(key2.getBytes(), 0, 5)).isNull();
+			connection.stringCommands().setRange(key2.getBytes(), "Valkey".getBytes(), 7); // void
+																							// method
+			assertThat(connection.stringCommands().get(key2.getBytes())).isNull();
+
+			java.util.List<Object> results = connection.closePipeline();
+
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(5);
+			assertThat(results.get(0)).isEqualTo(11L); // APPEND result (length)
+			assertThat(results.get(1)).isEqualTo(11L); // STRLEN result
+			assertThat(results.get(2)).isEqualTo("Valkey".getBytes()); // GETRANGE result
+			assertThat(results.get(3)).isEqualTo(13L); // SETRANGE result (new length)
+			assertThat(results.get(4)).isEqualTo("Valkey Valkey".getBytes()); // GET
+																				// result
+																				// after
+																				// setrange
+
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+		}
+	}
+
+	@Test
+	void testBitOperationsInPipelineMode() {
+		String key1 = "test:pipeline:bit1";
+		String key2 = "test:pipeline:bit2";
+		String destKey = "test:pipeline:bitop";
+
+		try {
+			// Set up initial data
+			connection.stringCommands().set(key1.getBytes(), new byte[] { (byte) 0xF0 }); // 11110000
+			connection.stringCommands().set(key2.getBytes(), new byte[] { (byte) 0x0F }); // 00001111
+
+			connection.openPipeline();
+
+			// Queue bit operations - assert they return null in pipeline mode
+			assertThat(connection.stringCommands().getBit(key1.getBytes(), 0)).isNull();
+			assertThat(connection.stringCommands().setBit(key1.getBytes(), 4, false)).isNull();
+			assertThat(connection.stringCommands().bitCount(key1.getBytes())).isNull();
+			assertThat(connection.stringCommands().bitCount(key2.getBytes(), 0, 0)).isNull();
+			assertThat(connection.stringCommands()
+				.bitOp(BitOperation.AND, destKey.getBytes(), key1.getBytes(), key2.getBytes())).isNull();
+			assertThat(connection.stringCommands().bitPos(key1.getBytes(), true)).isNull();
+
+			java.util.List<Object> results = connection.closePipeline();
+
+			assertThat(results).hasSize(6);
+			assertThat(results.get(0)).isEqualTo(true); // GETBIT result
+			assertThat(results.get(1)).isEqualTo(false); // SETBIT result (old value was
+															// 0)
+			assertThat(results.get(2)).isEqualTo(4L); // 4 bits still set
+			assertThat(results.get(3)).isEqualTo(4L); // BITCOUNT result with range
+			assertThat(results.get(4)).isEqualTo(1L); // BITOP result (1 byte processed)
+			assertThat(results.get(5)).isEqualTo(0L); // BITPOS result
+
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+			cleanupKey(destKey);
+		}
+	}
+
+	@Test
+	void testAdvancedStringOperationsInPipelineMode() {
+		String key1 = "test:pipeline:advanced1";
+		String key2 = "test:pipeline:advanced2";
+
+		try {
+			connection.openPipeline();
+
+			// Queue advanced operations - assert they return null in pipeline mode
+			assertThat(connection.stringCommands()
+				.set(key1.getBytes(), "test".getBytes(), Expiration.seconds(60), SetOption.ifAbsent())).isNull();
+			assertThat(connection.stringCommands()
+				.setGet(key2.getBytes(), "newvalue".getBytes(), Expiration.persistent(), SetOption.upsert())).isNull();
+
+			// BitField operations
+			BitFieldSubCommands subCommands = BitFieldSubCommands.create()
+				.set(BitFieldSubCommands.BitFieldType.unsigned(8))
+				.valueAt(0)
+				.to(255)
+				.get(BitFieldSubCommands.BitFieldType.unsigned(8))
+				.valueAt(0);
+			assertThat(connection.stringCommands().bitField(key1.getBytes(), subCommands)).isNull();
+
+			java.util.List<Object> results = connection.closePipeline();
+
+			assertThat(results).hasSize(3);
+			assertThat(results.get(0)).isEqualTo(true); // SET with options result
+			assertThat(results.get(1)).isNull(); // SETGET result (no previous value)
+
+			// BitField results
+			@SuppressWarnings("unchecked")
+			java.util.List<Long> bitFieldResults = (java.util.List<Long>) results.get(2);
+			assertThat(bitFieldResults).isNotNull();
+
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+		}
+	}
+
+	// ==================== Transaction Mode Tests ====================
+
+	@Test
+	void testBasicStringOperationsInTransactionMode() {
+		String key1 = "test:tx:basic1";
+		String key2 = "test:tx:basic2";
+		String key3 = "test:tx:basic3";
+		String key4 = "test:tx:basic4";
+
+		try {
+			// Start transaction
+			connection.multi();
+
+			// Queue basic string operations - assert they return null in transaction mode
+			assertThat(connection.stringCommands().set(key1.getBytes(), "txvalue1".getBytes())).isNull();
+			assertThat(connection.stringCommands().setNX(key2.getBytes(), "txvalue2".getBytes())).isNull();
+			assertThat(connection.stringCommands().get(key1.getBytes())).isNull();
+			assertThat(connection.stringCommands().getSet(key1.getBytes(), "newtxvalue1".getBytes())).isNull();
+			assertThat(connection.stringCommands().getDel(key1.getBytes())).isNull();
+			assertThat(connection.stringCommands().setEx(key3.getBytes(), 60, "expiring".getBytes())).isNull();
+			assertThat(connection.stringCommands().pSetEx(key4.getBytes(), 60000, "expiring_ms".getBytes())).isNull();
+
+			// Execute transaction
+			java.util.List<Object> results = connection.exec();
+
+			// Verify results
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(7);
+			assertThat(results.get(0)).isEqualTo(true); // SET result
+			assertThat(results.get(1)).isEqualTo(true); // SETNX result
+			assertThat(results.get(2)).isEqualTo("txvalue1".getBytes()); // GET result
+			assertThat(results.get(3)).isEqualTo("txvalue1".getBytes()); // GETSET result
+			assertThat(results.get(4)).isEqualTo("newtxvalue1".getBytes()); // GETDEL
+																			// result
+			assertThat(results.get(5)).isEqualTo(true); // SETEX result
+			assertThat(results.get(6)).isEqualTo(true); // PSETEX result
+
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+			cleanupKey(key3);
+			cleanupKey(key4);
+		}
+	}
+
+	@Test
+	void testMultiKeyOperationsInTransactionMode() {
+		String key1 = "test:tx:mkey1";
+		String key2 = "test:tx:mkey2";
+		String key3 = "test:tx:mkey3";
+		String key4 = "test:tx:mkey4";
+		String key5 = "test:tx:mkey5";
+
+		try {
+			// Set up initial data
+			connection.stringCommands().set(key1.getBytes(), "txinitial1".getBytes());
+			connection.stringCommands().set(key2.getBytes(), "txinitial2".getBytes());
+
+			connection.multi();
+
+			// Queue multi-key operations - assert they return null in transaction mode
+			assertThat(connection.stringCommands().mGet(key1.getBytes(), key2.getBytes(), key3.getBytes())).isNull();
+
+			Map<byte[], byte[]> msetData = new HashMap<>();
+			msetData.put(key4.getBytes(), "txmsetvalue1".getBytes());
+			msetData.put(key5.getBytes(), "txmsetvalue2".getBytes());
+			assertThat(connection.stringCommands().mSet(msetData)).isNull();
+
+			Map<byte[], byte[]> msetnxData = new HashMap<>();
+			msetnxData.put("txnew1".getBytes(), "txmsetnxvalue1".getBytes());
+			msetnxData.put("txnew2".getBytes(), "txmsetnxvalue2".getBytes());
+			assertThat(connection.stringCommands().mSetNX(msetnxData)).isNull();
+
+			assertThat(connection.stringCommands().mGet(key4.getBytes(), key5.getBytes())).isNull();
+
+			java.util.List<Object> results = connection.exec();
+
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(4);
+
+			// mGet result
+			@SuppressWarnings("unchecked")
+			java.util.List<byte[]> mgetResult1 = (java.util.List<byte[]>) results.get(0);
+			assertThat(mgetResult1).hasSize(3);
+			assertThat(mgetResult1.get(0)).isEqualTo("txinitial1".getBytes());
+			assertThat(mgetResult1.get(1)).isEqualTo("txinitial2".getBytes());
+			assertThat(mgetResult1.get(2)).isNull(); // key3 doesn't exist
+
+			assertThat(results.get(1)).isEqualTo(true); // MSET result
+			assertThat(results.get(2)).isEqualTo(true); // MSETNX result
+
+			// Second mGet result
+			@SuppressWarnings("unchecked")
+			java.util.List<byte[]> mgetResult2 = (java.util.List<byte[]>) results.get(3);
+			assertThat(mgetResult2).hasSize(2);
+			assertThat(mgetResult2.get(0)).isEqualTo("txmsetvalue1".getBytes());
+			assertThat(mgetResult2.get(1)).isEqualTo("txmsetvalue2".getBytes());
+
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+			cleanupKey(key3);
+			cleanupKey(key4);
+			cleanupKey(key5);
+			cleanupKey("txnew1");
+			cleanupKey("txnew2");
+		}
+	}
+
+	@Test
+	void testArithmeticOperationsInTransactionMode() {
+		String intKey = "test:tx:int";
+		String floatKey = "test:tx:float";
+		String decrKey = "test:tx:decr";
+
+		try {
+			connection.multi();
+
+			// Queue arithmetic operations - assert they return null in transaction mode
+			assertThat(connection.stringCommands().incr(intKey.getBytes())).isNull();
+			assertThat(connection.stringCommands().incrBy(intKey.getBytes(), 5L)).isNull();
+			assertThat(connection.stringCommands().incrBy(floatKey.getBytes(), 3.14)).isNull();
+			assertThat(connection.stringCommands().incrBy(floatKey.getBytes(), -1.14)).isNull();
+			assertThat(connection.stringCommands().decr(decrKey.getBytes())).isNull();
+			assertThat(connection.stringCommands().decrBy(decrKey.getBytes(), 3L)).isNull();
+
+			java.util.List<Object> results = connection.exec();
+
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(6);
+			assertThat(results.get(0)).isEqualTo(1L); // INCR result
+			assertThat(results.get(1)).isEqualTo(6L); // INCRBY result
+			assertThat(results.get(2)).isEqualTo(3.14); // INCRBYFLOAT result
+			assertThat(results.get(3)).isEqualTo(2.0); // INCRBYFLOAT result
+			assertThat(results.get(4)).isEqualTo(-1L); // DECR result
+			assertThat(results.get(5)).isEqualTo(-4L); // DECRBY result
+
+		}
+		finally {
+			cleanupKey(intKey);
+			cleanupKey(floatKey);
+			cleanupKey(decrKey);
+		}
+	}
+
+	@Test
+	void testStringManipulationInTransactionMode() {
+		String key1 = "test:tx:manip1";
+		String key2 = "test:tx:manip2";
+
+		try {
+			// Set up initial data
+			connection.stringCommands().set(key1.getBytes(), "TxHello".getBytes());
+			connection.stringCommands().set(key2.getBytes(), "TxValkey World".getBytes());
+
+			connection.multi();
+
+			// Queue string manipulation operations - assert they return null in
+			// transaction mode
+			assertThat(connection.stringCommands().append(key1.getBytes(), " World".getBytes())).isNull();
+			assertThat(connection.stringCommands().strLen(key1.getBytes())).isNull();
+			assertThat(connection.stringCommands().getRange(key2.getBytes(), 0, 7)).isNull();
+			connection.stringCommands().setRange(key2.getBytes(), "Valkey".getBytes(), 9); // void
+																							// method
+			assertThat(connection.stringCommands().get(key2.getBytes())).isNull();
+
+			java.util.List<Object> results = connection.exec();
+
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(5);
+			assertThat(results.get(0)).isEqualTo(13L); // APPEND result (length)
+			assertThat(results.get(1)).isEqualTo(13L); // STRLEN result
+			assertThat(results.get(2)).isEqualTo("TxValkey".getBytes()); // GETRANGE
+																			// result
+			assertThat(results.get(3)).isEqualTo(15L); // SETRANGE result (new length)
+			assertThat(results.get(4)).isEqualTo("TxValkey Valkey".getBytes()); // GET
+																				// result
+																				// after
+																				// setrange
+
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+		}
+	}
+
+	@Test
+	void testBitOperationsInTransactionMode() {
+		String key1 = "test:tx:bit1";
+		String key2 = "test:tx:bit2";
+		String destKey = "test:tx:bitop";
+
+		try {
+			// Set up initial data
+			connection.stringCommands().set(key1.getBytes(), new byte[] { (byte) 0xF0 }); // 11110000
+			connection.stringCommands().set(key2.getBytes(), new byte[] { (byte) 0x0F }); // 00001111
+
+			connection.multi();
+
+			// Queue bit operations - assert they return null in transaction mode
+			assertThat(connection.stringCommands().getBit(key1.getBytes(), 0)).isNull();
+			assertThat(connection.stringCommands().setBit(key1.getBytes(), 4, false)).isNull();
+			assertThat(connection.stringCommands().bitCount(key1.getBytes())).isNull();
+			assertThat(connection.stringCommands().bitCount(key2.getBytes(), 0, 0)).isNull();
+			assertThat(connection.stringCommands()
+				.bitOp(BitOperation.OR, destKey.getBytes(), key1.getBytes(), key2.getBytes())).isNull();
+			assertThat(connection.stringCommands().bitPos(key1.getBytes(), true)).isNull();
+
+			java.util.List<Object> results = connection.exec();
+
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(6);
+			assertThat(results.get(0)).isEqualTo(true); // GETBIT result
+			assertThat(results.get(1)).isEqualTo(false); // SETBIT resut (old value was 0)
+			assertThat(results.get(2)).isEqualTo(4L); // 4 bits still set
+			assertThat(results.get(3)).isEqualTo(4L); // BITCOUNT result with range
+			assertThat(results.get(4)).isEqualTo(1L); // BITOP result (1 byte processed)
+			assertThat(results.get(5)).isEqualTo(0L); // BITPOS result
+
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+			cleanupKey(destKey);
+		}
+	}
+
+	@Test
+	void testAdvancedStringOperationsInTransactionMode() {
+		String key1 = "test:tx:advanced1";
+		String key2 = "test:tx:advanced2";
+
+		try {
+			connection.multi();
+
+			// Queue advanced operations - assert they return null in transaction mode
+			assertThat(connection.stringCommands()
+				.set(key1.getBytes(), "txtest".getBytes(), Expiration.seconds(60), SetOption.ifAbsent())).isNull();
+			assertThat(connection.stringCommands()
+				.setGet(key2.getBytes(), "txnewvalue".getBytes(), Expiration.persistent(), SetOption.upsert()))
+				.isNull();
+
+			// BitField operations
+			BitFieldSubCommands subCommands = BitFieldSubCommands.create()
+				.set(BitFieldSubCommands.BitFieldType.unsigned(8))
+				.valueAt(0)
+				.to(200)
+				.get(BitFieldSubCommands.BitFieldType.unsigned(8))
+				.valueAt(0);
+			assertThat(connection.stringCommands().bitField(key1.getBytes(), subCommands)).isNull();
+
+			java.util.List<Object> results = connection.exec();
+
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(3);
+			assertThat(results.get(0)).isEqualTo(true); // SET with options result
+			assertThat(results.get(1)).isNull(); // SETGET result (no previous value)
+
+			// BitField results
+			@SuppressWarnings("unchecked")
+			java.util.List<Long> bitFieldResults = (java.util.List<Long>) results.get(2);
+			assertThat(bitFieldResults).isNotNull();
+
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+		}
+	}
+
+	@Test
+	void testTransactionWithWatchedKeys() {
+		String watchedKey = "test:tx:watched";
+		String valueKey = "test:tx:value";
+
+		try {
+			// Set initial value
+			connection.stringCommands().set(watchedKey.getBytes(), "initial".getBytes());
+
+			// Watch the key
+			connection.watch(watchedKey.getBytes());
+
+			// Start transaction
+			connection.multi();
+			connection.stringCommands().set(valueKey.getBytes(), "conditional_set".getBytes());
+
+			// Execute transaction (should succeed since key wasn't modified)
+			java.util.List<Object> results = connection.exec();
+
+			assertThat(results).hasSize(1);
+			assertThat(results.get(0)).isEqualTo(true);
+
+			// Verify the conditional set worked
+			assertThat(connection.stringCommands().get(valueKey.getBytes())).isEqualTo("conditional_set".getBytes());
+		}
+		finally {
+			cleanupKey(watchedKey);
+			cleanupKey(valueKey);
+		}
+	}
+
+	@Test
+	void testTransactionAbortWithWatchConflict() {
+		String watchedKey = "test:tx:conflict";
+		String valueKey = "test:tx:aborted";
+
+		try {
+			// Set initial value
+			connection.stringCommands().set(watchedKey.getBytes(), "initial".getBytes());
+
+			// Watch the key
+			connection.watch(watchedKey.getBytes());
+
+			// Modify the watched key from outside the transaction to simulate conflict
+			// In a real scenario, this would happen from another connection
+			connection.stringCommands().set(watchedKey.getBytes(), "modified".getBytes());
+
+			// Start transaction
+			connection.multi();
+			connection.stringCommands().set(valueKey.getBytes(), "should_not_be_set".getBytes());
+
+			// Execute transaction (should be aborted due to watch conflict)
+			// Valkey specification: aborted transactions return empty list
+			java.util.List<Object> results = connection.exec();
+
+			// Transaction should be aborted - expect empty list (not null or exception)
+			assertThat(results).isNotNull().isEmpty();
+
+			// Verify the conditional set was NOT executed
+			byte[] result = connection.stringCommands().get(valueKey.getBytes());
+			assertThat(result).isNull(); // Key should not exist
+		}
+		finally {
+			cleanupKey(watchedKey);
+			cleanupKey(valueKey);
+		}
+	}
+
+	@Test
+	void testMixedStringOperationsInTransaction() {
+		String baseKey = "test:tx:mixed";
+
+		try {
+			connection.multi();
+
+			// Mix of different string operations
+			connection.stringCommands().set((baseKey + ":1").getBytes(), "100".getBytes());
+			connection.stringCommands().incr((baseKey + ":1").getBytes());
+			connection.stringCommands().append((baseKey + ":1").getBytes(), ".5".getBytes());
+			connection.stringCommands().strLen((baseKey + ":1").getBytes());
+			connection.stringCommands().setNX((baseKey + ":2").getBytes(), "new_value".getBytes());
+
+			java.util.List<Object> results = connection.exec();
+
+			assertThat(results).hasSize(5);
+			assertThat(results.get(0)).isEqualTo(true); // SET
+			assertThat(results.get(1)).isEqualTo(101L); // INCR
+			assertThat(results.get(2)).isEqualTo(5L); // APPEND (length after append)
+			assertThat(results.get(3)).isEqualTo(5L); // STRLEN
+			assertThat(results.get(4)).isEqualTo(true); // SETNX
+
+			// Verify final state
+			assertThat(connection.stringCommands().get((baseKey + ":1").getBytes())).isEqualTo("101.5".getBytes());
+			assertThat(connection.stringCommands().get((baseKey + ":2").getBytes())).isEqualTo("new_value".getBytes());
+		}
+		finally {
+			cleanupKey(baseKey + ":1");
+			cleanupKey(baseKey + ":2");
+		}
+	}
 
 }

--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionTxCommandsIntegrationTests.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionTxCommandsIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,770 +30,793 @@ import io.valkey.springframework.data.valkey.connection.ValkeyConnection;
 /**
  * Comprehensive integration tests for {@link ValkeyGlideConnection} transaction
  * functionality using the ValkeyTxCommands interface directly.
- * 
- * <p>These tests validate the implementation of all ValkeyTxCommands methods and ensure
+ *
+ * <p>
+ * These tests validate the implementation of all ValkeyTxCommands methods and ensure
  * standard behavior for basic and edge cases including:
  * <ul>
- *   <li>Basic transaction flow: multi() → commands → exec()</li>
- *   <li>Empty transaction should return an empty list</li>
- *   <li>Calling exec() without previous multi()</li>
- *   <li>Double calling of multi()</li>
- *   <li>Watch/unwatch interoperability and conflict scenarios</li>
- *   <li>State management: isQueueing() behavior</li>
- *   <li>Error conditions and edge cases</li>
- *   <li>Complex scenarios: large transactions, concurrent access</li>
+ * <li>Basic transaction flow: multi() → commands → exec()</li>
+ * <li>Empty transaction should return an empty list</li>
+ * <li>Calling exec() without previous multi()</li>
+ * <li>Double calling of multi()</li>
+ * <li>Watch/unwatch interoperability and conflict scenarios</li>
+ * <li>State management: isQueueing() behavior</li>
+ * <li>Error conditions and edge cases</li>
+ * <li>Complex scenarios: large transactions, concurrent access</li>
  * </ul>
  *
- * <p>While other ValkeyGlideConnection*IntegrationTests cover their respective APIs
- * in transaction/pipeline modes as secondary concerns, this test class focuses
- * exclusively on validating transaction semantics and ValkeyTxCommands interface
- * compliance.
+ * <p>
+ * While other ValkeyGlideConnection*IntegrationTests cover their respective APIs in
+ * transaction/pipeline modes as secondary concerns, this test class focuses exclusively
+ * on validating transaction semantics and ValkeyTxCommands interface compliance.
  *
  * @author Ilia Kolominsky
  * @since 2.0
  */
 public class ValkeyGlideConnectionTxCommandsIntegrationTests extends AbstractValkeyGlideIntegrationTests {
 
-    @Override
-    protected String[] getTestKeyPatterns() {
-        return new String[]{
-            // Basic transaction test keys
-            "test:tx:basic:key1", "test:tx:basic:key2", "test:tx:basic:string", "test:tx:basic:hash",
-            
-            // Discard test keys
-            "test:tx:discard:key", "test:tx:discard:original",
-            
-            // Consecutive transaction test keys
-            "test:tx:consecutive:key1", "test:tx:consecutive:key2", "test:tx:consecutive:key3",
-            
-            // Watch test keys
-            "test:tx:watch:success", "test:tx:watch:conflict", "test:tx:watch:multi:key1", "test:tx:watch:multi:key2",
-            "test:tx:watch:external", "test:tx:watch:timeout", "test:tx:watch:unwatch",
-            
-            // Error handling test keys
-            "test:tx:error:key", "test:tx:error:watch", "test:tx:error:nested",
-            
-            // Complex scenario test keys
-            "test:tx:large:key", "test:tx:mixed:string", "test:tx:mixed:hash", "test:tx:mixed:list",
-            
-            // Concurrent test keys (with thread ID suffix pattern)
-            "test:tx:concurrent:key", "test:tx:concurrent:shared",
-            
-            // State management test keys
-            "test:tx:state:key", "test:tx:state:pipeline:key",
-            
-            // Performance test keys
-            "test:tx:performance:empty", "test:tx:performance:large"
-        };
-    }
+	@Override
+	protected String[] getTestKeyPatterns() {
+		return new String[] {
+				// Basic transaction test keys
+				"test:tx:basic:key1", "test:tx:basic:key2", "test:tx:basic:string", "test:tx:basic:hash",
 
-    // ==================== Basic Transaction Flow Tests ====================
+				// Discard test keys
+				"test:tx:discard:key", "test:tx:discard:original",
 
-    @Test
-    void testBasicMultiExecFlow() {
-        String key1 = "test:tx:basic:key1";
-        String key2 = "test:tx:basic:key2";
-        
-        try {
-            // Verify initial state
-            assertThat(connection.isQueueing()).isFalse();
-            
-            // Start transaction
-            connection.multi();
-            assertThat(connection.isQueueing()).isTrue();
-            
-            // Queue commands - should return null in transaction mode
-            Object setResult1 = connection.stringCommands().set(key1.getBytes(), "value1".getBytes());
-            Object setResult2 = connection.stringCommands().set(key2.getBytes(), "value2".getBytes());
-            Object getResult1 = connection.stringCommands().get(key1.getBytes());
-            Object getResult2 = connection.stringCommands().get(key2.getBytes());
-            
-            // All commands in transaction should return null (queued)
-            assertThat(setResult1).isNull();
-            assertThat(setResult2).isNull();
-            assertThat(getResult1).isNull();
-            assertThat(getResult2).isNull();
-            
-            // Still in queuing state
-            assertThat(connection.isQueueing()).isTrue();
-            
-            // Execute transaction
-            List<Object> results = connection.exec();
-            
-            // Transaction should complete
-            assertThat(connection.isQueueing()).isFalse();
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(4); // 2 SETs + 2 GETs
-            
-            // Verify results - SET commands typically return boolean true
-            assertThat(results.get(0)).isEqualTo(true); // SET result
-            assertThat(results.get(1)).isEqualTo(true); // SET result
-            assertThat(results.get(2)).isEqualTo("value1".getBytes()); // GET result
-            assertThat(results.get(3)).isEqualTo("value2".getBytes()); // GET result
-            
-            // Verify values were actually set
-            byte[] actualValue1 = connection.stringCommands().get(key1.getBytes());
-            byte[] actualValue2 = connection.stringCommands().get(key2.getBytes());
-            assertThat(actualValue1).isEqualTo("value1".getBytes());
-            assertThat(actualValue2).isEqualTo("value2".getBytes());
-            
-        } finally {
-            cleanupKeys(key1, key2);
-        }
-    }
+				// Consecutive transaction test keys
+				"test:tx:consecutive:key1", "test:tx:consecutive:key2", "test:tx:consecutive:key3",
 
-    @Test
-    void testEmptyTransaction() {
-        // Start and immediately execute empty transaction
-        assertThat(connection.isQueueing()).isFalse();
-        
-        connection.multi();
-        assertThat(connection.isQueueing()).isTrue();
-        
-        List<Object> results = connection.exec();
-        
-        // Empty transaction should return empty list, not null
-        assertThat(connection.isQueueing()).isFalse();
-        assertThat(results).isNotNull();
-        assertThat(results).isEmpty();
-    }
+				// Watch test keys
+				"test:tx:watch:success", "test:tx:watch:conflict", "test:tx:watch:multi:key1",
+				"test:tx:watch:multi:key2", "test:tx:watch:external", "test:tx:watch:timeout", "test:tx:watch:unwatch",
 
-    @Test
-    void testMultiDiscard() {
-        String key = "test:tx:discard:key";
-        String originalKey = "test:tx:discard:original";
-        
-        try {
-            // Set initial value
-            connection.stringCommands().set(originalKey.getBytes(), "initial".getBytes());
-            
-            // Start transaction
-            connection.multi();
-            assertThat(connection.isQueueing()).isTrue();
-            
-            // Queue commands that should be discarded
-            connection.stringCommands().set(key.getBytes(), "should_not_be_set".getBytes());
-            connection.stringCommands().set(originalKey.getBytes(), "should_not_overwrite".getBytes());
-            
-            // Discard transaction
-            connection.discard();
-            assertThat(connection.isQueueing()).isFalse();
-            
-            // Verify no commands were executed
-            byte[] keyValue = connection.stringCommands().get(key.getBytes());
-            assertThat(keyValue).isNull(); // Key should not exist
-            
-            byte[] originalValue = connection.stringCommands().get(originalKey.getBytes());
-            assertThat(originalValue).isEqualTo("initial".getBytes()); // Should remain unchanged
-            
-        } finally {
-            cleanupKeys(key, originalKey);
-        }
-    }
+				// Error handling test keys
+				"test:tx:error:key", "test:tx:error:watch", "test:tx:error:nested",
 
-    @Test
-    void testMultipleConsecutiveTransactions() {
-        String key1 = "test:tx:consecutive:key1";
-        String key2 = "test:tx:consecutive:key2";
-        String key3 = "test:tx:consecutive:key3";
-        
-        try {
-            // First transaction
-            connection.multi();
-            connection.stringCommands().set(key1.getBytes(), "tx1_value".getBytes());
-            List<Object> results1 = connection.exec();
-            
-            assertThat(connection.isQueueing()).isFalse();
-            assertThat(results1).hasSize(1);
-            assertThat(results1.get(0)).isEqualTo(true);
-            
-            // Second transaction
-            connection.multi();
-            connection.stringCommands().set(key2.getBytes(), "tx2_value".getBytes());
-            connection.stringCommands().get(key1.getBytes()); // Read from first transaction
-            List<Object> results2 = connection.exec();
-            
-            assertThat(connection.isQueueing()).isFalse();
-            assertThat(results2).hasSize(2);
-            assertThat(results2.get(0)).isEqualTo(true);
-            assertThat(results2.get(1)).isEqualTo("tx1_value".getBytes());
-            
-            // Third transaction with discard
-            connection.multi();
-            connection.stringCommands().set(key3.getBytes(), "should_be_discarded".getBytes());
-            connection.discard();
-            
-            assertThat(connection.isQueueing()).isFalse();
-            
-            // Verify final state
-            assertThat(connection.stringCommands().get(key1.getBytes())).isEqualTo("tx1_value".getBytes());
-            assertThat(connection.stringCommands().get(key2.getBytes())).isEqualTo("tx2_value".getBytes());
-            assertThat(connection.stringCommands().get(key3.getBytes())).isNull();
-            
-        } finally {
-            cleanupKeys(key1, key2, key3);
-        }
-    }
+				// Complex scenario test keys
+				"test:tx:large:key", "test:tx:mixed:string", "test:tx:mixed:hash", "test:tx:mixed:list",
 
-    // ==================== Edge Cases and Error Handling ====================
+				// Concurrent test keys (with thread ID suffix pattern)
+				"test:tx:concurrent:key", "test:tx:concurrent:shared",
 
-    @Test
-    void testExecWithoutMulti() {
-        // Should handle exec() without prior multi() gracefully
-        assertThat(connection.isQueueing()).isFalse();
-        
-        assertThatThrownBy(() -> connection.exec())
-            .isInstanceOf(InvalidDataAccessApiUsageException.class)
-            .hasMessageContaining("No ongoing transaction");
-        
-        assertThat(connection.isQueueing()).isFalse();
-    }
+				// State management test keys
+				"test:tx:state:key", "test:tx:state:pipeline:key",
 
-    @Test
-    void testDiscardWithoutMulti() {
-        // discard() without multi() should throw exception (matches Valkey server behavior)
-        assertThat(connection.isQueueing()).isFalse();
-        
-        assertThatThrownBy(() -> connection.discard())
-            .isInstanceOf(InvalidDataAccessApiUsageException.class)
-            .hasMessageContaining("No ongoing transaction");
-        
-        assertThat(connection.isQueueing()).isFalse();
-    }
+				// Performance test keys
+				"test:tx:performance:empty", "test:tx:performance:large" };
+	}
 
-    @Test
-    void testDoubleMultiCall() {
-        String key = "test:tx:error:nested";
-        
-        try {
-            // First multi() call
-            connection.multi();
-            assertThat(connection.isQueueing()).isTrue();
-            
-            // Second multi() call - should not change state or cause errors
-            connection.multi();
-            assertThat(connection.isQueueing()).isTrue();
-            
-            // Queue a command
-            connection.stringCommands().set(key.getBytes(), "nested_value".getBytes());
-            
-            // Execute transaction
-            List<Object> results = connection.exec();
-            
-            assertThat(connection.isQueueing()).isFalse();
-            assertThat(results).hasSize(1);
-            assertThat(results.get(0)).isEqualTo(true);
-            
-            // Verify command was executed
-            assertThat(connection.stringCommands().get(key.getBytes())).isEqualTo("nested_value".getBytes());
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+	// ==================== Basic Transaction Flow Tests ====================
 
-    @Test
-    void testStateManagementAfterException() {
-        String key = "test:tx:error:key";
-        
-        try {
-            connection.multi();
-            assertThat(connection.isQueueing()).isTrue();
-            
-            // Try to use WATCH during MULTI - should throw exception but preserve transaction state
-            assertThatThrownBy(() -> connection.watch(key.getBytes()))
-                .isInstanceOf(InvalidDataAccessApiUsageException.class)
-                .hasMessageContaining("WATCH is not allowed during MULTI");
-            
-            // Transaction state should still be active
-            assertThat(connection.isQueueing()).isTrue();
-            
-            // Should be able to continue with transaction
-            connection.stringCommands().set(key.getBytes(), "after_error".getBytes());
-            List<Object> results = connection.exec();
-            
-            assertThat(connection.isQueueing()).isFalse();
-            assertThat(results).hasSize(1);
-            assertThat(connection.stringCommands().get(key.getBytes())).isEqualTo("after_error".getBytes());
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+	@Test
+	void testBasicMultiExecFlow() {
+		String key1 = "test:tx:basic:key1";
+		String key2 = "test:tx:basic:key2";
 
-    // ==================== Watch/Unwatch Tests ====================
+		try {
+			// Verify initial state
+			assertThat(connection.isQueueing()).isFalse();
 
-    @Test
-    void testWatchSuccess() {
-        String key = "test:tx:watch:success";
-        
-        try {
-            // Set initial value
-            connection.stringCommands().set(key.getBytes(), "initial".getBytes());
-            
-            // Watch the key
-            connection.watch(key.getBytes());
-            
-            // Start transaction and modify the watched key
-            connection.multi();
-            connection.stringCommands().set(key.getBytes(), "modified_in_transaction".getBytes());
-            
-            List<Object> results = connection.exec();
-            
-            // Transaction should succeed since no external modification occurred
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(1);
-            assertThat(results.get(0)).isEqualTo(true);
-            
-            // Verify value was changed
-            assertThat(connection.stringCommands().get(key.getBytes())).isEqualTo("modified_in_transaction".getBytes());
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Start transaction
+			connection.multi();
+			assertThat(connection.isQueueing()).isTrue();
 
-    @Test
-    void testWatchConflict() {
-        String key = "test:tx:watch:conflict";
-        
-        try {
-            // Set initial value
-            connection.stringCommands().set(key.getBytes(), "initial".getBytes());
-            
-            // Watch the key
-            connection.watch(key.getBytes());
-            
-            // Simulate external modification using separate connection
-            try (ValkeyConnection otherConnection = connectionFactory.getConnection()) {
-                otherConnection.stringCommands().set(key.getBytes(), "external_change".getBytes());
-            }
-            
-            // Start transaction
-            connection.multi();
-            connection.stringCommands().set(key.getBytes(), "should_not_be_set".getBytes());
-            
-            List<Object> results = connection.exec();
-            
-            // Transaction should be aborted due to WATCH conflict - expect empty list
-            assertThat(results).isNotNull().isEmpty();
-            
-            // External change should remain
-            assertThat(connection.stringCommands().get(key.getBytes())).isEqualTo("external_change".getBytes());
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Queue commands - should return null in transaction mode
+			Object setResult1 = connection.stringCommands().set(key1.getBytes(), "value1".getBytes());
+			Object setResult2 = connection.stringCommands().set(key2.getBytes(), "value2".getBytes());
+			Object getResult1 = connection.stringCommands().get(key1.getBytes());
+			Object getResult2 = connection.stringCommands().get(key2.getBytes());
 
-    @Test
-    void testWatchMultipleKeys() {
-        String key1 = "test:tx:watch:multi:key1";
-        String key2 = "test:tx:watch:multi:key2";
-        
-        try {
-            // Set initial values
-            connection.stringCommands().set(key1.getBytes(), "initial1".getBytes());
-            connection.stringCommands().set(key2.getBytes(), "initial2".getBytes());
-            
-            // Watch both keys
-            connection.watch(key1.getBytes(), key2.getBytes());
-            
-            // Modify one watched key externally
-            try (ValkeyConnection otherConnection = connectionFactory.getConnection()) {
-                otherConnection.stringCommands().set(key1.getBytes(), "external1".getBytes());
-            }
-            
-            // Transaction should be aborted even if only one watched key was modified
-            connection.multi();
-            connection.stringCommands().set(key1.getBytes(), "tx1".getBytes());
-            connection.stringCommands().set(key2.getBytes(), "tx2".getBytes());
-            List<Object> results = connection.exec();
-            
-            assertThat(results).isNotNull().isEmpty();
-            
-            // Verify external change persists, original value for unmodified key remains
-            assertThat(connection.stringCommands().get(key1.getBytes())).isEqualTo("external1".getBytes());
-            assertThat(connection.stringCommands().get(key2.getBytes())).isEqualTo("initial2".getBytes());
-            
-        } finally {
-            cleanupKeys(key1, key2);
-        }
-    }
+			// All commands in transaction should return null (queued)
+			assertThat(setResult1).isNull();
+			assertThat(setResult2).isNull();
+			assertThat(getResult1).isNull();
+			assertThat(getResult2).isNull();
 
-    @Test
-    void testUnwatch() {
-        String key = "test:tx:watch:unwatch";
-        
-        try {
-            // Set initial value
-            connection.stringCommands().set(key.getBytes(), "initial".getBytes());
-            
-            // Watch then unwatch
-            connection.watch(key.getBytes());
-            connection.unwatch();
-            
-            // Modify key externally (should not affect transaction after unwatch)
-            try (ValkeyConnection otherConnection = connectionFactory.getConnection()) {
-                otherConnection.stringCommands().set(key.getBytes(), "external_change".getBytes());
-            }
-            
-            // Transaction should succeed despite external change
-            connection.multi();
-            connection.stringCommands().set(key.getBytes(), "transaction_value".getBytes());
-            List<Object> results = connection.exec();
-            
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(1);
-            assertThat(results.get(0)).isEqualTo(true);
-            assertThat(connection.stringCommands().get(key.getBytes())).isEqualTo("transaction_value".getBytes());
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Still in queuing state
+			assertThat(connection.isQueueing()).isTrue();
 
-    @Test
-    void testWatchDuringMultiThrowsException() {
-        String key = "test:tx:error:watch";
-        
-        try {
-            connection.multi();
-            
-            assertThatThrownBy(() -> connection.watch(key.getBytes()))
-                .isInstanceOf(InvalidDataAccessApiUsageException.class)
-                .hasMessageContaining("WATCH is not allowed during MULTI");
-            
-        } finally {
-            // Ensure we clean up transaction state
-            if (connection.isQueueing()) {
-                connection.discard();
-            }
-            cleanupKey(key);
-        }
-    }
+			// Execute transaction
+			List<Object> results = connection.exec();
 
-    @Test
-    void testWatchAutomaticCleanupAfterExec() {
-        String key = "test:tx:watch:external";
-        
-        try {
-            // Set initial value and watch
-            connection.stringCommands().set(key.getBytes(), "initial".getBytes());
-            connection.watch(key.getBytes());
-            
-            // Execute successful transaction
-            connection.multi();
-            connection.stringCommands().set(key.getBytes(), "first_tx".getBytes());
-            List<Object> results1 = connection.exec();
-            assertThat(results1).isNotNull();
-            
-            // Modify key externally
-            try (ValkeyConnection otherConnection = connectionFactory.getConnection()) {
-                otherConnection.stringCommands().set(key.getBytes(), "external".getBytes());
-            }
-            
-            // New transaction should succeed (watch was cleared after first exec)
-            connection.multi();
-            connection.stringCommands().set(key.getBytes(), "second_tx".getBytes());
-            List<Object> results2 = connection.exec();
-            
-            assertThat(results2).isNotNull();
-            assertThat(results2).hasSize(1);
-            assertThat(connection.stringCommands().get(key.getBytes())).isEqualTo("second_tx".getBytes());
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Transaction should complete
+			assertThat(connection.isQueueing()).isFalse();
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(4); // 2 SETs + 2 GETs
 
-    // ==================== Complex Scenarios ====================
+			// Verify results - SET commands typically return boolean true
+			assertThat(results.get(0)).isEqualTo(true); // SET result
+			assertThat(results.get(1)).isEqualTo(true); // SET result
+			assertThat(results.get(2)).isEqualTo("value1".getBytes()); // GET result
+			assertThat(results.get(3)).isEqualTo("value2".getBytes()); // GET result
 
-    @Test
-    void testLargeTransaction() {
-        String keyPrefix = "test:tx:large:key";
-        int commandCount = 100;
-        
-        try {
-            connection.multi();
-            
-            // Queue many commands
-            for (int i = 0; i < commandCount; i++) {
-                String key = keyPrefix + ":" + i;
-                String value = "value" + i;
-                Object result = connection.stringCommands().set(key.getBytes(), value.getBytes());
-                assertThat(result).isNull(); // Should be null in transaction mode
-            }
-            
-            List<Object> results = connection.exec();
-            
-            assertThat(results).hasSize(commandCount);
-            
-            // All SET operations should succeed
-            for (int i = 0; i < commandCount; i++) {
-                assertThat(results.get(i)).isEqualTo(true);
-            }
-            
-            // Verify a few random values were actually set
-            assertThat(connection.stringCommands().get((keyPrefix + ":0").getBytes())).isEqualTo("value0".getBytes());
-            assertThat(connection.stringCommands().get((keyPrefix + ":50").getBytes())).isEqualTo("value50".getBytes());
-            assertThat(connection.stringCommands().get((keyPrefix + ":99").getBytes())).isEqualTo("value99".getBytes());
-            
-        } finally {
-            // Clean up all generated keys
-            for (int i = 0; i < commandCount; i++) {
-                cleanupKey(keyPrefix + ":" + i);
-            }
-        }
-    }
+			// Verify values were actually set
+			byte[] actualValue1 = connection.stringCommands().get(key1.getBytes());
+			byte[] actualValue2 = connection.stringCommands().get(key2.getBytes());
+			assertThat(actualValue1).isEqualTo("value1".getBytes());
+			assertThat(actualValue2).isEqualTo("value2".getBytes());
 
-    @Test
-    void testMixedCommandTypes() {
-        String stringKey = "test:tx:mixed:string";
-        String hashKey = "test:tx:mixed:hash";
-        String listKey = "test:tx:mixed:list";
-        
-        try {
-            connection.multi();
-            
-            // Mix different command types
-            connection.stringCommands().set(stringKey.getBytes(), "string_value".getBytes());
-            connection.hashCommands().hSet(hashKey.getBytes(), "field1".getBytes(), "hash_value".getBytes());
-            connection.listCommands().lPush(listKey.getBytes(), "list_item".getBytes());
-            
-            // Add read operations
-            connection.stringCommands().get(stringKey.getBytes());
-            connection.hashCommands().hGet(hashKey.getBytes(), "field1".getBytes());
-            connection.listCommands().lLen(listKey.getBytes());
-            
-            List<Object> results = connection.exec();
-            
-            assertThat(results).hasSize(6);
-            
-            // Verify write results
-            assertThat(results.get(0)).isEqualTo(true); // SET
-            assertThat(results.get(1)).isEqualTo(true); // HSET
-            assertThat(results.get(2)).isEqualTo(1L);   // LPUSH (returns length)
-            
-            // Verify read results
-            assertThat(results.get(3)).isEqualTo("string_value".getBytes()); // GET
-            assertThat(results.get(4)).isEqualTo("hash_value".getBytes());   // HGET
-            assertThat(results.get(5)).isEqualTo(1L);                        // LLEN
-            
-            // Verify values exist outside transaction
-            assertThat(connection.stringCommands().get(stringKey.getBytes())).isEqualTo("string_value".getBytes());
-            assertThat(connection.hashCommands().hGet(hashKey.getBytes(), "field1".getBytes())).isEqualTo("hash_value".getBytes());
-            assertThat(connection.listCommands().lLen(listKey.getBytes())).isEqualTo(1L);
-            
-        } finally {
-            cleanupKeys(stringKey, hashKey, listKey);
-        }
-    }
+		}
+		finally {
+			cleanupKeys(key1, key2);
+		}
+	}
 
-    @Test
-    void testConcurrentTransactions() throws Exception {
-        String sharedKey = "test:tx:concurrent:shared";
-        String keyPrefix = "test:tx:concurrent:key";
-        ExecutorService executor = Executors.newFixedThreadPool(5);
-        
-        try {
-            // Set initial shared value
-            connection.stringCommands().set(sharedKey.getBytes(), "0".getBytes());
-            
-            CompletableFuture<?>[] futures = new CompletableFuture[5];
-            
-            for (int i = 0; i < 5; i++) {
-                final int threadId = i;
-                futures[i] = CompletableFuture.runAsync(() -> {
-                    try (ValkeyConnection conn = connectionFactory.getConnection()) {
-                        // Each thread runs its own transaction
-                        conn.multi();
-                        conn.stringCommands().set((keyPrefix + ":" + threadId).getBytes(), ("thread" + threadId).getBytes());
-                        conn.stringCommands().get(sharedKey.getBytes()); // Read shared value
-                        List<Object> results = conn.exec();
-                        
-                        assertThat(results).hasSize(2);
-                        assertThat(results.get(0)).isEqualTo(true); // SET result
-                        assertThat(results.get(1)).isEqualTo("0".getBytes()); // GET result
-                    }
-                }, executor);
-            }
-            
-            CompletableFuture.allOf(futures).get(10, TimeUnit.SECONDS);
-            
-            // Verify all threads succeeded
-            for (int i = 0; i < 5; i++) {
-                assertThat(connection.stringCommands().get((keyPrefix + ":" + i).getBytes()))
-                    .isEqualTo(("thread" + i).getBytes());
-            }
-            
-        } finally {
-            executor.shutdown();
-            cleanupKey(sharedKey);
-            for (int i = 0; i < 5; i++) {
-                cleanupKey(keyPrefix + ":" + i);
-            }
-        }
-    }
+	@Test
+	void testEmptyTransaction() {
+		// Start and immediately execute empty transaction
+		assertThat(connection.isQueueing()).isFalse();
 
-    // ==================== Pipeline vs Transaction Isolation ====================
+		connection.multi();
+		assertThat(connection.isQueueing()).isTrue();
 
-    @Test
-    void testPipelineTransactionIsolation() {
-        String key = "test:tx:state:pipeline:key";
-        
-        try {
-            // Cannot start transaction while pipeline is active
-            connection.openPipeline();
-            
-            assertThatThrownBy(() -> connection.multi())
-                .isInstanceOf(InvalidDataAccessApiUsageException.class)
-                .hasMessageContaining("Cannot use transaction while a pipeline is open");
-            
-            connection.closePipeline();
-            
-            // Cannot start pipeline while transaction is active  
-            connection.multi();
-            
-            assertThatThrownBy(() -> connection.openPipeline())
-                .isInstanceOf(InvalidDataAccessApiUsageException.class)
-                .hasMessageContaining("Cannot use pipelining while a transaction is active");
-            
-            connection.discard();
-            
-        } finally {
-            // Ensure clean state
-            if (connection.isPipelined()) {
-                connection.closePipeline();
-            }
-            if (connection.isQueueing()) {
-                connection.discard();
-            }
-            cleanupKey(key);
-        }
-    }
+		List<Object> results = connection.exec();
 
-    // ==================== State Management Tests ====================
+		// Empty transaction should return empty list, not null
+		assertThat(connection.isQueueing()).isFalse();
+		assertThat(results).isNotNull();
+		assertThat(results).isEmpty();
+	}
 
-    @Test
-    void testIsQueueingState() {
-        assertThat(connection.isQueueing()).isFalse();
-        
-        connection.multi();
-        assertThat(connection.isQueueing()).isTrue();
-        
-        connection.exec();
-        assertThat(connection.isQueueing()).isFalse();
-    }
+	@Test
+	void testMultiDiscard() {
+		String key = "test:tx:discard:key";
+		String originalKey = "test:tx:discard:original";
 
-    @Test
-    void testIsQueueingAfterDiscard() {
-        assertThat(connection.isQueueing()).isFalse();
-        
-        connection.multi();
-        assertThat(connection.isQueueing()).isTrue();
-        
-        connection.discard();
-        assertThat(connection.isQueueing()).isFalse();
-    }
+		try {
+			// Set initial value
+			connection.stringCommands().set(originalKey.getBytes(), "initial".getBytes());
 
-    @Test
-    void testIsQueueingAfterWatchAbort() {
-        String key = "test:tx:watch:timeout";
-        
-        try {
-            // Set up watch conflict scenario
-            connection.stringCommands().set(key.getBytes(), "initial".getBytes());
-            connection.watch(key.getBytes());
-            
-            // External modification
-            try (ValkeyConnection otherConnection = connectionFactory.getConnection()) {
-                otherConnection.stringCommands().set(key.getBytes(), "external".getBytes());
-            }
-            
-            connection.multi();
-            assertThat(connection.isQueueing()).isTrue();
-            
-            connection.stringCommands().set(key.getBytes(), "should_not_be_set".getBytes());
-            List<Object> results = connection.exec();
-            
-            // After aborted transaction, should not be in queuing state
-            assertThat(results).isNotNull().isEmpty();
-            assertThat(connection.isQueueing()).isFalse();
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Start transaction
+			connection.multi();
+			assertThat(connection.isQueueing()).isTrue();
 
-    // ==================== Performance and Edge Cases ====================
+			// Queue commands that should be discarded
+			connection.stringCommands().set(key.getBytes(), "should_not_be_set".getBytes());
+			connection.stringCommands().set(originalKey.getBytes(), "should_not_overwrite".getBytes());
 
-    @Test
-    void testEmptyTransactionPerformance() {
-        // Multiple empty transactions should be handled efficiently
-        for (int i = 0; i < 10; i++) {
-            connection.multi();
-            List<Object> results = connection.exec();
-            assertThat(results).isEmpty();
-            assertThat(connection.isQueueing()).isFalse();
-        }
-    }
+			// Discard transaction
+			connection.discard();
+			assertThat(connection.isQueueing()).isFalse();
 
-    @Test
-    void testWatchOnNonExistentKey() {
-        String nonExistentKey = "test:tx:watch:nonexistent";
-        String testKey = "test:tx:state:key";
-        
-        try {
-            // Watch a key that doesn't exist
-            connection.watch(nonExistentKey.getBytes());
-            
-            // Create the key externally
-            try (ValkeyConnection otherConnection = connectionFactory.getConnection()) {
-                otherConnection.stringCommands().set(nonExistentKey.getBytes(), "created_externally".getBytes());
-            }
-            
-            // Transaction should be aborted because watched key was created
-            connection.multi();
-            connection.stringCommands().set(testKey.getBytes(), "should_not_be_set".getBytes());
-            List<Object> results = connection.exec();
-            
-            assertThat(results).isNotNull().isEmpty(); // Transaction aborted
-            assertThat(connection.stringCommands().get(testKey.getBytes())).isNull();
-            
-        } finally {
-            cleanupKeys(nonExistentKey, testKey);
-        }
-    }
+			// Verify no commands were executed
+			byte[] keyValue = connection.stringCommands().get(key.getBytes());
+			assertThat(keyValue).isNull(); // Key should not exist
 
-    @Test
-    void testTransactionWithConnectionFailure() {
-        // This test ensures transaction state is properly managed even when underlying
-        // connection issues occur. However, since we're testing at the integration level
-        // and connection failures are hard to simulate reliably, we'll focus on
-        // verifying that our transaction state management is robust.
-        
-        String key = "test:tx:state:key";
-        
-        try {
-            // Test that transaction state is properly reset after various operations
-            connection.multi();
-            assertThat(connection.isQueueing()).isTrue();
-            
-            // Simulate a scenario where we might have connection issues
-            // by ensuring our state management is consistent
-            connection.stringCommands().set(key.getBytes(), "test_value".getBytes());
-            
-            List<Object> results = connection.exec();
-            assertThat(connection.isQueueing()).isFalse();
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(1);
-            
-            // Verify connection is still usable
-            assertThat(connection.stringCommands().get(key.getBytes())).isEqualTo("test_value".getBytes());
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			byte[] originalValue = connection.stringCommands().get(originalKey.getBytes());
+			assertThat(originalValue).isEqualTo("initial".getBytes()); // Should remain
+																		// unchanged
+
+		}
+		finally {
+			cleanupKeys(key, originalKey);
+		}
+	}
+
+	@Test
+	void testMultipleConsecutiveTransactions() {
+		String key1 = "test:tx:consecutive:key1";
+		String key2 = "test:tx:consecutive:key2";
+		String key3 = "test:tx:consecutive:key3";
+
+		try {
+			// First transaction
+			connection.multi();
+			connection.stringCommands().set(key1.getBytes(), "tx1_value".getBytes());
+			List<Object> results1 = connection.exec();
+
+			assertThat(connection.isQueueing()).isFalse();
+			assertThat(results1).hasSize(1);
+			assertThat(results1.get(0)).isEqualTo(true);
+
+			// Second transaction
+			connection.multi();
+			connection.stringCommands().set(key2.getBytes(), "tx2_value".getBytes());
+			connection.stringCommands().get(key1.getBytes()); // Read from first
+																// transaction
+			List<Object> results2 = connection.exec();
+
+			assertThat(connection.isQueueing()).isFalse();
+			assertThat(results2).hasSize(2);
+			assertThat(results2.get(0)).isEqualTo(true);
+			assertThat(results2.get(1)).isEqualTo("tx1_value".getBytes());
+
+			// Third transaction with discard
+			connection.multi();
+			connection.stringCommands().set(key3.getBytes(), "should_be_discarded".getBytes());
+			connection.discard();
+
+			assertThat(connection.isQueueing()).isFalse();
+
+			// Verify final state
+			assertThat(connection.stringCommands().get(key1.getBytes())).isEqualTo("tx1_value".getBytes());
+			assertThat(connection.stringCommands().get(key2.getBytes())).isEqualTo("tx2_value".getBytes());
+			assertThat(connection.stringCommands().get(key3.getBytes())).isNull();
+
+		}
+		finally {
+			cleanupKeys(key1, key2, key3);
+		}
+	}
+
+	// ==================== Edge Cases and Error Handling ====================
+
+	@Test
+	void testExecWithoutMulti() {
+		// Should handle exec() without prior multi() gracefully
+		assertThat(connection.isQueueing()).isFalse();
+
+		assertThatThrownBy(() -> connection.exec()).isInstanceOf(InvalidDataAccessApiUsageException.class)
+			.hasMessageContaining("No ongoing transaction");
+
+		assertThat(connection.isQueueing()).isFalse();
+	}
+
+	@Test
+	void testDiscardWithoutMulti() {
+		// discard() without multi() should throw exception (matches Valkey server
+		// behavior)
+		assertThat(connection.isQueueing()).isFalse();
+
+		assertThatThrownBy(() -> connection.discard()).isInstanceOf(InvalidDataAccessApiUsageException.class)
+			.hasMessageContaining("No ongoing transaction");
+
+		assertThat(connection.isQueueing()).isFalse();
+	}
+
+	@Test
+	void testDoubleMultiCall() {
+		String key = "test:tx:error:nested";
+
+		try {
+			// First multi() call
+			connection.multi();
+			assertThat(connection.isQueueing()).isTrue();
+
+			// Second multi() call - should not change state or cause errors
+			connection.multi();
+			assertThat(connection.isQueueing()).isTrue();
+
+			// Queue a command
+			connection.stringCommands().set(key.getBytes(), "nested_value".getBytes());
+
+			// Execute transaction
+			List<Object> results = connection.exec();
+
+			assertThat(connection.isQueueing()).isFalse();
+			assertThat(results).hasSize(1);
+			assertThat(results.get(0)).isEqualTo(true);
+
+			// Verify command was executed
+			assertThat(connection.stringCommands().get(key.getBytes())).isEqualTo("nested_value".getBytes());
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testStateManagementAfterException() {
+		String key = "test:tx:error:key";
+
+		try {
+			connection.multi();
+			assertThat(connection.isQueueing()).isTrue();
+
+			// Try to use WATCH during MULTI - should throw exception but preserve
+			// transaction state
+			assertThatThrownBy(() -> connection.watch(key.getBytes()))
+				.isInstanceOf(InvalidDataAccessApiUsageException.class)
+				.hasMessageContaining("WATCH is not allowed during MULTI");
+
+			// Transaction state should still be active
+			assertThat(connection.isQueueing()).isTrue();
+
+			// Should be able to continue with transaction
+			connection.stringCommands().set(key.getBytes(), "after_error".getBytes());
+			List<Object> results = connection.exec();
+
+			assertThat(connection.isQueueing()).isFalse();
+			assertThat(results).hasSize(1);
+			assertThat(connection.stringCommands().get(key.getBytes())).isEqualTo("after_error".getBytes());
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== Watch/Unwatch Tests ====================
+
+	@Test
+	void testWatchSuccess() {
+		String key = "test:tx:watch:success";
+
+		try {
+			// Set initial value
+			connection.stringCommands().set(key.getBytes(), "initial".getBytes());
+
+			// Watch the key
+			connection.watch(key.getBytes());
+
+			// Start transaction and modify the watched key
+			connection.multi();
+			connection.stringCommands().set(key.getBytes(), "modified_in_transaction".getBytes());
+
+			List<Object> results = connection.exec();
+
+			// Transaction should succeed since no external modification occurred
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(1);
+			assertThat(results.get(0)).isEqualTo(true);
+
+			// Verify value was changed
+			assertThat(connection.stringCommands().get(key.getBytes())).isEqualTo("modified_in_transaction".getBytes());
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testWatchConflict() {
+		String key = "test:tx:watch:conflict";
+
+		try {
+			// Set initial value
+			connection.stringCommands().set(key.getBytes(), "initial".getBytes());
+
+			// Watch the key
+			connection.watch(key.getBytes());
+
+			// Simulate external modification using separate connection
+			try (ValkeyConnection otherConnection = connectionFactory.getConnection()) {
+				otherConnection.stringCommands().set(key.getBytes(), "external_change".getBytes());
+			}
+
+			// Start transaction
+			connection.multi();
+			connection.stringCommands().set(key.getBytes(), "should_not_be_set".getBytes());
+
+			List<Object> results = connection.exec();
+
+			// Transaction should be aborted due to WATCH conflict - expect empty list
+			assertThat(results).isNotNull().isEmpty();
+
+			// External change should remain
+			assertThat(connection.stringCommands().get(key.getBytes())).isEqualTo("external_change".getBytes());
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testWatchMultipleKeys() {
+		String key1 = "test:tx:watch:multi:key1";
+		String key2 = "test:tx:watch:multi:key2";
+
+		try {
+			// Set initial values
+			connection.stringCommands().set(key1.getBytes(), "initial1".getBytes());
+			connection.stringCommands().set(key2.getBytes(), "initial2".getBytes());
+
+			// Watch both keys
+			connection.watch(key1.getBytes(), key2.getBytes());
+
+			// Modify one watched key externally
+			try (ValkeyConnection otherConnection = connectionFactory.getConnection()) {
+				otherConnection.stringCommands().set(key1.getBytes(), "external1".getBytes());
+			}
+
+			// Transaction should be aborted even if only one watched key was modified
+			connection.multi();
+			connection.stringCommands().set(key1.getBytes(), "tx1".getBytes());
+			connection.stringCommands().set(key2.getBytes(), "tx2".getBytes());
+			List<Object> results = connection.exec();
+
+			assertThat(results).isNotNull().isEmpty();
+
+			// Verify external change persists, original value for unmodified key remains
+			assertThat(connection.stringCommands().get(key1.getBytes())).isEqualTo("external1".getBytes());
+			assertThat(connection.stringCommands().get(key2.getBytes())).isEqualTo("initial2".getBytes());
+
+		}
+		finally {
+			cleanupKeys(key1, key2);
+		}
+	}
+
+	@Test
+	void testUnwatch() {
+		String key = "test:tx:watch:unwatch";
+
+		try {
+			// Set initial value
+			connection.stringCommands().set(key.getBytes(), "initial".getBytes());
+
+			// Watch then unwatch
+			connection.watch(key.getBytes());
+			connection.unwatch();
+
+			// Modify key externally (should not affect transaction after unwatch)
+			try (ValkeyConnection otherConnection = connectionFactory.getConnection()) {
+				otherConnection.stringCommands().set(key.getBytes(), "external_change".getBytes());
+			}
+
+			// Transaction should succeed despite external change
+			connection.multi();
+			connection.stringCommands().set(key.getBytes(), "transaction_value".getBytes());
+			List<Object> results = connection.exec();
+
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(1);
+			assertThat(results.get(0)).isEqualTo(true);
+			assertThat(connection.stringCommands().get(key.getBytes())).isEqualTo("transaction_value".getBytes());
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testWatchDuringMultiThrowsException() {
+		String key = "test:tx:error:watch";
+
+		try {
+			connection.multi();
+
+			assertThatThrownBy(() -> connection.watch(key.getBytes()))
+				.isInstanceOf(InvalidDataAccessApiUsageException.class)
+				.hasMessageContaining("WATCH is not allowed during MULTI");
+
+		}
+		finally {
+			// Ensure we clean up transaction state
+			if (connection.isQueueing()) {
+				connection.discard();
+			}
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testWatchAutomaticCleanupAfterExec() {
+		String key = "test:tx:watch:external";
+
+		try {
+			// Set initial value and watch
+			connection.stringCommands().set(key.getBytes(), "initial".getBytes());
+			connection.watch(key.getBytes());
+
+			// Execute successful transaction
+			connection.multi();
+			connection.stringCommands().set(key.getBytes(), "first_tx".getBytes());
+			List<Object> results1 = connection.exec();
+			assertThat(results1).isNotNull();
+
+			// Modify key externally
+			try (ValkeyConnection otherConnection = connectionFactory.getConnection()) {
+				otherConnection.stringCommands().set(key.getBytes(), "external".getBytes());
+			}
+
+			// New transaction should succeed (watch was cleared after first exec)
+			connection.multi();
+			connection.stringCommands().set(key.getBytes(), "second_tx".getBytes());
+			List<Object> results2 = connection.exec();
+
+			assertThat(results2).isNotNull();
+			assertThat(results2).hasSize(1);
+			assertThat(connection.stringCommands().get(key.getBytes())).isEqualTo("second_tx".getBytes());
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== Complex Scenarios ====================
+
+	@Test
+	void testLargeTransaction() {
+		String keyPrefix = "test:tx:large:key";
+		int commandCount = 100;
+
+		try {
+			connection.multi();
+
+			// Queue many commands
+			for (int i = 0; i < commandCount; i++) {
+				String key = keyPrefix + ":" + i;
+				String value = "value" + i;
+				Object result = connection.stringCommands().set(key.getBytes(), value.getBytes());
+				assertThat(result).isNull(); // Should be null in transaction mode
+			}
+
+			List<Object> results = connection.exec();
+
+			assertThat(results).hasSize(commandCount);
+
+			// All SET operations should succeed
+			for (int i = 0; i < commandCount; i++) {
+				assertThat(results.get(i)).isEqualTo(true);
+			}
+
+			// Verify a few random values were actually set
+			assertThat(connection.stringCommands().get((keyPrefix + ":0").getBytes())).isEqualTo("value0".getBytes());
+			assertThat(connection.stringCommands().get((keyPrefix + ":50").getBytes())).isEqualTo("value50".getBytes());
+			assertThat(connection.stringCommands().get((keyPrefix + ":99").getBytes())).isEqualTo("value99".getBytes());
+
+		}
+		finally {
+			// Clean up all generated keys
+			for (int i = 0; i < commandCount; i++) {
+				cleanupKey(keyPrefix + ":" + i);
+			}
+		}
+	}
+
+	@Test
+	void testMixedCommandTypes() {
+		String stringKey = "test:tx:mixed:string";
+		String hashKey = "test:tx:mixed:hash";
+		String listKey = "test:tx:mixed:list";
+
+		try {
+			connection.multi();
+
+			// Mix different command types
+			connection.stringCommands().set(stringKey.getBytes(), "string_value".getBytes());
+			connection.hashCommands().hSet(hashKey.getBytes(), "field1".getBytes(), "hash_value".getBytes());
+			connection.listCommands().lPush(listKey.getBytes(), "list_item".getBytes());
+
+			// Add read operations
+			connection.stringCommands().get(stringKey.getBytes());
+			connection.hashCommands().hGet(hashKey.getBytes(), "field1".getBytes());
+			connection.listCommands().lLen(listKey.getBytes());
+
+			List<Object> results = connection.exec();
+
+			assertThat(results).hasSize(6);
+
+			// Verify write results
+			assertThat(results.get(0)).isEqualTo(true); // SET
+			assertThat(results.get(1)).isEqualTo(true); // HSET
+			assertThat(results.get(2)).isEqualTo(1L); // LPUSH (returns length)
+
+			// Verify read results
+			assertThat(results.get(3)).isEqualTo("string_value".getBytes()); // GET
+			assertThat(results.get(4)).isEqualTo("hash_value".getBytes()); // HGET
+			assertThat(results.get(5)).isEqualTo(1L); // LLEN
+
+			// Verify values exist outside transaction
+			assertThat(connection.stringCommands().get(stringKey.getBytes())).isEqualTo("string_value".getBytes());
+			assertThat(connection.hashCommands().hGet(hashKey.getBytes(), "field1".getBytes()))
+				.isEqualTo("hash_value".getBytes());
+			assertThat(connection.listCommands().lLen(listKey.getBytes())).isEqualTo(1L);
+
+		}
+		finally {
+			cleanupKeys(stringKey, hashKey, listKey);
+		}
+	}
+
+	@Test
+	void testConcurrentTransactions() throws Exception {
+		String sharedKey = "test:tx:concurrent:shared";
+		String keyPrefix = "test:tx:concurrent:key";
+		ExecutorService executor = Executors.newFixedThreadPool(5);
+
+		try {
+			// Set initial shared value
+			connection.stringCommands().set(sharedKey.getBytes(), "0".getBytes());
+
+			CompletableFuture<?>[] futures = new CompletableFuture[5];
+
+			for (int i = 0; i < 5; i++) {
+				final int threadId = i;
+				futures[i] = CompletableFuture.runAsync(() -> {
+					try (ValkeyConnection conn = connectionFactory.getConnection()) {
+						// Each thread runs its own transaction
+						conn.multi();
+						conn.stringCommands()
+							.set((keyPrefix + ":" + threadId).getBytes(), ("thread" + threadId).getBytes());
+						conn.stringCommands().get(sharedKey.getBytes()); // Read shared
+																			// value
+						List<Object> results = conn.exec();
+
+						assertThat(results).hasSize(2);
+						assertThat(results.get(0)).isEqualTo(true); // SET result
+						assertThat(results.get(1)).isEqualTo("0".getBytes()); // GET
+																				// result
+					}
+				}, executor);
+			}
+
+			CompletableFuture.allOf(futures).get(10, TimeUnit.SECONDS);
+
+			// Verify all threads succeeded
+			for (int i = 0; i < 5; i++) {
+				assertThat(connection.stringCommands().get((keyPrefix + ":" + i).getBytes()))
+					.isEqualTo(("thread" + i).getBytes());
+			}
+
+		}
+		finally {
+			executor.shutdown();
+			cleanupKey(sharedKey);
+			for (int i = 0; i < 5; i++) {
+				cleanupKey(keyPrefix + ":" + i);
+			}
+		}
+	}
+
+	// ==================== Pipeline vs Transaction Isolation ====================
+
+	@Test
+	void testPipelineTransactionIsolation() {
+		String key = "test:tx:state:pipeline:key";
+
+		try {
+			// Cannot start transaction while pipeline is active
+			connection.openPipeline();
+
+			assertThatThrownBy(() -> connection.multi()).isInstanceOf(InvalidDataAccessApiUsageException.class)
+				.hasMessageContaining("Cannot use transaction while a pipeline is open");
+
+			connection.closePipeline();
+
+			// Cannot start pipeline while transaction is active
+			connection.multi();
+
+			assertThatThrownBy(() -> connection.openPipeline()).isInstanceOf(InvalidDataAccessApiUsageException.class)
+				.hasMessageContaining("Cannot use pipelining while a transaction is active");
+
+			connection.discard();
+
+		}
+		finally {
+			// Ensure clean state
+			if (connection.isPipelined()) {
+				connection.closePipeline();
+			}
+			if (connection.isQueueing()) {
+				connection.discard();
+			}
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== State Management Tests ====================
+
+	@Test
+	void testIsQueueingState() {
+		assertThat(connection.isQueueing()).isFalse();
+
+		connection.multi();
+		assertThat(connection.isQueueing()).isTrue();
+
+		connection.exec();
+		assertThat(connection.isQueueing()).isFalse();
+	}
+
+	@Test
+	void testIsQueueingAfterDiscard() {
+		assertThat(connection.isQueueing()).isFalse();
+
+		connection.multi();
+		assertThat(connection.isQueueing()).isTrue();
+
+		connection.discard();
+		assertThat(connection.isQueueing()).isFalse();
+	}
+
+	@Test
+	void testIsQueueingAfterWatchAbort() {
+		String key = "test:tx:watch:timeout";
+
+		try {
+			// Set up watch conflict scenario
+			connection.stringCommands().set(key.getBytes(), "initial".getBytes());
+			connection.watch(key.getBytes());
+
+			// External modification
+			try (ValkeyConnection otherConnection = connectionFactory.getConnection()) {
+				otherConnection.stringCommands().set(key.getBytes(), "external".getBytes());
+			}
+
+			connection.multi();
+			assertThat(connection.isQueueing()).isTrue();
+
+			connection.stringCommands().set(key.getBytes(), "should_not_be_set".getBytes());
+			List<Object> results = connection.exec();
+
+			// After aborted transaction, should not be in queuing state
+			assertThat(results).isNotNull().isEmpty();
+			assertThat(connection.isQueueing()).isFalse();
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== Performance and Edge Cases ====================
+
+	@Test
+	void testEmptyTransactionPerformance() {
+		// Multiple empty transactions should be handled efficiently
+		for (int i = 0; i < 10; i++) {
+			connection.multi();
+			List<Object> results = connection.exec();
+			assertThat(results).isEmpty();
+			assertThat(connection.isQueueing()).isFalse();
+		}
+	}
+
+	@Test
+	void testWatchOnNonExistentKey() {
+		String nonExistentKey = "test:tx:watch:nonexistent";
+		String testKey = "test:tx:state:key";
+
+		try {
+			// Watch a key that doesn't exist
+			connection.watch(nonExistentKey.getBytes());
+
+			// Create the key externally
+			try (ValkeyConnection otherConnection = connectionFactory.getConnection()) {
+				otherConnection.stringCommands().set(nonExistentKey.getBytes(), "created_externally".getBytes());
+			}
+
+			// Transaction should be aborted because watched key was created
+			connection.multi();
+			connection.stringCommands().set(testKey.getBytes(), "should_not_be_set".getBytes());
+			List<Object> results = connection.exec();
+
+			assertThat(results).isNotNull().isEmpty(); // Transaction aborted
+			assertThat(connection.stringCommands().get(testKey.getBytes())).isNull();
+
+		}
+		finally {
+			cleanupKeys(nonExistentKey, testKey);
+		}
+	}
+
+	@Test
+	void testTransactionWithConnectionFailure() {
+		// This test ensures transaction state is properly managed even when underlying
+		// connection issues occur. However, since we're testing at the integration level
+		// and connection failures are hard to simulate reliably, we'll focus on
+		// verifying that our transaction state management is robust.
+
+		String key = "test:tx:state:key";
+
+		try {
+			// Test that transaction state is properly reset after various operations
+			connection.multi();
+			assertThat(connection.isQueueing()).isTrue();
+
+			// Simulate a scenario where we might have connection issues
+			// by ensuring our state management is consistent
+			connection.stringCommands().set(key.getBytes(), "test_value".getBytes());
+
+			List<Object> results = connection.exec();
+			assertThat(connection.isQueueing()).isFalse();
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(1);
+
+			// Verify connection is still usable
+			assertThat(connection.stringCommands().get(key.getBytes())).isEqualTo("test_value".getBytes());
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
 }

--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionZSetCommandsIntegrationTests.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionZSetCommandsIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,1878 +35,1917 @@ import io.valkey.springframework.data.valkey.core.Cursor;
 import io.valkey.springframework.data.valkey.core.ScanOptions;
 
 /**
- * Comprehensive low-level integration tests for {@link ValkeyGlideConnection} 
- * sorted set functionality using the ValkeyZSetCommands interface directly.
- * 
- * These tests validate the implementation of all ValkeyZSetCommands methods:
- * - Basic sorted set operations (zAdd, zRem, zCard, zRange, zScore)
- * - Ranking operations (zRank, zRevRank)
- * - Random operations (zRandMember, zPopMin, zPopMax)
- * - Blocking operations (bZPopMin, bZPopMax)
- * - Range operations (zRangeByScore, zRangeByLex, zRevRange)
- * - Counting operations (zCount, zLexCount)
- * - Set algebra operations (zDiff, zInter, zUnion)
- * - Store operations (zDiffStore, zInterStore, zUnionStore)
- * - Range store operations (zRangeStore variants)
- * - Removal operations (zRemRange, zRemRangeByScore, zRemRangeByLex)
- * - Scanning operations (zScan)
- * - Error handling and edge cases
+ * Comprehensive low-level integration tests for {@link ValkeyGlideConnection} sorted set
+ * functionality using the ValkeyZSetCommands interface directly.
+ *
+ * These tests validate the implementation of all ValkeyZSetCommands methods: - Basic
+ * sorted set operations (zAdd, zRem, zCard, zRange, zScore) - Ranking operations (zRank,
+ * zRevRank) - Random operations (zRandMember, zPopMin, zPopMax) - Blocking operations
+ * (bZPopMin, bZPopMax) - Range operations (zRangeByScore, zRangeByLex, zRevRange) -
+ * Counting operations (zCount, zLexCount) - Set algebra operations (zDiff, zInter,
+ * zUnion) - Store operations (zDiffStore, zInterStore, zUnionStore) - Range store
+ * operations (zRangeStore variants) - Removal operations (zRemRange, zRemRangeByScore,
+ * zRemRangeByLex) - Scanning operations (zScan) - Error handling and edge cases
  *
  * @author Ilia Kolominsky
  * @since 2.0
  */
 public class ValkeyGlideConnectionZSetCommandsIntegrationTests extends AbstractValkeyGlideIntegrationTests {
 
-    @Override
-    protected String[] getTestKeyPatterns() {
-        return new String[]{
-            "test:zset:add:key", "test:zset:add:single:key", "test:zset:rem:key", "test:zset:mscore:key",
-            "test:zset:incrby:key", "test:zset:range:key", "test:zset:rangebyscore:key", "test:zset:rangebylex:key",
-            "test:zset:rank:key", "test:zset:count:key", "test:zset:lexcount:key", "test:zset:randmember:key",
-            "test:zset:pop:key", "test:zset:diff:key1", "test:zset:diff:key2", "test:zset:diff:dest",
-            "test:zset:inter:key1", "test:zset:inter:key2", "test:zset:inter:dest", "test:zset:union:key1",
-            "test:zset:union:key2", "test:zset:union:dest", "test:zset:rangestore:src", "test:zset:rangestore:dest",
-            "test:zset:rangestore:srclex", "test:zset:remrange:key", "test:zset:scan:key", "test:zset:lex:bounds:key",
-            "test:zset:lex:edge:key", "test:zset:lex:complex:key"
-        };
-    }
+	@Override
+	protected String[] getTestKeyPatterns() {
+		return new String[] { "test:zset:add:key", "test:zset:add:single:key", "test:zset:rem:key",
+				"test:zset:mscore:key", "test:zset:incrby:key", "test:zset:range:key", "test:zset:rangebyscore:key",
+				"test:zset:rangebylex:key", "test:zset:rank:key", "test:zset:count:key", "test:zset:lexcount:key",
+				"test:zset:randmember:key", "test:zset:pop:key", "test:zset:diff:key1", "test:zset:diff:key2",
+				"test:zset:diff:dest", "test:zset:inter:key1", "test:zset:inter:key2", "test:zset:inter:dest",
+				"test:zset:union:key1", "test:zset:union:key2", "test:zset:union:dest", "test:zset:rangestore:src",
+				"test:zset:rangestore:dest", "test:zset:rangestore:srclex", "test:zset:remrange:key",
+				"test:zset:scan:key", "test:zset:lex:bounds:key", "test:zset:lex:edge:key",
+				"test:zset:lex:complex:key" };
+	}
 
-    // ==================== Basic ZSet Operations ====================
+	// ==================== Basic ZSet Operations ====================
 
-    @Test
-    void testZAddAndZCard() {
-        String key = "test:zset:add:key";
-        
-        try {
-            // Test zCard on non-existent key
-            Long cardEmpty = connection.zSetCommands().zCard(key.getBytes());
-            assertThat(cardEmpty).isEqualTo(0L);
-            
-            // Test adding single tuple
-            Set<Tuple> tuples = new HashSet<>();
-            tuples.add(new DefaultTuple("member1".getBytes(), 1.0));
-            
-            Long addResult1 = connection.zSetCommands().zAdd(key.getBytes(), tuples, 
-                ValkeyZSetCommands.ZAddArgs.empty());
-            assertThat(addResult1).isEqualTo(1L);
-            
-            // Test cardinality after adding one element
-            Long card1 = connection.zSetCommands().zCard(key.getBytes());
-            assertThat(card1).isEqualTo(1L);
-            
-            // Test adding multiple tuples
-            tuples.clear();
-            tuples.add(new DefaultTuple("member2".getBytes(), 2.0));
-            tuples.add(new DefaultTuple("member3".getBytes(), 3.0));
-            
-            Long addResult2 = connection.zSetCommands().zAdd(key.getBytes(), tuples, 
-                ValkeyZSetCommands.ZAddArgs.empty());
-            assertThat(addResult2).isEqualTo(2L);
-            
-            // Test cardinality after adding three elements
-            Long card3 = connection.zSetCommands().zCard(key.getBytes());
-            assertThat(card3).isEqualTo(3L);
-            
-            // Test adding duplicate value with different score
-            tuples.clear();
-            tuples.add(new DefaultTuple("member1".getBytes(), 1.5));
-            
-            Long addDuplicate = connection.zSetCommands().zAdd(key.getBytes(), tuples, 
-                ValkeyZSetCommands.ZAddArgs.empty());
-            assertThat(addDuplicate).isEqualTo(0L); // Should update existing, not add new
-            
-            // Cardinality should remain the same
-            Long cardSame = connection.zSetCommands().zCard(key.getBytes());
-            assertThat(cardSame).isEqualTo(3L);
-            
-            // But score should be updated
-            Double score = connection.zSetCommands().zScore(key.getBytes(), "member1".getBytes());
-            assertThat(score).isEqualTo(1.5);
-        } finally {
-            cleanupKey(key);
-        }
-    }
+	@Test
+	void testZAddAndZCard() {
+		String key = "test:zset:add:key";
 
-    @Test
-    void testZAddSingleValueWithArgs() {
-        String key = "test:zset:add:single:key";
-        
-        try {
-            // Test adding with NX flag (only if not exists)
-            Boolean addNX1 = connection.zSetCommands().zAdd(key.getBytes(), 1.0, "member1".getBytes(), 
-                ValkeyZSetCommands.ZAddArgs.empty().nx());
-            assertThat(addNX1).isTrue();
-            
-            // Try to add same member with NX flag (should return false)
-            Boolean addNX2 = connection.zSetCommands().zAdd(key.getBytes(), 2.0, "member1".getBytes(), 
-                ValkeyZSetCommands.ZAddArgs.empty().nx());
-            assertThat(addNX2).isFalse();
-            
-            // Score should remain unchanged
-            Double score = connection.zSetCommands().zScore(key.getBytes(), "member1".getBytes());
-            assertThat(score).isEqualTo(1.0);
-            
-            // Test adding with XX flag (only if exists)
-            Boolean addXX1 = connection.zSetCommands().zAdd(key.getBytes(), 1.5, "member1".getBytes(), 
-                ValkeyZSetCommands.ZAddArgs.empty().xx());
-            assertThat(addXX1).isFalse();
-            
-            // Score should be updated
-            Double updatedScore = connection.zSetCommands().zScore(key.getBytes(), "member1".getBytes());
-            assertThat(updatedScore).isEqualTo(1.5);
-            
-            // Try to add new member with XX flag (should return false)
-            Boolean addXX2 = connection.zSetCommands().zAdd(key.getBytes(), 2.0, "member2".getBytes(), 
-                ValkeyZSetCommands.ZAddArgs.empty().xx());
-            assertThat(addXX2).isFalse();
-        } finally {
-            cleanupKey(key);
-        }
-    }
+		try {
+			// Test zCard on non-existent key
+			Long cardEmpty = connection.zSetCommands().zCard(key.getBytes());
+			assertThat(cardEmpty).isEqualTo(0L);
 
-    @Test
-    void testZRemAndZScore() {
-        String key = "test:zset:rem:key";
-        
-        try {
-            // Setup test data
-            Set<Tuple> tuples = new HashSet<>();
-            tuples.add(new DefaultTuple("member1".getBytes(), 1.0));
-            tuples.add(new DefaultTuple("member2".getBytes(), 2.0));
-            tuples.add(new DefaultTuple("member3".getBytes(), 3.0));
-            
-            connection.zSetCommands().zAdd(key.getBytes(), tuples, 
-                ValkeyZSetCommands.ZAddArgs.empty());
-            
-            // Test zScore for existing members
-            Double score1 = connection.zSetCommands().zScore(key.getBytes(), "member1".getBytes());
-            assertThat(score1).isEqualTo(1.0);
-            
-            Double score2 = connection.zSetCommands().zScore(key.getBytes(), "member2".getBytes());
-            assertThat(score2).isEqualTo(2.0);
-            
-            // Test zScore for non-existent member
-            Double scoreNonExistent = connection.zSetCommands().zScore(key.getBytes(), "nonexistent".getBytes());
-            assertThat(scoreNonExistent).isNull();
-            
-            // Test removing single member
-            Long remResult1 = connection.zSetCommands().zRem(key.getBytes(), "member1".getBytes());
-            assertThat(remResult1).isEqualTo(1L);
-            
-            // Verify member was removed
-            Double removedScore = connection.zSetCommands().zScore(key.getBytes(), "member1".getBytes());
-            assertThat(removedScore).isNull();
-            
-            // Test removing multiple members
-            Long remResult2 = connection.zSetCommands().zRem(key.getBytes(), 
-                "member2".getBytes(), "member3".getBytes());
-            assertThat(remResult2).isEqualTo(2L);
-            
-            // Test removing non-existent member
-            Long remNonExistent = connection.zSetCommands().zRem(key.getBytes(), "nonexistent".getBytes());
-            assertThat(remNonExistent).isEqualTo(0L);
-            
-            // Verify set is empty
-            Long card = connection.zSetCommands().zCard(key.getBytes());
-            assertThat(card).isEqualTo(0L);
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test adding single tuple
+			Set<Tuple> tuples = new HashSet<>();
+			tuples.add(new DefaultTuple("member1".getBytes(), 1.0));
 
-    @Test
-    void testZMScore() {
-        String key = "test:zset:mscore:key";
-        
-        try {
-            // Setup test data
-            Set<Tuple> tuples = new HashSet<>();
-            tuples.add(new DefaultTuple("member1".getBytes(), 1.0));
-            tuples.add(new DefaultTuple("member2".getBytes(), 2.0));
-            tuples.add(new DefaultTuple("member3".getBytes(), 3.0));
-            
-            connection.zSetCommands().zAdd(key.getBytes(), tuples, 
-                ValkeyZSetCommands.ZAddArgs.empty());
-            
-            // Test zMScore for multiple members
-            List<Double> scores = connection.zSetCommands().zMScore(key.getBytes(), 
-                "member1".getBytes(), "member2".getBytes(), "nonexistent".getBytes(), "member3".getBytes());
-            
-            assertThat(scores).hasSize(4);
-            assertThat(scores.get(0)).isEqualTo(1.0);
-            assertThat(scores.get(1)).isEqualTo(2.0);
-            assertThat(scores.get(2)).isNull(); // nonexistent member
-            assertThat(scores.get(3)).isEqualTo(3.0);
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			Long addResult1 = connection.zSetCommands()
+				.zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
+			assertThat(addResult1).isEqualTo(1L);
 
-    @Test
-    void testZIncrBy() {
-        String key = "test:zset:incrby:key";
-        
-        try {
-            // Add initial member
-            Set<Tuple> tuples = new HashSet<>();
-            tuples.add(new DefaultTuple("member1".getBytes(), 1.0));
-            connection.zSetCommands().zAdd(key.getBytes(), tuples, 
-                ValkeyZSetCommands.ZAddArgs.empty());
-            
-            // Test incrementing existing member
-            Double newScore1 = connection.zSetCommands().zIncrBy(key.getBytes(), 2.5, "member1".getBytes());
-            assertThat(newScore1).isEqualTo(3.5);
-            
-            // Verify score was updated
-            Double score = connection.zSetCommands().zScore(key.getBytes(), "member1".getBytes());
-            assertThat(score).isEqualTo(3.5);
-            
-            // Test incrementing non-existent member (should create with increment as score)
-            Double newScore2 = connection.zSetCommands().zIncrBy(key.getBytes(), 5.0, "member2".getBytes());
-            assertThat(newScore2).isEqualTo(5.0);
-            
-            // Test negative increment
-            Double newScore3 = connection.zSetCommands().zIncrBy(key.getBytes(), -1.5, "member1".getBytes());
-            assertThat(newScore3).isEqualTo(2.0);
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test cardinality after adding one element
+			Long card1 = connection.zSetCommands().zCard(key.getBytes());
+			assertThat(card1).isEqualTo(1L);
 
-    // ==================== Range Operations ====================
+			// Test adding multiple tuples
+			tuples.clear();
+			tuples.add(new DefaultTuple("member2".getBytes(), 2.0));
+			tuples.add(new DefaultTuple("member3".getBytes(), 3.0));
 
-    @Test
-    void testZRangeAndZRevRange() {
-        String key = "test:zset:range:key";
-        
-        try {
-            // Setup test data with different scores
-            Set<Tuple> tuples = new HashSet<>();
-            tuples.add(new DefaultTuple("member1".getBytes(), 1.0));
-            tuples.add(new DefaultTuple("member2".getBytes(), 2.0));
-            tuples.add(new DefaultTuple("member3".getBytes(), 3.0));
-            tuples.add(new DefaultTuple("member4".getBytes(), 4.0));
-            tuples.add(new DefaultTuple("member5".getBytes(), 5.0));
-            
-            connection.zSetCommands().zAdd(key.getBytes(), tuples, 
-                ValkeyZSetCommands.ZAddArgs.empty());
-            
-            // Test zRange (ascending order)
-            Set<byte[]> range1 = connection.zSetCommands().zRange(key.getBytes(), 0, 2);
-            assertThat(range1).hasSize(3);
-            List<String> rangeList1 = range1.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toList());
-            assertThat(rangeList1).containsExactly("member1", "member2", "member3");
-            
-            // Test zRange with negative indices
-            Set<byte[]> range2 = connection.zSetCommands().zRange(key.getBytes(), -2, -1);
-            assertThat(range2).hasSize(2);
-            List<String> rangeList2 = range2.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toList());
-            assertThat(rangeList2).containsExactly("member4", "member5");
-            
-            // Test zRangeWithScores
-            Set<Tuple> rangeWithScores = connection.zSetCommands().zRangeWithScores(key.getBytes(), 0, 2);
-            assertThat(rangeWithScores).hasSize(3);
-            
-            // Test zRevRange (descending order)
-            Set<byte[]> revRange = connection.zSetCommands().zRevRange(key.getBytes(), 0, 2);
-            assertThat(revRange).hasSize(3);
-            List<String> revRangeList = revRange.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toList());
-            assertThat(revRangeList).containsExactly("member5", "member4", "member3");
-            
-            // Test zRevRangeWithScores
-            Set<Tuple> revRangeWithScores = connection.zSetCommands().zRevRangeWithScores(key.getBytes(), 0, 2);
-            assertThat(revRangeWithScores).hasSize(3);
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			Long addResult2 = connection.zSetCommands()
+				.zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
+			assertThat(addResult2).isEqualTo(2L);
 
-    @Test
-    void testZRangeByScore() {
-        String key = "test:zset:rangebyscore:key";
-        
-        try {
-            // Setup test data
-            Set<Tuple> tuples = new HashSet<>();
-            tuples.add(new DefaultTuple("member1".getBytes(), 1.0));
-            tuples.add(new DefaultTuple("member2".getBytes(), 2.0));
-            tuples.add(new DefaultTuple("member3".getBytes(), 3.0));
-            tuples.add(new DefaultTuple("member4".getBytes(), 4.0));
-            tuples.add(new DefaultTuple("member5".getBytes(), 5.0));
-            
-            connection.zSetCommands().zAdd(key.getBytes(), tuples, 
-                ValkeyZSetCommands.ZAddArgs.empty());
-            
-            // Test zRangeByScore with Range
-            Range<Double> range1 = Range.closed(2.0, 4.0);
-            Set<byte[]> rangeResult1 = connection.zSetCommands().zRangeByScore(key.getBytes(), 
-                range1.map(Number.class::cast), Limit.unlimited());
-            assertThat(rangeResult1).hasSize(3);
-            
-            // Test zRangeByScore with string bounds
-            Set<byte[]> rangeResult2 = connection.zSetCommands().zRangeByScore(key.getBytes(), 
-                "2.0", "4.0", 0, 10);
-            assertThat(rangeResult2).hasSize(3);
-            
-            // Test zRangeByScore with limit
-            Set<byte[]> rangeResult3 = connection.zSetCommands().zRangeByScore(key.getBytes(), 
-                range1.map(Number.class::cast), Limit.limit().count(2));
-            assertThat(rangeResult3).hasSize(2);
-            
-            // Test zRangeByScoreWithScores
-            Set<Tuple> rangeWithScores = connection.zSetCommands().zRangeByScoreWithScores(key.getBytes(), 
-                range1.map(Number.class::cast), Limit.unlimited());
-            assertThat(rangeWithScores).hasSize(3);
-            
-            // Test zRevRangeByScore
-            Set<byte[]> revRangeResult = connection.zSetCommands().zRevRangeByScore(key.getBytes(), 
-                range1.map(Number.class::cast), Limit.unlimited());
-            assertThat(revRangeResult).hasSize(3);
-            
-            // Test zRevRangeByScoreWithScores
-            Set<Tuple> revRangeWithScores = connection.zSetCommands().zRevRangeByScoreWithScores(key.getBytes(), 
-                range1.map(Number.class::cast), Limit.unlimited());
-            assertThat(revRangeWithScores).hasSize(3);
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test cardinality after adding three elements
+			Long card3 = connection.zSetCommands().zCard(key.getBytes());
+			assertThat(card3).isEqualTo(3L);
 
-    @Test
-    void testZRangeByLex() {
-        String key = "test:zset:rangebylex:key";
-        
-        try {
-            // Setup test data with same score for lexicographical ordering
-            Set<Tuple> tuples = new HashSet<>();
-            tuples.add(new DefaultTuple("a".getBytes(), 0.0));
-            tuples.add(new DefaultTuple("b".getBytes(), 0.0));
-            tuples.add(new DefaultTuple("c".getBytes(), 0.0));
-            tuples.add(new DefaultTuple("d".getBytes(), 0.0));
-            tuples.add(new DefaultTuple("e".getBytes(), 0.0));
-            
-            connection.zSetCommands().zAdd(key.getBytes(), tuples, 
-                ValkeyZSetCommands.ZAddArgs.empty());
-            
-            // Test zRangeByLex
-            Range<byte[]> lexRange = Range.closed("b".getBytes(), "d".getBytes());
-            Set<byte[]> lexResult = connection.zSetCommands().zRangeByLex(key.getBytes(), 
-                lexRange, Limit.unlimited());
-            assertThat(lexResult).hasSize(3);
-            
-            List<String> lexResultList = lexResult.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toList());
-            assertThat(lexResultList).containsExactly("b", "c", "d");
-            
-            // Test zRevRangeByLex - should return results in reverse lexicographic order
-            Set<byte[]> revLexResult = connection.zSetCommands().zRevRangeByLex(key.getBytes(), 
-                lexRange, Limit.unlimited());
-            assertThat(revLexResult).hasSize(3);
-            
-            List<String> revLexResultList = revLexResult.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toList());
-            assertThat(revLexResultList).containsExactly("d", "c", "b");
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test adding duplicate value with different score
+			tuples.clear();
+			tuples.add(new DefaultTuple("member1".getBytes(), 1.5));
 
-    // ==================== Ranking Operations ====================
+			Long addDuplicate = connection.zSetCommands()
+				.zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
+			assertThat(addDuplicate).isEqualTo(0L); // Should update existing, not add new
 
-    @Test
-    void testZRankAndZRevRank() {
-        String key = "test:zset:rank:key";
-        
-        try {
-            // Setup test data
-            Set<Tuple> tuples = new HashSet<>();
-            tuples.add(new DefaultTuple("member1".getBytes(), 1.0));
-            tuples.add(new DefaultTuple("member2".getBytes(), 2.0));
-            tuples.add(new DefaultTuple("member3".getBytes(), 3.0));
-            tuples.add(new DefaultTuple("member4".getBytes(), 4.0));
-            
-            connection.zSetCommands().zAdd(key.getBytes(), tuples, 
-                ValkeyZSetCommands.ZAddArgs.empty());
-            
-            // Test zRank (0-based, ascending)
-            Long rank1 = connection.zSetCommands().zRank(key.getBytes(), "member1".getBytes());
-            assertThat(rank1).isEqualTo(0L);
-            
-            Long rank2 = connection.zSetCommands().zRank(key.getBytes(), "member2".getBytes());
-            assertThat(rank2).isEqualTo(1L);
-            
-            Long rank4 = connection.zSetCommands().zRank(key.getBytes(), "member4".getBytes());
-            assertThat(rank4).isEqualTo(3L);
-            
-            // Test zRank for non-existent member
-            Long rankNonExistent = connection.zSetCommands().zRank(key.getBytes(), "nonexistent".getBytes());
-            assertThat(rankNonExistent).isNull();
-            
-            // Test zRevRank (0-based, descending)
-            Long revRank1 = connection.zSetCommands().zRevRank(key.getBytes(), "member1".getBytes());
-            assertThat(revRank1).isEqualTo(3L);
-            
-            Long revRank4 = connection.zSetCommands().zRevRank(key.getBytes(), "member4".getBytes());
-            assertThat(revRank4).isEqualTo(0L);
-            
-            // Test zRevRank for non-existent member
-            Long revRankNonExistent = connection.zSetCommands().zRevRank(key.getBytes(), "nonexistent".getBytes());
-            assertThat(revRankNonExistent).isNull();
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Cardinality should remain the same
+			Long cardSame = connection.zSetCommands().zCard(key.getBytes());
+			assertThat(cardSame).isEqualTo(3L);
 
-    // ==================== Counting Operations ====================
+			// But score should be updated
+			Double score = connection.zSetCommands().zScore(key.getBytes(), "member1".getBytes());
+			assertThat(score).isEqualTo(1.5);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
 
-    @Test
-    void testZCount() {
-        String key = "test:zset:count:key";
-        
-        try {
-            // Setup test data
-            Set<Tuple> tuples = new HashSet<>();
-            tuples.add(new DefaultTuple("member1".getBytes(), 1.0));
-            tuples.add(new DefaultTuple("member2".getBytes(), 2.0));
-            tuples.add(new DefaultTuple("member3".getBytes(), 3.0));
-            tuples.add(new DefaultTuple("member4".getBytes(), 4.0));
-            tuples.add(new DefaultTuple("member5".getBytes(), 5.0));
-            
-            connection.zSetCommands().zAdd(key.getBytes(), tuples, 
-                ValkeyZSetCommands.ZAddArgs.empty());
-            
-            // Test zCount with inclusive range
-            Range<Double> range1 = Range.closed(2.0, 4.0);
-            Long count1 = connection.zSetCommands().zCount(key.getBytes(), range1.map(Number.class::cast));
-            assertThat(count1).isEqualTo(3L);
-            
-            // Test zCount with exclusive range
-            Range<Double> range2 = Range.open(2.0, 4.0);
-            Long count2 = connection.zSetCommands().zCount(key.getBytes(), range2.map(Number.class::cast));
-            assertThat(count2).isEqualTo(1L); // Only member3 with score 3.0
-            
-            // Test zCount with unbounded range
-            Range<Double> range3 = Range.from(Range.Bound.exclusive(3.0)).to(Range.Bound.unbounded());
-            Long count3 = connection.zSetCommands().zCount(key.getBytes(), range3.map(Number.class::cast));
-            assertThat(count3).isEqualTo(2L); // member4 and member5
-        } finally {
-            cleanupKey(key);
-        }
-    }
+	@Test
+	void testZAddSingleValueWithArgs() {
+		String key = "test:zset:add:single:key";
 
-    @Test
-    void testZLexCount() {
-        String key = "test:zset:lexcount:key";
-        
-        try {
-            // Setup test data with same score for lexicographical ordering
-            Set<Tuple> tuples = new HashSet<>();
-            tuples.add(new DefaultTuple("a".getBytes(), 0.0));
-            tuples.add(new DefaultTuple("b".getBytes(), 0.0));
-            tuples.add(new DefaultTuple("c".getBytes(), 0.0));
-            tuples.add(new DefaultTuple("d".getBytes(), 0.0));
-            tuples.add(new DefaultTuple("e".getBytes(), 0.0));
-            
-            connection.zSetCommands().zAdd(key.getBytes(), tuples, 
-                ValkeyZSetCommands.ZAddArgs.empty());
-            
-            // Test zLexCount with inclusive range
-            Range<byte[]> lexRange1 = Range.closed("b".getBytes(), "d".getBytes());
-            Long lexCount1 = connection.zSetCommands().zLexCount(key.getBytes(), lexRange1);
-            assertThat(lexCount1).isEqualTo(3L);
-            
-            // Test zLexCount with exclusive range
-            Range<byte[]> lexRange2 = Range.open("b".getBytes(), "d".getBytes());
-            Long lexCount2 = connection.zSetCommands().zLexCount(key.getBytes(), lexRange2);
-            assertThat(lexCount2).isEqualTo(1L); // Only "c"
-        } finally {
-            cleanupKey(key);
-        }
-    }
+		try {
+			// Test adding with NX flag (only if not exists)
+			Boolean addNX1 = connection.zSetCommands()
+				.zAdd(key.getBytes(), 1.0, "member1".getBytes(), ValkeyZSetCommands.ZAddArgs.empty().nx());
+			assertThat(addNX1).isTrue();
 
-    // ==================== Random and Pop Operations ====================
+			// Try to add same member with NX flag (should return false)
+			Boolean addNX2 = connection.zSetCommands()
+				.zAdd(key.getBytes(), 2.0, "member1".getBytes(), ValkeyZSetCommands.ZAddArgs.empty().nx());
+			assertThat(addNX2).isFalse();
 
-    @Test
-    void testZRandMember() {
-        String key = "test:zset:randmember:key";
-        
-        try {
-            // Test zRandMember on empty set
-            byte[] emptyRand = connection.zSetCommands().zRandMember(key.getBytes());
-            assertThat(emptyRand).isNull();
-            
-            // Setup test data
-            Set<Tuple> tuples = new HashSet<>();
-            tuples.add(new DefaultTuple("member1".getBytes(), 1.0));
-            tuples.add(new DefaultTuple("member2".getBytes(), 2.0));
-            tuples.add(new DefaultTuple("member3".getBytes(), 3.0));
-            
-            connection.zSetCommands().zAdd(key.getBytes(), tuples, 
-                ValkeyZSetCommands.ZAddArgs.empty());
-            
-            // Test single random member
-            byte[] randomMember = connection.zSetCommands().zRandMember(key.getBytes());
-            assertThat(randomMember).isNotNull();
-            String randomMemberStr = new String(randomMember);
-            assertThat(randomMemberStr).isIn("member1", "member2", "member3");
-            
-            // Test multiple random members
-            List<byte[]> randomMembers = connection.zSetCommands().zRandMember(key.getBytes(), 2);
-            assertThat(randomMembers).hasSize(2);
-            
-            // Test zRandMemberWithScore
-            Tuple randomTuple = connection.zSetCommands().zRandMemberWithScore(key.getBytes());
-            assertThat(randomTuple).isNotNull();
-            assertThat(randomTuple.getScore()).isIn(1.0, 2.0, 3.0);
-            
-            // Test zRandMemberWithScore with count
-            List<Tuple> randomTuples = connection.zSetCommands().zRandMemberWithScore(key.getBytes(), 2);
-            assertThat(randomTuples).hasSize(2);
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Score should remain unchanged
+			Double score = connection.zSetCommands().zScore(key.getBytes(), "member1".getBytes());
+			assertThat(score).isEqualTo(1.0);
 
-    @Test
-    void testZPopMinAndZPopMax() {
-        String key = "test:zset:pop:key";
-        
-        try {
-            // Test pop on empty set
-            Tuple emptyPop = connection.zSetCommands().zPopMin(key.getBytes());
-            assertThat(emptyPop).isNull();
-            
-            // Setup test data
-            Set<Tuple> tuples = new HashSet<>();
-            tuples.add(new DefaultTuple("member1".getBytes(), 1.0));
-            tuples.add(new DefaultTuple("member2".getBytes(), 2.0));
-            tuples.add(new DefaultTuple("member3".getBytes(), 3.0));
-            
-            connection.zSetCommands().zAdd(key.getBytes(), tuples, 
-                ValkeyZSetCommands.ZAddArgs.empty());
-            
-            // Test zPopMin single
-            Tuple minTuple = connection.zSetCommands().zPopMin(key.getBytes());
-            assertThat(minTuple).isNotNull();
-            assertThat(minTuple.getScore()).isEqualTo(1.0);
-            assertThat(new String(minTuple.getValue())).isEqualTo("member1");
-            
-            // Test zPopMax single
-            Tuple maxTuple = connection.zSetCommands().zPopMax(key.getBytes());
-            assertThat(maxTuple).isNotNull();
-            assertThat(maxTuple.getScore()).isEqualTo(3.0);
-            assertThat(new String(maxTuple.getValue())).isEqualTo("member3");
-            
-            // Add more data for multiple pop tests
-            tuples.clear();
-            tuples.add(new DefaultTuple("member4".getBytes(), 4.0));
-            tuples.add(new DefaultTuple("member5".getBytes(), 5.0));
-            connection.zSetCommands().zAdd(key.getBytes(), tuples, 
-                ValkeyZSetCommands.ZAddArgs.empty());
-            
-            // Test zPopMin multiple
-            Set<Tuple> minTuples = connection.zSetCommands().zPopMin(key.getBytes(), 2);
-            assertThat(minTuples).hasSize(2);
-            
-            // Test zPopMax multiple
-            Set<Tuple> maxTuples = connection.zSetCommands().zPopMax(key.getBytes(), 2);
-            assertThat(maxTuples).hasSize(1); // Only 1 element remaining after previous operations
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test adding with XX flag (only if exists)
+			Boolean addXX1 = connection.zSetCommands()
+				.zAdd(key.getBytes(), 1.5, "member1".getBytes(), ValkeyZSetCommands.ZAddArgs.empty().xx());
+			assertThat(addXX1).isFalse();
 
-    @Test
-    void testZPopMinAndZPopMaxOrdering() {
-        String key = "test:zset:pop:ordering:key";
-        
-        try {
-            // Setup test data with specific scores to test ordering
-            Set<Tuple> tuples = new HashSet<>();
-            tuples.add(new DefaultTuple("low".getBytes(), 1.0));
-            tuples.add(new DefaultTuple("medium".getBytes(), 2.0));
-            tuples.add(new DefaultTuple("high".getBytes(), 3.0));
-            tuples.add(new DefaultTuple("highest".getBytes(), 4.0));
-            
-            connection.zSetCommands().zAdd(key.getBytes(), tuples, 
-                ValkeyZSetCommands.ZAddArgs.empty());
-            
-            // Test zPopMin multiple - should return in ascending order (lowest scores first)
-            Set<Tuple> minTuples = connection.zSetCommands().zPopMin(key.getBytes(), 2);
-            assertThat(minTuples).hasSize(2);
-            
-            // Convert to list to check ordering
-            java.util.List<Tuple> minList = new java.util.ArrayList<>(minTuples);
-            assertThat(minList.get(0).getScore()).isEqualTo(1.0);
-            assertThat(new String(minList.get(0).getValue())).isEqualTo("low");
-            assertThat(minList.get(1).getScore()).isEqualTo(2.0);
-            assertThat(new String(minList.get(1).getValue())).isEqualTo("medium");
-            
-            // Test zPopMax multiple - should return in descending order (highest scores first)
-            Set<Tuple> maxTuples = connection.zSetCommands().zPopMax(key.getBytes(), 2);
-            assertThat(maxTuples).hasSize(2);
-            
-            // Convert to list to check ordering
-            java.util.List<Tuple> maxList = new java.util.ArrayList<>(maxTuples);
-            assertThat(maxList.get(0).getScore()).isEqualTo(4.0);
-            assertThat(new String(maxList.get(0).getValue())).isEqualTo("highest");
-            assertThat(maxList.get(1).getScore()).isEqualTo(3.0);
-            assertThat(new String(maxList.get(1).getValue())).isEqualTo("high");
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Score should be updated
+			Double updatedScore = connection.zSetCommands().zScore(key.getBytes(), "member1".getBytes());
+			assertThat(updatedScore).isEqualTo(1.5);
 
-    @Test
-    void testBlockingPopOperations() {
-        String key = "test:zset:blocking:pop:key";
-        
-        try {
-            // Setup test data
-            Set<Tuple> tuples = new HashSet<>();
-            tuples.add(new DefaultTuple("member1".getBytes(), 1.0));
-            tuples.add(new DefaultTuple("member2".getBytes(), 2.0));
-            
-            connection.zSetCommands().zAdd(key.getBytes(), tuples, 
-                ValkeyZSetCommands.ZAddArgs.empty());
-            
-            // Test bZPopMin with short timeout (should return immediately since data exists)
-            Tuple minTuple = connection.zSetCommands().bZPopMin(key.getBytes(), 1, TimeUnit.SECONDS);
-            assertThat(minTuple).isNotNull();
-            assertThat(minTuple.getScore()).isEqualTo(1.0);
-            assertThat(new String(minTuple.getValue())).isEqualTo("member1");
-            
-            // Test bZPopMax with short timeout (should return immediately since data exists)
-            Tuple maxTuple = connection.zSetCommands().bZPopMax(key.getBytes(), 1, TimeUnit.SECONDS);
-            assertThat(maxTuple).isNotNull();
-            assertThat(maxTuple.getScore()).isEqualTo(2.0);
-            assertThat(new String(maxTuple.getValue())).isEqualTo("member2");
-            
-            // Test bZPopMin on empty set with short timeout (should return null after timeout)
-            Tuple emptyResult = connection.zSetCommands().bZPopMin(key.getBytes(), 1, TimeUnit.SECONDS);
-            assertThat(emptyResult).isNull();
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Try to add new member with XX flag (should return false)
+			Boolean addXX2 = connection.zSetCommands()
+				.zAdd(key.getBytes(), 2.0, "member2".getBytes(), ValkeyZSetCommands.ZAddArgs.empty().xx());
+			assertThat(addXX2).isFalse();
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
 
-    // ==================== Set Algebra Operations ====================
+	@Test
+	void testZRemAndZScore() {
+		String key = "test:zset:rem:key";
 
-    @Test
-    void testZDiff() {
-        String key1 = "test:zset:diff:key1";
-        String key2 = "test:zset:diff:key2";
-        
-        try {
-            // Setup test data
-            Set<Tuple> tuples1 = new HashSet<>();
-            tuples1.add(new DefaultTuple("a".getBytes(), 1.0));
-            tuples1.add(new DefaultTuple("b".getBytes(), 2.0));
-            tuples1.add(new DefaultTuple("c".getBytes(), 3.0));
-            
-            Set<Tuple> tuples2 = new HashSet<>();
-            tuples2.add(new DefaultTuple("b".getBytes(), 2.5));
-            tuples2.add(new DefaultTuple("d".getBytes(), 4.0));
-            
-            connection.zSetCommands().zAdd(key1.getBytes(), tuples1, 
-                ValkeyZSetCommands.ZAddArgs.empty());
-            connection.zSetCommands().zAdd(key2.getBytes(), tuples2, 
-                ValkeyZSetCommands.ZAddArgs.empty());
-            
-            // Test zDiff
-            Set<byte[]> diff = connection.zSetCommands().zDiff(key1.getBytes(), key2.getBytes());
-            assertThat(diff).hasSize(2);
-            Set<String> diffStrings = diff.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toSet());
-            assertThat(diffStrings).containsExactlyInAnyOrder("a", "c");
-            
-            // Test zDiffWithScores
-            Set<Tuple> diffWithScores = connection.zSetCommands().zDiffWithScores(key1.getBytes(), key2.getBytes());
-            assertThat(diffWithScores).hasSize(2);
-            
-            // Test zDiffStore
-            String destKey = "test:zset:diff:dest";
-            Long storeResult = connection.zSetCommands().zDiffStore(destKey.getBytes(), key1.getBytes(), key2.getBytes());
-            assertThat(storeResult).isEqualTo(2L);
-            
-            cleanupKey(destKey);
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-        }
-    }
+		try {
+			// Setup test data
+			Set<Tuple> tuples = new HashSet<>();
+			tuples.add(new DefaultTuple("member1".getBytes(), 1.0));
+			tuples.add(new DefaultTuple("member2".getBytes(), 2.0));
+			tuples.add(new DefaultTuple("member3".getBytes(), 3.0));
 
-    @Test
-    void testZInter() {
-        String key1 = "test:zset:inter:key1";
-        String key2 = "test:zset:inter:key2";
-        
-        try {
-            // Setup test data
-            Set<Tuple> tuples1 = new HashSet<>();
-            tuples1.add(new DefaultTuple("a".getBytes(), 1.0));
-            tuples1.add(new DefaultTuple("b".getBytes(), 2.0));
-            tuples1.add(new DefaultTuple("c".getBytes(), 3.0));
-            
-            Set<Tuple> tuples2 = new HashSet<>();
-            tuples2.add(new DefaultTuple("b".getBytes(), 2.5));
-            tuples2.add(new DefaultTuple("c".getBytes(), 3.5));
-            tuples2.add(new DefaultTuple("d".getBytes(), 4.0));
-            
-            connection.zSetCommands().zAdd(key1.getBytes(), tuples1, 
-                ValkeyZSetCommands.ZAddArgs.empty());
-            connection.zSetCommands().zAdd(key2.getBytes(), tuples2, 
-                ValkeyZSetCommands.ZAddArgs.empty());
-            
-            // Test zInter
-            Set<byte[]> inter = connection.zSetCommands().zInter(key1.getBytes(), key2.getBytes());
-            assertThat(inter).hasSize(2);
-            Set<String> interStrings = inter.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toSet());
-            assertThat(interStrings).containsExactlyInAnyOrder("b", "c");
-            
-            // Test zInterWithScores
-            Set<Tuple> interWithScores = connection.zSetCommands().zInterWithScores(key1.getBytes(), key2.getBytes());
-            assertThat(interWithScores).hasSize(2);
-            
-            // Test zInterWithScores with weights and aggregate
-            Weights weights = Weights.of(1.0, 2.0);
-            Set<Tuple> interWeighted = connection.zSetCommands().zInterWithScores(Aggregate.SUM, weights, 
-                key1.getBytes(), key2.getBytes());
-            assertThat(interWeighted).hasSize(2);
-            
-            // Test zInterStore
-            String destKey = "test:zset:inter:dest";
-            Long storeResult = connection.zSetCommands().zInterStore(destKey.getBytes(), key1.getBytes(), key2.getBytes());
-            assertThat(storeResult).isEqualTo(2L);
-            
-            // Test zInterStore with weights and aggregate
-            Long storeWeightedResult = connection.zSetCommands().zInterStore(destKey.getBytes(), Aggregate.MAX, weights, 
-                key1.getBytes(), key2.getBytes());
-            assertThat(storeWeightedResult).isEqualTo(2L);
-            
-            cleanupKey(destKey);
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-        }
-    }
+			connection.zSetCommands().zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
 
-    @Test
-    void testZUnion() {
-        String key1 = "test:zset:union:key1";
-        String key2 = "test:zset:union:key2";
-        
-        try {
-            // Setup test data
-            Set<Tuple> tuples1 = new HashSet<>();
-            tuples1.add(new DefaultTuple("a".getBytes(), 1.0));
-            tuples1.add(new DefaultTuple("b".getBytes(), 2.0));
-            
-            Set<Tuple> tuples2 = new HashSet<>();
-            tuples2.add(new DefaultTuple("b".getBytes(), 2.5));
-            tuples2.add(new DefaultTuple("c".getBytes(), 3.0));
-            
-            connection.zSetCommands().zAdd(key1.getBytes(), tuples1, 
-                ValkeyZSetCommands.ZAddArgs.empty());
-            connection.zSetCommands().zAdd(key2.getBytes(), tuples2, 
-                ValkeyZSetCommands.ZAddArgs.empty());
-            
-            // Test zUnion
-            Set<byte[]> union = connection.zSetCommands().zUnion(key1.getBytes(), key2.getBytes());
-            assertThat(union).hasSize(3);
-            Set<String> unionStrings = union.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toSet());
-            assertThat(unionStrings).containsExactlyInAnyOrder("a", "b", "c");
-            
-            // Test zUnionWithScores
-            Set<Tuple> unionWithScores = connection.zSetCommands().zUnionWithScores(key1.getBytes(), key2.getBytes());
-            assertThat(unionWithScores).hasSize(3);
-            
-            // Test zUnionWithScores with weights and aggregate
-            Weights weights = Weights.of(1.0, 2.0);
-            Set<Tuple> unionWeighted = connection.zSetCommands().zUnionWithScores(Aggregate.MIN, weights, 
-                key1.getBytes(), key2.getBytes());
-            assertThat(unionWeighted).hasSize(3);
-            
-            // Test zUnionStore
-            String destKey = "test:zset:union:dest";
-            Long storeResult = connection.zSetCommands().zUnionStore(destKey.getBytes(), key1.getBytes(), key2.getBytes());
-            assertThat(storeResult).isEqualTo(3L);
-            
-            // Test zUnionStore with weights and aggregate
-            Long storeWeightedResult = connection.zSetCommands().zUnionStore(destKey.getBytes(), Aggregate.SUM, weights, 
-                key1.getBytes(), key2.getBytes());
-            assertThat(storeWeightedResult).isEqualTo(3L);
-            
-            cleanupKey(destKey);
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-        }
-    }
+			// Test zScore for existing members
+			Double score1 = connection.zSetCommands().zScore(key.getBytes(), "member1".getBytes());
+			assertThat(score1).isEqualTo(1.0);
 
-    // ==================== Range Store Operations ====================
+			Double score2 = connection.zSetCommands().zScore(key.getBytes(), "member2".getBytes());
+			assertThat(score2).isEqualTo(2.0);
 
-    @Test
-    void testZRangeStore() {
-        String srcKey = "test:zset:rangestore:src";
-        String destKey = "test:zset:rangestore:dest";
-        
-        try {
-            // Setup test data
-            Set<Tuple> tuples = new HashSet<>();
-            tuples.add(new DefaultTuple("member1".getBytes(), 1.0));
-            tuples.add(new DefaultTuple("member2".getBytes(), 2.0));
-            tuples.add(new DefaultTuple("member3".getBytes(), 3.0));
-            tuples.add(new DefaultTuple("member4".getBytes(), 4.0));
-            tuples.add(new DefaultTuple("member5".getBytes(), 5.0));
-            
-            connection.zSetCommands().zAdd(srcKey.getBytes(), tuples, 
-                ValkeyZSetCommands.ZAddArgs.empty());
-            
-            // Test zRangeStoreByScore
-            Range<Double> scoreRange = Range.closed(2.0, 4.0);
-            Long storeByScoreResult = connection.zSetCommands().zRangeStoreByScore(destKey.getBytes(), srcKey.getBytes(), 
-                scoreRange.map(Number.class::cast), Limit.unlimited());
-            assertThat(storeByScoreResult).isEqualTo(3L);
-            
-            // Test zRangeStoreRevByScore
-            Long storeRevByScoreResult = connection.zSetCommands().zRangeStoreRevByScore(destKey.getBytes(), srcKey.getBytes(), 
-                scoreRange.map(Number.class::cast), Limit.unlimited());
-            assertThat(storeRevByScoreResult).isEqualTo(3L);
-            
-            // Test zRangeStoreByLex (need same scores)
-            String srcLexKey = "test:zset:rangestore:srclex";
-            Set<Tuple> lexTuples = new HashSet<>();
-            lexTuples.add(new DefaultTuple("a".getBytes(), 0.0));
-            lexTuples.add(new DefaultTuple("b".getBytes(), 0.0));
-            lexTuples.add(new DefaultTuple("c".getBytes(), 0.0));
-            lexTuples.add(new DefaultTuple("d".getBytes(), 0.0));
-            
-            connection.zSetCommands().zAdd(srcLexKey.getBytes(), lexTuples, 
-                ValkeyZSetCommands.ZAddArgs.empty());
-            
-            Range<byte[]> lexRange = Range.closed("b".getBytes(), "d".getBytes());
-            Long storeByLexResult = connection.zSetCommands().zRangeStoreByLex(destKey.getBytes(), srcLexKey.getBytes(), 
-                lexRange, Limit.unlimited());
-            assertThat(storeByLexResult).isEqualTo(3L);
-            
-            // Test zRangeStoreRevByLex
-            Long storeRevByLexResult = connection.zSetCommands().zRangeStoreRevByLex(destKey.getBytes(), srcLexKey.getBytes(), 
-                lexRange, Limit.unlimited());
-            assertThat(storeRevByLexResult).isEqualTo(3L);
-            
-            cleanupKey(srcLexKey);
-        } finally {
-            cleanupKey(srcKey);
-            cleanupKey(destKey);
-        }
-    }
+			// Test zScore for non-existent member
+			Double scoreNonExistent = connection.zSetCommands().zScore(key.getBytes(), "nonexistent".getBytes());
+			assertThat(scoreNonExistent).isNull();
 
-    // ==================== Removal Operations ====================
+			// Test removing single member
+			Long remResult1 = connection.zSetCommands().zRem(key.getBytes(), "member1".getBytes());
+			assertThat(remResult1).isEqualTo(1L);
 
-    @Test
-    void testZRemRange() {
-        String key = "test:zset:remrange:key";
-        
-        try {
-            // Setup test data
-            Set<Tuple> tuples = new HashSet<>();
-            tuples.add(new DefaultTuple("member1".getBytes(), 1.0));
-            tuples.add(new DefaultTuple("member2".getBytes(), 2.0));
-            tuples.add(new DefaultTuple("member3".getBytes(), 3.0));
-            tuples.add(new DefaultTuple("member4".getBytes(), 4.0));
-            tuples.add(new DefaultTuple("member5".getBytes(), 5.0));
-            
-            connection.zSetCommands().zAdd(key.getBytes(), tuples, 
-                ValkeyZSetCommands.ZAddArgs.empty());
-            
-            // Test zRemRange by rank
-            Long remRangeResult = connection.zSetCommands().zRemRange(key.getBytes(), 1, 3);
-            assertThat(remRangeResult).isEqualTo(3L); // Removed member2, member3, member4
-            
-            // Verify remaining members
-            Long remainingCount = connection.zSetCommands().zCard(key.getBytes());
-            assertThat(remainingCount).isEqualTo(2L); // member1 and member5 should remain
-            
-            // Test zRemRangeByScore
-            tuples.clear();
-            tuples.add(new DefaultTuple("member2".getBytes(), 2.0));
-            tuples.add(new DefaultTuple("member3".getBytes(), 3.0));
-            tuples.add(new DefaultTuple("member4".getBytes(), 4.0));
-            connection.zSetCommands().zAdd(key.getBytes(), tuples, 
-                ValkeyZSetCommands.ZAddArgs.empty());
-            
-            Range<Double> scoreRange = Range.closed(2.0, 4.0);
-            Long remByScoreResult = connection.zSetCommands().zRemRangeByScore(key.getBytes(), 
-                scoreRange.map(Number.class::cast));
-            assertThat(remByScoreResult).isEqualTo(3L);
-            
-            // Test zRemRangeByLex (need same scores)
-            tuples.clear();
-            tuples.add(new DefaultTuple("a".getBytes(), 0.0));
-            tuples.add(new DefaultTuple("b".getBytes(), 0.0));
-            tuples.add(new DefaultTuple("c".getBytes(), 0.0));
-            tuples.add(new DefaultTuple("d".getBytes(), 0.0));
-            connection.zSetCommands().zAdd(key.getBytes(), tuples, 
-                ValkeyZSetCommands.ZAddArgs.empty());
-            
-            Range<byte[]> lexRange = Range.closed("b".getBytes(), "d".getBytes());
-            Long remByLexResult = connection.zSetCommands().zRemRangeByLex(key.getBytes(), lexRange);
-            assertThat(remByLexResult).isEqualTo(3L);
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Verify member was removed
+			Double removedScore = connection.zSetCommands().zScore(key.getBytes(), "member1".getBytes());
+			assertThat(removedScore).isNull();
 
-    // ==================== Comprehensive Lexicographic Range Tests ====================
+			// Test removing multiple members
+			Long remResult2 = connection.zSetCommands()
+				.zRem(key.getBytes(), "member2".getBytes(), "member3".getBytes());
+			assertThat(remResult2).isEqualTo(2L);
 
-    @Test
-    void testLexicographicRangeEdgeCases() {
-        String key = "test:zset:lex:bounds:key";
-        
-        try {
-            // Setup test data with same score for lexicographical ordering
-            Set<Tuple> tuples = new HashSet<>();
-            tuples.add(new DefaultTuple("apple".getBytes(), 0.0));
-            tuples.add(new DefaultTuple("banana".getBytes(), 0.0));
-            tuples.add(new DefaultTuple("cherry".getBytes(), 0.0));
-            tuples.add(new DefaultTuple("date".getBytes(), 0.0));
-            tuples.add(new DefaultTuple("elderberry".getBytes(), 0.0));
-            tuples.add(new DefaultTuple("fig".getBytes(), 0.0));
-            
-            connection.zSetCommands().zAdd(key.getBytes(), tuples, 
-                ValkeyZSetCommands.ZAddArgs.empty());
-            
-            // Test inclusive lower and upper bounds [banana, date]
-            Range<byte[]> inclusiveRange = Range.closed("banana".getBytes(), "date".getBytes());
-            Set<byte[]> inclusiveResult = connection.zSetCommands().zRangeByLex(key.getBytes(), 
-                inclusiveRange, Limit.unlimited());
-            assertThat(inclusiveResult).hasSize(3);
-            List<String> inclusiveList = inclusiveResult.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toList());
-            assertThat(inclusiveList).containsExactly("banana", "cherry", "date");
-            
-            // Test exclusive lower bound (banana, elderberry]
-            Range<byte[]> exclusiveLowerRange = Range.from(Range.Bound.exclusive("banana".getBytes()))
-                .to(Range.Bound.inclusive("elderberry".getBytes()));
-            Set<byte[]> exclusiveLowerResult = connection.zSetCommands().zRangeByLex(key.getBytes(), 
-                exclusiveLowerRange, Limit.unlimited());
-            assertThat(exclusiveLowerResult).hasSize(3);
-            List<String> exclusiveLowerList = exclusiveLowerResult.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toList());
-            assertThat(exclusiveLowerList).containsExactly("cherry", "date", "elderberry");
-            
-            // Test exclusive upper bound [cherry, elderberry)
-            Range<byte[]> exclusiveUpperRange = Range.from(Range.Bound.inclusive("cherry".getBytes()))
-                .to(Range.Bound.exclusive("elderberry".getBytes()));
-            Set<byte[]> exclusiveUpperResult = connection.zSetCommands().zRangeByLex(key.getBytes(), 
-                exclusiveUpperRange, Limit.unlimited());
-            assertThat(exclusiveUpperResult).hasSize(2);
-            List<String> exclusiveUpperList = exclusiveUpperResult.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toList());
-            assertThat(exclusiveUpperList).containsExactly("cherry", "date");
-            
-            // Test both bounds exclusive (banana, date)
-            Range<byte[]> bothExclusiveRange = Range.open("banana".getBytes(), "date".getBytes());
-            Set<byte[]> bothExclusiveResult = connection.zSetCommands().zRangeByLex(key.getBytes(), 
-                bothExclusiveRange, Limit.unlimited());
-            assertThat(bothExclusiveResult).hasSize(1);
-            List<String> bothExclusiveList = bothExclusiveResult.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toList());
-            assertThat(bothExclusiveList).containsExactly("cherry");
-            
-            // Test unbounded lower range (-, date]
-            Range<byte[]> unboundedLowerRange = Range.<byte[]>from(Range.Bound.unbounded())
-                .to(Range.Bound.inclusive("date".getBytes()));
-            Set<byte[]> unboundedLowerResult = connection.zSetCommands().zRangeByLex(key.getBytes(), 
-                unboundedLowerRange, Limit.unlimited());
-            assertThat(unboundedLowerResult).hasSize(4);
-            List<String> unboundedLowerList = unboundedLowerResult.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toList());
-            assertThat(unboundedLowerList).containsExactly("apple", "banana", "cherry", "date");
-            
-            // Test unbounded upper range [cherry, +)
-            Range<byte[]> unboundedUpperRange = Range.<byte[]>from(Range.Bound.inclusive("cherry".getBytes()))
-                .to(Range.Bound.unbounded());
-            Set<byte[]> unboundedUpperResult = connection.zSetCommands().zRangeByLex(key.getBytes(), 
-                unboundedUpperRange, Limit.unlimited());
-            assertThat(unboundedUpperResult).hasSize(4);
-            List<String> unboundedUpperList = unboundedUpperResult.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toList());
-            assertThat(unboundedUpperList).containsExactly("cherry", "date", "elderberry", "fig");
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test removing non-existent member
+			Long remNonExistent = connection.zSetCommands().zRem(key.getBytes(), "nonexistent".getBytes());
+			assertThat(remNonExistent).isEqualTo(0L);
 
-    @Test
-    void testLexicographicCountWithComplexBounds() {
-        String key = "test:zset:lex:edge:key";
-        
-        try {
-            // Setup test data with special characters and edge cases
-            Set<Tuple> tuples = new HashSet<>();
-            tuples.add(new DefaultTuple("!special".getBytes(), 0.0));
-            tuples.add(new DefaultTuple("@symbol".getBytes(), 0.0));
-            tuples.add(new DefaultTuple("Apple".getBytes(), 0.0));  // Capital A
-            tuples.add(new DefaultTuple("apple".getBytes(), 0.0));  // Lower case a
-            tuples.add(new DefaultTuple("banana".getBytes(), 0.0));
-            tuples.add(new DefaultTuple("z_last".getBytes(), 0.0));
-            
-            connection.zSetCommands().zAdd(key.getBytes(), tuples, 
-                ValkeyZSetCommands.ZAddArgs.empty());
-            
-            // Test count with inclusive bounds including special characters
-            Range<byte[]> specialRange = Range.closed("!special".getBytes(), "Apple".getBytes());
-            Long specialCount = connection.zSetCommands().zLexCount(key.getBytes(), specialRange);
-            assertThat(specialCount).isEqualTo(3L); // !special, @symbol, Apple
-            
-            // Test count with case-sensitive boundaries
-            Range<byte[]> caseRange = Range.closed("Apple".getBytes(), "apple".getBytes());
-            Long caseCount = connection.zSetCommands().zLexCount(key.getBytes(), caseRange);
-            assertThat(caseCount).isEqualTo(2L); // Apple, apple
-            
-            // Test count with exclusive bounds
-            Range<byte[]> exclusiveRange = Range.open("Apple".getBytes(), "banana".getBytes());
-            Long exclusiveCount = connection.zSetCommands().zLexCount(key.getBytes(), exclusiveRange);
-            assertThat(exclusiveCount).isEqualTo(1L); // apple
-            
-            // Test count with unbounded ranges
-            Range<byte[]> unboundedRange = Range.from(Range.Bound.inclusive("banana".getBytes()))
-                .to(Range.Bound.unbounded());
-            Long unboundedCount = connection.zSetCommands().zLexCount(key.getBytes(), unboundedRange);
-            assertThat(unboundedCount).isEqualTo(2L); // banana, z_last
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Verify set is empty
+			Long card = connection.zSetCommands().zCard(key.getBytes());
+			assertThat(card).isEqualTo(0L);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
 
-    @Test
-    void testLexicographicRemovalWithEdgeCases() {
-        String key = "test:zset:lex:complex:key";
-        
-        try {
-            // Setup test data with mixed content
-            Set<Tuple> tuples = new HashSet<>();
-            tuples.add(new DefaultTuple("01_numeric".getBytes(), 0.0));
-            tuples.add(new DefaultTuple("alpha".getBytes(), 0.0));
-            tuples.add(new DefaultTuple("beta".getBytes(), 0.0));
-            tuples.add(new DefaultTuple("gamma".getBytes(), 0.0));
-            tuples.add(new DefaultTuple("omega".getBytes(), 0.0));
-            tuples.add(new DefaultTuple("zulu".getBytes(), 0.0));
-            
-            connection.zSetCommands().zAdd(key.getBytes(), tuples, 
-                ValkeyZSetCommands.ZAddArgs.empty());
-            
-            // Test removal with inclusive bounds
-            Range<byte[]> removalRange = Range.closed("beta".getBytes(), "gamma".getBytes());
-            Long removalCount = connection.zSetCommands().zRemRangeByLex(key.getBytes(), removalRange);
-            assertThat(removalCount).isEqualTo(2L); // beta, gamma
-            
-            // Verify remaining elements
-            Long remainingCount = connection.zSetCommands().zCard(key.getBytes());
-            assertThat(remainingCount).isEqualTo(4L);
-            
-            // Test removal with exclusive bounds
-            Range<byte[]> exclusiveRemovalRange = Range.open("alpha".getBytes(), "omega".getBytes());
-            Long exclusiveRemovalCount = connection.zSetCommands().zRemRangeByLex(key.getBytes(), exclusiveRemovalRange);
-            assertThat(exclusiveRemovalCount).isEqualTo(0L); // No elements between "alpha" and "omega" exclusively
-            
-            // Test removal with unbounded lower bound
-            Range<byte[]> unboundedRemovalRange = Range.<byte[]>from(Range.Bound.unbounded())
-                .to(Range.Bound.inclusive("alpha".getBytes()));
-            Long unboundedRemovalCount = connection.zSetCommands().zRemRangeByLex(key.getBytes(), unboundedRemovalRange);
-            assertThat(unboundedRemovalCount).isEqualTo(2L); // 01_numeric, alpha
-            
-            // Final verification
-            Long finalCount = connection.zSetCommands().zCard(key.getBytes());
-            assertThat(finalCount).isEqualTo(2L); // omega, zulu should remain
-        } finally {
-            cleanupKey(key);
-        }
-    }
+	@Test
+	void testZMScore() {
+		String key = "test:zset:mscore:key";
 
-    @Test
-    void testLexicographicReverseOperationsWithBounds() {
-        String key = "test:zset:lex:reverse:key";
-        
-        try {
-            // Setup test data
-            Set<Tuple> tuples = new HashSet<>();
-            tuples.add(new DefaultTuple("first".getBytes(), 0.0));
-            tuples.add(new DefaultTuple("middle".getBytes(), 0.0));
-            tuples.add(new DefaultTuple("second".getBytes(), 0.0));
-            tuples.add(new DefaultTuple("third".getBytes(), 0.0));
-            tuples.add(new DefaultTuple("zebra".getBytes(), 0.0));
-            
-            connection.zSetCommands().zAdd(key.getBytes(), tuples, 
-                ValkeyZSetCommands.ZAddArgs.empty());
-            
-            // Test zRevRangeByLex with various bound combinations
-            Range<byte[]> reverseRange = Range.closed("middle".getBytes(), "third".getBytes());
-            Set<byte[]> reverseResult = connection.zSetCommands().zRevRangeByLex(key.getBytes(), 
-                reverseRange, Limit.unlimited());
-            assertThat(reverseResult).hasSize(3);
-            List<String> reverseList = reverseResult.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toList());
-            assertThat(reverseList).containsExactly("third", "second", "middle");
-            
-            // Test with limit
-            Set<byte[]> limitedResult = connection.zSetCommands().zRevRangeByLex(key.getBytes(), 
-                reverseRange, Limit.limit().count(2));
-            assertThat(limitedResult).hasSize(2);
-            List<String> limitedList = limitedResult.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toList());
-            assertThat(limitedList).containsExactly("third", "second");
-            
-            // Test with offset and limit
-            Set<byte[]> offsetResult = connection.zSetCommands().zRevRangeByLex(key.getBytes(), 
-                reverseRange, Limit.limit().offset(1).count(1));
-            assertThat(offsetResult).hasSize(1);
-            List<String> offsetList = offsetResult.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toList());
-            assertThat(offsetList).containsExactly("second");
-            
-            // Test zRangeStoreRevByLex
-            String destKey = "test:zset:lex:reverse:dest";
-            Long storeResult = connection.zSetCommands().zRangeStoreRevByLex(destKey.getBytes(), key.getBytes(), 
-                reverseRange, Limit.unlimited());
-            assertThat(storeResult).isEqualTo(3L);
-            
-            Set<byte[]> storedData = connection.zSetCommands().zRange(destKey.getBytes(), 0, -1);
-            List<String> storedList = storedData.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toList());
-            assertThat(storedList).containsExactly("middle", "second", "third");
-            
-            cleanupKey(destKey);
-        } finally {
-            cleanupKey(key);
-        }
-    }
+		try {
+			// Setup test data
+			Set<Tuple> tuples = new HashSet<>();
+			tuples.add(new DefaultTuple("member1".getBytes(), 1.0));
+			tuples.add(new DefaultTuple("member2".getBytes(), 2.0));
+			tuples.add(new DefaultTuple("member3".getBytes(), 3.0));
 
-    // ==================== Scan Operations ====================
+			connection.zSetCommands().zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
 
-    @Test
-    void testZScan() {
-        String key = "test:zset:scan:key";
-        
-        try {
-            // Setup test data
-            Set<Tuple> tuples = new HashSet<>();
-            for (int i = 0; i < 10; i++) {
-                tuples.add(new DefaultTuple(("member" + i).getBytes(), i * 1.0));
-            }
-            
-            connection.zSetCommands().zAdd(key.getBytes(), tuples, 
-                ValkeyZSetCommands.ZAddArgs.empty());
-            
-            // Test basic scan
-            ScanOptions options = ScanOptions.scanOptions().build();
-            Cursor<Tuple> cursor = connection.zSetCommands().zScan(key.getBytes(), options);
-            
-            java.util.List<Tuple> scannedTuples = new java.util.ArrayList<>();
-            while (cursor.hasNext()) {
-                scannedTuples.add(cursor.next());
-            }
-            cursor.close();
-            
-            // Should find all tuples
-            assertThat(scannedTuples).hasSize(10);
-            
-            // Test scan with pattern
-            ScanOptions patternOptions = ScanOptions.scanOptions().match("member[1-3]").build();
-            Cursor<Tuple> patternCursor = connection.zSetCommands().zScan(key.getBytes(), patternOptions);
-            
-            java.util.List<Tuple> patternTuples = new java.util.ArrayList<>();
-            while (patternCursor.hasNext()) {
-                patternTuples.add(patternCursor.next());
-            }
-            patternCursor.close();
-            
-            // Should find fewer tuples due to pattern filter
-            assertThat(patternTuples.size()).isLessThanOrEqualTo(3);
-            
-            // Test scan with count
-            ScanOptions countOptions = ScanOptions.scanOptions().count(2).build();
-            Cursor<Tuple> countCursor = connection.zSetCommands().zScan(key.getBytes(), countOptions);
-            
-            java.util.List<Tuple> countTuples = new java.util.ArrayList<>();
-            while (countCursor.hasNext()) {
-                countTuples.add(countCursor.next());
-            }
-            countCursor.close();
-            
-            // Should still find all tuples, but in smaller batches
-            assertThat(countTuples).hasSize(10);
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test zMScore for multiple members
+			List<Double> scores = connection.zSetCommands()
+				.zMScore(key.getBytes(), "member1".getBytes(), "member2".getBytes(), "nonexistent".getBytes(),
+						"member3".getBytes());
 
-    // ==================== PIPELINE MODE TESTS ====================
-    // All ZSet operations tested in pipeline mode to ensure proper null return handling
-    // and correct batch result processing via closePipeline()
+			assertThat(scores).hasSize(4);
+			assertThat(scores.get(0)).isEqualTo(1.0);
+			assertThat(scores.get(1)).isEqualTo(2.0);
+			assertThat(scores.get(2)).isNull(); // nonexistent member
+			assertThat(scores.get(3)).isEqualTo(3.0);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
 
-    @Test
-    void testBasicZSetOperationsInPipelineMode() {
-        String key = "test:zset:pipeline:basic";
-        
-        try {
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Queue basic operations - all should return null in pipeline mode
-            Set<Tuple> tuples = new HashSet<>();
-            tuples.add(new DefaultTuple("member1".getBytes(), 1.0));
-            tuples.add(new DefaultTuple("member2".getBytes(), 2.0));
-            tuples.add(new DefaultTuple("member3".getBytes(), 3.0));
-            
-            assertThat(connection.zSetCommands().zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty())).isNull();
-            assertThat(connection.zSetCommands().zCard(key.getBytes())).isNull();
-            assertThat(connection.zSetCommands().zScore(key.getBytes(), "member2".getBytes())).isNull();
-            assertThat(connection.zSetCommands().zMScore(key.getBytes(), "member1".getBytes(), "member2".getBytes())).isNull();
-            assertThat(connection.zSetCommands().zRank(key.getBytes(), "member2".getBytes())).isNull();
-            assertThat(connection.zSetCommands().zRevRank(key.getBytes(), "member2".getBytes())).isNull();
-            assertThat(connection.zSetCommands().zIncrBy(key.getBytes(), 1.5, "member2".getBytes())).isNull();
-            assertThat(connection.zSetCommands().zRem(key.getBytes(), "member1".getBytes())).isNull();
-            
-            // Execute pipeline
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(8);
-            assertThat((Long) results.get(0)).isEqualTo(3L); // zAdd result
-            assertThat((Long) results.get(1)).isEqualTo(3L); // zCard result
-            assertThat((Double) results.get(2)).isEqualTo(2.0); // zScore result
-            
-            @SuppressWarnings("unchecked")
-            List<Double> mScoreResult = (List<Double>) results.get(3);
-            assertThat(mScoreResult).containsExactly(1.0, 2.0); // zMScore result
-            
-            assertThat((Long) results.get(4)).isEqualTo(1L); // zRank result (0-based)
-            assertThat((Long) results.get(5)).isEqualTo(1L); // zRevRank result
-            assertThat((Double) results.get(6)).isEqualTo(3.5); // zIncrBy result
-            assertThat((Long) results.get(7)).isEqualTo(1L); // zRem result
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+	@Test
+	void testZIncrBy() {
+		String key = "test:zset:incrby:key";
 
-    @Test
-    void testRangeOperationsInPipelineMode() {
-        String key = "test:zset:pipeline:range";
-        
-        try {
-            // Setup test data
-            Set<Tuple> tuples = new HashSet<>();
-            tuples.add(new DefaultTuple("member1".getBytes(), 1.0));
-            tuples.add(new DefaultTuple("member2".getBytes(), 2.0));
-            tuples.add(new DefaultTuple("member3".getBytes(), 3.0));
-            tuples.add(new DefaultTuple("member4".getBytes(), 4.0));
-            tuples.add(new DefaultTuple("member5".getBytes(), 5.0));
-            
-            connection.zSetCommands().zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
-            
-            // Start pipeline
-            connection.openPipeline();
-            
-            Range<Double> scoreRange = Range.closed(2.0, 4.0);
-            Range<byte[]> lexRange = Range.closed("member2".getBytes(), "member4".getBytes());
-            
-            // Queue range operations - all should return null in pipeline mode
-            assertThat(connection.zSetCommands().zRange(key.getBytes(), 0, 2)).isNull();
-            assertThat(connection.zSetCommands().zRangeWithScores(key.getBytes(), 0, 2)).isNull();
-            assertThat(connection.zSetCommands().zRevRange(key.getBytes(), 0, 2)).isNull();
-            assertThat(connection.zSetCommands().zRevRangeWithScores(key.getBytes(), 0, 2)).isNull();
-            assertThat(connection.zSetCommands().zRangeByScore(key.getBytes(), scoreRange.map(Number.class::cast), Limit.unlimited())).isNull();
-            assertThat(connection.zSetCommands().zRangeByScoreWithScores(key.getBytes(), scoreRange.map(Number.class::cast), Limit.unlimited())).isNull();
-            assertThat(connection.zSetCommands().zRevRangeByScore(key.getBytes(), scoreRange.map(Number.class::cast), Limit.unlimited())).isNull();
-            assertThat(connection.zSetCommands().zRevRangeByScoreWithScores(key.getBytes(), scoreRange.map(Number.class::cast), Limit.unlimited())).isNull();
-            assertThat(connection.zSetCommands().zCount(key.getBytes(), scoreRange.map(Number.class::cast))).isNull();
-            
-            // Execute pipeline
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(9);
-            
-            @SuppressWarnings("unchecked")
-            Set<byte[]> range1 = (Set<byte[]>) results.get(0);
-            assertThat(range1).hasSize(3);
-            
-            @SuppressWarnings("unchecked")
-            Set<Tuple> rangeWithScores = (Set<Tuple>) results.get(1);
-            assertThat(rangeWithScores).hasSize(3);
-            
-            assertThat((Long) results.get(8)).isEqualTo(3L); // zCount result
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+		try {
+			// Add initial member
+			Set<Tuple> tuples = new HashSet<>();
+			tuples.add(new DefaultTuple("member1".getBytes(), 1.0));
+			connection.zSetCommands().zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
 
-    @Test
-    void testSetAlgebraOperationsInPipelineMode() {
-        String key1 = "test:zset:pipeline:set1";
-        String key2 = "test:zset:pipeline:set2";
-        String destKey = "test:zset:pipeline:dest";
-        
-        try {
-            // Setup test data
-            Set<Tuple> tuples1 = new HashSet<>();
-            tuples1.add(new DefaultTuple("a".getBytes(), 1.0));
-            tuples1.add(new DefaultTuple("b".getBytes(), 2.0));
-            tuples1.add(new DefaultTuple("c".getBytes(), 3.0));
-            
-            Set<Tuple> tuples2 = new HashSet<>();
-            tuples2.add(new DefaultTuple("b".getBytes(), 2.5));
-            tuples2.add(new DefaultTuple("c".getBytes(), 3.5));
-            tuples2.add(new DefaultTuple("d".getBytes(), 4.0));
-            
-            connection.zSetCommands().zAdd(key1.getBytes(), tuples1, ValkeyZSetCommands.ZAddArgs.empty());
-            connection.zSetCommands().zAdd(key2.getBytes(), tuples2, ValkeyZSetCommands.ZAddArgs.empty());
-            
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Queue set algebra operations - all should return null in pipeline mode
-            assertThat(connection.zSetCommands().zDiff(key1.getBytes(), key2.getBytes())).isNull();
-            assertThat(connection.zSetCommands().zDiffWithScores(key1.getBytes(), key2.getBytes())).isNull();
-            assertThat(connection.zSetCommands().zDiffStore(destKey.getBytes(), key1.getBytes(), key2.getBytes())).isNull();
-            assertThat(connection.zSetCommands().zInter(key1.getBytes(), key2.getBytes())).isNull();
-            assertThat(connection.zSetCommands().zInterWithScores(key1.getBytes(), key2.getBytes())).isNull();
-            assertThat(connection.zSetCommands().zInterStore(destKey.getBytes(), key1.getBytes(), key2.getBytes())).isNull();
-            assertThat(connection.zSetCommands().zUnion(key1.getBytes(), key2.getBytes())).isNull();
-            assertThat(connection.zSetCommands().zUnionWithScores(key1.getBytes(), key2.getBytes())).isNull();
-            assertThat(connection.zSetCommands().zUnionStore(destKey.getBytes(), key1.getBytes(), key2.getBytes())).isNull();
-            
-            // Execute pipeline
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(9);
-            
-            @SuppressWarnings("unchecked")
-            Set<byte[]> diffResult = (Set<byte[]>) results.get(0);
-            assertThat(diffResult).hasSize(1); // Only "a" in key1 but not key2
-            
-            assertThat((Long) results.get(2)).isEqualTo(1L); // zDiffStore result
-            assertThat((Long) results.get(5)).isEqualTo(2L); // zInterStore result
-            assertThat((Long) results.get(8)).isEqualTo(4L); // zUnionStore result
-            
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-            cleanupKey(destKey);
-        }
-    }
+			// Test incrementing existing member
+			Double newScore1 = connection.zSetCommands().zIncrBy(key.getBytes(), 2.5, "member1".getBytes());
+			assertThat(newScore1).isEqualTo(3.5);
 
-    @Test
-    void testPopAndRandomOperationsInPipelineMode() {
-        String key = "test:zset:pipeline:pop";
-        
-        try {
-            // Setup test data
-            Set<Tuple> tuples = new HashSet<>();
-            tuples.add(new DefaultTuple("member1".getBytes(), 1.0));
-            tuples.add(new DefaultTuple("member2".getBytes(), 2.0));
-            tuples.add(new DefaultTuple("member3".getBytes(), 3.0));
-            tuples.add(new DefaultTuple("member4".getBytes(), 4.0));
-            tuples.add(new DefaultTuple("member5".getBytes(), 5.0));
-            
-            connection.zSetCommands().zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
-            
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Queue pop and random operations - all should return null in pipeline mode
-            assertThat(connection.zSetCommands().zRandMember(key.getBytes())).isNull();
-            assertThat(connection.zSetCommands().zRandMember(key.getBytes(), 2)).isNull();
-            assertThat(connection.zSetCommands().zRandMemberWithScore(key.getBytes())).isNull();
-            assertThat(connection.zSetCommands().zRandMemberWithScore(key.getBytes(), 2)).isNull();
-            assertThat(connection.zSetCommands().zPopMin(key.getBytes())).isNull();
-            assertThat(connection.zSetCommands().zPopMax(key.getBytes())).isNull();
-            
-            // Execute pipeline
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(6);
-            
-            assertThat((byte[]) results.get(0)).isNotNull(); // random member
-            
-            @SuppressWarnings("unchecked")
-            List<byte[]> randomMembers = (List<byte[]>) results.get(1);
-            assertThat(randomMembers).hasSize(2);
-            
-            assertThat((Tuple) results.get(2)).isNotNull(); // random member with score
-            
-            @SuppressWarnings("unchecked")
-            List<Tuple> randomMembersWithScores = (List<Tuple>) results.get(3);
-            assertThat(randomMembersWithScores).hasSize(2);
-            
-            Tuple minTuple = (Tuple) results.get(4);
-            assertThat(minTuple).isNotNull();
-            assertThat(minTuple.getScore()).isEqualTo(1.0); // Should be the minimum
-            
-            Tuple maxTuple = (Tuple) results.get(5);
-            assertThat(maxTuple).isNotNull();
-            assertThat(maxTuple.getScore()).isEqualTo(5.0); // Should be the maximum
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Verify score was updated
+			Double score = connection.zSetCommands().zScore(key.getBytes(), "member1".getBytes());
+			assertThat(score).isEqualTo(3.5);
 
-    @Test
-    void testRangeStoreAndRemovalOperationsInPipelineMode() {
-        String srcKey = "test:zset:pipeline:rangestore:src";
-        String destKey = "test:zset:pipeline:rangestore:dest";
-        String remKey = "test:zset:pipeline:removal:key";
-        
-        try {
-            // Setup test data for range store operations
-            Set<Tuple> tuples = new HashSet<>();
-            tuples.add(new DefaultTuple("member1".getBytes(), 1.0));
-            tuples.add(new DefaultTuple("member2".getBytes(), 2.0));
-            tuples.add(new DefaultTuple("member3".getBytes(), 3.0));
-            tuples.add(new DefaultTuple("member4".getBytes(), 4.0));
-            tuples.add(new DefaultTuple("member5".getBytes(), 5.0));
-            
-            connection.zSetCommands().zAdd(srcKey.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
-            
-            // Setup test data for removal operations
-            connection.zSetCommands().zAdd(remKey.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
-            
-            // Start pipeline
-            connection.openPipeline();
-            
-            Range<Double> scoreRange = Range.closed(2.0, 4.0);
-            Range<byte[]> lexRange = Range.closed("member2".getBytes(), "member4".getBytes());
-            
-            // Queue range store operations - all should return null in pipeline mode
-            assertThat(connection.zSetCommands().zRangeStoreByScore(destKey.getBytes(), srcKey.getBytes(), 
-                scoreRange.map(Number.class::cast), Limit.unlimited())).isNull();
-            assertThat(connection.zSetCommands().zRangeStoreRevByScore(destKey.getBytes(), srcKey.getBytes(), 
-                scoreRange.map(Number.class::cast), Limit.unlimited())).isNull();
-            
-            // Queue removal operations - all should return null in pipeline mode
-            assertThat(connection.zSetCommands().zRemRange(remKey.getBytes(), 1, 3)).isNull();
-            assertThat(connection.zSetCommands().zRemRangeByScore(remKey.getBytes(), scoreRange.map(Number.class::cast))).isNull();
-            
-            // Execute pipeline
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(4);
-            assertThat((Long) results.get(0)).isEqualTo(3L); // zRangeStoreByScore result
-            assertThat((Long) results.get(1)).isEqualTo(3L); // zRangeStoreRevByScore result
-            assertThat((Long) results.get(2)).isEqualTo(3L); // zRemRange result
-            assertThat((Long) results.get(3)).isEqualTo(0L); // zRemRangeByScore result (already removed by previous operation)
-            
-        } finally {
-            cleanupKey(srcKey);
-            cleanupKey(destKey);
-            cleanupKey(remKey);
-        }
-    }
+			// Test incrementing non-existent member (should create with increment as
+			// score)
+			Double newScore2 = connection.zSetCommands().zIncrBy(key.getBytes(), 5.0, "member2".getBytes());
+			assertThat(newScore2).isEqualTo(5.0);
 
-    @Test
-    void testScanOperationsInPipelineMode() {
-        String key = "test:zset:pipeline:scan";
-        
-        try {
-            // Setup test data
-            Set<Tuple> tuples = new HashSet<>();
-            for (int i = 0; i < 5; i++) {
-                tuples.add(new DefaultTuple(("member" + i).getBytes(), i * 1.0));
-            }
-            
-            connection.zSetCommands().zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
-            
-            // Start pipeline
-            connection.openPipeline();
-            
-            // Note: zScan with cursor operations are complex in pipeline mode
-            // We test that the scan setup doesn't break pipeline mode
-            ScanOptions options = ScanOptions.scanOptions().count(2).build();
-            
-            // We can't easily test zScan in pipeline mode due to cursor nature
-            // But we can verify pipeline doesn't break with scan setup
-            assertThat(connection.zSetCommands().zCard(key.getBytes())).isNull();
-            
-            // Execute pipeline
-            List<Object> results = connection.closePipeline();
-            
-            // Verify results
-            assertThat(results).hasSize(1);
-            assertThat((Long) results.get(0)).isEqualTo(5L); // zCard result
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test negative increment
+			Double newScore3 = connection.zSetCommands().zIncrBy(key.getBytes(), -1.5, "member1".getBytes());
+			assertThat(newScore3).isEqualTo(2.0);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
 
-    // ==================== TRANSACTION MODE TESTS ====================
-    // All ZSet operations tested in transaction mode to ensure proper null return handling
-    // and correct atomic execution via exec()
+	// ==================== Range Operations ====================
 
-    @Test
-    void testBasicZSetOperationsInTransactionMode() {
-        String key = "test:zset:transaction:basic";
-        
-        try {
-            // Start transaction
-            connection.multi();
-            
-            // Queue basic operations - all should return null in transaction mode
-            Set<Tuple> tuples = new HashSet<>();
-            tuples.add(new DefaultTuple("member1".getBytes(), 1.0));
-            tuples.add(new DefaultTuple("member2".getBytes(), 2.0));
-            tuples.add(new DefaultTuple("member3".getBytes(), 3.0));
-            
-            assertThat(connection.zSetCommands().zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty())).isNull();
-            assertThat(connection.zSetCommands().zCard(key.getBytes())).isNull();
-            assertThat(connection.zSetCommands().zScore(key.getBytes(), "member2".getBytes())).isNull();
-            assertThat(connection.zSetCommands().zMScore(key.getBytes(), "member1".getBytes(), "member2".getBytes())).isNull();
-            assertThat(connection.zSetCommands().zRank(key.getBytes(), "member2".getBytes())).isNull();
-            assertThat(connection.zSetCommands().zRevRank(key.getBytes(), "member2".getBytes())).isNull();
-            assertThat(connection.zSetCommands().zIncrBy(key.getBytes(), 1.5, "member2".getBytes())).isNull();
-            assertThat(connection.zSetCommands().zRem(key.getBytes(), "member1".getBytes())).isNull();
-            
-            // Execute transaction
-            List<Object> results = connection.exec();
-            
-            // Verify results
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(8);
-            assertThat((Long) results.get(0)).isEqualTo(3L); // zAdd result
-            assertThat((Long) results.get(1)).isEqualTo(3L); // zCard result
-            assertThat((Double) results.get(2)).isEqualTo(2.0); // zScore result
-            
-            @SuppressWarnings("unchecked")
-            List<Double> mScoreResult = (List<Double>) results.get(3);
-            assertThat(mScoreResult).containsExactly(1.0, 2.0); // zMScore result
-            
-            assertThat((Long) results.get(4)).isEqualTo(1L); // zRank result (0-based)
-            assertThat((Long) results.get(5)).isEqualTo(1L); // zRevRank result
-            assertThat((Double) results.get(6)).isEqualTo(3.5); // zIncrBy result
-            assertThat((Long) results.get(7)).isEqualTo(1L); // zRem result
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+	@Test
+	void testZRangeAndZRevRange() {
+		String key = "test:zset:range:key";
 
-    @Test
-    void testRangeOperationsInTransactionMode() {
-        String key = "test:zset:transaction:range";
-        
-        try {
-            // Setup test data
-            Set<Tuple> tuples = new HashSet<>();
-            tuples.add(new DefaultTuple("member1".getBytes(), 1.0));
-            tuples.add(new DefaultTuple("member2".getBytes(), 2.0));
-            tuples.add(new DefaultTuple("member3".getBytes(), 3.0));
-            tuples.add(new DefaultTuple("member4".getBytes(), 4.0));
-            tuples.add(new DefaultTuple("member5".getBytes(), 5.0));
-            
-            connection.zSetCommands().zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
-            
-            // Start transaction
-            connection.multi();
-            
-            Range<Double> scoreRange = Range.closed(2.0, 4.0);
-            
-            // Queue range operations - all should return null in transaction mode
-            assertThat(connection.zSetCommands().zRange(key.getBytes(), 0, 2)).isNull();
-            assertThat(connection.zSetCommands().zRangeWithScores(key.getBytes(), 0, 2)).isNull();
-            assertThat(connection.zSetCommands().zRevRange(key.getBytes(), 0, 2)).isNull();
-            assertThat(connection.zSetCommands().zRevRangeWithScores(key.getBytes(), 0, 2)).isNull();
-            assertThat(connection.zSetCommands().zRangeByScore(key.getBytes(), scoreRange.map(Number.class::cast), Limit.unlimited())).isNull();
-            assertThat(connection.zSetCommands().zRangeByScoreWithScores(key.getBytes(), scoreRange.map(Number.class::cast), Limit.unlimited())).isNull();
-            assertThat(connection.zSetCommands().zRevRangeByScore(key.getBytes(), scoreRange.map(Number.class::cast), Limit.unlimited())).isNull();
-            assertThat(connection.zSetCommands().zRevRangeByScoreWithScores(key.getBytes(), scoreRange.map(Number.class::cast), Limit.unlimited())).isNull();
-            assertThat(connection.zSetCommands().zCount(key.getBytes(), scoreRange.map(Number.class::cast))).isNull();
-            
-            // Execute transaction
-            List<Object> results = connection.exec();
-            
-            // Verify results
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(9);
-            
-            @SuppressWarnings("unchecked")
-            Set<byte[]> range1 = (Set<byte[]>) results.get(0);
-            assertThat(range1).hasSize(3);
-            
-            @SuppressWarnings("unchecked")
-            Set<Tuple> rangeWithScores = (Set<Tuple>) results.get(1);
-            assertThat(rangeWithScores).hasSize(3);
-            
-            assertThat((Long) results.get(8)).isEqualTo(3L); // zCount result
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+		try {
+			// Setup test data with different scores
+			Set<Tuple> tuples = new HashSet<>();
+			tuples.add(new DefaultTuple("member1".getBytes(), 1.0));
+			tuples.add(new DefaultTuple("member2".getBytes(), 2.0));
+			tuples.add(new DefaultTuple("member3".getBytes(), 3.0));
+			tuples.add(new DefaultTuple("member4".getBytes(), 4.0));
+			tuples.add(new DefaultTuple("member5".getBytes(), 5.0));
 
-    @Test
-    void testSetAlgebraOperationsInTransactionMode() {
-        String key1 = "test:zset:transaction:set1";
-        String key2 = "test:zset:transaction:set2";
-        String destKey = "test:zset:transaction:dest";
-        
-        try {
-            // Setup test data
-            Set<Tuple> tuples1 = new HashSet<>();
-            tuples1.add(new DefaultTuple("a".getBytes(), 1.0));
-            tuples1.add(new DefaultTuple("b".getBytes(), 2.0));
-            tuples1.add(new DefaultTuple("c".getBytes(), 3.0));
-            
-            Set<Tuple> tuples2 = new HashSet<>();
-            tuples2.add(new DefaultTuple("b".getBytes(), 2.5));
-            tuples2.add(new DefaultTuple("c".getBytes(), 3.5));
-            tuples2.add(new DefaultTuple("d".getBytes(), 4.0));
-            
-            connection.zSetCommands().zAdd(key1.getBytes(), tuples1, ValkeyZSetCommands.ZAddArgs.empty());
-            connection.zSetCommands().zAdd(key2.getBytes(), tuples2, ValkeyZSetCommands.ZAddArgs.empty());
-            
-            // Start transaction
-            connection.multi();
-            
-            // Queue set algebra operations - all should return null in transaction mode
-            assertThat(connection.zSetCommands().zDiff(key1.getBytes(), key2.getBytes())).isNull();
-            assertThat(connection.zSetCommands().zDiffWithScores(key1.getBytes(), key2.getBytes())).isNull();
-            assertThat(connection.zSetCommands().zDiffStore(destKey.getBytes(), key1.getBytes(), key2.getBytes())).isNull();
-            assertThat(connection.zSetCommands().zInter(key1.getBytes(), key2.getBytes())).isNull();
-            assertThat(connection.zSetCommands().zInterWithScores(key1.getBytes(), key2.getBytes())).isNull();
-            assertThat(connection.zSetCommands().zInterStore(destKey.getBytes(), key1.getBytes(), key2.getBytes())).isNull();
-            assertThat(connection.zSetCommands().zUnion(key1.getBytes(), key2.getBytes())).isNull();
-            assertThat(connection.zSetCommands().zUnionWithScores(key1.getBytes(), key2.getBytes())).isNull();
-            assertThat(connection.zSetCommands().zUnionStore(destKey.getBytes(), key1.getBytes(), key2.getBytes())).isNull();
-            
-            // Execute transaction
-            List<Object> results = connection.exec();
-            
-            // Verify results
-            assertThat(results).isNotNull();
-            assertThat(results).hasSize(9);
-            
-            @SuppressWarnings("unchecked")
-            Set<byte[]> diffResult = (Set<byte[]>) results.get(0);
-            assertThat(diffResult).hasSize(1); // Only "a" in key1 but not key2
-            
-            assertThat((Long) results.get(2)).isEqualTo(1L); // zDiffStore result
-            assertThat((Long) results.get(5)).isEqualTo(2L); // zInterStore result
-            assertThat((Long) results.get(8)).isEqualTo(4L); // zUnionStore result
-            
-        } finally {
-            cleanupKey(key1);
-            cleanupKey(key2);
-            cleanupKey(destKey);
-        }
-    }
+			connection.zSetCommands().zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
 
-    @Test
-    void testTransactionDiscardWithZSetCommands() {
-        String key = "test:zset:transaction:discard";
-        
-        try {
-            // Start transaction
-            connection.multi();
-            
-            // Queue ZSet commands
-            Set<Tuple> tuples = new HashSet<>();
-            tuples.add(new DefaultTuple("shouldnotbeset".getBytes(), 1.0));
-            connection.zSetCommands().zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
-            connection.zSetCommands().zScore(key.getBytes(), "shouldnotbeset".getBytes());
-            
-            // Discard transaction
-            connection.discard();
-            
-            // Verify key does not exist (transaction was discarded)
-            Long card = connection.zSetCommands().zCard(key.getBytes());
-            assertThat(card).isEqualTo(0L);
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test zRange (ascending order)
+			Set<byte[]> range1 = connection.zSetCommands().zRange(key.getBytes(), 0, 2);
+			assertThat(range1).hasSize(3);
+			List<String> rangeList1 = range1.stream().map(String::new).collect(java.util.stream.Collectors.toList());
+			assertThat(rangeList1).containsExactly("member1", "member2", "member3");
 
-    @Test
-    void testWatchWithZSetCommandsTransaction() {
-        String watchKey = "test:zset:transaction:watch";
-        String otherKey = "test:zset:transaction:other";
-        
-        try {
-            // Setup initial data
-            Set<Tuple> tuples = new HashSet<>();
-            tuples.add(new DefaultTuple("initial".getBytes(), 1.0));
-            connection.zSetCommands().zAdd(watchKey.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
-            
-            // Watch the key
-            connection.watch(watchKey.getBytes());
-            
-            // Modify the watched key from "outside" the transaction
-            tuples.clear();
-            tuples.add(new DefaultTuple("modified".getBytes(), 2.0));
-            connection.zSetCommands().zAdd(watchKey.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
-            
-            // Start transaction
-            connection.multi();
-            
-            // Queue ZSet commands
-            tuples.clear();
-            tuples.add(new DefaultTuple("value".getBytes(), 3.0));
-            connection.zSetCommands().zAdd(otherKey.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
-            connection.zSetCommands().zScore(otherKey.getBytes(), "value".getBytes());
-            
-            // Execute transaction - should be aborted due to WATCH
-            List<Object> results = connection.exec();
-            
-            // Transaction should be aborted (results should be null)
-            assertThat(results).isNotNull().isEmpty();
-            
-            // Verify that the other key was not set
-            Long card = connection.zSetCommands().zCard(otherKey.getBytes());
-            assertThat(card).isEqualTo(0L);
-            
-        } finally {
-            cleanupKey(watchKey);
-            cleanupKey(otherKey);
-        }
-    }
+			// Test zRange with negative indices
+			Set<byte[]> range2 = connection.zSetCommands().zRange(key.getBytes(), -2, -1);
+			assertThat(range2).hasSize(2);
+			List<String> rangeList2 = range2.stream().map(String::new).collect(java.util.stream.Collectors.toList());
+			assertThat(rangeList2).containsExactly("member4", "member5");
 
-    // ==================== ADDITIONAL EDGE CASES ====================
-    // Additional comprehensive edge case testing for robustness
+			// Test zRangeWithScores
+			Set<Tuple> rangeWithScores = connection.zSetCommands().zRangeWithScores(key.getBytes(), 0, 2);
+			assertThat(rangeWithScores).hasSize(3);
 
-    @Test
-    void testZSetWithBinaryData() {
-        String key = "test:zset:binary:data";
-        
-        try {
-            // Test with binary data containing null bytes and various byte values
-            byte[] binaryValue = new byte[]{0x00, 0x01, 0x02, (byte) 0xFF, (byte) 0xFE, (byte) 0x80};
-            Set<Tuple> tuples = new HashSet<>();
-            tuples.add(new DefaultTuple(binaryValue, 1.0));
-            
-            Long addResult = connection.zSetCommands().zAdd(key.getBytes(), tuples, 
-                ValkeyZSetCommands.ZAddArgs.empty());
-            assertThat(addResult).isEqualTo(1L);
-            
-            // Verify binary data is preserved exactly
-            Double score = connection.zSetCommands().zScore(key.getBytes(), binaryValue);
-            assertThat(score).isEqualTo(1.0);
-            
-            Set<byte[]> range = connection.zSetCommands().zRange(key.getBytes(), 0, -1);
-            assertThat(range).hasSize(1);
-            assertThat(range.iterator().next()).isEqualTo(binaryValue);
-            
-            // Test binary data in range operations
-            Set<Tuple> rangeWithScores = connection.zSetCommands().zRangeWithScores(key.getBytes(), 0, -1);
-            assertThat(rangeWithScores).hasSize(1);
-            Tuple tuple = rangeWithScores.iterator().next();
-            assertThat(tuple.getValue()).isEqualTo(binaryValue);
-            assertThat(tuple.getScore()).isEqualTo(1.0);
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test zRevRange (descending order)
+			Set<byte[]> revRange = connection.zSetCommands().zRevRange(key.getBytes(), 0, 2);
+			assertThat(revRange).hasSize(3);
+			List<String> revRangeList = revRange.stream()
+				.map(String::new)
+				.collect(java.util.stream.Collectors.toList());
+			assertThat(revRangeList).containsExactly("member5", "member4", "member3");
 
-    @Test
-    void testZSetWithExtremeScoreValues() {
-        String key = "test:zset:extreme:scores";
-        
-        try {
-            // Test with extreme score values
-            Set<Tuple> tuples = new HashSet<>();
-            tuples.add(new DefaultTuple("negative_large".getBytes(), -Double.MAX_VALUE / 2));
-            tuples.add(new DefaultTuple("negative_small".getBytes(), -0.000001));
-            tuples.add(new DefaultTuple("zero".getBytes(), 0.0));
-            tuples.add(new DefaultTuple("positive_small".getBytes(), 0.000001));
-            tuples.add(new DefaultTuple("positive_large".getBytes(), Double.MAX_VALUE / 2));
-            tuples.add(new DefaultTuple("max_precision".getBytes(), 1.7976931348623157E308)); // Near Double.MAX_VALUE
-            
-            Long addResult = connection.zSetCommands().zAdd(key.getBytes(), tuples, 
-                ValkeyZSetCommands.ZAddArgs.empty());
-            assertThat(addResult).isEqualTo(6L);
-            
-            // Test ordering is maintained with extreme values
-            Set<byte[]> range = connection.zSetCommands().zRange(key.getBytes(), 0, -1);
-            List<String> orderedMembers = range.stream()
-                .map(String::new)
-                .collect(java.util.stream.Collectors.toList());
-            
-            assertThat(orderedMembers.get(0)).isEqualTo("negative_large");
-            assertThat(orderedMembers.get(1)).isEqualTo("negative_small");
-            assertThat(orderedMembers.get(2)).isEqualTo("zero");
-            assertThat(orderedMembers.get(3)).isEqualTo("positive_small");
-            assertThat(orderedMembers.get(4)).isEqualTo("positive_large");
-            assertThat(orderedMembers.get(5)).isEqualTo("max_precision");
-            
-            // Test range operations with extreme values
-            Range<Double> extremeRange = Range.closed(-Double.MAX_VALUE, Double.MAX_VALUE);
-            Long count = connection.zSetCommands().zCount(key.getBytes(), extremeRange.map(Number.class::cast));
-            assertThat(count).isEqualTo(6L);
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+			// Test zRevRangeWithScores
+			Set<Tuple> revRangeWithScores = connection.zSetCommands().zRevRangeWithScores(key.getBytes(), 0, 2);
+			assertThat(revRangeWithScores).hasSize(3);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
 
-    @Test
-    void testZSetLargeDatasetPerformance() {
-        String key = "test:zset:large:dataset:performance";
-        
-        try {
-            // Create a large dataset to test performance characteristics
-            Set<Tuple> tuples = new HashSet<>();
-            for (int i = 0; i < 10000; i++) {
-                tuples.add(new DefaultTuple(("member" + String.format("%05d", i)).getBytes(), i * 1.0));
-            }
-            
-            // Test large add operation
-            Long addResult = connection.zSetCommands().zAdd(key.getBytes(), tuples, 
-                ValkeyZSetCommands.ZAddArgs.empty());
-            assertThat(addResult).isEqualTo(10000L);
-            
-            // Test cardinality
-            Long card = connection.zSetCommands().zCard(key.getBytes());
-            assertThat(card).isEqualTo(10000L);
-            
-            // Test range operations on large dataset
-            Set<byte[]> range = connection.zSetCommands().zRange(key.getBytes(), 0, 99);
-            assertThat(range).hasSize(100);
-            
-        } finally {
-            cleanupKey(key);
-        }
-    }
+	@Test
+	void testZRangeByScore() {
+		String key = "test:zset:rangebyscore:key";
+
+		try {
+			// Setup test data
+			Set<Tuple> tuples = new HashSet<>();
+			tuples.add(new DefaultTuple("member1".getBytes(), 1.0));
+			tuples.add(new DefaultTuple("member2".getBytes(), 2.0));
+			tuples.add(new DefaultTuple("member3".getBytes(), 3.0));
+			tuples.add(new DefaultTuple("member4".getBytes(), 4.0));
+			tuples.add(new DefaultTuple("member5".getBytes(), 5.0));
+
+			connection.zSetCommands().zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
+
+			// Test zRangeByScore with Range
+			Range<Double> range1 = Range.closed(2.0, 4.0);
+			Set<byte[]> rangeResult1 = connection.zSetCommands()
+				.zRangeByScore(key.getBytes(), range1.map(Number.class::cast), Limit.unlimited());
+			assertThat(rangeResult1).hasSize(3);
+
+			// Test zRangeByScore with string bounds
+			Set<byte[]> rangeResult2 = connection.zSetCommands().zRangeByScore(key.getBytes(), "2.0", "4.0", 0, 10);
+			assertThat(rangeResult2).hasSize(3);
+
+			// Test zRangeByScore with limit
+			Set<byte[]> rangeResult3 = connection.zSetCommands()
+				.zRangeByScore(key.getBytes(), range1.map(Number.class::cast), Limit.limit().count(2));
+			assertThat(rangeResult3).hasSize(2);
+
+			// Test zRangeByScoreWithScores
+			Set<Tuple> rangeWithScores = connection.zSetCommands()
+				.zRangeByScoreWithScores(key.getBytes(), range1.map(Number.class::cast), Limit.unlimited());
+			assertThat(rangeWithScores).hasSize(3);
+
+			// Test zRevRangeByScore
+			Set<byte[]> revRangeResult = connection.zSetCommands()
+				.zRevRangeByScore(key.getBytes(), range1.map(Number.class::cast), Limit.unlimited());
+			assertThat(revRangeResult).hasSize(3);
+
+			// Test zRevRangeByScoreWithScores
+			Set<Tuple> revRangeWithScores = connection.zSetCommands()
+				.zRevRangeByScoreWithScores(key.getBytes(), range1.map(Number.class::cast), Limit.unlimited());
+			assertThat(revRangeWithScores).hasSize(3);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testZRangeByLex() {
+		String key = "test:zset:rangebylex:key";
+
+		try {
+			// Setup test data with same score for lexicographical ordering
+			Set<Tuple> tuples = new HashSet<>();
+			tuples.add(new DefaultTuple("a".getBytes(), 0.0));
+			tuples.add(new DefaultTuple("b".getBytes(), 0.0));
+			tuples.add(new DefaultTuple("c".getBytes(), 0.0));
+			tuples.add(new DefaultTuple("d".getBytes(), 0.0));
+			tuples.add(new DefaultTuple("e".getBytes(), 0.0));
+
+			connection.zSetCommands().zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
+
+			// Test zRangeByLex
+			Range<byte[]> lexRange = Range.closed("b".getBytes(), "d".getBytes());
+			Set<byte[]> lexResult = connection.zSetCommands().zRangeByLex(key.getBytes(), lexRange, Limit.unlimited());
+			assertThat(lexResult).hasSize(3);
+
+			List<String> lexResultList = lexResult.stream()
+				.map(String::new)
+				.collect(java.util.stream.Collectors.toList());
+			assertThat(lexResultList).containsExactly("b", "c", "d");
+
+			// Test zRevRangeByLex - should return results in reverse lexicographic order
+			Set<byte[]> revLexResult = connection.zSetCommands()
+				.zRevRangeByLex(key.getBytes(), lexRange, Limit.unlimited());
+			assertThat(revLexResult).hasSize(3);
+
+			List<String> revLexResultList = revLexResult.stream()
+				.map(String::new)
+				.collect(java.util.stream.Collectors.toList());
+			assertThat(revLexResultList).containsExactly("d", "c", "b");
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== Ranking Operations ====================
+
+	@Test
+	void testZRankAndZRevRank() {
+		String key = "test:zset:rank:key";
+
+		try {
+			// Setup test data
+			Set<Tuple> tuples = new HashSet<>();
+			tuples.add(new DefaultTuple("member1".getBytes(), 1.0));
+			tuples.add(new DefaultTuple("member2".getBytes(), 2.0));
+			tuples.add(new DefaultTuple("member3".getBytes(), 3.0));
+			tuples.add(new DefaultTuple("member4".getBytes(), 4.0));
+
+			connection.zSetCommands().zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
+
+			// Test zRank (0-based, ascending)
+			Long rank1 = connection.zSetCommands().zRank(key.getBytes(), "member1".getBytes());
+			assertThat(rank1).isEqualTo(0L);
+
+			Long rank2 = connection.zSetCommands().zRank(key.getBytes(), "member2".getBytes());
+			assertThat(rank2).isEqualTo(1L);
+
+			Long rank4 = connection.zSetCommands().zRank(key.getBytes(), "member4".getBytes());
+			assertThat(rank4).isEqualTo(3L);
+
+			// Test zRank for non-existent member
+			Long rankNonExistent = connection.zSetCommands().zRank(key.getBytes(), "nonexistent".getBytes());
+			assertThat(rankNonExistent).isNull();
+
+			// Test zRevRank (0-based, descending)
+			Long revRank1 = connection.zSetCommands().zRevRank(key.getBytes(), "member1".getBytes());
+			assertThat(revRank1).isEqualTo(3L);
+
+			Long revRank4 = connection.zSetCommands().zRevRank(key.getBytes(), "member4".getBytes());
+			assertThat(revRank4).isEqualTo(0L);
+
+			// Test zRevRank for non-existent member
+			Long revRankNonExistent = connection.zSetCommands().zRevRank(key.getBytes(), "nonexistent".getBytes());
+			assertThat(revRankNonExistent).isNull();
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== Counting Operations ====================
+
+	@Test
+	void testZCount() {
+		String key = "test:zset:count:key";
+
+		try {
+			// Setup test data
+			Set<Tuple> tuples = new HashSet<>();
+			tuples.add(new DefaultTuple("member1".getBytes(), 1.0));
+			tuples.add(new DefaultTuple("member2".getBytes(), 2.0));
+			tuples.add(new DefaultTuple("member3".getBytes(), 3.0));
+			tuples.add(new DefaultTuple("member4".getBytes(), 4.0));
+			tuples.add(new DefaultTuple("member5".getBytes(), 5.0));
+
+			connection.zSetCommands().zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
+
+			// Test zCount with inclusive range
+			Range<Double> range1 = Range.closed(2.0, 4.0);
+			Long count1 = connection.zSetCommands().zCount(key.getBytes(), range1.map(Number.class::cast));
+			assertThat(count1).isEqualTo(3L);
+
+			// Test zCount with exclusive range
+			Range<Double> range2 = Range.open(2.0, 4.0);
+			Long count2 = connection.zSetCommands().zCount(key.getBytes(), range2.map(Number.class::cast));
+			assertThat(count2).isEqualTo(1L); // Only member3 with score 3.0
+
+			// Test zCount with unbounded range
+			Range<Double> range3 = Range.from(Range.Bound.exclusive(3.0)).to(Range.Bound.unbounded());
+			Long count3 = connection.zSetCommands().zCount(key.getBytes(), range3.map(Number.class::cast));
+			assertThat(count3).isEqualTo(2L); // member4 and member5
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testZLexCount() {
+		String key = "test:zset:lexcount:key";
+
+		try {
+			// Setup test data with same score for lexicographical ordering
+			Set<Tuple> tuples = new HashSet<>();
+			tuples.add(new DefaultTuple("a".getBytes(), 0.0));
+			tuples.add(new DefaultTuple("b".getBytes(), 0.0));
+			tuples.add(new DefaultTuple("c".getBytes(), 0.0));
+			tuples.add(new DefaultTuple("d".getBytes(), 0.0));
+			tuples.add(new DefaultTuple("e".getBytes(), 0.0));
+
+			connection.zSetCommands().zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
+
+			// Test zLexCount with inclusive range
+			Range<byte[]> lexRange1 = Range.closed("b".getBytes(), "d".getBytes());
+			Long lexCount1 = connection.zSetCommands().zLexCount(key.getBytes(), lexRange1);
+			assertThat(lexCount1).isEqualTo(3L);
+
+			// Test zLexCount with exclusive range
+			Range<byte[]> lexRange2 = Range.open("b".getBytes(), "d".getBytes());
+			Long lexCount2 = connection.zSetCommands().zLexCount(key.getBytes(), lexRange2);
+			assertThat(lexCount2).isEqualTo(1L); // Only "c"
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== Random and Pop Operations ====================
+
+	@Test
+	void testZRandMember() {
+		String key = "test:zset:randmember:key";
+
+		try {
+			// Test zRandMember on empty set
+			byte[] emptyRand = connection.zSetCommands().zRandMember(key.getBytes());
+			assertThat(emptyRand).isNull();
+
+			// Setup test data
+			Set<Tuple> tuples = new HashSet<>();
+			tuples.add(new DefaultTuple("member1".getBytes(), 1.0));
+			tuples.add(new DefaultTuple("member2".getBytes(), 2.0));
+			tuples.add(new DefaultTuple("member3".getBytes(), 3.0));
+
+			connection.zSetCommands().zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
+
+			// Test single random member
+			byte[] randomMember = connection.zSetCommands().zRandMember(key.getBytes());
+			assertThat(randomMember).isNotNull();
+			String randomMemberStr = new String(randomMember);
+			assertThat(randomMemberStr).isIn("member1", "member2", "member3");
+
+			// Test multiple random members
+			List<byte[]> randomMembers = connection.zSetCommands().zRandMember(key.getBytes(), 2);
+			assertThat(randomMembers).hasSize(2);
+
+			// Test zRandMemberWithScore
+			Tuple randomTuple = connection.zSetCommands().zRandMemberWithScore(key.getBytes());
+			assertThat(randomTuple).isNotNull();
+			assertThat(randomTuple.getScore()).isIn(1.0, 2.0, 3.0);
+
+			// Test zRandMemberWithScore with count
+			List<Tuple> randomTuples = connection.zSetCommands().zRandMemberWithScore(key.getBytes(), 2);
+			assertThat(randomTuples).hasSize(2);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testZPopMinAndZPopMax() {
+		String key = "test:zset:pop:key";
+
+		try {
+			// Test pop on empty set
+			Tuple emptyPop = connection.zSetCommands().zPopMin(key.getBytes());
+			assertThat(emptyPop).isNull();
+
+			// Setup test data
+			Set<Tuple> tuples = new HashSet<>();
+			tuples.add(new DefaultTuple("member1".getBytes(), 1.0));
+			tuples.add(new DefaultTuple("member2".getBytes(), 2.0));
+			tuples.add(new DefaultTuple("member3".getBytes(), 3.0));
+
+			connection.zSetCommands().zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
+
+			// Test zPopMin single
+			Tuple minTuple = connection.zSetCommands().zPopMin(key.getBytes());
+			assertThat(minTuple).isNotNull();
+			assertThat(minTuple.getScore()).isEqualTo(1.0);
+			assertThat(new String(minTuple.getValue())).isEqualTo("member1");
+
+			// Test zPopMax single
+			Tuple maxTuple = connection.zSetCommands().zPopMax(key.getBytes());
+			assertThat(maxTuple).isNotNull();
+			assertThat(maxTuple.getScore()).isEqualTo(3.0);
+			assertThat(new String(maxTuple.getValue())).isEqualTo("member3");
+
+			// Add more data for multiple pop tests
+			tuples.clear();
+			tuples.add(new DefaultTuple("member4".getBytes(), 4.0));
+			tuples.add(new DefaultTuple("member5".getBytes(), 5.0));
+			connection.zSetCommands().zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
+
+			// Test zPopMin multiple
+			Set<Tuple> minTuples = connection.zSetCommands().zPopMin(key.getBytes(), 2);
+			assertThat(minTuples).hasSize(2);
+
+			// Test zPopMax multiple
+			Set<Tuple> maxTuples = connection.zSetCommands().zPopMax(key.getBytes(), 2);
+			assertThat(maxTuples).hasSize(1); // Only 1 element remaining after previous
+												// operations
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testZPopMinAndZPopMaxOrdering() {
+		String key = "test:zset:pop:ordering:key";
+
+		try {
+			// Setup test data with specific scores to test ordering
+			Set<Tuple> tuples = new HashSet<>();
+			tuples.add(new DefaultTuple("low".getBytes(), 1.0));
+			tuples.add(new DefaultTuple("medium".getBytes(), 2.0));
+			tuples.add(new DefaultTuple("high".getBytes(), 3.0));
+			tuples.add(new DefaultTuple("highest".getBytes(), 4.0));
+
+			connection.zSetCommands().zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
+
+			// Test zPopMin multiple - should return in ascending order (lowest scores
+			// first)
+			Set<Tuple> minTuples = connection.zSetCommands().zPopMin(key.getBytes(), 2);
+			assertThat(minTuples).hasSize(2);
+
+			// Convert to list to check ordering
+			java.util.List<Tuple> minList = new java.util.ArrayList<>(minTuples);
+			assertThat(minList.get(0).getScore()).isEqualTo(1.0);
+			assertThat(new String(minList.get(0).getValue())).isEqualTo("low");
+			assertThat(minList.get(1).getScore()).isEqualTo(2.0);
+			assertThat(new String(minList.get(1).getValue())).isEqualTo("medium");
+
+			// Test zPopMax multiple - should return in descending order (highest scores
+			// first)
+			Set<Tuple> maxTuples = connection.zSetCommands().zPopMax(key.getBytes(), 2);
+			assertThat(maxTuples).hasSize(2);
+
+			// Convert to list to check ordering
+			java.util.List<Tuple> maxList = new java.util.ArrayList<>(maxTuples);
+			assertThat(maxList.get(0).getScore()).isEqualTo(4.0);
+			assertThat(new String(maxList.get(0).getValue())).isEqualTo("highest");
+			assertThat(maxList.get(1).getScore()).isEqualTo(3.0);
+			assertThat(new String(maxList.get(1).getValue())).isEqualTo("high");
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testBlockingPopOperations() {
+		String key = "test:zset:blocking:pop:key";
+
+		try {
+			// Setup test data
+			Set<Tuple> tuples = new HashSet<>();
+			tuples.add(new DefaultTuple("member1".getBytes(), 1.0));
+			tuples.add(new DefaultTuple("member2".getBytes(), 2.0));
+
+			connection.zSetCommands().zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
+
+			// Test bZPopMin with short timeout (should return immediately since data
+			// exists)
+			Tuple minTuple = connection.zSetCommands().bZPopMin(key.getBytes(), 1, TimeUnit.SECONDS);
+			assertThat(minTuple).isNotNull();
+			assertThat(minTuple.getScore()).isEqualTo(1.0);
+			assertThat(new String(minTuple.getValue())).isEqualTo("member1");
+
+			// Test bZPopMax with short timeout (should return immediately since data
+			// exists)
+			Tuple maxTuple = connection.zSetCommands().bZPopMax(key.getBytes(), 1, TimeUnit.SECONDS);
+			assertThat(maxTuple).isNotNull();
+			assertThat(maxTuple.getScore()).isEqualTo(2.0);
+			assertThat(new String(maxTuple.getValue())).isEqualTo("member2");
+
+			// Test bZPopMin on empty set with short timeout (should return null after
+			// timeout)
+			Tuple emptyResult = connection.zSetCommands().bZPopMin(key.getBytes(), 1, TimeUnit.SECONDS);
+			assertThat(emptyResult).isNull();
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== Set Algebra Operations ====================
+
+	@Test
+	void testZDiff() {
+		String key1 = "test:zset:diff:key1";
+		String key2 = "test:zset:diff:key2";
+
+		try {
+			// Setup test data
+			Set<Tuple> tuples1 = new HashSet<>();
+			tuples1.add(new DefaultTuple("a".getBytes(), 1.0));
+			tuples1.add(new DefaultTuple("b".getBytes(), 2.0));
+			tuples1.add(new DefaultTuple("c".getBytes(), 3.0));
+
+			Set<Tuple> tuples2 = new HashSet<>();
+			tuples2.add(new DefaultTuple("b".getBytes(), 2.5));
+			tuples2.add(new DefaultTuple("d".getBytes(), 4.0));
+
+			connection.zSetCommands().zAdd(key1.getBytes(), tuples1, ValkeyZSetCommands.ZAddArgs.empty());
+			connection.zSetCommands().zAdd(key2.getBytes(), tuples2, ValkeyZSetCommands.ZAddArgs.empty());
+
+			// Test zDiff
+			Set<byte[]> diff = connection.zSetCommands().zDiff(key1.getBytes(), key2.getBytes());
+			assertThat(diff).hasSize(2);
+			Set<String> diffStrings = diff.stream().map(String::new).collect(java.util.stream.Collectors.toSet());
+			assertThat(diffStrings).containsExactlyInAnyOrder("a", "c");
+
+			// Test zDiffWithScores
+			Set<Tuple> diffWithScores = connection.zSetCommands().zDiffWithScores(key1.getBytes(), key2.getBytes());
+			assertThat(diffWithScores).hasSize(2);
+
+			// Test zDiffStore
+			String destKey = "test:zset:diff:dest";
+			Long storeResult = connection.zSetCommands()
+				.zDiffStore(destKey.getBytes(), key1.getBytes(), key2.getBytes());
+			assertThat(storeResult).isEqualTo(2L);
+
+			cleanupKey(destKey);
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+		}
+	}
+
+	@Test
+	void testZInter() {
+		String key1 = "test:zset:inter:key1";
+		String key2 = "test:zset:inter:key2";
+
+		try {
+			// Setup test data
+			Set<Tuple> tuples1 = new HashSet<>();
+			tuples1.add(new DefaultTuple("a".getBytes(), 1.0));
+			tuples1.add(new DefaultTuple("b".getBytes(), 2.0));
+			tuples1.add(new DefaultTuple("c".getBytes(), 3.0));
+
+			Set<Tuple> tuples2 = new HashSet<>();
+			tuples2.add(new DefaultTuple("b".getBytes(), 2.5));
+			tuples2.add(new DefaultTuple("c".getBytes(), 3.5));
+			tuples2.add(new DefaultTuple("d".getBytes(), 4.0));
+
+			connection.zSetCommands().zAdd(key1.getBytes(), tuples1, ValkeyZSetCommands.ZAddArgs.empty());
+			connection.zSetCommands().zAdd(key2.getBytes(), tuples2, ValkeyZSetCommands.ZAddArgs.empty());
+
+			// Test zInter
+			Set<byte[]> inter = connection.zSetCommands().zInter(key1.getBytes(), key2.getBytes());
+			assertThat(inter).hasSize(2);
+			Set<String> interStrings = inter.stream().map(String::new).collect(java.util.stream.Collectors.toSet());
+			assertThat(interStrings).containsExactlyInAnyOrder("b", "c");
+
+			// Test zInterWithScores
+			Set<Tuple> interWithScores = connection.zSetCommands().zInterWithScores(key1.getBytes(), key2.getBytes());
+			assertThat(interWithScores).hasSize(2);
+
+			// Test zInterWithScores with weights and aggregate
+			Weights weights = Weights.of(1.0, 2.0);
+			Set<Tuple> interWeighted = connection.zSetCommands()
+				.zInterWithScores(Aggregate.SUM, weights, key1.getBytes(), key2.getBytes());
+			assertThat(interWeighted).hasSize(2);
+
+			// Test zInterStore
+			String destKey = "test:zset:inter:dest";
+			Long storeResult = connection.zSetCommands()
+				.zInterStore(destKey.getBytes(), key1.getBytes(), key2.getBytes());
+			assertThat(storeResult).isEqualTo(2L);
+
+			// Test zInterStore with weights and aggregate
+			Long storeWeightedResult = connection.zSetCommands()
+				.zInterStore(destKey.getBytes(), Aggregate.MAX, weights, key1.getBytes(), key2.getBytes());
+			assertThat(storeWeightedResult).isEqualTo(2L);
+
+			cleanupKey(destKey);
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+		}
+	}
+
+	@Test
+	void testZUnion() {
+		String key1 = "test:zset:union:key1";
+		String key2 = "test:zset:union:key2";
+
+		try {
+			// Setup test data
+			Set<Tuple> tuples1 = new HashSet<>();
+			tuples1.add(new DefaultTuple("a".getBytes(), 1.0));
+			tuples1.add(new DefaultTuple("b".getBytes(), 2.0));
+
+			Set<Tuple> tuples2 = new HashSet<>();
+			tuples2.add(new DefaultTuple("b".getBytes(), 2.5));
+			tuples2.add(new DefaultTuple("c".getBytes(), 3.0));
+
+			connection.zSetCommands().zAdd(key1.getBytes(), tuples1, ValkeyZSetCommands.ZAddArgs.empty());
+			connection.zSetCommands().zAdd(key2.getBytes(), tuples2, ValkeyZSetCommands.ZAddArgs.empty());
+
+			// Test zUnion
+			Set<byte[]> union = connection.zSetCommands().zUnion(key1.getBytes(), key2.getBytes());
+			assertThat(union).hasSize(3);
+			Set<String> unionStrings = union.stream().map(String::new).collect(java.util.stream.Collectors.toSet());
+			assertThat(unionStrings).containsExactlyInAnyOrder("a", "b", "c");
+
+			// Test zUnionWithScores
+			Set<Tuple> unionWithScores = connection.zSetCommands().zUnionWithScores(key1.getBytes(), key2.getBytes());
+			assertThat(unionWithScores).hasSize(3);
+
+			// Test zUnionWithScores with weights and aggregate
+			Weights weights = Weights.of(1.0, 2.0);
+			Set<Tuple> unionWeighted = connection.zSetCommands()
+				.zUnionWithScores(Aggregate.MIN, weights, key1.getBytes(), key2.getBytes());
+			assertThat(unionWeighted).hasSize(3);
+
+			// Test zUnionStore
+			String destKey = "test:zset:union:dest";
+			Long storeResult = connection.zSetCommands()
+				.zUnionStore(destKey.getBytes(), key1.getBytes(), key2.getBytes());
+			assertThat(storeResult).isEqualTo(3L);
+
+			// Test zUnionStore with weights and aggregate
+			Long storeWeightedResult = connection.zSetCommands()
+				.zUnionStore(destKey.getBytes(), Aggregate.SUM, weights, key1.getBytes(), key2.getBytes());
+			assertThat(storeWeightedResult).isEqualTo(3L);
+
+			cleanupKey(destKey);
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+		}
+	}
+
+	// ==================== Range Store Operations ====================
+
+	@Test
+	void testZRangeStore() {
+		String srcKey = "test:zset:rangestore:src";
+		String destKey = "test:zset:rangestore:dest";
+
+		try {
+			// Setup test data
+			Set<Tuple> tuples = new HashSet<>();
+			tuples.add(new DefaultTuple("member1".getBytes(), 1.0));
+			tuples.add(new DefaultTuple("member2".getBytes(), 2.0));
+			tuples.add(new DefaultTuple("member3".getBytes(), 3.0));
+			tuples.add(new DefaultTuple("member4".getBytes(), 4.0));
+			tuples.add(new DefaultTuple("member5".getBytes(), 5.0));
+
+			connection.zSetCommands().zAdd(srcKey.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
+
+			// Test zRangeStoreByScore
+			Range<Double> scoreRange = Range.closed(2.0, 4.0);
+			Long storeByScoreResult = connection.zSetCommands()
+				.zRangeStoreByScore(destKey.getBytes(), srcKey.getBytes(), scoreRange.map(Number.class::cast),
+						Limit.unlimited());
+			assertThat(storeByScoreResult).isEqualTo(3L);
+
+			// Test zRangeStoreRevByScore
+			Long storeRevByScoreResult = connection.zSetCommands()
+				.zRangeStoreRevByScore(destKey.getBytes(), srcKey.getBytes(), scoreRange.map(Number.class::cast),
+						Limit.unlimited());
+			assertThat(storeRevByScoreResult).isEqualTo(3L);
+
+			// Test zRangeStoreByLex (need same scores)
+			String srcLexKey = "test:zset:rangestore:srclex";
+			Set<Tuple> lexTuples = new HashSet<>();
+			lexTuples.add(new DefaultTuple("a".getBytes(), 0.0));
+			lexTuples.add(new DefaultTuple("b".getBytes(), 0.0));
+			lexTuples.add(new DefaultTuple("c".getBytes(), 0.0));
+			lexTuples.add(new DefaultTuple("d".getBytes(), 0.0));
+
+			connection.zSetCommands().zAdd(srcLexKey.getBytes(), lexTuples, ValkeyZSetCommands.ZAddArgs.empty());
+
+			Range<byte[]> lexRange = Range.closed("b".getBytes(), "d".getBytes());
+			Long storeByLexResult = connection.zSetCommands()
+				.zRangeStoreByLex(destKey.getBytes(), srcLexKey.getBytes(), lexRange, Limit.unlimited());
+			assertThat(storeByLexResult).isEqualTo(3L);
+
+			// Test zRangeStoreRevByLex
+			Long storeRevByLexResult = connection.zSetCommands()
+				.zRangeStoreRevByLex(destKey.getBytes(), srcLexKey.getBytes(), lexRange, Limit.unlimited());
+			assertThat(storeRevByLexResult).isEqualTo(3L);
+
+			cleanupKey(srcLexKey);
+		}
+		finally {
+			cleanupKey(srcKey);
+			cleanupKey(destKey);
+		}
+	}
+
+	// ==================== Removal Operations ====================
+
+	@Test
+	void testZRemRange() {
+		String key = "test:zset:remrange:key";
+
+		try {
+			// Setup test data
+			Set<Tuple> tuples = new HashSet<>();
+			tuples.add(new DefaultTuple("member1".getBytes(), 1.0));
+			tuples.add(new DefaultTuple("member2".getBytes(), 2.0));
+			tuples.add(new DefaultTuple("member3".getBytes(), 3.0));
+			tuples.add(new DefaultTuple("member4".getBytes(), 4.0));
+			tuples.add(new DefaultTuple("member5".getBytes(), 5.0));
+
+			connection.zSetCommands().zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
+
+			// Test zRemRange by rank
+			Long remRangeResult = connection.zSetCommands().zRemRange(key.getBytes(), 1, 3);
+			assertThat(remRangeResult).isEqualTo(3L); // Removed member2, member3, member4
+
+			// Verify remaining members
+			Long remainingCount = connection.zSetCommands().zCard(key.getBytes());
+			assertThat(remainingCount).isEqualTo(2L); // member1 and member5 should remain
+
+			// Test zRemRangeByScore
+			tuples.clear();
+			tuples.add(new DefaultTuple("member2".getBytes(), 2.0));
+			tuples.add(new DefaultTuple("member3".getBytes(), 3.0));
+			tuples.add(new DefaultTuple("member4".getBytes(), 4.0));
+			connection.zSetCommands().zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
+
+			Range<Double> scoreRange = Range.closed(2.0, 4.0);
+			Long remByScoreResult = connection.zSetCommands()
+				.zRemRangeByScore(key.getBytes(), scoreRange.map(Number.class::cast));
+			assertThat(remByScoreResult).isEqualTo(3L);
+
+			// Test zRemRangeByLex (need same scores)
+			tuples.clear();
+			tuples.add(new DefaultTuple("a".getBytes(), 0.0));
+			tuples.add(new DefaultTuple("b".getBytes(), 0.0));
+			tuples.add(new DefaultTuple("c".getBytes(), 0.0));
+			tuples.add(new DefaultTuple("d".getBytes(), 0.0));
+			connection.zSetCommands().zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
+
+			Range<byte[]> lexRange = Range.closed("b".getBytes(), "d".getBytes());
+			Long remByLexResult = connection.zSetCommands().zRemRangeByLex(key.getBytes(), lexRange);
+			assertThat(remByLexResult).isEqualTo(3L);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== Comprehensive Lexicographic Range Tests ====================
+
+	@Test
+	void testLexicographicRangeEdgeCases() {
+		String key = "test:zset:lex:bounds:key";
+
+		try {
+			// Setup test data with same score for lexicographical ordering
+			Set<Tuple> tuples = new HashSet<>();
+			tuples.add(new DefaultTuple("apple".getBytes(), 0.0));
+			tuples.add(new DefaultTuple("banana".getBytes(), 0.0));
+			tuples.add(new DefaultTuple("cherry".getBytes(), 0.0));
+			tuples.add(new DefaultTuple("date".getBytes(), 0.0));
+			tuples.add(new DefaultTuple("elderberry".getBytes(), 0.0));
+			tuples.add(new DefaultTuple("fig".getBytes(), 0.0));
+
+			connection.zSetCommands().zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
+
+			// Test inclusive lower and upper bounds [banana, date]
+			Range<byte[]> inclusiveRange = Range.closed("banana".getBytes(), "date".getBytes());
+			Set<byte[]> inclusiveResult = connection.zSetCommands()
+				.zRangeByLex(key.getBytes(), inclusiveRange, Limit.unlimited());
+			assertThat(inclusiveResult).hasSize(3);
+			List<String> inclusiveList = inclusiveResult.stream()
+				.map(String::new)
+				.collect(java.util.stream.Collectors.toList());
+			assertThat(inclusiveList).containsExactly("banana", "cherry", "date");
+
+			// Test exclusive lower bound (banana, elderberry]
+			Range<byte[]> exclusiveLowerRange = Range.from(Range.Bound.exclusive("banana".getBytes()))
+				.to(Range.Bound.inclusive("elderberry".getBytes()));
+			Set<byte[]> exclusiveLowerResult = connection.zSetCommands()
+				.zRangeByLex(key.getBytes(), exclusiveLowerRange, Limit.unlimited());
+			assertThat(exclusiveLowerResult).hasSize(3);
+			List<String> exclusiveLowerList = exclusiveLowerResult.stream()
+				.map(String::new)
+				.collect(java.util.stream.Collectors.toList());
+			assertThat(exclusiveLowerList).containsExactly("cherry", "date", "elderberry");
+
+			// Test exclusive upper bound [cherry, elderberry)
+			Range<byte[]> exclusiveUpperRange = Range.from(Range.Bound.inclusive("cherry".getBytes()))
+				.to(Range.Bound.exclusive("elderberry".getBytes()));
+			Set<byte[]> exclusiveUpperResult = connection.zSetCommands()
+				.zRangeByLex(key.getBytes(), exclusiveUpperRange, Limit.unlimited());
+			assertThat(exclusiveUpperResult).hasSize(2);
+			List<String> exclusiveUpperList = exclusiveUpperResult.stream()
+				.map(String::new)
+				.collect(java.util.stream.Collectors.toList());
+			assertThat(exclusiveUpperList).containsExactly("cherry", "date");
+
+			// Test both bounds exclusive (banana, date)
+			Range<byte[]> bothExclusiveRange = Range.open("banana".getBytes(), "date".getBytes());
+			Set<byte[]> bothExclusiveResult = connection.zSetCommands()
+				.zRangeByLex(key.getBytes(), bothExclusiveRange, Limit.unlimited());
+			assertThat(bothExclusiveResult).hasSize(1);
+			List<String> bothExclusiveList = bothExclusiveResult.stream()
+				.map(String::new)
+				.collect(java.util.stream.Collectors.toList());
+			assertThat(bothExclusiveList).containsExactly("cherry");
+
+			// Test unbounded lower range (-, date]
+			Range<byte[]> unboundedLowerRange = Range.<byte[]>from(Range.Bound.unbounded())
+				.to(Range.Bound.inclusive("date".getBytes()));
+			Set<byte[]> unboundedLowerResult = connection.zSetCommands()
+				.zRangeByLex(key.getBytes(), unboundedLowerRange, Limit.unlimited());
+			assertThat(unboundedLowerResult).hasSize(4);
+			List<String> unboundedLowerList = unboundedLowerResult.stream()
+				.map(String::new)
+				.collect(java.util.stream.Collectors.toList());
+			assertThat(unboundedLowerList).containsExactly("apple", "banana", "cherry", "date");
+
+			// Test unbounded upper range [cherry, +)
+			Range<byte[]> unboundedUpperRange = Range.<byte[]>from(Range.Bound.inclusive("cherry".getBytes()))
+				.to(Range.Bound.unbounded());
+			Set<byte[]> unboundedUpperResult = connection.zSetCommands()
+				.zRangeByLex(key.getBytes(), unboundedUpperRange, Limit.unlimited());
+			assertThat(unboundedUpperResult).hasSize(4);
+			List<String> unboundedUpperList = unboundedUpperResult.stream()
+				.map(String::new)
+				.collect(java.util.stream.Collectors.toList());
+			assertThat(unboundedUpperList).containsExactly("cherry", "date", "elderberry", "fig");
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testLexicographicCountWithComplexBounds() {
+		String key = "test:zset:lex:edge:key";
+
+		try {
+			// Setup test data with special characters and edge cases
+			Set<Tuple> tuples = new HashSet<>();
+			tuples.add(new DefaultTuple("!special".getBytes(), 0.0));
+			tuples.add(new DefaultTuple("@symbol".getBytes(), 0.0));
+			tuples.add(new DefaultTuple("Apple".getBytes(), 0.0)); // Capital A
+			tuples.add(new DefaultTuple("apple".getBytes(), 0.0)); // Lower case a
+			tuples.add(new DefaultTuple("banana".getBytes(), 0.0));
+			tuples.add(new DefaultTuple("z_last".getBytes(), 0.0));
+
+			connection.zSetCommands().zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
+
+			// Test count with inclusive bounds including special characters
+			Range<byte[]> specialRange = Range.closed("!special".getBytes(), "Apple".getBytes());
+			Long specialCount = connection.zSetCommands().zLexCount(key.getBytes(), specialRange);
+			assertThat(specialCount).isEqualTo(3L); // !special, @symbol, Apple
+
+			// Test count with case-sensitive boundaries
+			Range<byte[]> caseRange = Range.closed("Apple".getBytes(), "apple".getBytes());
+			Long caseCount = connection.zSetCommands().zLexCount(key.getBytes(), caseRange);
+			assertThat(caseCount).isEqualTo(2L); // Apple, apple
+
+			// Test count with exclusive bounds
+			Range<byte[]> exclusiveRange = Range.open("Apple".getBytes(), "banana".getBytes());
+			Long exclusiveCount = connection.zSetCommands().zLexCount(key.getBytes(), exclusiveRange);
+			assertThat(exclusiveCount).isEqualTo(1L); // apple
+
+			// Test count with unbounded ranges
+			Range<byte[]> unboundedRange = Range.from(Range.Bound.inclusive("banana".getBytes()))
+				.to(Range.Bound.unbounded());
+			Long unboundedCount = connection.zSetCommands().zLexCount(key.getBytes(), unboundedRange);
+			assertThat(unboundedCount).isEqualTo(2L); // banana, z_last
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testLexicographicRemovalWithEdgeCases() {
+		String key = "test:zset:lex:complex:key";
+
+		try {
+			// Setup test data with mixed content
+			Set<Tuple> tuples = new HashSet<>();
+			tuples.add(new DefaultTuple("01_numeric".getBytes(), 0.0));
+			tuples.add(new DefaultTuple("alpha".getBytes(), 0.0));
+			tuples.add(new DefaultTuple("beta".getBytes(), 0.0));
+			tuples.add(new DefaultTuple("gamma".getBytes(), 0.0));
+			tuples.add(new DefaultTuple("omega".getBytes(), 0.0));
+			tuples.add(new DefaultTuple("zulu".getBytes(), 0.0));
+
+			connection.zSetCommands().zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
+
+			// Test removal with inclusive bounds
+			Range<byte[]> removalRange = Range.closed("beta".getBytes(), "gamma".getBytes());
+			Long removalCount = connection.zSetCommands().zRemRangeByLex(key.getBytes(), removalRange);
+			assertThat(removalCount).isEqualTo(2L); // beta, gamma
+
+			// Verify remaining elements
+			Long remainingCount = connection.zSetCommands().zCard(key.getBytes());
+			assertThat(remainingCount).isEqualTo(4L);
+
+			// Test removal with exclusive bounds
+			Range<byte[]> exclusiveRemovalRange = Range.open("alpha".getBytes(), "omega".getBytes());
+			Long exclusiveRemovalCount = connection.zSetCommands()
+				.zRemRangeByLex(key.getBytes(), exclusiveRemovalRange);
+			assertThat(exclusiveRemovalCount).isEqualTo(0L); // No elements between
+																// "alpha" and "omega"
+																// exclusively
+
+			// Test removal with unbounded lower bound
+			Range<byte[]> unboundedRemovalRange = Range.<byte[]>from(Range.Bound.unbounded())
+				.to(Range.Bound.inclusive("alpha".getBytes()));
+			Long unboundedRemovalCount = connection.zSetCommands()
+				.zRemRangeByLex(key.getBytes(), unboundedRemovalRange);
+			assertThat(unboundedRemovalCount).isEqualTo(2L); // 01_numeric, alpha
+
+			// Final verification
+			Long finalCount = connection.zSetCommands().zCard(key.getBytes());
+			assertThat(finalCount).isEqualTo(2L); // omega, zulu should remain
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testLexicographicReverseOperationsWithBounds() {
+		String key = "test:zset:lex:reverse:key";
+
+		try {
+			// Setup test data
+			Set<Tuple> tuples = new HashSet<>();
+			tuples.add(new DefaultTuple("first".getBytes(), 0.0));
+			tuples.add(new DefaultTuple("middle".getBytes(), 0.0));
+			tuples.add(new DefaultTuple("second".getBytes(), 0.0));
+			tuples.add(new DefaultTuple("third".getBytes(), 0.0));
+			tuples.add(new DefaultTuple("zebra".getBytes(), 0.0));
+
+			connection.zSetCommands().zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
+
+			// Test zRevRangeByLex with various bound combinations
+			Range<byte[]> reverseRange = Range.closed("middle".getBytes(), "third".getBytes());
+			Set<byte[]> reverseResult = connection.zSetCommands()
+				.zRevRangeByLex(key.getBytes(), reverseRange, Limit.unlimited());
+			assertThat(reverseResult).hasSize(3);
+			List<String> reverseList = reverseResult.stream()
+				.map(String::new)
+				.collect(java.util.stream.Collectors.toList());
+			assertThat(reverseList).containsExactly("third", "second", "middle");
+
+			// Test with limit
+			Set<byte[]> limitedResult = connection.zSetCommands()
+				.zRevRangeByLex(key.getBytes(), reverseRange, Limit.limit().count(2));
+			assertThat(limitedResult).hasSize(2);
+			List<String> limitedList = limitedResult.stream()
+				.map(String::new)
+				.collect(java.util.stream.Collectors.toList());
+			assertThat(limitedList).containsExactly("third", "second");
+
+			// Test with offset and limit
+			Set<byte[]> offsetResult = connection.zSetCommands()
+				.zRevRangeByLex(key.getBytes(), reverseRange, Limit.limit().offset(1).count(1));
+			assertThat(offsetResult).hasSize(1);
+			List<String> offsetList = offsetResult.stream()
+				.map(String::new)
+				.collect(java.util.stream.Collectors.toList());
+			assertThat(offsetList).containsExactly("second");
+
+			// Test zRangeStoreRevByLex
+			String destKey = "test:zset:lex:reverse:dest";
+			Long storeResult = connection.zSetCommands()
+				.zRangeStoreRevByLex(destKey.getBytes(), key.getBytes(), reverseRange, Limit.unlimited());
+			assertThat(storeResult).isEqualTo(3L);
+
+			Set<byte[]> storedData = connection.zSetCommands().zRange(destKey.getBytes(), 0, -1);
+			List<String> storedList = storedData.stream()
+				.map(String::new)
+				.collect(java.util.stream.Collectors.toList());
+			assertThat(storedList).containsExactly("middle", "second", "third");
+
+			cleanupKey(destKey);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== Scan Operations ====================
+
+	@Test
+	void testZScan() {
+		String key = "test:zset:scan:key";
+
+		try {
+			// Setup test data
+			Set<Tuple> tuples = new HashSet<>();
+			for (int i = 0; i < 10; i++) {
+				tuples.add(new DefaultTuple(("member" + i).getBytes(), i * 1.0));
+			}
+
+			connection.zSetCommands().zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
+
+			// Test basic scan
+			ScanOptions options = ScanOptions.scanOptions().build();
+			Cursor<Tuple> cursor = connection.zSetCommands().zScan(key.getBytes(), options);
+
+			java.util.List<Tuple> scannedTuples = new java.util.ArrayList<>();
+			while (cursor.hasNext()) {
+				scannedTuples.add(cursor.next());
+			}
+			cursor.close();
+
+			// Should find all tuples
+			assertThat(scannedTuples).hasSize(10);
+
+			// Test scan with pattern
+			ScanOptions patternOptions = ScanOptions.scanOptions().match("member[1-3]").build();
+			Cursor<Tuple> patternCursor = connection.zSetCommands().zScan(key.getBytes(), patternOptions);
+
+			java.util.List<Tuple> patternTuples = new java.util.ArrayList<>();
+			while (patternCursor.hasNext()) {
+				patternTuples.add(patternCursor.next());
+			}
+			patternCursor.close();
+
+			// Should find fewer tuples due to pattern filter
+			assertThat(patternTuples.size()).isLessThanOrEqualTo(3);
+
+			// Test scan with count
+			ScanOptions countOptions = ScanOptions.scanOptions().count(2).build();
+			Cursor<Tuple> countCursor = connection.zSetCommands().zScan(key.getBytes(), countOptions);
+
+			java.util.List<Tuple> countTuples = new java.util.ArrayList<>();
+			while (countCursor.hasNext()) {
+				countTuples.add(countCursor.next());
+			}
+			countCursor.close();
+
+			// Should still find all tuples, but in smaller batches
+			assertThat(countTuples).hasSize(10);
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== PIPELINE MODE TESTS ====================
+	// All ZSet operations tested in pipeline mode to ensure proper null return handling
+	// and correct batch result processing via closePipeline()
+
+	@Test
+	void testBasicZSetOperationsInPipelineMode() {
+		String key = "test:zset:pipeline:basic";
+
+		try {
+			// Start pipeline
+			connection.openPipeline();
+
+			// Queue basic operations - all should return null in pipeline mode
+			Set<Tuple> tuples = new HashSet<>();
+			tuples.add(new DefaultTuple("member1".getBytes(), 1.0));
+			tuples.add(new DefaultTuple("member2".getBytes(), 2.0));
+			tuples.add(new DefaultTuple("member3".getBytes(), 3.0));
+
+			assertThat(connection.zSetCommands().zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty()))
+				.isNull();
+			assertThat(connection.zSetCommands().zCard(key.getBytes())).isNull();
+			assertThat(connection.zSetCommands().zScore(key.getBytes(), "member2".getBytes())).isNull();
+			assertThat(connection.zSetCommands().zMScore(key.getBytes(), "member1".getBytes(), "member2".getBytes()))
+				.isNull();
+			assertThat(connection.zSetCommands().zRank(key.getBytes(), "member2".getBytes())).isNull();
+			assertThat(connection.zSetCommands().zRevRank(key.getBytes(), "member2".getBytes())).isNull();
+			assertThat(connection.zSetCommands().zIncrBy(key.getBytes(), 1.5, "member2".getBytes())).isNull();
+			assertThat(connection.zSetCommands().zRem(key.getBytes(), "member1".getBytes())).isNull();
+
+			// Execute pipeline
+			List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(8);
+			assertThat((Long) results.get(0)).isEqualTo(3L); // zAdd result
+			assertThat((Long) results.get(1)).isEqualTo(3L); // zCard result
+			assertThat((Double) results.get(2)).isEqualTo(2.0); // zScore result
+
+			@SuppressWarnings("unchecked")
+			List<Double> mScoreResult = (List<Double>) results.get(3);
+			assertThat(mScoreResult).containsExactly(1.0, 2.0); // zMScore result
+
+			assertThat((Long) results.get(4)).isEqualTo(1L); // zRank result (0-based)
+			assertThat((Long) results.get(5)).isEqualTo(1L); // zRevRank result
+			assertThat((Double) results.get(6)).isEqualTo(3.5); // zIncrBy result
+			assertThat((Long) results.get(7)).isEqualTo(1L); // zRem result
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testRangeOperationsInPipelineMode() {
+		String key = "test:zset:pipeline:range";
+
+		try {
+			// Setup test data
+			Set<Tuple> tuples = new HashSet<>();
+			tuples.add(new DefaultTuple("member1".getBytes(), 1.0));
+			tuples.add(new DefaultTuple("member2".getBytes(), 2.0));
+			tuples.add(new DefaultTuple("member3".getBytes(), 3.0));
+			tuples.add(new DefaultTuple("member4".getBytes(), 4.0));
+			tuples.add(new DefaultTuple("member5".getBytes(), 5.0));
+
+			connection.zSetCommands().zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
+
+			// Start pipeline
+			connection.openPipeline();
+
+			Range<Double> scoreRange = Range.closed(2.0, 4.0);
+			Range<byte[]> lexRange = Range.closed("member2".getBytes(), "member4".getBytes());
+
+			// Queue range operations - all should return null in pipeline mode
+			assertThat(connection.zSetCommands().zRange(key.getBytes(), 0, 2)).isNull();
+			assertThat(connection.zSetCommands().zRangeWithScores(key.getBytes(), 0, 2)).isNull();
+			assertThat(connection.zSetCommands().zRevRange(key.getBytes(), 0, 2)).isNull();
+			assertThat(connection.zSetCommands().zRevRangeWithScores(key.getBytes(), 0, 2)).isNull();
+			assertThat(connection.zSetCommands()
+				.zRangeByScore(key.getBytes(), scoreRange.map(Number.class::cast), Limit.unlimited())).isNull();
+			assertThat(connection.zSetCommands()
+				.zRangeByScoreWithScores(key.getBytes(), scoreRange.map(Number.class::cast), Limit.unlimited()))
+				.isNull();
+			assertThat(connection.zSetCommands()
+				.zRevRangeByScore(key.getBytes(), scoreRange.map(Number.class::cast), Limit.unlimited())).isNull();
+			assertThat(connection.zSetCommands()
+				.zRevRangeByScoreWithScores(key.getBytes(), scoreRange.map(Number.class::cast), Limit.unlimited()))
+				.isNull();
+			assertThat(connection.zSetCommands().zCount(key.getBytes(), scoreRange.map(Number.class::cast))).isNull();
+
+			// Execute pipeline
+			List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(9);
+
+			@SuppressWarnings("unchecked")
+			Set<byte[]> range1 = (Set<byte[]>) results.get(0);
+			assertThat(range1).hasSize(3);
+
+			@SuppressWarnings("unchecked")
+			Set<Tuple> rangeWithScores = (Set<Tuple>) results.get(1);
+			assertThat(rangeWithScores).hasSize(3);
+
+			assertThat((Long) results.get(8)).isEqualTo(3L); // zCount result
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testSetAlgebraOperationsInPipelineMode() {
+		String key1 = "test:zset:pipeline:set1";
+		String key2 = "test:zset:pipeline:set2";
+		String destKey = "test:zset:pipeline:dest";
+
+		try {
+			// Setup test data
+			Set<Tuple> tuples1 = new HashSet<>();
+			tuples1.add(new DefaultTuple("a".getBytes(), 1.0));
+			tuples1.add(new DefaultTuple("b".getBytes(), 2.0));
+			tuples1.add(new DefaultTuple("c".getBytes(), 3.0));
+
+			Set<Tuple> tuples2 = new HashSet<>();
+			tuples2.add(new DefaultTuple("b".getBytes(), 2.5));
+			tuples2.add(new DefaultTuple("c".getBytes(), 3.5));
+			tuples2.add(new DefaultTuple("d".getBytes(), 4.0));
+
+			connection.zSetCommands().zAdd(key1.getBytes(), tuples1, ValkeyZSetCommands.ZAddArgs.empty());
+			connection.zSetCommands().zAdd(key2.getBytes(), tuples2, ValkeyZSetCommands.ZAddArgs.empty());
+
+			// Start pipeline
+			connection.openPipeline();
+
+			// Queue set algebra operations - all should return null in pipeline mode
+			assertThat(connection.zSetCommands().zDiff(key1.getBytes(), key2.getBytes())).isNull();
+			assertThat(connection.zSetCommands().zDiffWithScores(key1.getBytes(), key2.getBytes())).isNull();
+			assertThat(connection.zSetCommands().zDiffStore(destKey.getBytes(), key1.getBytes(), key2.getBytes()))
+				.isNull();
+			assertThat(connection.zSetCommands().zInter(key1.getBytes(), key2.getBytes())).isNull();
+			assertThat(connection.zSetCommands().zInterWithScores(key1.getBytes(), key2.getBytes())).isNull();
+			assertThat(connection.zSetCommands().zInterStore(destKey.getBytes(), key1.getBytes(), key2.getBytes()))
+				.isNull();
+			assertThat(connection.zSetCommands().zUnion(key1.getBytes(), key2.getBytes())).isNull();
+			assertThat(connection.zSetCommands().zUnionWithScores(key1.getBytes(), key2.getBytes())).isNull();
+			assertThat(connection.zSetCommands().zUnionStore(destKey.getBytes(), key1.getBytes(), key2.getBytes()))
+				.isNull();
+
+			// Execute pipeline
+			List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(9);
+
+			@SuppressWarnings("unchecked")
+			Set<byte[]> diffResult = (Set<byte[]>) results.get(0);
+			assertThat(diffResult).hasSize(1); // Only "a" in key1 but not key2
+
+			assertThat((Long) results.get(2)).isEqualTo(1L); // zDiffStore result
+			assertThat((Long) results.get(5)).isEqualTo(2L); // zInterStore result
+			assertThat((Long) results.get(8)).isEqualTo(4L); // zUnionStore result
+
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+			cleanupKey(destKey);
+		}
+	}
+
+	@Test
+	void testPopAndRandomOperationsInPipelineMode() {
+		String key = "test:zset:pipeline:pop";
+
+		try {
+			// Setup test data
+			Set<Tuple> tuples = new HashSet<>();
+			tuples.add(new DefaultTuple("member1".getBytes(), 1.0));
+			tuples.add(new DefaultTuple("member2".getBytes(), 2.0));
+			tuples.add(new DefaultTuple("member3".getBytes(), 3.0));
+			tuples.add(new DefaultTuple("member4".getBytes(), 4.0));
+			tuples.add(new DefaultTuple("member5".getBytes(), 5.0));
+
+			connection.zSetCommands().zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
+
+			// Start pipeline
+			connection.openPipeline();
+
+			// Queue pop and random operations - all should return null in pipeline mode
+			assertThat(connection.zSetCommands().zRandMember(key.getBytes())).isNull();
+			assertThat(connection.zSetCommands().zRandMember(key.getBytes(), 2)).isNull();
+			assertThat(connection.zSetCommands().zRandMemberWithScore(key.getBytes())).isNull();
+			assertThat(connection.zSetCommands().zRandMemberWithScore(key.getBytes(), 2)).isNull();
+			assertThat(connection.zSetCommands().zPopMin(key.getBytes())).isNull();
+			assertThat(connection.zSetCommands().zPopMax(key.getBytes())).isNull();
+
+			// Execute pipeline
+			List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(6);
+
+			assertThat((byte[]) results.get(0)).isNotNull(); // random member
+
+			@SuppressWarnings("unchecked")
+			List<byte[]> randomMembers = (List<byte[]>) results.get(1);
+			assertThat(randomMembers).hasSize(2);
+
+			assertThat((Tuple) results.get(2)).isNotNull(); // random member with score
+
+			@SuppressWarnings("unchecked")
+			List<Tuple> randomMembersWithScores = (List<Tuple>) results.get(3);
+			assertThat(randomMembersWithScores).hasSize(2);
+
+			Tuple minTuple = (Tuple) results.get(4);
+			assertThat(minTuple).isNotNull();
+			assertThat(minTuple.getScore()).isEqualTo(1.0); // Should be the minimum
+
+			Tuple maxTuple = (Tuple) results.get(5);
+			assertThat(maxTuple).isNotNull();
+			assertThat(maxTuple.getScore()).isEqualTo(5.0); // Should be the maximum
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testRangeStoreAndRemovalOperationsInPipelineMode() {
+		String srcKey = "test:zset:pipeline:rangestore:src";
+		String destKey = "test:zset:pipeline:rangestore:dest";
+		String remKey = "test:zset:pipeline:removal:key";
+
+		try {
+			// Setup test data for range store operations
+			Set<Tuple> tuples = new HashSet<>();
+			tuples.add(new DefaultTuple("member1".getBytes(), 1.0));
+			tuples.add(new DefaultTuple("member2".getBytes(), 2.0));
+			tuples.add(new DefaultTuple("member3".getBytes(), 3.0));
+			tuples.add(new DefaultTuple("member4".getBytes(), 4.0));
+			tuples.add(new DefaultTuple("member5".getBytes(), 5.0));
+
+			connection.zSetCommands().zAdd(srcKey.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
+
+			// Setup test data for removal operations
+			connection.zSetCommands().zAdd(remKey.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
+
+			// Start pipeline
+			connection.openPipeline();
+
+			Range<Double> scoreRange = Range.closed(2.0, 4.0);
+			Range<byte[]> lexRange = Range.closed("member2".getBytes(), "member4".getBytes());
+
+			// Queue range store operations - all should return null in pipeline mode
+			assertThat(connection.zSetCommands()
+				.zRangeStoreByScore(destKey.getBytes(), srcKey.getBytes(), scoreRange.map(Number.class::cast),
+						Limit.unlimited()))
+				.isNull();
+			assertThat(connection.zSetCommands()
+				.zRangeStoreRevByScore(destKey.getBytes(), srcKey.getBytes(), scoreRange.map(Number.class::cast),
+						Limit.unlimited()))
+				.isNull();
+
+			// Queue removal operations - all should return null in pipeline mode
+			assertThat(connection.zSetCommands().zRemRange(remKey.getBytes(), 1, 3)).isNull();
+			assertThat(
+					connection.zSetCommands().zRemRangeByScore(remKey.getBytes(), scoreRange.map(Number.class::cast)))
+				.isNull();
+
+			// Execute pipeline
+			List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(4);
+			assertThat((Long) results.get(0)).isEqualTo(3L); // zRangeStoreByScore result
+			assertThat((Long) results.get(1)).isEqualTo(3L); // zRangeStoreRevByScore
+																// result
+			assertThat((Long) results.get(2)).isEqualTo(3L); // zRemRange result
+			assertThat((Long) results.get(3)).isEqualTo(0L); // zRemRangeByScore result
+																// (already removed by
+																// previous operation)
+
+		}
+		finally {
+			cleanupKey(srcKey);
+			cleanupKey(destKey);
+			cleanupKey(remKey);
+		}
+	}
+
+	@Test
+	void testScanOperationsInPipelineMode() {
+		String key = "test:zset:pipeline:scan";
+
+		try {
+			// Setup test data
+			Set<Tuple> tuples = new HashSet<>();
+			for (int i = 0; i < 5; i++) {
+				tuples.add(new DefaultTuple(("member" + i).getBytes(), i * 1.0));
+			}
+
+			connection.zSetCommands().zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
+
+			// Start pipeline
+			connection.openPipeline();
+
+			// Note: zScan with cursor operations are complex in pipeline mode
+			// We test that the scan setup doesn't break pipeline mode
+			ScanOptions options = ScanOptions.scanOptions().count(2).build();
+
+			// We can't easily test zScan in pipeline mode due to cursor nature
+			// But we can verify pipeline doesn't break with scan setup
+			assertThat(connection.zSetCommands().zCard(key.getBytes())).isNull();
+
+			// Execute pipeline
+			List<Object> results = connection.closePipeline();
+
+			// Verify results
+			assertThat(results).hasSize(1);
+			assertThat((Long) results.get(0)).isEqualTo(5L); // zCard result
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	// ==================== TRANSACTION MODE TESTS ====================
+	// All ZSet operations tested in transaction mode to ensure proper null return
+	// handling
+	// and correct atomic execution via exec()
+
+	@Test
+	void testBasicZSetOperationsInTransactionMode() {
+		String key = "test:zset:transaction:basic";
+
+		try {
+			// Start transaction
+			connection.multi();
+
+			// Queue basic operations - all should return null in transaction mode
+			Set<Tuple> tuples = new HashSet<>();
+			tuples.add(new DefaultTuple("member1".getBytes(), 1.0));
+			tuples.add(new DefaultTuple("member2".getBytes(), 2.0));
+			tuples.add(new DefaultTuple("member3".getBytes(), 3.0));
+
+			assertThat(connection.zSetCommands().zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty()))
+				.isNull();
+			assertThat(connection.zSetCommands().zCard(key.getBytes())).isNull();
+			assertThat(connection.zSetCommands().zScore(key.getBytes(), "member2".getBytes())).isNull();
+			assertThat(connection.zSetCommands().zMScore(key.getBytes(), "member1".getBytes(), "member2".getBytes()))
+				.isNull();
+			assertThat(connection.zSetCommands().zRank(key.getBytes(), "member2".getBytes())).isNull();
+			assertThat(connection.zSetCommands().zRevRank(key.getBytes(), "member2".getBytes())).isNull();
+			assertThat(connection.zSetCommands().zIncrBy(key.getBytes(), 1.5, "member2".getBytes())).isNull();
+			assertThat(connection.zSetCommands().zRem(key.getBytes(), "member1".getBytes())).isNull();
+
+			// Execute transaction
+			List<Object> results = connection.exec();
+
+			// Verify results
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(8);
+			assertThat((Long) results.get(0)).isEqualTo(3L); // zAdd result
+			assertThat((Long) results.get(1)).isEqualTo(3L); // zCard result
+			assertThat((Double) results.get(2)).isEqualTo(2.0); // zScore result
+
+			@SuppressWarnings("unchecked")
+			List<Double> mScoreResult = (List<Double>) results.get(3);
+			assertThat(mScoreResult).containsExactly(1.0, 2.0); // zMScore result
+
+			assertThat((Long) results.get(4)).isEqualTo(1L); // zRank result (0-based)
+			assertThat((Long) results.get(5)).isEqualTo(1L); // zRevRank result
+			assertThat((Double) results.get(6)).isEqualTo(3.5); // zIncrBy result
+			assertThat((Long) results.get(7)).isEqualTo(1L); // zRem result
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testRangeOperationsInTransactionMode() {
+		String key = "test:zset:transaction:range";
+
+		try {
+			// Setup test data
+			Set<Tuple> tuples = new HashSet<>();
+			tuples.add(new DefaultTuple("member1".getBytes(), 1.0));
+			tuples.add(new DefaultTuple("member2".getBytes(), 2.0));
+			tuples.add(new DefaultTuple("member3".getBytes(), 3.0));
+			tuples.add(new DefaultTuple("member4".getBytes(), 4.0));
+			tuples.add(new DefaultTuple("member5".getBytes(), 5.0));
+
+			connection.zSetCommands().zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
+
+			// Start transaction
+			connection.multi();
+
+			Range<Double> scoreRange = Range.closed(2.0, 4.0);
+
+			// Queue range operations - all should return null in transaction mode
+			assertThat(connection.zSetCommands().zRange(key.getBytes(), 0, 2)).isNull();
+			assertThat(connection.zSetCommands().zRangeWithScores(key.getBytes(), 0, 2)).isNull();
+			assertThat(connection.zSetCommands().zRevRange(key.getBytes(), 0, 2)).isNull();
+			assertThat(connection.zSetCommands().zRevRangeWithScores(key.getBytes(), 0, 2)).isNull();
+			assertThat(connection.zSetCommands()
+				.zRangeByScore(key.getBytes(), scoreRange.map(Number.class::cast), Limit.unlimited())).isNull();
+			assertThat(connection.zSetCommands()
+				.zRangeByScoreWithScores(key.getBytes(), scoreRange.map(Number.class::cast), Limit.unlimited()))
+				.isNull();
+			assertThat(connection.zSetCommands()
+				.zRevRangeByScore(key.getBytes(), scoreRange.map(Number.class::cast), Limit.unlimited())).isNull();
+			assertThat(connection.zSetCommands()
+				.zRevRangeByScoreWithScores(key.getBytes(), scoreRange.map(Number.class::cast), Limit.unlimited()))
+				.isNull();
+			assertThat(connection.zSetCommands().zCount(key.getBytes(), scoreRange.map(Number.class::cast))).isNull();
+
+			// Execute transaction
+			List<Object> results = connection.exec();
+
+			// Verify results
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(9);
+
+			@SuppressWarnings("unchecked")
+			Set<byte[]> range1 = (Set<byte[]>) results.get(0);
+			assertThat(range1).hasSize(3);
+
+			@SuppressWarnings("unchecked")
+			Set<Tuple> rangeWithScores = (Set<Tuple>) results.get(1);
+			assertThat(rangeWithScores).hasSize(3);
+
+			assertThat((Long) results.get(8)).isEqualTo(3L); // zCount result
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testSetAlgebraOperationsInTransactionMode() {
+		String key1 = "test:zset:transaction:set1";
+		String key2 = "test:zset:transaction:set2";
+		String destKey = "test:zset:transaction:dest";
+
+		try {
+			// Setup test data
+			Set<Tuple> tuples1 = new HashSet<>();
+			tuples1.add(new DefaultTuple("a".getBytes(), 1.0));
+			tuples1.add(new DefaultTuple("b".getBytes(), 2.0));
+			tuples1.add(new DefaultTuple("c".getBytes(), 3.0));
+
+			Set<Tuple> tuples2 = new HashSet<>();
+			tuples2.add(new DefaultTuple("b".getBytes(), 2.5));
+			tuples2.add(new DefaultTuple("c".getBytes(), 3.5));
+			tuples2.add(new DefaultTuple("d".getBytes(), 4.0));
+
+			connection.zSetCommands().zAdd(key1.getBytes(), tuples1, ValkeyZSetCommands.ZAddArgs.empty());
+			connection.zSetCommands().zAdd(key2.getBytes(), tuples2, ValkeyZSetCommands.ZAddArgs.empty());
+
+			// Start transaction
+			connection.multi();
+
+			// Queue set algebra operations - all should return null in transaction mode
+			assertThat(connection.zSetCommands().zDiff(key1.getBytes(), key2.getBytes())).isNull();
+			assertThat(connection.zSetCommands().zDiffWithScores(key1.getBytes(), key2.getBytes())).isNull();
+			assertThat(connection.zSetCommands().zDiffStore(destKey.getBytes(), key1.getBytes(), key2.getBytes()))
+				.isNull();
+			assertThat(connection.zSetCommands().zInter(key1.getBytes(), key2.getBytes())).isNull();
+			assertThat(connection.zSetCommands().zInterWithScores(key1.getBytes(), key2.getBytes())).isNull();
+			assertThat(connection.zSetCommands().zInterStore(destKey.getBytes(), key1.getBytes(), key2.getBytes()))
+				.isNull();
+			assertThat(connection.zSetCommands().zUnion(key1.getBytes(), key2.getBytes())).isNull();
+			assertThat(connection.zSetCommands().zUnionWithScores(key1.getBytes(), key2.getBytes())).isNull();
+			assertThat(connection.zSetCommands().zUnionStore(destKey.getBytes(), key1.getBytes(), key2.getBytes()))
+				.isNull();
+
+			// Execute transaction
+			List<Object> results = connection.exec();
+
+			// Verify results
+			assertThat(results).isNotNull();
+			assertThat(results).hasSize(9);
+
+			@SuppressWarnings("unchecked")
+			Set<byte[]> diffResult = (Set<byte[]>) results.get(0);
+			assertThat(diffResult).hasSize(1); // Only "a" in key1 but not key2
+
+			assertThat((Long) results.get(2)).isEqualTo(1L); // zDiffStore result
+			assertThat((Long) results.get(5)).isEqualTo(2L); // zInterStore result
+			assertThat((Long) results.get(8)).isEqualTo(4L); // zUnionStore result
+
+		}
+		finally {
+			cleanupKey(key1);
+			cleanupKey(key2);
+			cleanupKey(destKey);
+		}
+	}
+
+	@Test
+	void testTransactionDiscardWithZSetCommands() {
+		String key = "test:zset:transaction:discard";
+
+		try {
+			// Start transaction
+			connection.multi();
+
+			// Queue ZSet commands
+			Set<Tuple> tuples = new HashSet<>();
+			tuples.add(new DefaultTuple("shouldnotbeset".getBytes(), 1.0));
+			connection.zSetCommands().zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
+			connection.zSetCommands().zScore(key.getBytes(), "shouldnotbeset".getBytes());
+
+			// Discard transaction
+			connection.discard();
+
+			// Verify key does not exist (transaction was discarded)
+			Long card = connection.zSetCommands().zCard(key.getBytes());
+			assertThat(card).isEqualTo(0L);
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testWatchWithZSetCommandsTransaction() {
+		String watchKey = "test:zset:transaction:watch";
+		String otherKey = "test:zset:transaction:other";
+
+		try {
+			// Setup initial data
+			Set<Tuple> tuples = new HashSet<>();
+			tuples.add(new DefaultTuple("initial".getBytes(), 1.0));
+			connection.zSetCommands().zAdd(watchKey.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
+
+			// Watch the key
+			connection.watch(watchKey.getBytes());
+
+			// Modify the watched key from "outside" the transaction
+			tuples.clear();
+			tuples.add(new DefaultTuple("modified".getBytes(), 2.0));
+			connection.zSetCommands().zAdd(watchKey.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
+
+			// Start transaction
+			connection.multi();
+
+			// Queue ZSet commands
+			tuples.clear();
+			tuples.add(new DefaultTuple("value".getBytes(), 3.0));
+			connection.zSetCommands().zAdd(otherKey.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
+			connection.zSetCommands().zScore(otherKey.getBytes(), "value".getBytes());
+
+			// Execute transaction - should be aborted due to WATCH
+			List<Object> results = connection.exec();
+
+			// Transaction should be aborted (results should be null)
+			assertThat(results).isNotNull().isEmpty();
+
+			// Verify that the other key was not set
+			Long card = connection.zSetCommands().zCard(otherKey.getBytes());
+			assertThat(card).isEqualTo(0L);
+
+		}
+		finally {
+			cleanupKey(watchKey);
+			cleanupKey(otherKey);
+		}
+	}
+
+	// ==================== ADDITIONAL EDGE CASES ====================
+	// Additional comprehensive edge case testing for robustness
+
+	@Test
+	void testZSetWithBinaryData() {
+		String key = "test:zset:binary:data";
+
+		try {
+			// Test with binary data containing null bytes and various byte values
+			byte[] binaryValue = new byte[] { 0x00, 0x01, 0x02, (byte) 0xFF, (byte) 0xFE, (byte) 0x80 };
+			Set<Tuple> tuples = new HashSet<>();
+			tuples.add(new DefaultTuple(binaryValue, 1.0));
+
+			Long addResult = connection.zSetCommands()
+				.zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
+			assertThat(addResult).isEqualTo(1L);
+
+			// Verify binary data is preserved exactly
+			Double score = connection.zSetCommands().zScore(key.getBytes(), binaryValue);
+			assertThat(score).isEqualTo(1.0);
+
+			Set<byte[]> range = connection.zSetCommands().zRange(key.getBytes(), 0, -1);
+			assertThat(range).hasSize(1);
+			assertThat(range.iterator().next()).isEqualTo(binaryValue);
+
+			// Test binary data in range operations
+			Set<Tuple> rangeWithScores = connection.zSetCommands().zRangeWithScores(key.getBytes(), 0, -1);
+			assertThat(rangeWithScores).hasSize(1);
+			Tuple tuple = rangeWithScores.iterator().next();
+			assertThat(tuple.getValue()).isEqualTo(binaryValue);
+			assertThat(tuple.getScore()).isEqualTo(1.0);
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testZSetWithExtremeScoreValues() {
+		String key = "test:zset:extreme:scores";
+
+		try {
+			// Test with extreme score values
+			Set<Tuple> tuples = new HashSet<>();
+			tuples.add(new DefaultTuple("negative_large".getBytes(), -Double.MAX_VALUE / 2));
+			tuples.add(new DefaultTuple("negative_small".getBytes(), -0.000001));
+			tuples.add(new DefaultTuple("zero".getBytes(), 0.0));
+			tuples.add(new DefaultTuple("positive_small".getBytes(), 0.000001));
+			tuples.add(new DefaultTuple("positive_large".getBytes(), Double.MAX_VALUE / 2));
+			tuples.add(new DefaultTuple("max_precision".getBytes(), 1.7976931348623157E308)); // Near
+																								// Double.MAX_VALUE
+
+			Long addResult = connection.zSetCommands()
+				.zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
+			assertThat(addResult).isEqualTo(6L);
+
+			// Test ordering is maintained with extreme values
+			Set<byte[]> range = connection.zSetCommands().zRange(key.getBytes(), 0, -1);
+			List<String> orderedMembers = range.stream().map(String::new).collect(java.util.stream.Collectors.toList());
+
+			assertThat(orderedMembers.get(0)).isEqualTo("negative_large");
+			assertThat(orderedMembers.get(1)).isEqualTo("negative_small");
+			assertThat(orderedMembers.get(2)).isEqualTo("zero");
+			assertThat(orderedMembers.get(3)).isEqualTo("positive_small");
+			assertThat(orderedMembers.get(4)).isEqualTo("positive_large");
+			assertThat(orderedMembers.get(5)).isEqualTo("max_precision");
+
+			// Test range operations with extreme values
+			Range<Double> extremeRange = Range.closed(-Double.MAX_VALUE, Double.MAX_VALUE);
+			Long count = connection.zSetCommands().zCount(key.getBytes(), extremeRange.map(Number.class::cast));
+			assertThat(count).isEqualTo(6L);
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
+
+	@Test
+	void testZSetLargeDatasetPerformance() {
+		String key = "test:zset:large:dataset:performance";
+
+		try {
+			// Create a large dataset to test performance characteristics
+			Set<Tuple> tuples = new HashSet<>();
+			for (int i = 0; i < 10000; i++) {
+				tuples.add(new DefaultTuple(("member" + String.format("%05d", i)).getBytes(), i * 1.0));
+			}
+
+			// Test large add operation
+			Long addResult = connection.zSetCommands()
+				.zAdd(key.getBytes(), tuples, ValkeyZSetCommands.ZAddArgs.empty());
+			assertThat(addResult).isEqualTo(10000L);
+
+			// Test cardinality
+			Long card = connection.zSetCommands().zCard(key.getBytes());
+			assertThat(card).isEqualTo(10000L);
+
+			// Test range operations on large dataset
+			Set<byte[]> range = connection.zSetCommands().zRange(key.getBytes(), 0, 99);
+			assertThat(range).hasSize(100);
+
+		}
+		finally {
+			cleanupKey(key);
+		}
+	}
 
 }

--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideIamAuthenticationConfigurationTests.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideIamAuthenticationConfigurationTests.java
@@ -14,124 +14,125 @@ import io.valkey.springframework.data.valkey.connection.valkeyglide.ValkeyGlideC
  */
 class ValkeyGlideIamAuthenticationConfigurationTests {
 
-    @Test
-    void shouldCreateIamAuthConfigWithAllFields() {
+	@Test
+	void shouldCreateIamAuthConfigWithAllFields() {
 
-        IamAuthenticationForGlide config = new IamAuthenticationForGlide(
-                "my-cluster", AwsServiceType.ELASTICACHE, "us-east-1", 600);
+		IamAuthenticationForGlide config = new IamAuthenticationForGlide("my-cluster", AwsServiceType.ELASTICACHE,
+				"us-east-1", 600);
 
-        assertThat(config.clusterName()).isEqualTo("my-cluster");
-        assertThat(config.serviceType()).isEqualTo(AwsServiceType.ELASTICACHE);
-        assertThat(config.region()).isEqualTo("us-east-1");
-        assertThat(config.refreshIntervalSeconds()).isEqualTo(600);
-    }
+		assertThat(config.clusterName()).isEqualTo("my-cluster");
+		assertThat(config.serviceType()).isEqualTo(AwsServiceType.ELASTICACHE);
+		assertThat(config.region()).isEqualTo("us-east-1");
+		assertThat(config.refreshIntervalSeconds()).isEqualTo(600);
+	}
 
-    @Test
-    void shouldCreateIamAuthConfigWithMemoryDb() {
+	@Test
+	void shouldCreateIamAuthConfigWithMemoryDb() {
 
-        IamAuthenticationForGlide config = new IamAuthenticationForGlide(
-                "memdb-cluster", AwsServiceType.MEMORYDB, "eu-west-1", null);
+		IamAuthenticationForGlide config = new IamAuthenticationForGlide("memdb-cluster", AwsServiceType.MEMORYDB,
+				"eu-west-1", null);
 
-        assertThat(config.clusterName()).isEqualTo("memdb-cluster");
-        assertThat(config.serviceType()).isEqualTo(AwsServiceType.MEMORYDB);
-        assertThat(config.region()).isEqualTo("eu-west-1");
-        assertThat(config.refreshIntervalSeconds()).isNull();
-    }
+		assertThat(config.clusterName()).isEqualTo("memdb-cluster");
+		assertThat(config.serviceType()).isEqualTo(AwsServiceType.MEMORYDB);
+		assertThat(config.region()).isEqualTo("eu-west-1");
+		assertThat(config.refreshIntervalSeconds()).isNull();
+	}
 
-    @Test
-    void shouldThrowWhenClusterNameIsNull() {
+	@Test
+	void shouldThrowWhenClusterNameIsNull() {
 
-        assertThatIllegalArgumentException()
-                .isThrownBy(() -> new IamAuthenticationForGlide(null, AwsServiceType.ELASTICACHE, "us-east-1", null))
-                .withMessageContaining("clusterName must not be null");
-    }
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> new IamAuthenticationForGlide(null, AwsServiceType.ELASTICACHE, "us-east-1", null))
+			.withMessageContaining("clusterName must not be null");
+	}
 
-    @Test
-    void shouldThrowWhenServiceTypeIsNull() {
+	@Test
+	void shouldThrowWhenServiceTypeIsNull() {
 
-        assertThatIllegalArgumentException()
-                .isThrownBy(() -> new IamAuthenticationForGlide("my-cluster", null, "us-east-1", null))
-                .withMessageContaining("serviceType must not be null");
-    }
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> new IamAuthenticationForGlide("my-cluster", null, "us-east-1", null))
+			.withMessageContaining("serviceType must not be null");
+	}
 
-    @Test
-    void shouldThrowWhenRegionIsNull() {
+	@Test
+	void shouldThrowWhenRegionIsNull() {
 
-        assertThatIllegalArgumentException()
-                .isThrownBy(() -> new IamAuthenticationForGlide("my-cluster", AwsServiceType.ELASTICACHE, null, null))
-                .withMessageContaining("region must not be null");
-    }
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> new IamAuthenticationForGlide("my-cluster", AwsServiceType.ELASTICACHE, null, null))
+			.withMessageContaining("region must not be null");
+	}
 
-    @Test
-    void shouldAllowNullRefreshIntervalSeconds() {
+	@Test
+	void shouldAllowNullRefreshIntervalSeconds() {
 
-        IamAuthenticationForGlide config = new IamAuthenticationForGlide(
-                "my-cluster", AwsServiceType.ELASTICACHE, "us-east-1", null);
+		IamAuthenticationForGlide config = new IamAuthenticationForGlide("my-cluster", AwsServiceType.ELASTICACHE,
+				"us-east-1", null);
 
-        assertThat(config.refreshIntervalSeconds()).isNull();
-    }
+		assertThat(config.refreshIntervalSeconds()).isNull();
+	}
 
-    @Test
-    void builderShouldStoreIamAuthConfiguration() {
+	@Test
+	void builderShouldStoreIamAuthConfiguration() {
 
-        IamAuthenticationForGlide iamConfig = new IamAuthenticationForGlide(
-                "my-cluster", AwsServiceType.ELASTICACHE, "us-east-1", 300);
+		IamAuthenticationForGlide iamConfig = new IamAuthenticationForGlide("my-cluster", AwsServiceType.ELASTICACHE,
+				"us-east-1", 300);
 
-        ValkeyGlideClientConfiguration config = ValkeyGlideClientConfiguration.builder()
-                .useIamAuthentication(iamConfig)
-                .build();
+		ValkeyGlideClientConfiguration config = ValkeyGlideClientConfiguration.builder()
+			.useIamAuthentication(iamConfig)
+			.build();
 
-        assertThat(config.getIamAuthentication()).isNotNull();
-        assertThat(config.getIamAuthentication().clusterName()).isEqualTo("my-cluster");
-        assertThat(config.getIamAuthentication().serviceType()).isEqualTo(AwsServiceType.ELASTICACHE);
-        assertThat(config.getIamAuthentication().region()).isEqualTo("us-east-1");
-        assertThat(config.getIamAuthentication().refreshIntervalSeconds()).isEqualTo(300);
-    }
+		assertThat(config.getIamAuthentication()).isNotNull();
+		assertThat(config.getIamAuthentication().clusterName()).isEqualTo("my-cluster");
+		assertThat(config.getIamAuthentication().serviceType()).isEqualTo(AwsServiceType.ELASTICACHE);
+		assertThat(config.getIamAuthentication().region()).isEqualTo("us-east-1");
+		assertThat(config.getIamAuthentication().refreshIntervalSeconds()).isEqualTo(300);
+	}
 
-    @Test
-    void builderShouldDefaultToNullIamAuth() {
+	@Test
+	void builderShouldDefaultToNullIamAuth() {
 
-        ValkeyGlideClientConfiguration config = ValkeyGlideClientConfiguration.builder().build();
+		ValkeyGlideClientConfiguration config = ValkeyGlideClientConfiguration.builder().build();
 
-        assertThat(config.getIamAuthentication()).isNull();
-    }
+		assertThat(config.getIamAuthentication()).isNull();
+	}
 
-    @Test
-    void defaultConfigurationShouldHaveNullIamAuth() {
+	@Test
+	void defaultConfigurationShouldHaveNullIamAuth() {
 
-        ValkeyGlideClientConfiguration config = ValkeyGlideClientConfiguration.defaultConfiguration();
+		ValkeyGlideClientConfiguration config = ValkeyGlideClientConfiguration.defaultConfiguration();
 
-        assertThat(config.getIamAuthentication()).isNull();
-    }
+		assertThat(config.getIamAuthentication()).isNull();
+	}
 
-    @Test
-    void builderShouldCombineIamAuthWithOtherSettings() {
+	@Test
+	void builderShouldCombineIamAuthWithOtherSettings() {
 
-        IamAuthenticationForGlide iamConfig = new IamAuthenticationForGlide(
-                "my-cluster", AwsServiceType.MEMORYDB, "ap-southeast-1", 120);
+		IamAuthenticationForGlide iamConfig = new IamAuthenticationForGlide("my-cluster", AwsServiceType.MEMORYDB,
+				"ap-southeast-1", 120);
 
-        ValkeyGlideClientConfiguration config = ValkeyGlideClientConfiguration.builder()
-                .useSsl()
-                .useIamAuthentication(iamConfig)
-                .maxPoolSize(16)
-                .build();
+		ValkeyGlideClientConfiguration config = ValkeyGlideClientConfiguration.builder()
+			.useSsl()
+			.useIamAuthentication(iamConfig)
+			.maxPoolSize(16)
+			.build();
 
-        assertThat(config.isUseSsl()).isTrue();
-        assertThat(config.getMaxPoolSize()).isEqualTo(16);
-        assertThat(config.getIamAuthentication()).isNotNull();
-        assertThat(config.getIamAuthentication().serviceType()).isEqualTo(AwsServiceType.MEMORYDB);
-    }
+		assertThat(config.isUseSsl()).isTrue();
+		assertThat(config.getMaxPoolSize()).isEqualTo(16);
+		assertThat(config.getIamAuthentication()).isNotNull();
+		assertThat(config.getIamAuthentication().serviceType()).isEqualTo(AwsServiceType.MEMORYDB);
+	}
 
-    @Test
-    void awsServiceTypeEnumShouldHaveExpectedValues() {
+	@Test
+	void awsServiceTypeEnumShouldHaveExpectedValues() {
 
-        assertThat(AwsServiceType.values()).containsExactly(AwsServiceType.ELASTICACHE, AwsServiceType.MEMORYDB);
-    }
+		assertThat(AwsServiceType.values()).containsExactly(AwsServiceType.ELASTICACHE, AwsServiceType.MEMORYDB);
+	}
 
-    @Test
-    void awsServiceTypeShouldBeResolvableFromString() {
+	@Test
+	void awsServiceTypeShouldBeResolvableFromString() {
 
-        assertThat(AwsServiceType.valueOf("ELASTICACHE")).isEqualTo(AwsServiceType.ELASTICACHE);
-        assertThat(AwsServiceType.valueOf("MEMORYDB")).isEqualTo(AwsServiceType.MEMORYDB);
-    }
+		assertThat(AwsServiceType.valueOf("ELASTICACHE")).isEqualTo(AwsServiceType.ELASTICACHE);
+		assertThat(AwsServiceType.valueOf("MEMORYDB")).isEqualTo(AwsServiceType.MEMORYDB);
+	}
+
 }

--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideNewCommandsUnitTests.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideNewCommandsUnitTests.java
@@ -37,17 +37,21 @@ import io.valkey.springframework.data.valkey.core.types.Expiration;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 
 /**
- * Wire-level unit tests for GLIDE commands that require Valkey 8.2+ or Redis 8.4+.
- * These validate the correct command serialization without needing a running server.
+ * Wire-level unit tests for GLIDE commands that require Valkey 8.2+ or Redis 8.4+. These
+ * validate the correct command serialization without needing a running server.
  *
  * @author Jeremy Parr-Pearson
  */
 class ValkeyGlideNewCommandsUnitTests {
 
 	private UnifiedGlideClient client;
+
 	private ValkeyGlideConnection connection;
+
 	private ValkeyGlideStreamCommands streamCommands;
+
 	private ValkeyGlideKeyCommands keyCommands;
+
 	private ValkeyGlideHashCommands hashCommands;
 
 	@BeforeEach
@@ -68,8 +72,7 @@ class ValkeyGlideNewCommandsUnitTests {
 		when(client.customCommand(any(GlideString[].class))).thenReturn(mockResult);
 
 		XDelOptions options = XDelOptions.deletionPolicy(StreamDeletionPolicy.DELETE_REFERENCES);
-		streamCommands.xAckDel("stream".getBytes(), "group", options,
-				RecordId.of("1-1"), RecordId.of("2-2"));
+		streamCommands.xAckDel("stream".getBytes(), "group", options, RecordId.of("1-1"), RecordId.of("2-2"));
 
 		ArgumentCaptor<GlideString[]> captor = ArgumentCaptor.forClass(GlideString[].class);
 		verify(client).customCommand(captor.capture());
@@ -115,8 +118,7 @@ class ValkeyGlideNewCommandsUnitTests {
 		when(client.customCommand(any(GlideString[].class))).thenReturn(mockResult);
 
 		XDelOptions options = XDelOptions.deletionPolicy(StreamDeletionPolicy.DELETE_REFERENCES);
-		streamCommands.xDelEx("stream".getBytes(), options,
-				RecordId.of("1-1"), RecordId.of("2-2"), RecordId.of("3-3"));
+		streamCommands.xDelEx("stream".getBytes(), options, RecordId.of("1-1"), RecordId.of("2-2"), RecordId.of("3-3"));
 
 		ArgumentCaptor<GlideString[]> captor = ArgumentCaptor.forClass(GlideString[].class);
 		verify(client).customCommand(captor.capture());
@@ -246,8 +248,8 @@ class ValkeyGlideNewCommandsUnitTests {
 		CompareCondition condition = CompareCondition.ifEquals("value".getBytes());
 
 		assertThatThrownBy(() -> keyCommands.delex("key".getBytes(), condition))
-				.isInstanceOf(InvalidDataAccessApiUsageException.class)
-				.hasMessageContaining("WRONGTYPE");
+			.isInstanceOf(InvalidDataAccessApiUsageException.class)
+			.hasMessageContaining("WRONGTYPE");
 	}
 
 	@Test
@@ -271,4 +273,5 @@ class ValkeyGlideNewCommandsUnitTests {
 
 		assertThat(result).isFalse();
 	}
+
 }

--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideOpenTelemetryConfigurationTests.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideOpenTelemetryConfigurationTests.java
@@ -15,266 +15,240 @@ import io.valkey.springframework.data.valkey.connection.ValkeyClusterConfigurati
 /**
  * Unit tests for OpenTelemetry configuration in Valkey-Glide integration.
  *
- * Important: Validation + "init once" logic lives in ValkeyGlideConnectionFactory#useOpenTelemetry,
- * not in ValkeyGlideClientConfigurationBuilder#useOpenTelemetry (builder only stores config).
+ * Important: Validation + "init once" logic lives in
+ * ValkeyGlideConnectionFactory#useOpenTelemetry, not in
+ * ValkeyGlideClientConfigurationBuilder#useOpenTelemetry (builder only stores config).
  */
 class ValkeyGlideOpenTelemetryConfigurationTests {
 
-    private static final String TRACES_ENDPOINT = "http://localhost:4318/v1/traces";
-    private static final String METRICS_ENDPOINT = "http://localhost:4318/v1/metrics";
+	private static final String TRACES_ENDPOINT = "http://localhost:4318/v1/traces";
 
-    @BeforeEach
-    void resetOtelInitializationState() {
-        resetFactoryStaticOpenTelemetryState();
-    }
+	private static final String METRICS_ENDPOINT = "http://localhost:4318/v1/metrics";
 
-    @Test
-    void defaultsShouldReturnExpectedValues() {
+	@BeforeEach
+	void resetOtelInitializationState() {
+		resetFactoryStaticOpenTelemetryState();
+	}
 
-        ValkeyGlideClientConfiguration.OpenTelemetryForGlide defaults =
-                ValkeyGlideClientConfiguration.OpenTelemetryForGlide.defaults();
+	@Test
+	void defaultsShouldReturnExpectedValues() {
 
-        assertThat(defaults.tracesEndpoint()).isEqualTo(TRACES_ENDPOINT);
-        assertThat(defaults.metricsEndpoint()).isEqualTo(METRICS_ENDPOINT);
-        assertThat(defaults.samplePercentage()).isEqualTo(1);
-        assertThat(defaults.flushIntervalMs()).isEqualTo(5000L);
-    }
+		ValkeyGlideClientConfiguration.OpenTelemetryForGlide defaults = ValkeyGlideClientConfiguration.OpenTelemetryForGlide
+			.defaults();
 
-    @Test
-    void shouldThrowExceptionWhenBothEndpointsAreNull() {
+		assertThat(defaults.tracesEndpoint()).isEqualTo(TRACES_ENDPOINT);
+		assertThat(defaults.metricsEndpoint()).isEqualTo(METRICS_ENDPOINT);
+		assertThat(defaults.samplePercentage()).isEqualTo(1);
+		assertThat(defaults.flushIntervalMs()).isEqualTo(5000L);
+	}
 
-        ValkeyGlideClientConfiguration.OpenTelemetryForGlide cfg =
-                new ValkeyGlideClientConfiguration.OpenTelemetryForGlide(null, null, 10, 100L);
+	@Test
+	void shouldThrowExceptionWhenBothEndpointsAreNull() {
 
-        ValkeyGlideConnectionFactory factory = new ValkeyGlideConnectionFactory(
-                new ValkeyClusterConfiguration(),
-                ValkeyGlideClientConfiguration.builder().useOpenTelemetry(cfg).build()
-        );
+		ValkeyGlideClientConfiguration.OpenTelemetryForGlide cfg = new ValkeyGlideClientConfiguration.OpenTelemetryForGlide(
+				null, null, 10, 100L);
 
-        assertThatIllegalArgumentException()
-                .isThrownBy(() -> invokeUseOpenTelemetry(factory, cfg));
-    }
+		ValkeyGlideConnectionFactory factory = new ValkeyGlideConnectionFactory(new ValkeyClusterConfiguration(),
+				ValkeyGlideClientConfiguration.builder().useOpenTelemetry(cfg).build());
 
-    @Test
-    void shouldInitializeWhenTracesOnlyIsProvided() {
+		assertThatIllegalArgumentException().isThrownBy(() -> invokeUseOpenTelemetry(factory, cfg));
+	}
 
-        ValkeyGlideClientConfiguration.OpenTelemetryForGlide cfg =
-                new ValkeyGlideClientConfiguration.OpenTelemetryForGlide(TRACES_ENDPOINT, null, 10, 100L);
+	@Test
+	void shouldInitializeWhenTracesOnlyIsProvided() {
 
-        ValkeyGlideConnectionFactory factory = new ValkeyGlideConnectionFactory(
-                new ValkeyClusterConfiguration(),
-                ValkeyGlideClientConfiguration.builder().useOpenTelemetry(cfg).build()
-        );
+		ValkeyGlideClientConfiguration.OpenTelemetryForGlide cfg = new ValkeyGlideClientConfiguration.OpenTelemetryForGlide(
+				TRACES_ENDPOINT, null, 10, 100L);
 
-        assertThatNoException().isThrownBy(() -> invokeUseOpenTelemetry(factory, cfg));
-    }
+		ValkeyGlideConnectionFactory factory = new ValkeyGlideConnectionFactory(new ValkeyClusterConfiguration(),
+				ValkeyGlideClientConfiguration.builder().useOpenTelemetry(cfg).build());
 
-    @Test
-    void shouldInitializeWhenMetricsOnlyIsProvided() {
+		assertThatNoException().isThrownBy(() -> invokeUseOpenTelemetry(factory, cfg));
+	}
 
-        ValkeyGlideClientConfiguration.OpenTelemetryForGlide cfg =
-                new ValkeyGlideClientConfiguration.OpenTelemetryForGlide(null, METRICS_ENDPOINT, null, null);
+	@Test
+	void shouldInitializeWhenMetricsOnlyIsProvided() {
 
-        ValkeyGlideConnectionFactory factory = new ValkeyGlideConnectionFactory(
-                new ValkeyClusterConfiguration(),
-                ValkeyGlideClientConfiguration.builder().useOpenTelemetry(cfg).build()
-        );
+		ValkeyGlideClientConfiguration.OpenTelemetryForGlide cfg = new ValkeyGlideClientConfiguration.OpenTelemetryForGlide(
+				null, METRICS_ENDPOINT, null, null);
 
-        assertThatNoException().isThrownBy(() -> invokeUseOpenTelemetry(factory, cfg));
-    }
+		ValkeyGlideConnectionFactory factory = new ValkeyGlideConnectionFactory(new ValkeyClusterConfiguration(),
+				ValkeyGlideClientConfiguration.builder().useOpenTelemetry(cfg).build());
 
-    @Test
-    void shouldNotFailWhenAlreadyInitializedWithSameConfig() {
+		assertThatNoException().isThrownBy(() -> invokeUseOpenTelemetry(factory, cfg));
+	}
 
-        ValkeyGlideClientConfiguration.OpenTelemetryForGlide cfg =
-                new ValkeyGlideClientConfiguration.OpenTelemetryForGlide(
-                        TRACES_ENDPOINT, METRICS_ENDPOINT, 10, 100L
-                );
+	@Test
+	void shouldNotFailWhenAlreadyInitializedWithSameConfig() {
 
-        ValkeyGlideConnectionFactory factory = new ValkeyGlideConnectionFactory(
-                new ValkeyClusterConfiguration(),
-                ValkeyGlideClientConfiguration.builder().useOpenTelemetry(cfg).build()
-        );
+		ValkeyGlideClientConfiguration.OpenTelemetryForGlide cfg = new ValkeyGlideClientConfiguration.OpenTelemetryForGlide(
+				TRACES_ENDPOINT, METRICS_ENDPOINT, 10, 100L);
 
-        assertThatNoException().isThrownBy(() -> invokeUseOpenTelemetry(factory, cfg));
-        assertThatNoException().isThrownBy(() -> invokeUseOpenTelemetry(factory, cfg));
-    }
+		ValkeyGlideConnectionFactory factory = new ValkeyGlideConnectionFactory(new ValkeyClusterConfiguration(),
+				ValkeyGlideClientConfiguration.builder().useOpenTelemetry(cfg).build());
 
-    @Test
-    void shouldThrowWhenAlreadyInitializedWithDifferentConfig() {
+		assertThatNoException().isThrownBy(() -> invokeUseOpenTelemetry(factory, cfg));
+		assertThatNoException().isThrownBy(() -> invokeUseOpenTelemetry(factory, cfg));
+	}
 
-        ValkeyGlideClientConfiguration.OpenTelemetryForGlide first =
-                new ValkeyGlideClientConfiguration.OpenTelemetryForGlide(TRACES_ENDPOINT, null, 10, 100L);
+	@Test
+	void shouldThrowWhenAlreadyInitializedWithDifferentConfig() {
 
-        ValkeyGlideClientConfiguration.OpenTelemetryForGlide second =
-                new ValkeyGlideClientConfiguration.OpenTelemetryForGlide(
-                        "http://different-endpoint.com:4318/v1/traces", null, 10, 100L
-                );
+		ValkeyGlideClientConfiguration.OpenTelemetryForGlide first = new ValkeyGlideClientConfiguration.OpenTelemetryForGlide(
+				TRACES_ENDPOINT, null, 10, 100L);
 
-        ValkeyGlideConnectionFactory factory = new ValkeyGlideConnectionFactory(
-                new ValkeyClusterConfiguration(),
-                ValkeyGlideClientConfiguration.builder().useOpenTelemetry(first).build()
-        );
+		ValkeyGlideClientConfiguration.OpenTelemetryForGlide second = new ValkeyGlideClientConfiguration.OpenTelemetryForGlide(
+				"http://different-endpoint.com:4318/v1/traces", null, 10, 100L);
 
-        assertThatNoException().isThrownBy(() -> invokeUseOpenTelemetry(factory, first));
+		ValkeyGlideConnectionFactory factory = new ValkeyGlideConnectionFactory(new ValkeyClusterConfiguration(),
+				ValkeyGlideClientConfiguration.builder().useOpenTelemetry(first).build());
 
-        assertThatThrownBy(() -> invokeUseOpenTelemetry(factory, second))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("already initialized with a different configuration");
-    }
+		assertThatNoException().isThrownBy(() -> invokeUseOpenTelemetry(factory, first));
 
-    @Test
-    void shouldTreatBlankEndpointsAsMissingAndFail() {
+		assertThatThrownBy(() -> invokeUseOpenTelemetry(factory, second)).isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("already initialized with a different configuration");
+	}
 
-        ValkeyGlideClientConfiguration.OpenTelemetryForGlide cfg =
-                new ValkeyGlideClientConfiguration.OpenTelemetryForGlide("   ", "\t", 10, 100L);
+	@Test
+	void shouldTreatBlankEndpointsAsMissingAndFail() {
 
-        ValkeyGlideConnectionFactory factory = new ValkeyGlideConnectionFactory(
-                new ValkeyClusterConfiguration(),
-                ValkeyGlideClientConfiguration.builder().useOpenTelemetry(cfg).build()
-        );
+		ValkeyGlideClientConfiguration.OpenTelemetryForGlide cfg = new ValkeyGlideClientConfiguration.OpenTelemetryForGlide(
+				"   ", "\t", 10, 100L);
 
-        assertThatIllegalArgumentException()
-                .isThrownBy(() -> invokeUseOpenTelemetry(factory, cfg))
-                .withMessageContaining("requires at least one of tracesEndpoint or metricsEndpoint");
-    }
+		ValkeyGlideConnectionFactory factory = new ValkeyGlideConnectionFactory(new ValkeyClusterConfiguration(),
+				ValkeyGlideClientConfiguration.builder().useOpenTelemetry(cfg).build());
 
-    @Test
-    void shouldInitializeWhenTracesEndpointIsBlankButMetricsIsProvided() {
+		assertThatIllegalArgumentException().isThrownBy(() -> invokeUseOpenTelemetry(factory, cfg))
+			.withMessageContaining("requires at least one of tracesEndpoint or metricsEndpoint");
+	}
 
-        ValkeyGlideClientConfiguration.OpenTelemetryForGlide cfg =
-                new ValkeyGlideClientConfiguration.OpenTelemetryForGlide("   ", METRICS_ENDPOINT, null, null);
+	@Test
+	void shouldInitializeWhenTracesEndpointIsBlankButMetricsIsProvided() {
 
-        ValkeyGlideConnectionFactory factory = new ValkeyGlideConnectionFactory(
-                new ValkeyClusterConfiguration(),
-                ValkeyGlideClientConfiguration.builder().useOpenTelemetry(cfg).build()
-        );
+		ValkeyGlideClientConfiguration.OpenTelemetryForGlide cfg = new ValkeyGlideClientConfiguration.OpenTelemetryForGlide(
+				"   ", METRICS_ENDPOINT, null, null);
 
-        assertThatNoException().isThrownBy(() -> invokeUseOpenTelemetry(factory, cfg));
-    }
+		ValkeyGlideConnectionFactory factory = new ValkeyGlideConnectionFactory(new ValkeyClusterConfiguration(),
+				ValkeyGlideClientConfiguration.builder().useOpenTelemetry(cfg).build());
 
-    @Test
-    void shouldInitializeWhenMetricsEndpointIsBlankButTracesIsProvided() {
+		assertThatNoException().isThrownBy(() -> invokeUseOpenTelemetry(factory, cfg));
+	}
 
-        ValkeyGlideClientConfiguration.OpenTelemetryForGlide cfg =
-                new ValkeyGlideClientConfiguration.OpenTelemetryForGlide(TRACES_ENDPOINT, "   ", 10, 100L);
+	@Test
+	void shouldInitializeWhenMetricsEndpointIsBlankButTracesIsProvided() {
 
-        ValkeyGlideConnectionFactory factory = new ValkeyGlideConnectionFactory(
-                new ValkeyClusterConfiguration(),
-                ValkeyGlideClientConfiguration.builder().useOpenTelemetry(cfg).build()
-        );
+		ValkeyGlideClientConfiguration.OpenTelemetryForGlide cfg = new ValkeyGlideClientConfiguration.OpenTelemetryForGlide(
+				TRACES_ENDPOINT, "   ", 10, 100L);
 
-        assertThatNoException().isThrownBy(() -> invokeUseOpenTelemetry(factory, cfg));
-    }
+		ValkeyGlideConnectionFactory factory = new ValkeyGlideConnectionFactory(new ValkeyClusterConfiguration(),
+				ValkeyGlideClientConfiguration.builder().useOpenTelemetry(cfg).build());
 
-    @Test
-    void shouldNotInitializeWhenOpenTelemetryConfigIsNull() {
-        assertThat(isOtelInitialized()).isFalse();
-        assertThat(getInitializedConfig()).isNull();
-    }
+		assertThatNoException().isThrownBy(() -> invokeUseOpenTelemetry(factory, cfg));
+	}
 
-    @Test
-    void shouldThrowWhenSamplePercentageIsOutOfRange() {
+	@Test
+	void shouldNotInitializeWhenOpenTelemetryConfigIsNull() {
+		assertThat(isOtelInitialized()).isFalse();
+		assertThat(getInitializedConfig()).isNull();
+	}
 
-        ValkeyGlideClientConfiguration.OpenTelemetryForGlide cfg =
-                new ValkeyGlideClientConfiguration.OpenTelemetryForGlide(TRACES_ENDPOINT, null, 101, 100L);
+	@Test
+	void shouldThrowWhenSamplePercentageIsOutOfRange() {
 
-        ValkeyGlideConnectionFactory factory = new ValkeyGlideConnectionFactory(
-                new ValkeyClusterConfiguration(),
-                ValkeyGlideClientConfiguration.builder().useOpenTelemetry(cfg).build()
-        );
+		ValkeyGlideClientConfiguration.OpenTelemetryForGlide cfg = new ValkeyGlideClientConfiguration.OpenTelemetryForGlide(
+				TRACES_ENDPOINT, null, 101, 100L);
 
-        assertThatIllegalArgumentException()
-                .isThrownBy(() -> invokeUseOpenTelemetry(factory, cfg))
-                .withMessageContaining("samplePercentage");
-    }
+		ValkeyGlideConnectionFactory factory = new ValkeyGlideConnectionFactory(new ValkeyClusterConfiguration(),
+				ValkeyGlideClientConfiguration.builder().useOpenTelemetry(cfg).build());
 
-    @Test
-    void shouldThrowWhenFlushIntervalMsIsNonPositive() {
+		assertThatIllegalArgumentException().isThrownBy(() -> invokeUseOpenTelemetry(factory, cfg))
+			.withMessageContaining("samplePercentage");
+	}
 
-        ValkeyGlideClientConfiguration.OpenTelemetryForGlide cfg =
-                new ValkeyGlideClientConfiguration.OpenTelemetryForGlide(TRACES_ENDPOINT, null, 10, 0L);
+	@Test
+	void shouldThrowWhenFlushIntervalMsIsNonPositive() {
 
-        ValkeyGlideConnectionFactory factory = new ValkeyGlideConnectionFactory(
-                new ValkeyClusterConfiguration(),
-                ValkeyGlideClientConfiguration.builder().useOpenTelemetry(cfg).build()
-        );
+		ValkeyGlideClientConfiguration.OpenTelemetryForGlide cfg = new ValkeyGlideClientConfiguration.OpenTelemetryForGlide(
+				TRACES_ENDPOINT, null, 10, 0L);
 
-        assertThatIllegalArgumentException()
-                .isThrownBy(() -> invokeUseOpenTelemetry(factory, cfg))
-                .withMessageContaining("flushIntervalMs");
-    }
+		ValkeyGlideConnectionFactory factory = new ValkeyGlideConnectionFactory(new ValkeyClusterConfiguration(),
+				ValkeyGlideClientConfiguration.builder().useOpenTelemetry(cfg).build());
 
-    // ----------------- helpers -----------------
+		assertThatIllegalArgumentException().isThrownBy(() -> invokeUseOpenTelemetry(factory, cfg))
+			.withMessageContaining("flushIntervalMs");
+	}
 
-    private static boolean isOtelInitialized() {
-        try {
-            Field initializedField = ValkeyGlideConnectionFactory.class.getDeclaredField("OTEL_INITIALIZED");
-            initializedField.setAccessible(true);
-            AtomicBoolean initialized = (AtomicBoolean) initializedField.get(null);
-            return initialized.get();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
+	// ----------------- helpers -----------------
 
-    private static ValkeyGlideClientConfiguration.OpenTelemetryForGlide getInitializedConfig() {
-        try {
-            Field configField = ValkeyGlideConnectionFactory.class.getDeclaredField("OTEL_INITIALIZED_CONFIG");
-            configField.setAccessible(true);
-            return (ValkeyGlideClientConfiguration.OpenTelemetryForGlide) configField.get(null);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
+	private static boolean isOtelInitialized() {
+		try {
+			Field initializedField = ValkeyGlideConnectionFactory.class.getDeclaredField("OTEL_INITIALIZED");
+			initializedField.setAccessible(true);
+			AtomicBoolean initialized = (AtomicBoolean) initializedField.get(null);
+			return initialized.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
 
-    /**
-     * Invoke the private useOpenTelemetry method via reflection.
-     */
-    private static void invokeUseOpenTelemetry(
-            ValkeyGlideConnectionFactory factory,
-            ValkeyGlideClientConfiguration.OpenTelemetryForGlide openTelemetryForGlide
-    ) throws Exception {
+	private static ValkeyGlideClientConfiguration.OpenTelemetryForGlide getInitializedConfig() {
+		try {
+			Field configField = ValkeyGlideConnectionFactory.class.getDeclaredField("OTEL_INITIALIZED_CONFIG");
+			configField.setAccessible(true);
+			return (ValkeyGlideClientConfiguration.OpenTelemetryForGlide) configField.get(null);
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
 
-        Method m = ValkeyGlideConnectionFactory.class
-                .getDeclaredMethod(
-                        "useOpenTelemetry",
-                        ValkeyGlideClientConfiguration.OpenTelemetryForGlide.class
-                );
-        m.setAccessible(true);
+	/**
+	 * Invoke the private useOpenTelemetry method via reflection.
+	 */
+	private static void invokeUseOpenTelemetry(ValkeyGlideConnectionFactory factory,
+			ValkeyGlideClientConfiguration.OpenTelemetryForGlide openTelemetryForGlide) throws Exception {
 
-        try {
-            m.invoke(factory, openTelemetryForGlide);
-        } catch (InvocationTargetException ite) {
-            Throwable cause = ite.getCause();
-            if (cause instanceof Exception e) {
-                throw e;
-            }
-            if (cause instanceof Error err) {
-                throw err;
-            }
-            throw new RuntimeException(cause);
-        }
-    }
+		Method m = ValkeyGlideConnectionFactory.class.getDeclaredMethod("useOpenTelemetry",
+				ValkeyGlideClientConfiguration.OpenTelemetryForGlide.class);
+		m.setAccessible(true);
 
-    /**
-     * Reset the static OpenTelemetry initialization state in ValkeyGlideConnectionFactory.
-     */
-    private static void resetFactoryStaticOpenTelemetryState() {
-        try {
-        Class<?> factoryClass = ValkeyGlideConnectionFactory.class;
+		try {
+			m.invoke(factory, openTelemetryForGlide);
+		}
+		catch (InvocationTargetException ite) {
+			Throwable cause = ite.getCause();
+			if (cause instanceof Exception e) {
+				throw e;
+			}
+			if (cause instanceof Error err) {
+				throw err;
+			}
+			throw new RuntimeException(cause);
+		}
+	}
 
-            Field initializedField = factoryClass.getDeclaredField("OTEL_INITIALIZED");
-            initializedField.setAccessible(true);
-            AtomicBoolean initialized = (AtomicBoolean) initializedField.get(null);
-            initialized.set(false);
+	/**
+	 * Reset the static OpenTelemetry initialization state in
+	 * ValkeyGlideConnectionFactory.
+	 */
+	private static void resetFactoryStaticOpenTelemetryState() {
+		try {
+			Class<?> factoryClass = ValkeyGlideConnectionFactory.class;
 
-            Field configField = factoryClass.getDeclaredField("OTEL_INITIALIZED_CONFIG");
-            configField.setAccessible(true);
-            configField.set(null, null);
+			Field initializedField = factoryClass.getDeclaredField("OTEL_INITIALIZED");
+			initializedField.setAccessible(true);
+			AtomicBoolean initialized = (AtomicBoolean) initializedField.get(null);
+			initialized.set(false);
 
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to reset OpenTelemetry static state for tests", e);
-        }
-    }
+			Field configField = factoryClass.getDeclaredField("OTEL_INITIALIZED_CONFIG");
+			configField.setAccessible(true);
+			configField.set(null, null);
+
+		}
+		catch (Exception e) {
+			throw new RuntimeException("Failed to reset OpenTelemetry static state for tests", e);
+		}
+	}
+
 }

--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlidePubSubPoolingIntegrationTests.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlidePubSubPoolingIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,650 +50,668 @@ import io.valkey.springframework.data.valkey.test.condition.ValkeyDetector;
 import org.springframework.lang.Nullable;
 
 /**
- * Integration tests for Valkey Glide pub/sub with connection pooling.
- * These tests specifically target issues that can arise when clients are pooled
- * and their state may persist between uses.
+ * Integration tests for Valkey Glide pub/sub with connection pooling. These tests
+ * specifically target issues that can arise when clients are pooled and their state may
+ * persist between uses.
  */
 @ParameterizedClass
 @MethodSource("testParams")
 class ValkeyGlidePubSubPoolingIntegrationTests {
 
-    private static final Logger logger = LoggerFactory.getLogger(ValkeyGlidePubSubPoolingIntegrationTests.class);
-
-    private static final Duration AWAIT_TIMEOUT = Duration.ofSeconds(2);
-    private static final long TERMINATION_TIMEOUT_SECONDS = 10;
-
-    private final boolean useCluster;
-
-    // Shared publisher factory - created in setUp, destroyed in tearDown
-    private ValkeyGlideConnectionFactory publisherFactory;
-
-    // Test-specific factories - tests manage their own lifecycle
-    private final List<ValkeyGlideConnectionFactory> testFactories = new ArrayList<>();
-
-    public ValkeyGlidePubSubPoolingIntegrationTests(boolean useCluster) {
-        this.useCluster = useCluster;
-    }
-
-    public static Collection<Object[]> testParams() {
-        List<Object[]> params = new ArrayList<>();
-
-        // Always test standalone
-        params.add(new Object[] { false });
-
-        // Also test cluster if available
-        if (clusterAvailable()) {
-            params.add(new Object[] { true });
-        }
-
-        return params;
-    }
-
-    private static boolean clusterAvailable() {
-        return ValkeyDetector.isClusterAvailable();
-    }
+	private static final Logger logger = LoggerFactory.getLogger(ValkeyGlidePubSubPoolingIntegrationTests.class);
+
+	private static final Duration AWAIT_TIMEOUT = Duration.ofSeconds(2);
+
+	private static final long TERMINATION_TIMEOUT_SECONDS = 10;
+
+	private final boolean useCluster;
+
+	// Shared publisher factory - created in setUp, destroyed in tearDown
+	private ValkeyGlideConnectionFactory publisherFactory;
+
+	// Test-specific factories - tests manage their own lifecycle
+	private final List<ValkeyGlideConnectionFactory> testFactories = new ArrayList<>();
+
+	public ValkeyGlidePubSubPoolingIntegrationTests(boolean useCluster) {
+		this.useCluster = useCluster;
+	}
+
+	public static Collection<Object[]> testParams() {
+		List<Object[]> params = new ArrayList<>();
+
+		// Always test standalone
+		params.add(new Object[] { false });
+
+		// Also test cluster if available
+		if (clusterAvailable()) {
+			params.add(new Object[] { true });
+		}
+
+		return params;
+	}
+
+	private static boolean clusterAvailable() {
+		return ValkeyDetector.isClusterAvailable();
+	}
 
-    @BeforeEach
-    void setUp() {
-        publisherFactory = createConnectionFactory(2);
-    }
+	@BeforeEach
+	void setUp() {
+		publisherFactory = createConnectionFactory(2);
+	}
 
-    @AfterEach
-    void tearDown() {
-        // Clean up all test-created factories
-        for (ValkeyGlideConnectionFactory factory : testFactories) {
-            destroyFactory(factory);
-        }
-        testFactories.clear();
+	@AfterEach
+	void tearDown() {
+		// Clean up all test-created factories
+		for (ValkeyGlideConnectionFactory factory : testFactories) {
+			destroyFactory(factory);
+		}
+		testFactories.clear();
 
-        destroyFactory(publisherFactory);
-    }
+		destroyFactory(publisherFactory);
+	}
 
-    /**
-     * Creates a connection factory with the specified pool size and registers it for cleanup.
-     */
-    private ValkeyGlideConnectionFactory createTestFactory(int poolSize) {
-        ValkeyGlideConnectionFactory factory = createConnectionFactory(poolSize);
-        testFactories.add(factory);
-        return factory;
-    }
+	/**
+	 * Creates a connection factory with the specified pool size and registers it for
+	 * cleanup.
+	 */
+	private ValkeyGlideConnectionFactory createTestFactory(int poolSize) {
+		ValkeyGlideConnectionFactory factory = createConnectionFactory(poolSize);
+		testFactories.add(factory);
+		return factory;
+	}
 
-    private ValkeyGlideConnectionFactory createConnectionFactory(int poolSize) {
-        ValkeyGlideClientConfiguration clientConfig = ValkeyGlideClientConfiguration.builder()
-                .maxPoolSize(poolSize)
-                .build();
+	private ValkeyGlideConnectionFactory createConnectionFactory(int poolSize) {
+		ValkeyGlideClientConfiguration clientConfig = ValkeyGlideClientConfiguration.builder()
+			.maxPoolSize(poolSize)
+			.build();
 
-        ValkeyGlideConnectionFactory factory;
-        if (useCluster) {
-            ValkeyClusterConfiguration clusterConfig = SettingsUtils.clusterConfiguration();
-            factory = new ValkeyGlideConnectionFactory(clusterConfig, clientConfig);
-        } else {
-            ValkeyStandaloneConfiguration standaloneConfig = SettingsUtils.standaloneConfiguration();
-            factory = new ValkeyGlideConnectionFactory(standaloneConfig, clientConfig);
-        }
+		ValkeyGlideConnectionFactory factory;
+		if (useCluster) {
+			ValkeyClusterConfiguration clusterConfig = SettingsUtils.clusterConfiguration();
+			factory = new ValkeyGlideConnectionFactory(clusterConfig, clientConfig);
+		}
+		else {
+			ValkeyStandaloneConfiguration standaloneConfig = SettingsUtils.standaloneConfiguration();
+			factory = new ValkeyGlideConnectionFactory(standaloneConfig, clientConfig);
+		}
 
-        factory.afterPropertiesSet();
-        factory.start();
-        return factory;
-    }
+		factory.afterPropertiesSet();
+		factory.start();
+		return factory;
+	}
 
-    private void destroyFactory(@Nullable ValkeyGlideConnectionFactory factory) {
-        if (factory != null) {
-            try {
-                factory.destroy();
-            } catch (Exception e) {
-                logger.warn("Failed to destroy factory: {}", e.getMessage());
-            }
-        }
-    }
+	private void destroyFactory(@Nullable ValkeyGlideConnectionFactory factory) {
+		if (factory != null) {
+			try {
+				factory.destroy();
+			}
+			catch (Exception e) {
+				logger.warn("Failed to destroy factory: {}", e.getMessage());
+			}
+		}
+	}
 
-    private void publish(String channel, String message) {
-        try (ValkeyConnection publisher = publisherFactory.getConnection()) {
-            publisher.publish(channel.getBytes(), message.getBytes());
-        }
-    }
+	private void publish(String channel, String message) {
+		try (ValkeyConnection publisher = publisherFactory.getConnection()) {
+			publisher.publish(channel.getBytes(), message.getBytes());
+		}
+	}
 
-    interface CompositeListener extends MessageListener, SubscriptionListener {}
+	interface CompositeListener extends MessageListener, SubscriptionListener {
 
-    // ==================== Single Client Pool Tests ====================
-    // These tests use pool size 1 to guarantee client reuse
+	}
 
-    @Test
-    void sameClientShouldNotReceiveMessagesFromPreviousSubscription() throws Exception {
-        ValkeyGlideConnectionFactory connectionFactory = createTestFactory(1);
+	// ==================== Single Client Pool Tests ====================
+	// These tests use pool size 1 to guarantee client reuse
 
-        String channel1 = "test:pool:prev:ch1";
-        String channel2 = "test:pool:prev:ch2";
+	@Test
+	void sameClientShouldNotReceiveMessagesFromPreviousSubscription() throws Exception {
+		ValkeyGlideConnectionFactory connectionFactory = createTestFactory(1);
 
-        List<String> listener1Messages = Collections.synchronizedList(new ArrayList<>());
-        List<String> listener2Messages = Collections.synchronizedList(new ArrayList<>());
+		String channel1 = "test:pool:prev:ch1";
+		String channel2 = "test:pool:prev:ch2";
 
-        ValkeyConnection conn1 = connectionFactory.getConnection();
-        Object nativeClient1 = conn1.getNativeConnection();
+		List<String> listener1Messages = Collections.synchronizedList(new ArrayList<>());
+		List<String> listener2Messages = Collections.synchronizedList(new ArrayList<>());
 
-        conn1.subscribe((message, pattern) -> listener1Messages.add(new String(message.getBody())),
-                channel1.getBytes());
+		ValkeyConnection conn1 = connectionFactory.getConnection();
+		Object nativeClient1 = conn1.getNativeConnection();
 
-        publish(channel1, "message1");
+		conn1.subscribe((message, pattern) -> listener1Messages.add(new String(message.getBody())),
+				channel1.getBytes());
 
-        await().atMost(AWAIT_TIMEOUT).until(() -> listener1Messages.size() >= 1);
-        assertThat(listener1Messages).contains("message1");
+		publish(channel1, "message1");
 
-        conn1.close();
+		await().atMost(AWAIT_TIMEOUT).until(() -> listener1Messages.size() >= 1);
+		assertThat(listener1Messages).contains("message1");
 
-        ValkeyConnection conn2 = connectionFactory.getConnection();
-        assertThat(conn2.getNativeConnection()).isSameAs(nativeClient1);
+		conn1.close();
 
-        conn2.subscribe((message, pattern) -> listener2Messages.add(new String(message.getBody())),
-                channel2.getBytes());
+		ValkeyConnection conn2 = connectionFactory.getConnection();
+		assertThat(conn2.getNativeConnection()).isSameAs(nativeClient1);
 
-        publish(channel1, "message_to_old_channel");
-        publish(channel2, "message2");
+		conn2.subscribe((message, pattern) -> listener2Messages.add(new String(message.getBody())),
+				channel2.getBytes());
 
-        await().atMost(AWAIT_TIMEOUT).until(() -> listener2Messages.size() >= 1);
+		publish(channel1, "message_to_old_channel");
+		publish(channel2, "message2");
 
-        assertThat(listener2Messages).contains("message2");
-        assertThat(listener2Messages).doesNotContain("message_to_old_channel");
-        assertThat(listener1Messages).hasSize(1);
+		await().atMost(AWAIT_TIMEOUT).until(() -> listener2Messages.size() >= 1);
 
-        conn2.close();
-    }
+		assertThat(listener2Messages).contains("message2");
+		assertThat(listener2Messages).doesNotContain("message_to_old_channel");
+		assertThat(listener1Messages).hasSize(1);
 
-    @Test
-    void rapidSubscribeUnsubscribeCyclesOnSameClient() throws Exception {
-        ValkeyGlideConnectionFactory connectionFactory = createTestFactory(1);
+		conn2.close();
+	}
 
-        String channelBase = "test:pool:rapid";
-        int cycles = 10;
-        Object firstClient = null;
+	@Test
+	void rapidSubscribeUnsubscribeCyclesOnSameClient() throws Exception {
+		ValkeyGlideConnectionFactory connectionFactory = createTestFactory(1);
 
-        for (int i = 0; i < cycles; i++) {
-            String channel = channelBase + ":" + i;
-            AtomicInteger received = new AtomicInteger(0);
+		String channelBase = "test:pool:rapid";
+		int cycles = 10;
+		Object firstClient = null;
 
-            ValkeyConnection conn = connectionFactory.getConnection();
+		for (int i = 0; i < cycles; i++) {
+			String channel = channelBase + ":" + i;
+			AtomicInteger received = new AtomicInteger(0);
 
-            if (firstClient == null) {
-                firstClient = conn.getNativeConnection();
-            } else {
-                assertThat(conn.getNativeConnection()).isSameAs(firstClient);
-            }
+			ValkeyConnection conn = connectionFactory.getConnection();
 
-            conn.subscribe((message, pattern) -> received.incrementAndGet(), channel.getBytes());
+			if (firstClient == null) {
+				firstClient = conn.getNativeConnection();
+			}
+			else {
+				assertThat(conn.getNativeConnection()).isSameAs(firstClient);
+			}
 
-            publish(channel, "msg" + i);
+			conn.subscribe((message, pattern) -> received.incrementAndGet(), channel.getBytes());
 
-            await().atMost(AWAIT_TIMEOUT).until(() -> received.get() >= 1);
+			publish(channel, "msg" + i);
 
-            conn.close();
-        }
-    }
+			await().atMost(AWAIT_TIMEOUT).until(() -> received.get() >= 1);
 
-    @Test
-    void subscriptionCallbacksWithCompositeListener() throws Exception {
-        ValkeyGlideConnectionFactory connectionFactory = createTestFactory(1);
+			conn.close();
+		}
+	}
 
-        String channel = "test:pool:callbacks";
-        Object firstClient = null;
+	@Test
+	void subscriptionCallbacksWithCompositeListener() throws Exception {
+		ValkeyGlideConnectionFactory connectionFactory = createTestFactory(1);
 
-        for (int i = 0; i < 3; i++) {
-            CompletableFuture<Void> subscribed = new CompletableFuture<>();
-            CompletableFuture<Void> unsubscribed = new CompletableFuture<>();
-            AtomicReference<byte[]> subscribedChannel = new AtomicReference<>();
-            AtomicReference<byte[]> unsubscribedChannel = new AtomicReference<>();
+		String channel = "test:pool:callbacks";
+		Object firstClient = null;
 
-            ValkeyConnection conn = connectionFactory.getConnection();
+		for (int i = 0; i < 3; i++) {
+			CompletableFuture<Void> subscribed = new CompletableFuture<>();
+			CompletableFuture<Void> unsubscribed = new CompletableFuture<>();
+			AtomicReference<byte[]> subscribedChannel = new AtomicReference<>();
+			AtomicReference<byte[]> unsubscribedChannel = new AtomicReference<>();
 
-            if (firstClient == null) {
-                firstClient = conn.getNativeConnection();
-            } else {
-                assertThat(conn.getNativeConnection()).isSameAs(firstClient);
-            }
+			ValkeyConnection conn = connectionFactory.getConnection();
 
-            CompositeListener listener = new CompositeListener() {
-                @Override
-                public void onMessage(Message message, @Nullable byte[] pattern) {}
+			if (firstClient == null) {
+				firstClient = conn.getNativeConnection();
+			}
+			else {
+				assertThat(conn.getNativeConnection()).isSameAs(firstClient);
+			}
 
-                @Override
-                public void onChannelSubscribed(byte[] ch, long count) {
-                    subscribedChannel.set(ch);
-                    subscribed.complete(null);
-                }
+			CompositeListener listener = new CompositeListener() {
+				@Override
+				public void onMessage(Message message, @Nullable byte[] pattern) {
+				}
 
-                @Override
-                public void onChannelUnsubscribed(byte[] ch, long count) {
-                    unsubscribedChannel.set(ch);
-                    unsubscribed.complete(null);
-                }
-            };
+				@Override
+				public void onChannelSubscribed(byte[] ch, long count) {
+					subscribedChannel.set(ch);
+					subscribed.complete(null);
+				}
 
-            conn.subscribe(listener, channel.getBytes());
+				@Override
+				public void onChannelUnsubscribed(byte[] ch, long count) {
+					unsubscribedChannel.set(ch);
+					unsubscribed.complete(null);
+				}
+			};
 
-            subscribed.get(1, TimeUnit.SECONDS);
-            assertThat(subscribedChannel.get()).isEqualTo(channel.getBytes());
+			conn.subscribe(listener, channel.getBytes());
 
-            conn.close();
+			subscribed.get(1, TimeUnit.SECONDS);
+			assertThat(subscribedChannel.get()).isEqualTo(channel.getBytes());
 
-            unsubscribed.get(1, TimeUnit.SECONDS);
-            assertThat(unsubscribedChannel.get()).isEqualTo(channel.getBytes());
-        }
-    }
+			conn.close();
 
-    @Test
-    void partialUnsubscribeThenReuseClient() throws Exception {
-        ValkeyGlideConnectionFactory connectionFactory = createTestFactory(1);
+			unsubscribed.get(1, TimeUnit.SECONDS);
+			assertThat(unsubscribedChannel.get()).isEqualTo(channel.getBytes());
+		}
+	}
 
-        String channel1 = "test:pool:partial:ch1";
-        String channel2 = "test:pool:partial:ch2";
-        String channel3 = "test:pool:partial:ch3";
+	@Test
+	void partialUnsubscribeThenReuseClient() throws Exception {
+		ValkeyGlideConnectionFactory connectionFactory = createTestFactory(1);
 
-        List<String> messages = Collections.synchronizedList(new ArrayList<>());
+		String channel1 = "test:pool:partial:ch1";
+		String channel2 = "test:pool:partial:ch2";
+		String channel3 = "test:pool:partial:ch3";
 
-        ValkeyConnection conn1 = connectionFactory.getConnection();
-        Object nativeClient = conn1.getNativeConnection();
+		List<String> messages = Collections.synchronizedList(new ArrayList<>());
 
-        conn1.subscribe((message, pattern) -> {
-            messages.add(new String(message.getChannel()) + ":" + new String(message.getBody()));
-        }, channel1.getBytes(), channel2.getBytes());
+		ValkeyConnection conn1 = connectionFactory.getConnection();
+		Object nativeClient = conn1.getNativeConnection();
 
-        publish(channel1, "msg1");
-        publish(channel2, "msg2");
+		conn1.subscribe((message, pattern) -> {
+			messages.add(new String(message.getChannel()) + ":" + new String(message.getBody()));
+		}, channel1.getBytes(), channel2.getBytes());
 
-        await().atMost(AWAIT_TIMEOUT).until(() -> messages.size() >= 2);
+		publish(channel1, "msg1");
+		publish(channel2, "msg2");
 
-        conn1.getSubscription().unsubscribe(channel1.getBytes());
-        conn1.close();
+		await().atMost(AWAIT_TIMEOUT).until(() -> messages.size() >= 2);
 
-        messages.clear();
+		conn1.getSubscription().unsubscribe(channel1.getBytes());
+		conn1.close();
 
-        ValkeyConnection conn2 = connectionFactory.getConnection();
-        assertThat(conn2.getNativeConnection()).isSameAs(nativeClient);
+		messages.clear();
 
-        conn2.subscribe((message, pattern) -> {
-            messages.add(new String(message.getChannel()) + ":" + new String(message.getBody()));
-        }, channel3.getBytes());
+		ValkeyConnection conn2 = connectionFactory.getConnection();
+		assertThat(conn2.getNativeConnection()).isSameAs(nativeClient);
 
-        publish(channel1, "should_not_receive1");
-        publish(channel2, "should_not_receive2");
-        publish(channel3, "msg3");
+		conn2.subscribe((message, pattern) -> {
+			messages.add(new String(message.getChannel()) + ":" + new String(message.getBody()));
+		}, channel3.getBytes());
 
-        await().atMost(AWAIT_TIMEOUT).until(() -> messages.stream().anyMatch(m -> m.contains("msg3")));
+		publish(channel1, "should_not_receive1");
+		publish(channel2, "should_not_receive2");
+		publish(channel3, "msg3");
 
-        assertThat(messages.stream().filter(m -> m.contains("msg3")).count()).isEqualTo(1);
-        assertThat(messages.stream().filter(m -> m.contains("should_not")).count()).isZero();
+		await().atMost(AWAIT_TIMEOUT).until(() -> messages.stream().anyMatch(m -> m.contains("msg3")));
 
-        conn2.close();
-    }
+		assertThat(messages.stream().filter(m -> m.contains("msg3")).count()).isEqualTo(1);
+		assertThat(messages.stream().filter(m -> m.contains("should_not")).count()).isZero();
 
-    @Test
-    void clientStateShouldBeCleanAfterNoOpConnection() throws Exception {
-        ValkeyGlideConnectionFactory connectionFactory = createTestFactory(1);
+		conn2.close();
+	}
 
-        String channel = "test:pool:noop";
+	@Test
+	void clientStateShouldBeCleanAfterNoOpConnection() throws Exception {
+		ValkeyGlideConnectionFactory connectionFactory = createTestFactory(1);
 
-        ValkeyConnection conn1 = connectionFactory.getConnection();
-        Object nativeClient = conn1.getNativeConnection();
-        conn1.close();
+		String channel = "test:pool:noop";
 
-        ValkeyConnection conn2 = connectionFactory.getConnection();
-        assertThat(conn2.getNativeConnection()).isSameAs(nativeClient);
+		ValkeyConnection conn1 = connectionFactory.getConnection();
+		Object nativeClient = conn1.getNativeConnection();
+		conn1.close();
 
-        AtomicReference<String> received = new AtomicReference<>();
-        conn2.subscribe((message, pattern) -> received.set(new String(message.getBody())),
-                channel.getBytes());
+		ValkeyConnection conn2 = connectionFactory.getConnection();
+		assertThat(conn2.getNativeConnection()).isSameAs(nativeClient);
 
-        publish(channel, "test_msg");
+		AtomicReference<String> received = new AtomicReference<>();
+		conn2.subscribe((message, pattern) -> received.set(new String(message.getBody())), channel.getBytes());
 
-        await().atMost(AWAIT_TIMEOUT).until(() -> received.get() != null);
-        assertThat(received.get()).isEqualTo("test_msg");
+		publish(channel, "test_msg");
 
-        conn2.close();
-    }
+		await().atMost(AWAIT_TIMEOUT).until(() -> received.get() != null);
+		assertThat(received.get()).isEqualTo("test_msg");
 
-    @Test
-    void mixedChannelAndPatternSubscriptionsOnSameConnection() throws Exception {
-        ValkeyGlideConnectionFactory connectionFactory = createTestFactory(1);
+		conn2.close();
+	}
 
-        String channel = "test:pool:mixed:exact";
-        String patternBase = "test:pool:mixed:pattern";
-        String pattern = patternBase + ":*";
-        String patternMatch = patternBase + ":foo";
+	@Test
+	void mixedChannelAndPatternSubscriptionsOnSameConnection() throws Exception {
+		ValkeyGlideConnectionFactory connectionFactory = createTestFactory(1);
 
-        List<String> receivedFromChannel = Collections.synchronizedList(new ArrayList<>());
-        List<String> receivedFromPattern = Collections.synchronizedList(new ArrayList<>());
+		String channel = "test:pool:mixed:exact";
+		String patternBase = "test:pool:mixed:pattern";
+		String pattern = patternBase + ":*";
+		String patternMatch = patternBase + ":foo";
 
-        ValkeyConnection conn = connectionFactory.getConnection();
-        Object nativeClient = conn.getNativeConnection();
+		List<String> receivedFromChannel = Collections.synchronizedList(new ArrayList<>());
+		List<String> receivedFromPattern = Collections.synchronizedList(new ArrayList<>());
 
-        conn.subscribe((message, pat) -> {
-            if (pat == null) {
-                receivedFromChannel.add(new String(message.getBody()));
-            } else {
-                receivedFromPattern.add(new String(message.getBody()));
-            }
-        }, channel.getBytes());
+		ValkeyConnection conn = connectionFactory.getConnection();
+		Object nativeClient = conn.getNativeConnection();
 
-        conn.getSubscription().pSubscribe(pattern.getBytes());
+		conn.subscribe((message, pat) -> {
+			if (pat == null) {
+				receivedFromChannel.add(new String(message.getBody()));
+			}
+			else {
+				receivedFromPattern.add(new String(message.getBody()));
+			}
+		}, channel.getBytes());
 
-        publish(channel, "channel_msg");
-        publish(patternMatch, "pattern_msg");
+		conn.getSubscription().pSubscribe(pattern.getBytes());
 
-        await().atMost(AWAIT_TIMEOUT).until(() ->
-                receivedFromChannel.size() >= 1 && receivedFromPattern.size() >= 1);
+		publish(channel, "channel_msg");
+		publish(patternMatch, "pattern_msg");
 
-        assertThat(receivedFromChannel).contains("channel_msg");
-        assertThat(receivedFromPattern).contains("pattern_msg");
+		await().atMost(AWAIT_TIMEOUT).until(() -> receivedFromChannel.size() >= 1 && receivedFromPattern.size() >= 1);
 
-        conn.close();
+		assertThat(receivedFromChannel).contains("channel_msg");
+		assertThat(receivedFromPattern).contains("pattern_msg");
 
-        ValkeyConnection conn2 = connectionFactory.getConnection();
-        assertThat(conn2.getNativeConnection()).isSameAs(nativeClient);
+		conn.close();
 
-        List<String> newMessages = Collections.synchronizedList(new ArrayList<>());
-        String newChannel = "test:pool:mixed:new";
+		ValkeyConnection conn2 = connectionFactory.getConnection();
+		assertThat(conn2.getNativeConnection()).isSameAs(nativeClient);
 
-        conn2.subscribe((message, pat) -> newMessages.add(new String(message.getBody())),
-                newChannel.getBytes());
+		List<String> newMessages = Collections.synchronizedList(new ArrayList<>());
+		String newChannel = "test:pool:mixed:new";
 
-        publish(channel, "old_channel");
-        publish(patternMatch, "old_pattern");
-        publish(newChannel, "new_msg");
+		conn2.subscribe((message, pat) -> newMessages.add(new String(message.getBody())), newChannel.getBytes());
 
-        await().atMost(AWAIT_TIMEOUT).until(() -> newMessages.contains("new_msg"));
+		publish(channel, "old_channel");
+		publish(patternMatch, "old_pattern");
+		publish(newChannel, "new_msg");
 
-        assertThat(newMessages).containsExactly("new_msg");
+		await().atMost(AWAIT_TIMEOUT).until(() -> newMessages.contains("new_msg"));
 
-        conn2.close();
-    }
+		assertThat(newMessages).containsExactly("new_msg");
 
-    // ==================== Concurrent Usage Tests ====================
-    // These tests use pool size 3 with semaphore to force reuse
+		conn2.close();
+	}
 
-    @Test
-    void concurrentThreadsReceiveOnlyTheirOwnMessages() throws Exception {
-        int poolSize = 3;
-        ValkeyGlideConnectionFactory connectionFactory = createTestFactory(poolSize);
-        Semaphore connectionLimiter = new Semaphore(poolSize);
+	// ==================== Concurrent Usage Tests ====================
+	// These tests use pool size 3 with semaphore to force reuse
 
-        int threadCount = 6;
-        int iterationsPerThread = 10;
-        String channelBase = "test:concurrent:isolation";
+	@Test
+	void concurrentThreadsReceiveOnlyTheirOwnMessages() throws Exception {
+		int poolSize = 3;
+		ValkeyGlideConnectionFactory connectionFactory = createTestFactory(poolSize);
+		Semaphore connectionLimiter = new Semaphore(poolSize);
 
-        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
-        AtomicInteger errorCount = new AtomicInteger(0);
+		int threadCount = 6;
+		int iterationsPerThread = 10;
+		String channelBase = "test:concurrent:isolation";
 
-        for (int t = 0; t < threadCount; t++) {
-            final int threadId = t;
+		ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+		AtomicInteger errorCount = new AtomicInteger(0);
 
-            executor.submit(() -> {
-                try {
-                    for (int iter = 0; iter < iterationsPerThread; iter++) {
-                        String myChannel = channelBase + ":t" + threadId + ":i" + iter;
-                        String expectedMsg = "t" + threadId + "_i" + iter;
-                        AtomicReference<String> received = new AtomicReference<>();
+		for (int t = 0; t < threadCount; t++) {
+			final int threadId = t;
 
-                        connectionLimiter.acquire();
-                        try {
-                            ValkeyConnection conn = connectionFactory.getConnection();
+			executor.submit(() -> {
+				try {
+					for (int iter = 0; iter < iterationsPerThread; iter++) {
+						String myChannel = channelBase + ":t" + threadId + ":i" + iter;
+						String expectedMsg = "t" + threadId + "_i" + iter;
+						AtomicReference<String> received = new AtomicReference<>();
 
-                            conn.subscribe((message, pattern) -> {
-                                received.set(new String(message.getBody()));
-                            }, myChannel.getBytes());
+						connectionLimiter.acquire();
+						try {
+							ValkeyConnection conn = connectionFactory.getConnection();
 
-                            publish(myChannel, expectedMsg);
+							conn.subscribe((message, pattern) -> {
+								received.set(new String(message.getBody()));
+							}, myChannel.getBytes());
 
-                            await().atMost(AWAIT_TIMEOUT).until(() -> received.get() != null);
-                            assertThat(received.get()).isEqualTo(expectedMsg);
+							publish(myChannel, expectedMsg);
 
-                            conn.close();
-                        } finally {
-                            connectionLimiter.release();
-                        }
-                    }
-                } catch (Exception e) {
-                    logger.error("Thread {} failed: {}", threadId, e.getMessage(), e);
-                    errorCount.incrementAndGet();
-                }
-            });
-        }
+							await().atMost(AWAIT_TIMEOUT).until(() -> received.get() != null);
+							assertThat(received.get()).isEqualTo(expectedMsg);
 
-        executor.shutdown();
-        assertThat(executor.awaitTermination(TERMINATION_TIMEOUT_SECONDS, TimeUnit.SECONDS)).isTrue();
-        assertThat(errorCount.get()).isZero();
-    }
+							conn.close();
+						}
+						finally {
+							connectionLimiter.release();
+						}
+					}
+				}
+				catch (Exception e) {
+					logger.error("Thread {} failed: {}", threadId, e.getMessage(), e);
+					errorCount.incrementAndGet();
+				}
+			});
+		}
 
-    @Test
-    void concurrentPatternSubscriptions() throws Exception {
-        int poolSize = 3;
-        ValkeyGlideConnectionFactory connectionFactory = createTestFactory(poolSize);
-        Semaphore connectionLimiter = new Semaphore(poolSize);
+		executor.shutdown();
+		assertThat(executor.awaitTermination(TERMINATION_TIMEOUT_SECONDS, TimeUnit.SECONDS)).isTrue();
+		assertThat(errorCount.get()).isZero();
+	}
 
-        int threadCount = 4;
-        int iterationsPerThread = 8;
-        String patternBase = "test:concurrent:pattern";
+	@Test
+	void concurrentPatternSubscriptions() throws Exception {
+		int poolSize = 3;
+		ValkeyGlideConnectionFactory connectionFactory = createTestFactory(poolSize);
+		Semaphore connectionLimiter = new Semaphore(poolSize);
 
-        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
-        AtomicInteger errorCount = new AtomicInteger(0);
+		int threadCount = 4;
+		int iterationsPerThread = 8;
+		String patternBase = "test:concurrent:pattern";
 
-        for (int t = 0; t < threadCount; t++) {
-            final int threadId = t;
+		ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+		AtomicInteger errorCount = new AtomicInteger(0);
 
-            executor.submit(() -> {
-                try {
-                    for (int iter = 0; iter < iterationsPerThread; iter++) {
-                        String myPattern = patternBase + ":t" + threadId + ":*";
-                        String myChannel = patternBase + ":t" + threadId + ":i" + iter;
-                        String expectedMsg = "t" + threadId + "_iter" + iter;
-                        AtomicReference<String> received = new AtomicReference<>();
+		for (int t = 0; t < threadCount; t++) {
+			final int threadId = t;
 
-                        connectionLimiter.acquire();
-                        try {
-                            ValkeyConnection conn = connectionFactory.getConnection();
+			executor.submit(() -> {
+				try {
+					for (int iter = 0; iter < iterationsPerThread; iter++) {
+						String myPattern = patternBase + ":t" + threadId + ":*";
+						String myChannel = patternBase + ":t" + threadId + ":i" + iter;
+						String expectedMsg = "t" + threadId + "_iter" + iter;
+						AtomicReference<String> received = new AtomicReference<>();
 
-                            conn.pSubscribe((message, pattern) -> {
-                                received.set(new String(message.getBody()));
-                            }, myPattern.getBytes());
+						connectionLimiter.acquire();
+						try {
+							ValkeyConnection conn = connectionFactory.getConnection();
 
-                            publish(myChannel, expectedMsg);
+							conn.pSubscribe((message, pattern) -> {
+								received.set(new String(message.getBody()));
+							}, myPattern.getBytes());
 
-                            await().atMost(AWAIT_TIMEOUT).until(() -> received.get() != null);
-                            assertThat(received.get()).isEqualTo(expectedMsg);
+							publish(myChannel, expectedMsg);
 
-                            conn.close();
-                        } finally {
-                            connectionLimiter.release();
-                        }
-                    }
-                } catch (Exception e) {
-                    logger.error("Thread {} failed: {}", threadId, e.getMessage(), e);
-                    errorCount.incrementAndGet();
-                }
-            });
-        }
+							await().atMost(AWAIT_TIMEOUT).until(() -> received.get() != null);
+							assertThat(received.get()).isEqualTo(expectedMsg);
 
-        executor.shutdown();
-        assertThat(executor.awaitTermination(TERMINATION_TIMEOUT_SECONDS, TimeUnit.SECONDS)).isTrue();
-        assertThat(errorCount.get()).isZero();
-    }
+							conn.close();
+						}
+						finally {
+							connectionLimiter.release();
+						}
+					}
+				}
+				catch (Exception e) {
+					logger.error("Thread {} failed: {}", threadId, e.getMessage(), e);
+					errorCount.incrementAndGet();
+				}
+			});
+		}
 
-    @Test
-    void rapidConcurrentSubscribeUnsubscribeCycles() throws Exception {
-        int poolSize = 3;
-        ValkeyGlideConnectionFactory connectionFactory = createTestFactory(poolSize);
-        Semaphore connectionLimiter = new Semaphore(poolSize);
+		executor.shutdown();
+		assertThat(executor.awaitTermination(TERMINATION_TIMEOUT_SECONDS, TimeUnit.SECONDS)).isTrue();
+		assertThat(errorCount.get()).isZero();
+	}
 
-        int threadCount = 5;
-        int cyclesPerThread = 20;
-        String channelBase = "test:concurrent:rapid";
+	@Test
+	void rapidConcurrentSubscribeUnsubscribeCycles() throws Exception {
+		int poolSize = 3;
+		ValkeyGlideConnectionFactory connectionFactory = createTestFactory(poolSize);
+		Semaphore connectionLimiter = new Semaphore(poolSize);
 
-        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
-        AtomicInteger successCount = new AtomicInteger(0);
-        AtomicInteger errorCount = new AtomicInteger(0);
+		int threadCount = 5;
+		int cyclesPerThread = 20;
+		String channelBase = "test:concurrent:rapid";
 
-        for (int t = 0; t < threadCount; t++) {
-            final int threadId = t;
+		ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+		AtomicInteger successCount = new AtomicInteger(0);
+		AtomicInteger errorCount = new AtomicInteger(0);
 
-            executor.submit(() -> {
-                try {
-                    for (int cycle = 0; cycle < cyclesPerThread; cycle++) {
-                        String channel = channelBase + ":t" + threadId + ":c" + cycle;
-                        String expectedMsg = "t" + threadId + "_c" + cycle;
-                        AtomicReference<String> received = new AtomicReference<>();
+		for (int t = 0; t < threadCount; t++) {
+			final int threadId = t;
 
-                        connectionLimiter.acquire();
-                        try {
-                            ValkeyConnection conn = connectionFactory.getConnection();
+			executor.submit(() -> {
+				try {
+					for (int cycle = 0; cycle < cyclesPerThread; cycle++) {
+						String channel = channelBase + ":t" + threadId + ":c" + cycle;
+						String expectedMsg = "t" + threadId + "_c" + cycle;
+						AtomicReference<String> received = new AtomicReference<>();
 
-                            conn.subscribe((message, pattern) -> {
-                                received.set(new String(message.getBody()));
-                            }, channel.getBytes());
+						connectionLimiter.acquire();
+						try {
+							ValkeyConnection conn = connectionFactory.getConnection();
 
-                            publish(channel, expectedMsg);
+							conn.subscribe((message, pattern) -> {
+								received.set(new String(message.getBody()));
+							}, channel.getBytes());
 
-                            await().atMost(AWAIT_TIMEOUT).until(() -> received.get() != null);
-                            assertThat(received.get()).isEqualTo(expectedMsg);
+							publish(channel, expectedMsg);
 
-                            conn.close();
-                            successCount.incrementAndGet();
-                        } finally {
-                            connectionLimiter.release();
-                        }
-                    }
-                } catch (Exception e) {
-                    logger.error("Thread {} failed: {}", threadId, e.getMessage(), e);
-                    errorCount.incrementAndGet();
-                }
-            });
-        }
+							await().atMost(AWAIT_TIMEOUT).until(() -> received.get() != null);
+							assertThat(received.get()).isEqualTo(expectedMsg);
 
-        executor.shutdown();
-        assertThat(executor.awaitTermination(2 * TERMINATION_TIMEOUT_SECONDS, TimeUnit.SECONDS)).isTrue();
-        assertThat(errorCount.get()).isZero();
-        assertThat(successCount.get()).isEqualTo(threadCount * cyclesPerThread);
-    }
+							conn.close();
+							successCount.incrementAndGet();
+						}
+						finally {
+							connectionLimiter.release();
+						}
+					}
+				}
+				catch (Exception e) {
+					logger.error("Thread {} failed: {}", threadId, e.getMessage(), e);
+					errorCount.incrementAndGet();
+				}
+			});
+		}
 
-    @Test
-    void concurrentMixedChannelAndPatternSubscriptions() throws Exception {
-        int poolSize = 3;
-        ValkeyGlideConnectionFactory connectionFactory = createTestFactory(poolSize);
-        Semaphore connectionLimiter = new Semaphore(poolSize);
+		executor.shutdown();
+		assertThat(executor.awaitTermination(2 * TERMINATION_TIMEOUT_SECONDS, TimeUnit.SECONDS)).isTrue();
+		assertThat(errorCount.get()).isZero();
+		assertThat(successCount.get()).isEqualTo(threadCount * cyclesPerThread);
+	}
 
-        int threadCount = 4;
-        int iterationsPerThread = 5;
-        String base = "test:concurrent:mixed";
+	@Test
+	void concurrentMixedChannelAndPatternSubscriptions() throws Exception {
+		int poolSize = 3;
+		ValkeyGlideConnectionFactory connectionFactory = createTestFactory(poolSize);
+		Semaphore connectionLimiter = new Semaphore(poolSize);
 
-        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
-        AtomicInteger errorCount = new AtomicInteger(0);
+		int threadCount = 4;
+		int iterationsPerThread = 5;
+		String base = "test:concurrent:mixed";
 
-        for (int t = 0; t < threadCount; t++) {
-            final int threadId = t;
+		ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+		AtomicInteger errorCount = new AtomicInteger(0);
 
-            executor.submit(() -> {
-                try {
-                    for (int iter = 0; iter < iterationsPerThread; iter++) {
-                        String myChannel = base + ":channel:t" + threadId + ":i" + iter;
-                        String myPattern = base + ":pattern:t" + threadId + ":*";
-                        String myPatternChannel = base + ":pattern:t" + threadId + ":i" + iter;
+		for (int t = 0; t < threadCount; t++) {
+			final int threadId = t;
 
-                        AtomicReference<String> channelMsg = new AtomicReference<>();
-                        AtomicReference<String> patternMsg = new AtomicReference<>();
+			executor.submit(() -> {
+				try {
+					for (int iter = 0; iter < iterationsPerThread; iter++) {
+						String myChannel = base + ":channel:t" + threadId + ":i" + iter;
+						String myPattern = base + ":pattern:t" + threadId + ":*";
+						String myPatternChannel = base + ":pattern:t" + threadId + ":i" + iter;
+
+						AtomicReference<String> channelMsg = new AtomicReference<>();
+						AtomicReference<String> patternMsg = new AtomicReference<>();
 
-                        connectionLimiter.acquire();
-                        try {
-                            ValkeyConnection conn = connectionFactory.getConnection();
+						connectionLimiter.acquire();
+						try {
+							ValkeyConnection conn = connectionFactory.getConnection();
 
-                            conn.subscribe((message, pattern) -> {
-                                String body = new String(message.getBody());
-                                if (pattern != null) {
-                                    patternMsg.set(body);
-                                } else {
-                                    channelMsg.set(body);
-                                }
-                            }, myChannel.getBytes());
+							conn.subscribe((message, pattern) -> {
+								String body = new String(message.getBody());
+								if (pattern != null) {
+									patternMsg.set(body);
+								}
+								else {
+									channelMsg.set(body);
+								}
+							}, myChannel.getBytes());
 
-                            conn.getSubscription().pSubscribe(myPattern.getBytes());
+							conn.getSubscription().pSubscribe(myPattern.getBytes());
 
-                            Thread.sleep(50);
+							Thread.sleep(50);
 
-                            publish(myChannel, "channel_" + threadId);
-                            publish(myPatternChannel, "pattern_" + threadId);
+							publish(myChannel, "channel_" + threadId);
+							publish(myPatternChannel, "pattern_" + threadId);
 
-                            await().atMost(AWAIT_TIMEOUT).until(() ->
-                                    channelMsg.get() != null && patternMsg.get() != null);
+							await().atMost(AWAIT_TIMEOUT)
+								.until(() -> channelMsg.get() != null && patternMsg.get() != null);
 
-                            assertThat(channelMsg.get()).isEqualTo("channel_" + threadId);
-                            assertThat(patternMsg.get()).isEqualTo("pattern_" + threadId);
+							assertThat(channelMsg.get()).isEqualTo("channel_" + threadId);
+							assertThat(patternMsg.get()).isEqualTo("pattern_" + threadId);
 
-                            conn.close();
-                        } finally {
-                            connectionLimiter.release();
-                        }
-                    }
-                } catch (Exception e) {
-                    logger.error("Thread {} failed: {}", threadId, e.getMessage(), e);
-                    errorCount.incrementAndGet();
-                }
-            });
-        }
+							conn.close();
+						}
+						finally {
+							connectionLimiter.release();
+						}
+					}
+				}
+				catch (Exception e) {
+					logger.error("Thread {} failed: {}", threadId, e.getMessage(), e);
+					errorCount.incrementAndGet();
+				}
+			});
+		}
 
-        executor.shutdown();
-        assertThat(executor.awaitTermination(TERMINATION_TIMEOUT_SECONDS, TimeUnit.SECONDS)).isTrue();
-        assertThat(errorCount.get()).isZero();
-    }
+		executor.shutdown();
+		assertThat(executor.awaitTermination(TERMINATION_TIMEOUT_SECONDS, TimeUnit.SECONDS)).isTrue();
+		assertThat(errorCount.get()).isZero();
+	}
 
-    @Test
-    void highThroughputMessaging() throws Exception {
-        int poolSize = 3;
-        ValkeyGlideConnectionFactory connectionFactory = createTestFactory(poolSize);
-        Semaphore connectionLimiter = new Semaphore(poolSize);
+	@Test
+	void highThroughputMessaging() throws Exception {
+		int poolSize = 3;
+		ValkeyGlideConnectionFactory connectionFactory = createTestFactory(poolSize);
+		Semaphore connectionLimiter = new Semaphore(poolSize);
 
-        int threadCount = 4;
-        int messagesPerThread = 50;
-        String channelBase = "test:concurrent:highthroughput";
+		int threadCount = 4;
+		int messagesPerThread = 50;
+		String channelBase = "test:concurrent:highthroughput";
 
-        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
-        AtomicInteger errorCount = new AtomicInteger(0);
+		ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+		AtomicInteger errorCount = new AtomicInteger(0);
 
-        for (int t = 0; t < threadCount; t++) {
-            final int threadId = t;
+		for (int t = 0; t < threadCount; t++) {
+			final int threadId = t;
 
-            executor.submit(() -> {
-                try {
-                    String myChannel = channelBase + ":t" + threadId;
-                    AtomicInteger receivedCount = new AtomicInteger(0);
+			executor.submit(() -> {
+				try {
+					String myChannel = channelBase + ":t" + threadId;
+					AtomicInteger receivedCount = new AtomicInteger(0);
 
-                    connectionLimiter.acquire();
-                    try {
-                        ValkeyConnection conn = connectionFactory.getConnection();
+					connectionLimiter.acquire();
+					try {
+						ValkeyConnection conn = connectionFactory.getConnection();
 
-                        conn.subscribe((message, pattern) -> {
-                            receivedCount.incrementAndGet();
-                        }, myChannel.getBytes());
+						conn.subscribe((message, pattern) -> {
+							receivedCount.incrementAndGet();
+						}, myChannel.getBytes());
 
-                        try (ValkeyConnection pub = publisherFactory.getConnection()) {
-                            for (int m = 0; m < messagesPerThread; m++) {
-                                pub.publish(myChannel.getBytes(), ("msg" + m).getBytes());
-                            }
-                        }
+						try (ValkeyConnection pub = publisherFactory.getConnection()) {
+							for (int m = 0; m < messagesPerThread; m++) {
+								pub.publish(myChannel.getBytes(), ("msg" + m).getBytes());
+							}
+						}
 
-                        await().atMost(Duration.ofSeconds(10))
-                                .until(() -> receivedCount.get() >= messagesPerThread);
+						await().atMost(Duration.ofSeconds(10)).until(() -> receivedCount.get() >= messagesPerThread);
 
-                        assertThat(receivedCount.get()).isEqualTo(messagesPerThread);
+						assertThat(receivedCount.get()).isEqualTo(messagesPerThread);
 
-                        conn.close();
-                    } finally {
-                        connectionLimiter.release();
-                    }
-                } catch (Exception e) {
-                    logger.error("Thread {} failed: {}", threadId, e.getMessage(), e);
-                    errorCount.incrementAndGet();
-                }
-            });
-        }
+						conn.close();
+					}
+					finally {
+						connectionLimiter.release();
+					}
+				}
+				catch (Exception e) {
+					logger.error("Thread {} failed: {}", threadId, e.getMessage(), e);
+					errorCount.incrementAndGet();
+				}
+			});
+		}
 
-        executor.shutdown();
-        assertThat(executor.awaitTermination(TERMINATION_TIMEOUT_SECONDS, TimeUnit.SECONDS)).isTrue();
-        assertThat(errorCount.get()).isZero();
-    }
+		executor.shutdown();
+		assertThat(executor.awaitTermination(TERMINATION_TIMEOUT_SECONDS, TimeUnit.SECONDS)).isTrue();
+		assertThat(errorCount.get()).isZero();
+	}
+
 }

--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideSubscriptionUnitTests.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideSubscriptionUnitTests.java
@@ -17,441 +17,435 @@ import io.valkey.springframework.data.valkey.connection.SubscriptionListener;
 
 class ValkeyGlideSubscriptionUnitTests {
 
-    private ValkeyGlideSubscription subscription;
-    private UnifiedGlideClient client;
-    private DelegatingPubSubListener pubSubListener;
-    private MessageListener messageListener;
+	private ValkeyGlideSubscription subscription;
 
-    @BeforeEach
-    void setUp() throws Exception {
-        client = mock(UnifiedGlideClient.class);
-        pubSubListener = mock(DelegatingPubSubListener.class);
-        messageListener = mock(MessageListener.class);
-
-        // Mock customCommand to return null (no exception)
-        when(client.customCommand(any(GlideString[].class))).thenReturn(null);
-
-        subscription = new ValkeyGlideSubscription(messageListener, client, pubSubListener);
-    }
+	private UnifiedGlideClient client;
 
-    @Test
-    void testUnsubscribeAllAndClose() {
-        subscription.subscribe(new byte[][] { "a".getBytes() });
-        subscription.unsubscribe();
-
-        verify(pubSubListener).clearListener();
-
-        assertThat(subscription.isAlive()).isFalse();
-        assertThat(subscription.getChannels()).isEmpty();
-        assertThat(subscription.getPatterns()).isEmpty();
-    }
+	private DelegatingPubSubListener pubSubListener;
 
-    @Test
-    void testUnsubscribeAllChannelsWithPatterns() {
-        subscription.subscribe(new byte[][] { "a".getBytes() });
-        subscription.pSubscribe(new byte[][] { "s*".getBytes() });
-        subscription.unsubscribe();
+	private MessageListener messageListener;
 
-        assertThat(subscription.isAlive()).isTrue();
-        assertThat(subscription.getChannels()).isEmpty();
-
-        Collection<byte[]> patterns = subscription.getPatterns();
-        assertThat(patterns).hasSize(1);
-        assertThat(patterns.iterator().next()).isEqualTo("s*".getBytes());
-    }
+	@BeforeEach
+	void setUp() throws Exception {
+		client = mock(UnifiedGlideClient.class);
+		pubSubListener = mock(DelegatingPubSubListener.class);
+		messageListener = mock(MessageListener.class);
 
-    @Test
-    void testUnsubscribeChannelAndClose() {
-        byte[][] channel = new byte[][] { "a".getBytes() };
+		// Mock customCommand to return null (no exception)
+		when(client.customCommand(any(GlideString[].class))).thenReturn(null);
 
-        subscription.subscribe(channel);
-        subscription.unsubscribe(channel);
+		subscription = new ValkeyGlideSubscription(messageListener, client, pubSubListener);
+	}
 
-        verify(pubSubListener).clearListener();
+	@Test
+	void testUnsubscribeAllAndClose() {
+		subscription.subscribe(new byte[][] { "a".getBytes() });
+		subscription.unsubscribe();
 
-        assertThat(subscription.isAlive()).isFalse();
-        assertThat(subscription.getChannels()).isEmpty();
-        assertThat(subscription.getPatterns()).isEmpty();
-    }
+		verify(pubSubListener).clearListener();
 
-    @Test
-    void testUnsubscribeChannelSomeLeft() {
-        byte[][] channels = new byte[][] { "a".getBytes(), "b".getBytes() };
+		assertThat(subscription.isAlive()).isFalse();
+		assertThat(subscription.getChannels()).isEmpty();
+		assertThat(subscription.getPatterns()).isEmpty();
+	}
 
-        subscription.subscribe(channels);
-        subscription.unsubscribe(new byte[][] { "a".getBytes() });
+	@Test
+	void testUnsubscribeAllChannelsWithPatterns() {
+		subscription.subscribe(new byte[][] { "a".getBytes() });
+		subscription.pSubscribe(new byte[][] { "s*".getBytes() });
+		subscription.unsubscribe();
 
-        assertThat(subscription.isAlive()).isTrue();
+		assertThat(subscription.isAlive()).isTrue();
+		assertThat(subscription.getChannels()).isEmpty();
 
-        Collection<byte[]> subChannels = subscription.getChannels();
-        assertThat(subChannels).hasSize(1);
-        assertThat(subChannels.iterator().next()).isEqualTo("b".getBytes());
-        assertThat(subscription.getPatterns()).isEmpty();
-    }
+		Collection<byte[]> patterns = subscription.getPatterns();
+		assertThat(patterns).hasSize(1);
+		assertThat(patterns.iterator().next()).isEqualTo("s*".getBytes());
+	}
 
-    @Test
-    void testUnsubscribeChannelWithPatterns() {
-        byte[][] channel = new byte[][] { "a".getBytes() };
+	@Test
+	void testUnsubscribeChannelAndClose() {
+		byte[][] channel = new byte[][] { "a".getBytes() };
 
-        subscription.subscribe(channel);
-        subscription.pSubscribe(new byte[][] { "s*".getBytes() });
-        subscription.unsubscribe(channel);
+		subscription.subscribe(channel);
+		subscription.unsubscribe(channel);
 
-        assertThat(subscription.isAlive()).isTrue();
-        assertThat(subscription.getChannels()).isEmpty();
+		verify(pubSubListener).clearListener();
 
-        Collection<byte[]> patterns = subscription.getPatterns();
-        assertThat(patterns).hasSize(1);
-        assertThat(patterns.iterator().next()).isEqualTo("s*".getBytes());
-    }
+		assertThat(subscription.isAlive()).isFalse();
+		assertThat(subscription.getChannels()).isEmpty();
+		assertThat(subscription.getPatterns()).isEmpty();
+	}
 
-    @Test
-    void testUnsubscribeChannelWithPatternsSomeLeft() {
-        byte[][] channel = new byte[][] { "a".getBytes() };
+	@Test
+	void testUnsubscribeChannelSomeLeft() {
+		byte[][] channels = new byte[][] { "a".getBytes(), "b".getBytes() };
 
-        subscription.subscribe("a".getBytes(), "b".getBytes());
-        subscription.pSubscribe(new byte[][] { "s*".getBytes() });
-        subscription.unsubscribe(channel);
+		subscription.subscribe(channels);
+		subscription.unsubscribe(new byte[][] { "a".getBytes() });
 
-        assertThat(subscription.isAlive()).isTrue();
-
-        Collection<byte[]> channels = subscription.getChannels();
-        assertThat(channels).hasSize(1);
-        assertThat(channels.iterator().next()).isEqualTo("b".getBytes());
-
-        Collection<byte[]> patterns = subscription.getPatterns();
-        assertThat(patterns).hasSize(1);
-        assertThat(patterns.iterator().next()).isEqualTo("s*".getBytes());
-    }
+		assertThat(subscription.isAlive()).isTrue();
 
-    @Test
-    void testUnsubscribeAllNoChannels() {
-        subscription.pSubscribe(new byte[][] { "s*".getBytes() });
-        subscription.unsubscribe();
+		Collection<byte[]> subChannels = subscription.getChannels();
+		assertThat(subChannels).hasSize(1);
+		assertThat(subChannels.iterator().next()).isEqualTo("b".getBytes());
+		assertThat(subscription.getPatterns()).isEmpty();
+	}
 
-        assertThat(subscription.isAlive()).isTrue();
-        assertThat(subscription.getChannels()).isEmpty();
+	@Test
+	void testUnsubscribeChannelWithPatterns() {
+		byte[][] channel = new byte[][] { "a".getBytes() };
 
-        Collection<byte[]> patterns = subscription.getPatterns();
-        assertThat(patterns).hasSize(1);
-        assertThat(patterns.iterator().next()).isEqualTo("s*".getBytes());
-    }
+		subscription.subscribe(channel);
+		subscription.pSubscribe(new byte[][] { "s*".getBytes() });
+		subscription.unsubscribe(channel);
 
-    @Test
-    void testUnsubscribeNotAlive() {
-        subscription.subscribe(new byte[][] { "a".getBytes() });
-        subscription.unsubscribe();
+		assertThat(subscription.isAlive()).isTrue();
+		assertThat(subscription.getChannels()).isEmpty();
 
-        verify(pubSubListener).clearListener();
+		Collection<byte[]> patterns = subscription.getPatterns();
+		assertThat(patterns).hasSize(1);
+		assertThat(patterns.iterator().next()).isEqualTo("s*".getBytes());
+	}
 
-        assertThat(subscription.isAlive()).isFalse();
+	@Test
+	void testUnsubscribeChannelWithPatternsSomeLeft() {
+		byte[][] channel = new byte[][] { "a".getBytes() };
 
-        // Calling unsubscribe again should not throw
-        subscription.unsubscribe();
-    }
+		subscription.subscribe("a".getBytes(), "b".getBytes());
+		subscription.pSubscribe(new byte[][] { "s*".getBytes() });
+		subscription.unsubscribe(channel);
 
-    @Test
-    void testSubscribeNotAlive() {
-        subscription.subscribe(new byte[][] { "a".getBytes() });
-        subscription.unsubscribe();
-
-        assertThat(subscription.isAlive()).isFalse();
+		assertThat(subscription.isAlive()).isTrue();
 
-        assertThatExceptionOfType(ValkeyInvalidSubscriptionException.class)
-                .isThrownBy(() -> subscription.subscribe(new byte[][] { "s".getBytes() }));
-    }
+		Collection<byte[]> channels = subscription.getChannels();
+		assertThat(channels).hasSize(1);
+		assertThat(channels.iterator().next()).isEqualTo("b".getBytes());
 
-    @Test
-    void testPUnsubscribeAllAndClose() {
-        subscription.pSubscribe(new byte[][] { "a*".getBytes() });
-        subscription.pUnsubscribe();
+		Collection<byte[]> patterns = subscription.getPatterns();
+		assertThat(patterns).hasSize(1);
+		assertThat(patterns.iterator().next()).isEqualTo("s*".getBytes());
+	}
 
-        verify(pubSubListener).clearListener();
-
-        assertThat(subscription.isAlive()).isFalse();
-        assertThat(subscription.getChannels()).isEmpty();
-        assertThat(subscription.getPatterns()).isEmpty();
-    }
+	@Test
+	void testUnsubscribeAllNoChannels() {
+		subscription.pSubscribe(new byte[][] { "s*".getBytes() });
+		subscription.unsubscribe();
 
-    @Test
-    void testPUnsubscribeAllPatternsWithChannels() {
-        subscription.subscribe(new byte[][] { "a".getBytes() });
-        subscription.pSubscribe(new byte[][] { "s*".getBytes() });
-        subscription.pUnsubscribe();
+		assertThat(subscription.isAlive()).isTrue();
+		assertThat(subscription.getChannels()).isEmpty();
 
-        assertThat(subscription.isAlive()).isTrue();
-        assertThat(subscription.getPatterns()).isEmpty();
+		Collection<byte[]> patterns = subscription.getPatterns();
+		assertThat(patterns).hasSize(1);
+		assertThat(patterns.iterator().next()).isEqualTo("s*".getBytes());
+	}
 
-        Collection<byte[]> channels = subscription.getChannels();
-        assertThat(channels).hasSize(1);
-        assertThat(channels.iterator().next()).isEqualTo("a".getBytes());
-    }
+	@Test
+	void testUnsubscribeNotAlive() {
+		subscription.subscribe(new byte[][] { "a".getBytes() });
+		subscription.unsubscribe();
 
-    @Test
-    void testPUnsubscribeAndClose() {
-        byte[][] pattern = new byte[][] { "a*".getBytes() };
+		verify(pubSubListener).clearListener();
 
-        subscription.pSubscribe(pattern);
-        subscription.pUnsubscribe(pattern);
+		assertThat(subscription.isAlive()).isFalse();
 
-        verify(pubSubListener).clearListener();
+		// Calling unsubscribe again should not throw
+		subscription.unsubscribe();
+	}
 
-        assertThat(subscription.isAlive()).isFalse();
-        assertThat(subscription.getChannels()).isEmpty();
-        assertThat(subscription.getPatterns()).isEmpty();
-    }
+	@Test
+	void testSubscribeNotAlive() {
+		subscription.subscribe(new byte[][] { "a".getBytes() });
+		subscription.unsubscribe();
 
-    @Test
-    void testPUnsubscribePatternSomeLeft() {
-        byte[][] patterns = new byte[][] { "a*".getBytes(), "b*".getBytes() };
-        subscription.pSubscribe(patterns);
-        subscription.pUnsubscribe(new byte[][] { "a*".getBytes() });
-
-        assertThat(subscription.isAlive()).isTrue();
+		assertThat(subscription.isAlive()).isFalse();
 
-        Collection<byte[]> subPatterns = subscription.getPatterns();
-        assertThat(subPatterns).hasSize(1);
-        assertThat(subPatterns.iterator().next()).isEqualTo("b*".getBytes());
-        assertThat(subscription.getChannels()).isEmpty();
-    }
-
-    @Test
-    void testPUnsubscribePatternWithChannels() {
-        byte[][] pattern = new byte[][] { "s*".getBytes() };
-
-        subscription.subscribe(new byte[][] { "a".getBytes() });
-        subscription.pSubscribe(pattern);
-        subscription.pUnsubscribe(pattern);
-
-        assertThat(subscription.isAlive()).isTrue();
-        assertThat(subscription.getPatterns()).isEmpty();
-
-        Collection<byte[]> channels = subscription.getChannels();
-        assertThat(channels).hasSize(1);
-        assertThat(channels.iterator().next()).isEqualTo("a".getBytes());
-    }
-
-    @Test
-    void testUnsubscribePatternWithChannelsSomeLeft() {
-        byte[][] pattern = new byte[][] { "a*".getBytes() };
-
-        subscription.pSubscribe("a*".getBytes(), "b*".getBytes());
-        subscription.subscribe(new byte[][] { "a".getBytes() });
-        subscription.pUnsubscribe(pattern);
-
-        assertThat(subscription.isAlive()).isTrue();
-
-        Collection<byte[]> channels = subscription.getChannels();
-        assertThat(channels).hasSize(1);
-        assertThat(channels.iterator().next()).isEqualTo("a".getBytes());
-
-        Collection<byte[]> patterns = subscription.getPatterns();
-        assertThat(patterns).hasSize(1);
-        assertThat(patterns.iterator().next()).isEqualTo("b*".getBytes());
-    }
-
-    @Test
-    void testPUnsubscribeAllNoPatterns() {
-        subscription.subscribe(new byte[][] { "s".getBytes() });
-        subscription.pUnsubscribe();
-
-        assertThat(subscription.isAlive()).isTrue();
-        assertThat(subscription.getPatterns()).isEmpty();
-
-        Collection<byte[]> channels = subscription.getChannels();
-        assertThat(channels).hasSize(1);
-        assertThat(channels.iterator().next()).isEqualTo("s".getBytes());
-    }
-
-    @Test
-    void testPUnsubscribeNotAlive() {
-        subscription.subscribe(new byte[][] { "a".getBytes() });
-        subscription.unsubscribe();
-
-        assertThat(subscription.isAlive()).isFalse();
-
-        // Calling pUnsubscribe when not alive should not throw
-        subscription.pUnsubscribe();
-
-        verify(pubSubListener).clearListener();
-    }
-
-    @Test
-    void testPSubscribeNotAlive() {
-        subscription.subscribe(new byte[][] { "a".getBytes() });
-        subscription.unsubscribe();
-
-        assertThat(subscription.isAlive()).isFalse();
-
-        assertThatExceptionOfType(ValkeyInvalidSubscriptionException.class)
-                .isThrownBy(() -> subscription.pSubscribe(new byte[][] { "s*".getBytes() }));
-    }
-
-    @Test
-    void testDoCloseNotSubscribed() {
-        subscription.doClose();
-
-        verify(pubSubListener).clearListener();
-    }
-
-    @Test
-    void testDoCloseSubscribedChannels() throws Exception {
-        subscription.subscribe(new byte[][] { "a".getBytes() });
-        subscription.doClose();
-
-        verify(pubSubListener).clearListener();
-        verify(client).customCommand(argThat(args ->
-            args.length >= 2 &&
-            "UNSUBSCRIBE_BLOCKING".equals(args[0].getString()) &&
-            "0".equals(args[args.length - 1].getString())
-        ));
-    }
-
-    @Test
-    void testDoCloseSubscribedPatterns() throws Exception {
-        subscription.pSubscribe(new byte[][] { "a*".getBytes() });
-        subscription.doClose();
+		assertThatExceptionOfType(ValkeyInvalidSubscriptionException.class)
+			.isThrownBy(() -> subscription.subscribe(new byte[][] { "s".getBytes() }));
+	}
 
-        verify(pubSubListener).clearListener();
-        verify(client).customCommand(argThat(args ->
-            args.length >= 2 &&
-            "PUNSUBSCRIBE_BLOCKING".equals(args[0].getString()) &&
-            "0".equals(args[args.length - 1].getString())
-        ));
-    }
+	@Test
+	void testPUnsubscribeAllAndClose() {
+		subscription.pSubscribe(new byte[][] { "a*".getBytes() });
+		subscription.pUnsubscribe();
 
-    @Test
-    void testDoCloseSubscribedChannelsAndPatterns() throws Exception {
-        subscription.subscribe(new byte[][] { "a".getBytes() });
-        subscription.pSubscribe(new byte[][] { "a*".getBytes() });
-        subscription.doClose();
+		verify(pubSubListener).clearListener();
+
+		assertThat(subscription.isAlive()).isFalse();
+		assertThat(subscription.getChannels()).isEmpty();
+		assertThat(subscription.getPatterns()).isEmpty();
+	}
 
-        verify(pubSubListener).clearListener();
-    }
+	@Test
+	void testPUnsubscribeAllPatternsWithChannels() {
+		subscription.subscribe(new byte[][] { "a".getBytes() });
+		subscription.pSubscribe(new byte[][] { "s*".getBytes() });
+		subscription.pUnsubscribe();
 
-    @Test
-    void testSubscribeCallsCustomCommand() throws Exception {
-        subscription.subscribe(new byte[][] { "channel1".getBytes() });
+		assertThat(subscription.isAlive()).isTrue();
+		assertThat(subscription.getPatterns()).isEmpty();
 
-        verify(client).customCommand(argThat(args ->
-            args.length == 3 &&
-            "SUBSCRIBE_BLOCKING".equals(args[0].getString()) &&
-            "channel1".equals(args[1].getString()) &&
-            "0".equals(args[2].getString())
-        ));
-    }
+		Collection<byte[]> channels = subscription.getChannels();
+		assertThat(channels).hasSize(1);
+		assertThat(channels.iterator().next()).isEqualTo("a".getBytes());
+	}
 
-    @Test
-    void testPSubscribeCallsCustomCommand() throws Exception {
-        subscription.pSubscribe(new byte[][] { "pattern*".getBytes() });
+	@Test
+	void testPUnsubscribeAndClose() {
+		byte[][] pattern = new byte[][] { "a*".getBytes() };
 
-        verify(client).customCommand(argThat(args ->
-            args.length == 3 &&
-            "PSUBSCRIBE_BLOCKING".equals(args[0].getString()) &&
-            "pattern*".equals(args[1].getString()) &&
-            "0".equals(args[2].getString())
-        ));
-    }
+		subscription.pSubscribe(pattern);
+		subscription.pUnsubscribe(pattern);
 
-    @Test
-    void testSubscribeCallsSubscriptionListener() {
-        MessageListener compositeListener = mock(MessageListener.class,
-                withSettings().extraInterfaces(SubscriptionListener.class));
+		verify(pubSubListener).clearListener();
 
-        ValkeyGlideSubscription sub = new ValkeyGlideSubscription(compositeListener, client, pubSubListener);
+		assertThat(subscription.isAlive()).isFalse();
+		assertThat(subscription.getChannels()).isEmpty();
+		assertThat(subscription.getPatterns()).isEmpty();
+	}
 
-        sub.subscribe(new byte[][] { "channel1".getBytes() });
+	@Test
+	void testPUnsubscribePatternSomeLeft() {
+		byte[][] patterns = new byte[][] { "a*".getBytes(), "b*".getBytes() };
+		subscription.pSubscribe(patterns);
+		subscription.pUnsubscribe(new byte[][] { "a*".getBytes() });
 
-        verify((SubscriptionListener) compositeListener).onChannelSubscribed(eq("channel1".getBytes()), anyLong());
-    }
+		assertThat(subscription.isAlive()).isTrue();
 
-    @Test
-    void testSubscribeMultipleChannelsCallsSubscriptionListener() {
-        MessageListener compositeListener = mock(MessageListener.class,
-                withSettings().extraInterfaces(SubscriptionListener.class));
+		Collection<byte[]> subPatterns = subscription.getPatterns();
+		assertThat(subPatterns).hasSize(1);
+		assertThat(subPatterns.iterator().next()).isEqualTo("b*".getBytes());
+		assertThat(subscription.getChannels()).isEmpty();
+	}
 
-        ValkeyGlideSubscription sub = new ValkeyGlideSubscription(compositeListener, client, pubSubListener);
+	@Test
+	void testPUnsubscribePatternWithChannels() {
+		byte[][] pattern = new byte[][] { "s*".getBytes() };
 
-        sub.subscribe(new byte[][] { "channel1".getBytes(), "channel2".getBytes() });
+		subscription.subscribe(new byte[][] { "a".getBytes() });
+		subscription.pSubscribe(pattern);
+		subscription.pUnsubscribe(pattern);
 
-        verify((SubscriptionListener) compositeListener).onChannelSubscribed(eq("channel1".getBytes()), anyLong());
-        verify((SubscriptionListener) compositeListener).onChannelSubscribed(eq("channel2".getBytes()), anyLong());
-    }
+		assertThat(subscription.isAlive()).isTrue();
+		assertThat(subscription.getPatterns()).isEmpty();
 
-    @Test
-    void testPSubscribeCallsSubscriptionListener() {
-        MessageListener compositeListener = mock(MessageListener.class,
-                withSettings().extraInterfaces(SubscriptionListener.class));
+		Collection<byte[]> channels = subscription.getChannels();
+		assertThat(channels).hasSize(1);
+		assertThat(channels.iterator().next()).isEqualTo("a".getBytes());
+	}
 
-        ValkeyGlideSubscription sub = new ValkeyGlideSubscription(compositeListener, client, pubSubListener);
+	@Test
+	void testUnsubscribePatternWithChannelsSomeLeft() {
+		byte[][] pattern = new byte[][] { "a*".getBytes() };
 
-        sub.pSubscribe(new byte[][] { "pattern*".getBytes() });
+		subscription.pSubscribe("a*".getBytes(), "b*".getBytes());
+		subscription.subscribe(new byte[][] { "a".getBytes() });
+		subscription.pUnsubscribe(pattern);
 
-        verify((SubscriptionListener) compositeListener).onPatternSubscribed(eq("pattern*".getBytes()), anyLong());
-    }
+		assertThat(subscription.isAlive()).isTrue();
+
+		Collection<byte[]> channels = subscription.getChannels();
+		assertThat(channels).hasSize(1);
+		assertThat(channels.iterator().next()).isEqualTo("a".getBytes());
+
+		Collection<byte[]> patterns = subscription.getPatterns();
+		assertThat(patterns).hasSize(1);
+		assertThat(patterns.iterator().next()).isEqualTo("b*".getBytes());
+	}
+
+	@Test
+	void testPUnsubscribeAllNoPatterns() {
+		subscription.subscribe(new byte[][] { "s".getBytes() });
+		subscription.pUnsubscribe();
 
-    @Test
-    void testUnsubscribeCallsSubscriptionListener() {
-        MessageListener compositeListener = mock(MessageListener.class,
-                withSettings().extraInterfaces(SubscriptionListener.class));
+		assertThat(subscription.isAlive()).isTrue();
+		assertThat(subscription.getPatterns()).isEmpty();
 
-        ValkeyGlideSubscription sub = new ValkeyGlideSubscription(compositeListener, client, pubSubListener);
+		Collection<byte[]> channels = subscription.getChannels();
+		assertThat(channels).hasSize(1);
+		assertThat(channels.iterator().next()).isEqualTo("s".getBytes());
+	}
 
-        sub.subscribe(new byte[][] { "channel1".getBytes(), "channel2".getBytes() });
-        sub.unsubscribe(new byte[][] { "channel1".getBytes() });
+	@Test
+	void testPUnsubscribeNotAlive() {
+		subscription.subscribe(new byte[][] { "a".getBytes() });
+		subscription.unsubscribe();
 
-        verify((SubscriptionListener) compositeListener).onChannelUnsubscribed(eq("channel1".getBytes()), anyLong());
-    }
+		assertThat(subscription.isAlive()).isFalse();
 
-    @Test
-    void testDoCloseCallsSubscriptionListenerForChannels() {
-        MessageListener compositeListener = mock(MessageListener.class,
-                withSettings().extraInterfaces(SubscriptionListener.class));
+		// Calling pUnsubscribe when not alive should not throw
+		subscription.pUnsubscribe();
 
-        ValkeyGlideSubscription sub = new ValkeyGlideSubscription(compositeListener, client, pubSubListener);
+		verify(pubSubListener).clearListener();
+	}
 
-        sub.subscribe(new byte[][] { "channel1".getBytes() });
-        sub.doClose();
+	@Test
+	void testPSubscribeNotAlive() {
+		subscription.subscribe(new byte[][] { "a".getBytes() });
+		subscription.unsubscribe();
 
-        verify((SubscriptionListener) compositeListener).onChannelUnsubscribed(eq("channel1".getBytes()), anyLong());
-    }
+		assertThat(subscription.isAlive()).isFalse();
 
-    @Test
-    void testDoCloseCallsSubscriptionListenerForPatterns() {
-        MessageListener compositeListener = mock(MessageListener.class,
-                withSettings().extraInterfaces(SubscriptionListener.class));
+		assertThatExceptionOfType(ValkeyInvalidSubscriptionException.class)
+			.isThrownBy(() -> subscription.pSubscribe(new byte[][] { "s*".getBytes() }));
+	}
 
-        ValkeyGlideSubscription sub = new ValkeyGlideSubscription(compositeListener, client, pubSubListener);
+	@Test
+	void testDoCloseNotSubscribed() {
+		subscription.doClose();
 
-        sub.pSubscribe(new byte[][] { "pattern*".getBytes() });
-        sub.doClose();
+		verify(pubSubListener).clearListener();
+	}
 
-        verify((SubscriptionListener) compositeListener).onPatternUnsubscribed(eq("pattern*".getBytes()), anyLong());
-    }
+	@Test
+	void testDoCloseSubscribedChannels() throws Exception {
+		subscription.subscribe(new byte[][] { "a".getBytes() });
+		subscription.doClose();
 
-    @Test
-    void testNonSubscriptionListenerDoesNotFail() {
-        MessageListener plainListener = mock(MessageListener.class);
+		verify(pubSubListener).clearListener();
+		verify(client)
+			.customCommand(argThat(args -> args.length >= 2 && "UNSUBSCRIBE_BLOCKING".equals(args[0].getString())
+					&& "0".equals(args[args.length - 1].getString())));
+	}
 
-        ValkeyGlideSubscription sub = new ValkeyGlideSubscription(plainListener, client, pubSubListener);
+	@Test
+	void testDoCloseSubscribedPatterns() throws Exception {
+		subscription.pSubscribe(new byte[][] { "a*".getBytes() });
+		subscription.doClose();
 
-        sub.subscribe(new byte[][] { "channel1".getBytes() });
-        sub.pSubscribe(new byte[][] { "pattern*".getBytes() });
-        sub.unsubscribe(new byte[][] { "channel1".getBytes() });
-        sub.pUnsubscribe(new byte[][] { "pattern*".getBytes() });
-        sub.doClose();
+		verify(pubSubListener).clearListener();
+		verify(client)
+			.customCommand(argThat(args -> args.length >= 2 && "PUNSUBSCRIBE_BLOCKING".equals(args[0].getString())
+					&& "0".equals(args[args.length - 1].getString())));
+	}
 
-        assertThat(sub.isAlive()).isFalse();
-    }
+	@Test
+	void testDoCloseSubscribedChannelsAndPatterns() throws Exception {
+		subscription.subscribe(new byte[][] { "a".getBytes() });
+		subscription.pSubscribe(new byte[][] { "a*".getBytes() });
+		subscription.doClose();
 
-    @Test
-    void closeTwiceShouldNotFail() {
-        subscription.subscribe(new byte[][] { "a".getBytes() });
+		verify(pubSubListener).clearListener();
+	}
 
-        subscription.close();
-        subscription.close();
+	@Test
+	void testSubscribeCallsCustomCommand() throws Exception {
+		subscription.subscribe(new byte[][] { "channel1".getBytes() });
 
-        verify(pubSubListener, times(1)).clearListener();
-        assertThat(subscription.isAlive()).isFalse();
-    }
+		verify(client)
+			.customCommand(argThat(args -> args.length == 3 && "SUBSCRIBE_BLOCKING".equals(args[0].getString())
+					&& "channel1".equals(args[1].getString()) && "0".equals(args[2].getString())));
+	}
+
+	@Test
+	void testPSubscribeCallsCustomCommand() throws Exception {
+		subscription.pSubscribe(new byte[][] { "pattern*".getBytes() });
+
+		verify(client)
+			.customCommand(argThat(args -> args.length == 3 && "PSUBSCRIBE_BLOCKING".equals(args[0].getString())
+					&& "pattern*".equals(args[1].getString()) && "0".equals(args[2].getString())));
+	}
+
+	@Test
+	void testSubscribeCallsSubscriptionListener() {
+		MessageListener compositeListener = mock(MessageListener.class,
+				withSettings().extraInterfaces(SubscriptionListener.class));
+
+		ValkeyGlideSubscription sub = new ValkeyGlideSubscription(compositeListener, client, pubSubListener);
+
+		sub.subscribe(new byte[][] { "channel1".getBytes() });
+
+		verify((SubscriptionListener) compositeListener).onChannelSubscribed(eq("channel1".getBytes()), anyLong());
+	}
+
+	@Test
+	void testSubscribeMultipleChannelsCallsSubscriptionListener() {
+		MessageListener compositeListener = mock(MessageListener.class,
+				withSettings().extraInterfaces(SubscriptionListener.class));
+
+		ValkeyGlideSubscription sub = new ValkeyGlideSubscription(compositeListener, client, pubSubListener);
+
+		sub.subscribe(new byte[][] { "channel1".getBytes(), "channel2".getBytes() });
+
+		verify((SubscriptionListener) compositeListener).onChannelSubscribed(eq("channel1".getBytes()), anyLong());
+		verify((SubscriptionListener) compositeListener).onChannelSubscribed(eq("channel2".getBytes()), anyLong());
+	}
+
+	@Test
+	void testPSubscribeCallsSubscriptionListener() {
+		MessageListener compositeListener = mock(MessageListener.class,
+				withSettings().extraInterfaces(SubscriptionListener.class));
+
+		ValkeyGlideSubscription sub = new ValkeyGlideSubscription(compositeListener, client, pubSubListener);
+
+		sub.pSubscribe(new byte[][] { "pattern*".getBytes() });
+
+		verify((SubscriptionListener) compositeListener).onPatternSubscribed(eq("pattern*".getBytes()), anyLong());
+	}
+
+	@Test
+	void testUnsubscribeCallsSubscriptionListener() {
+		MessageListener compositeListener = mock(MessageListener.class,
+				withSettings().extraInterfaces(SubscriptionListener.class));
+
+		ValkeyGlideSubscription sub = new ValkeyGlideSubscription(compositeListener, client, pubSubListener);
+
+		sub.subscribe(new byte[][] { "channel1".getBytes(), "channel2".getBytes() });
+		sub.unsubscribe(new byte[][] { "channel1".getBytes() });
+
+		verify((SubscriptionListener) compositeListener).onChannelUnsubscribed(eq("channel1".getBytes()), anyLong());
+	}
+
+	@Test
+	void testDoCloseCallsSubscriptionListenerForChannels() {
+		MessageListener compositeListener = mock(MessageListener.class,
+				withSettings().extraInterfaces(SubscriptionListener.class));
+
+		ValkeyGlideSubscription sub = new ValkeyGlideSubscription(compositeListener, client, pubSubListener);
+
+		sub.subscribe(new byte[][] { "channel1".getBytes() });
+		sub.doClose();
+
+		verify((SubscriptionListener) compositeListener).onChannelUnsubscribed(eq("channel1".getBytes()), anyLong());
+	}
+
+	@Test
+	void testDoCloseCallsSubscriptionListenerForPatterns() {
+		MessageListener compositeListener = mock(MessageListener.class,
+				withSettings().extraInterfaces(SubscriptionListener.class));
+
+		ValkeyGlideSubscription sub = new ValkeyGlideSubscription(compositeListener, client, pubSubListener);
+
+		sub.pSubscribe(new byte[][] { "pattern*".getBytes() });
+		sub.doClose();
+
+		verify((SubscriptionListener) compositeListener).onPatternUnsubscribed(eq("pattern*".getBytes()), anyLong());
+	}
+
+	@Test
+	void testNonSubscriptionListenerDoesNotFail() {
+		MessageListener plainListener = mock(MessageListener.class);
+
+		ValkeyGlideSubscription sub = new ValkeyGlideSubscription(plainListener, client, pubSubListener);
+
+		sub.subscribe(new byte[][] { "channel1".getBytes() });
+		sub.pSubscribe(new byte[][] { "pattern*".getBytes() });
+		sub.unsubscribe(new byte[][] { "channel1".getBytes() });
+		sub.pUnsubscribe(new byte[][] { "pattern*".getBytes() });
+		sub.doClose();
+
+		assertThat(sub.isAlive()).isFalse();
+	}
+
+	@Test
+	void closeTwiceShouldNotFail() {
+		subscription.subscribe(new byte[][] { "a".getBytes() });
+
+		subscription.close();
+		subscription.close();
+
+		verify(pubSubListener, times(1)).clearListener();
+		assertThat(subscription.isAlive()).isFalse();
+	}
+
 }

--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideZSetOrderingIntegrationTests.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideZSetOrderingIntegrationTests.java
@@ -29,8 +29,8 @@ import io.valkey.springframework.data.valkey.test.extension.ValkeyCluster;
 import io.valkey.springframework.data.valkey.test.extension.ValkeyStandalone;
 
 /**
- * Integration tests verifying that ZSet rangeWithScores operations maintain
- * score-based ordering for both standalone and cluster connections.
+ * Integration tests verifying that ZSet rangeWithScores operations maintain score-based
+ * ordering for both standalone and cluster connections.
  *
  * @see <a href="https://github.com/valkey-io/spring-data-valkey/issues/36">Issue #36</a>
  * @see <a href="https://github.com/valkey-io/valkey-glide/issues/4963">Glide #4963</a>
@@ -57,12 +57,14 @@ class ValkeyGlideZSetOrderingIntegrationTests {
 			assertThat(rangeArray[3]).isEqualTo("value3");
 
 			Set<ZSetOperations.TypedTuple<String>> rangeWithScoresResult = opsForZSet.rangeWithScores("testKey", 0, 3);
-			ZSetOperations.TypedTuple<String>[] tuplesArray = rangeWithScoresResult.toArray(new ZSetOperations.TypedTuple[0]);
+			ZSetOperations.TypedTuple<String>[] tuplesArray = rangeWithScoresResult
+				.toArray(new ZSetOperations.TypedTuple[0]);
 			assertThat(tuplesArray[0].getValue()).isEqualTo("value2");
 			assertThat(tuplesArray[1].getValue()).isEqualTo("value1");
 			assertThat(tuplesArray[2].getValue()).isEqualTo("value4");
 			assertThat(tuplesArray[3].getValue()).isEqualTo("value3");
-		} finally {
+		}
+		finally {
 			template.delete("testKey");
 		}
 	}
@@ -88,13 +90,16 @@ class ValkeyGlideZSetOrderingIntegrationTests {
 			assertThat(rangeArray[3]).isEqualTo("value3");
 
 			Set<ZSetOperations.TypedTuple<String>> rangeWithScoresResult = opsForZSet.rangeWithScores("testKey", 0, 3);
-			ZSetOperations.TypedTuple<String>[] tuplesArray = rangeWithScoresResult.toArray(new ZSetOperations.TypedTuple[0]);
+			ZSetOperations.TypedTuple<String>[] tuplesArray = rangeWithScoresResult
+				.toArray(new ZSetOperations.TypedTuple[0]);
 			assertThat(tuplesArray[0].getValue()).isEqualTo("value2");
 			assertThat(tuplesArray[1].getValue()).isEqualTo("value1");
 			assertThat(tuplesArray[2].getValue()).isEqualTo("value4");
 			assertThat(tuplesArray[3].getValue()).isEqualTo("value3");
-		} finally {
+		}
+		finally {
 			template.delete("testKey");
 		}
 	}
+
 }

--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/extension/ValkeyGlideConnectionFactoryExtension.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/extension/ValkeyGlideConnectionFactoryExtension.java
@@ -40,12 +40,15 @@ import io.valkey.springframework.data.valkey.test.extension.ShutdownQueue;
 import org.springframework.data.util.Lazy;
 
 /**
- * JUnit {@link ParameterResolver} providing pre-cached {@link ValkeyGlideConnectionFactory} instances. Connection factories
- * can be qualified with {@code @ValkeyStandalone} (default) or {@code @ValkeyCluster} to obtain a specific factory instance.
- * Instances are managed by this extension and will be shut down on JVM shutdown.
- * 
- * <p><strong>Note:</strong> Sentinel configurations are not supported by Valkey-Glide and will throw an 
- * {@link UnsupportedOperationException}.
+ * JUnit {@link ParameterResolver} providing pre-cached
+ * {@link ValkeyGlideConnectionFactory} instances. Connection factories can be qualified
+ * with {@code @ValkeyStandalone} (default) or {@code @ValkeyCluster} to obtain a specific
+ * factory instance. Instances are managed by this extension and will be shut down on JVM
+ * shutdown.
+ *
+ * <p>
+ * <strong>Note:</strong> Sentinel configurations are not supported by Valkey-Glide and
+ * will throw an {@link UnsupportedOperationException}.
  *
  * @author Ilia Kolominsky
  * @see ValkeyStandalone
@@ -54,10 +57,10 @@ import org.springframework.data.util.Lazy;
 public class ValkeyGlideConnectionFactoryExtension implements ParameterResolver {
 
 	private static final ExtensionContext.Namespace NAMESPACE = ExtensionContext.Namespace
-			.create(ValkeyGlideConnectionFactoryExtension.class);
+		.create(ValkeyGlideConnectionFactoryExtension.class);
 
 	private static final ValkeyGlideClientConfiguration CLIENT_CONFIGURATION = ValkeyGlideClientConfiguration.builder()
-			.build();
+		.build();
 
 	private static final NewableLazy<ValkeyGlideConnectionFactory> STANDALONE = NewableLazy.of(() -> {
 
@@ -94,46 +97,47 @@ public class ValkeyGlideConnectionFactoryExtension implements ParameterResolver 
 	}
 
 	/**
-	 * Obtain a cached {@link ValkeyGlideConnectionFactory} described by {@code qualifier}. Instances are managed by this
-	 * extension and will be shut down on JVM shutdown.
-	 *
-	 * @param qualifier can be any of {@link ValkeyStandalone}, {@link ValkeyCluster}. {@link ValkeySentinel} is not supported.
+	 * Obtain a cached {@link ValkeyGlideConnectionFactory} described by
+	 * {@code qualifier}. Instances are managed by this extension and will be shut down on
+	 * JVM shutdown.
+	 * @param qualifier can be any of {@link ValkeyStandalone}, {@link ValkeyCluster}.
+	 * {@link ValkeySentinel} is not supported.
 	 * @return the managed {@link ValkeyGlideConnectionFactory}.
 	 * @throws UnsupportedOperationException if {@link ValkeySentinel} is requested.
 	 */
 	public static ValkeyGlideConnectionFactory getConnectionFactory(Class<? extends Annotation> qualifier) {
-		
+
 		if (ValkeySentinel.class.equals(qualifier)) {
 			throw new UnsupportedOperationException("Sentinel connections are not supported with Valkey-Glide!");
 		}
-		
+
 		NewableLazy<ValkeyGlideConnectionFactory> factory = factories.get(qualifier);
 		if (factory == null) {
 			throw new IllegalArgumentException("Unsupported qualifier: " + qualifier);
 		}
-		
+
 		return factory.getNew();
 	}
 
 	/**
-	 * Obtain a new {@link ValkeyGlideConnectionFactory} described by {@code qualifier}. Instances are managed by this extension
-	 * and will be shut down on JVM shutdown.
-	 *
-	 * @param qualifier can be any of {@link ValkeyStandalone}, {@link ValkeyCluster}. {@link ValkeySentinel} is not supported.
+	 * Obtain a new {@link ValkeyGlideConnectionFactory} described by {@code qualifier}.
+	 * Instances are managed by this extension and will be shut down on JVM shutdown.
+	 * @param qualifier can be any of {@link ValkeyStandalone}, {@link ValkeyCluster}.
+	 * {@link ValkeySentinel} is not supported.
 	 * @return the managed {@link ValkeyGlideConnectionFactory}.
 	 * @throws UnsupportedOperationException if {@link ValkeySentinel} is requested.
 	 */
 	public static ValkeyGlideConnectionFactory getNewConnectionFactory(Class<? extends Annotation> qualifier) {
-		
+
 		if (ValkeySentinel.class.equals(qualifier)) {
 			throw new UnsupportedOperationException("Sentinel connections are not supported with Valkey-Glide!");
 		}
-		
+
 		NewableLazy<ValkeyGlideConnectionFactory> factory = factories.get(qualifier);
 		if (factory == null) {
 			throw new IllegalArgumentException("Unsupported qualifier: " + qualifier);
 		}
-		
+
 		return factory.getNew();
 	}
 
@@ -183,6 +187,7 @@ public class ValkeyGlideConnectionFactoryExtension implements ParameterResolver 
 		public T getNew() {
 			return lazy.get();
 		}
+
 	}
 
 	static class ManagedValkeyGlideConnectionFactory extends ValkeyGlideConnectionFactory
@@ -218,7 +223,8 @@ public class ValkeyGlideConnectionFactoryExtension implements ParameterResolver 
 
 			if (isClusterAware()) {
 				builder.append(" Cluster");
-			} else {
+			}
+			else {
 				builder.append(" Standalone");
 			}
 
@@ -230,9 +236,12 @@ public class ValkeyGlideConnectionFactoryExtension implements ParameterResolver 
 			try {
 				mayClose = true;
 				destroy();
-			} catch (Exception ex) {
+			}
+			catch (Exception ex) {
 				ex.printStackTrace();
 			}
 		}
+
 	}
+
 }


### PR DESCRIPTION
## Summary

Applies spring-javaformat conventions to all GLIDE-authored classes and adds the formatter plugin for ongoing style enforcement.

Closes #49

## Changes

- Add `spring-javaformat-maven-plugin` 0.0.47 to root, examples, and performance pom.xml
- Format all `valkeyglide` package classes (main + test) with spring-javaformat
- Format all examples and performance module sources
- Fix copyright headers to `2025-present` for all classes we authored
- Add Code Style section to DEVELOPER.md (IDE plugin recommended, CLI documented)
- Update AGENTS.md with formatting guidance and upstream convention note

## Limitations

Formatting is applied only to classes authored by this project (GLIDE driver, boot GLIDE config, examples, performance). Upstream-synced classes (Lettuce, Jedis, common) are intentionally left unformatted to avoid merge conflicts on future syncs.