### PR TITLE
Upgrade to Spring Boot 4.1

### DIFF
--- a/.kiro/agents/rules/spring-boot-4.md
+++ b/.kiro/agents/rules/spring-boot-4.md
@@ -4,7 +4,7 @@
 
 | Dependency | Version |
 |-----------|---------|
-| Spring Boot | 4.0.7 |
+| Spring Boot | 4.1.0 |
 | Spring Data Parent | 4.1.0 |
 | Lettuce | 7.5.2.RELEASE |
 | Jedis | 7.4.1 |

--- a/.kiro/agents/upstream-sync-orchestrator.md
+++ b/.kiro/agents/upstream-sync-orchestrator.md
@@ -16,7 +16,7 @@ You are the orchestrator for syncing spring-data-valkey with upstream Spring Dat
 
 You will be given:
 - **Source version**: The current upstream version (default: `3.5.1`)
-- **Target version**: The upstream version to upgrade to (default: `4.1.0` for spring-data-redis, `4.0.7` for spring-boot)
+- **Target version**: The upstream version to upgrade to (default: `4.1.0` for spring-data-redis, `4.1.0` for spring-boot)
 - **Upstream repo paths**:
   - spring-data-redis: `/workspace/amazon/spring-data-redis`
   - spring-boot: `/workspace/amazon/spring-boot`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Spring Data Valkey is a Spring Data module providing first-class Valkey/Redis in
 
 **Primary Language:** Java 17+
 **Build System:** Maven (use `./mvnw` wrapper)
-**Framework:** Spring Data 4.1.x, Spring Boot 4.0.x
+**Framework:** Spring Data 4.1.x, Spring Boot 4.1.x
 **Origin:** Synced with Spring Data Redis 4.1.0 — class and package renames follow the pattern `*Redis*` → `*Valkey*`, `*redis*` → `*valkey*` (see [MIGRATION.md](./MIGRATION.md) for full mapping, [DEVELOPER.md](./DEVELOPER.md) for source alignment and detailed build/release info)
 
 **Key Components:**

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -190,7 +190,7 @@ This repository is forked from Spring Data Redis and related projects. This sect
 |--------------|------------------------|------------|-------|
 | `./` | [spring-data-build](https://github.com/spring-projects/spring-data-build) | `4.1.0` | Parent for Spring Data modules |
 | `spring-data-valkey/` | [spring-data-redis](https://github.com/spring-projects/spring-data-redis) | `4.1.0` | Core Spring Data Redis functionality |
-| `spring-boot-starter-data-valkey/` | [spring-boot](https://github.com/spring-projects/spring-boot) | `4.0.7` | Spring Boot auto-configuration for Redis |
+| `spring-boot-starter-data-valkey/` | [spring-boot](https://github.com/spring-projects/spring-boot) | `4.1.0` | Spring Boot auto-configuration for Redis |
 | `docs/` | [spring-data-redis](https://github.com/spring-projects/spring-data-redis) | `4.1.0` | Documentation |
 | `examples/` | [spring-data-examples](https://github.com/spring-projects/spring-data-examples) | `main` | Redis examples |
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 		<maven.deploy.skip>true</maven.deploy.skip>
 
 		<!-- Spring versions -->
-		<spring-boot.version>4.0.7</spring-boot.version>
+		<spring-boot.version>4.1.0</spring-boot.version>
 		<springdata.parent.version>4.1.0</springdata.parent.version>
 
 		<!-- Valkey/Redis client versions -->

--- a/spring-boot-starter-data-valkey/README.md
+++ b/spring-boot-starter-data-valkey/README.md
@@ -4,7 +4,7 @@ A Spring Boot starter that provides auto-configuration for Valkey, enabling seam
 
 This starter simplifies the setup and configuration of Valkey in Spring Boot applications by providing auto-configuration for Valkey connections and Spring Data integration.
 
-The project is a fork of Spring Boot Starter Data Redis 4.0.7 (part of the [Spring Boot](https://github.com/spring-projects/spring-boot) repository).
+The project is a fork of Spring Boot Starter Data Redis 4.1.0 (part of the [Spring Boot](https://github.com/spring-projects/spring-boot) repository).
 
 ## Features
 

--- a/spring-boot-starter-data-valkey/src/main/java/io/valkey/springframework/boot/autoconfigure/data/valkey/JedisConnectionConfiguration.java
+++ b/spring-boot-starter-data-valkey/src/main/java/io/valkey/springframework/boot/autoconfigure/data/valkey/JedisConnectionConfiguration.java
@@ -19,8 +19,8 @@ package io.valkey.springframework.boot.autoconfigure.data.valkey;
 import javax.net.ssl.SSLParameters;
 
 import org.apache.commons.pool2.impl.GenericObjectPool;
+import redis.clients.jedis.ConnectionPoolConfig;
 import redis.clients.jedis.Jedis;
-import redis.clients.jedis.JedisPoolConfig;
 
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -151,11 +151,11 @@ class JedisConnectionConfiguration extends ValkeyConnectionConfiguration {
 
 	private void applyPooling(ValkeyProperties.Pool pool,
 			JedisClientConfiguration.JedisClientConfigurationBuilder builder) {
-		builder.usePooling().poolConfig(jedisPoolConfig(pool));
+		builder.usePooling().poolConfig(poolConfig(pool));
 	}
 
-	private JedisPoolConfig jedisPoolConfig(ValkeyProperties.Pool pool) {
-		JedisPoolConfig config = new JedisPoolConfig();
+	private ConnectionPoolConfig poolConfig(ValkeyProperties.Pool pool) {
+		ConnectionPoolConfig config = new ConnectionPoolConfig();
 		config.setMaxTotal(pool.getMaxActive());
 		config.setMaxIdle(pool.getMaxIdle());
 		config.setMinIdle(pool.getMinIdle());

--- a/spring-boot-starter-data-valkey/src/main/java/io/valkey/springframework/boot/autoconfigure/data/valkey/LettuceConnectionConfiguration.java
+++ b/spring-boot-starter-data-valkey/src/main/java/io/valkey/springframework/boot/autoconfigure/data/valkey/LettuceConnectionConfiguration.java
@@ -240,9 +240,6 @@ class LettuceConnectionConfiguration extends ValkeyConnectionConfiguration {
 			if (refreshProperties.getPeriod() != null) {
 				refreshBuilder.enablePeriodicRefresh(refreshProperties.getPeriod());
 			}
-			if (refreshProperties.isAdaptive()) {
-				refreshBuilder.enableAllAdaptiveRefreshTriggers();
-			}
 			return builder.topologyRefreshOptions(refreshBuilder.build());
 		}
 		return ClientOptions.builder();

--- a/spring-boot-starter-data-valkey/src/main/java/io/valkey/springframework/boot/autoconfigure/data/valkey/ValkeyProperties.java
+++ b/spring-boot-starter-data-valkey/src/main/java/io/valkey/springframework/boot/autoconfigure/data/valkey/ValkeyProperties.java
@@ -577,12 +577,6 @@ public class ValkeyProperties {
 				 */
 				private @Nullable Duration period;
 
-				/**
-				 * Whether adaptive topology refreshing using all available refresh
-				 * triggers should be used.
-				 */
-				private boolean adaptive;
-
 				public boolean isDynamicRefreshSources() {
 					return this.dynamicRefreshSources;
 				}
@@ -597,14 +591,6 @@ public class ValkeyProperties {
 
 				public void setPeriod(@Nullable Duration period) {
 					this.period = period;
-				}
-
-				public boolean isAdaptive() {
-					return this.adaptive;
-				}
-
-				public void setAdaptive(boolean adaptive) {
-					this.adaptive = adaptive;
 				}
 
 			}
@@ -720,7 +706,6 @@ public class ValkeyProperties {
 
 				private boolean dynamicRefreshSources = true;
 				private Duration period;
-				private boolean adaptive;
 
 				public boolean isDynamicRefreshSources() {
 					return this.dynamicRefreshSources;
@@ -736,14 +721,6 @@ public class ValkeyProperties {
 
 				public void setPeriod(Duration period) {
 					this.period = period;
-				}
-
-				public boolean isAdaptive() {
-					return this.adaptive;
-				}
-
-				public void setAdaptive(boolean adaptive) {
-					this.adaptive = adaptive;
 				}
 			}
 		}

--- a/spring-boot-starter-data-valkey/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-starter-data-valkey/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -8,6 +8,15 @@
       "defaultValue": true
     },
     {
+      "name": "spring.data.valkey.lettuce.cluster.refresh.adaptive",
+      "type": "java.lang.Boolean",
+      "deprecation": {
+        "reason": "All adaptive triggers are enabled by default.",
+        "level": "error",
+        "since": "4.1.0"
+      }
+    },
+    {
       "name": "spring.data.valkey.repositories.enabled",
       "type": "java.lang.Boolean",
       "description": "Whether to enable Valkey repositories.",

--- a/spring-boot-starter-data-valkey/src/test/java/io/valkey/springframework/boot/autoconfigure/data/valkey/ValkeyAutoConfigurationLettuceTests.java
+++ b/spring-boot-starter-data-valkey/src/test/java/io/valkey/springframework/boot/autoconfigure/data/valkey/ValkeyAutoConfigurationLettuceTests.java
@@ -18,7 +18,6 @@ package io.valkey.springframework.boot.autoconfigure.data.valkey;
 
 import java.time.Duration;
 import java.util.Arrays;
-import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -31,7 +30,6 @@ import io.lettuce.core.ReadFrom;
 import io.lettuce.core.ReadFrom.Nodes;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.cluster.ClusterClientOptions;
-import io.lettuce.core.cluster.ClusterTopologyRefreshOptions.RefreshTrigger;
 import io.lettuce.core.cluster.models.partitions.RedisClusterNode;
 import io.lettuce.core.models.role.RedisNodeDescription;
 import io.lettuce.core.resource.DefaultClientResources;
@@ -569,16 +567,6 @@ class ValkeyAutoConfigurationLettuceTests {
 					"spring.data.valkey.lettuce.cluster.refresh.period=30s")
 			.run(assertClientOptions(ClusterClientOptions.class,
 					(options) -> assertThat(options.getTopologyRefreshOptions().getRefreshPeriod()).hasSeconds(30)));
-	}
-
-	@Test
-	void testValkeyConfigurationWithClusterAdaptiveRefresh() {
-		this.contextRunner
-			.withPropertyValues("spring.data.valkey.cluster.nodes=127.0.0.1:27379,127.0.0.1:27380",
-					"spring.data.valkey.lettuce.cluster.refresh.adaptive=true")
-			.run(assertClientOptions(ClusterClientOptions.class,
-					(options) -> assertThat(options.getTopologyRefreshOptions().getAdaptiveRefreshTriggers())
-						.isEqualTo(EnumSet.allOf(RefreshTrigger.class))));
 	}
 
 	@Test

--- a/spring-boot-starter-data-valkey/src/test/java/io/valkey/springframework/boot/autoconfigure/data/valkey/ValkeyAutoConfigurationTests.java
+++ b/spring-boot-starter-data-valkey/src/test/java/io/valkey/springframework/boot/autoconfigure/data/valkey/ValkeyAutoConfigurationTests.java
@@ -263,17 +263,6 @@ class ValkeyAutoConfigurationTests {
 	}
 
 	@Test
-	void testValkeyConfigurationWithClusterAdaptiveRefresh() {
-		this.contextRunner
-			.withPropertyValues("spring.data.valkey.cluster.nodes=127.0.0.1:27379,127.0.0.1:27380",
-					"spring.data.valkey.valkeyglide.cluster.refresh.adaptive=true")
-			.run((context) -> {
-				ValkeyProperties properties = context.getBean(ValkeyProperties.class);
-				assertThat(properties.getValkeyGlide().getCluster().getRefresh().isAdaptive()).isTrue();
-			});
-	}
-
-	@Test
 	void testValkeyConfigurationWithClusterRefreshPeriodHasNoEffectWithNonClusteredConfiguration() {
 		this.contextRunner.withPropertyValues("spring.data.valkey.cluster.refresh.period=30s")
 			.run(assertClientOptions((config) -> {


### PR DESCRIPTION
## Summary

Aligns spring-boot-starter-data-valkey with Spring Boot 4.1.0 (from 4.0.7).  Resolves version mismatch noted in #84.

## Changes

- Upgrade Spring Boot 4.0.7 → 4.1.0
- Replace deprecated `JedisPoolConfig` with `ConnectionPoolConfig` (Jedis 7.x)
- Remove `adaptive` cluster refresh property (all adaptive triggers now enabled by default in Lettuce 7.x)
- Add deprecation metadata for `spring.data.valkey.lettuce.cluster.refresh.adaptive`
- Remove associated tests for the deprecated property

Dependency alignment:
- Spring Framework: 7.0.8
- Valkey GLIDE: 2.4.0
- Lettuce: 7.5.2.RELEASE
- Jedis: 7.4.1
- commons-pool2: 2.13.1

## Testing

- All unit tests pass and examples run
- Manual verification of GLIDE, Lettuce, and Jedis clients against local Valkey
