### PR TITLE
Add automated Maven Central publishing to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,36 +159,12 @@ jobs:
           GPG_KEYNAME=$(gpg --list-secret-keys --keyid-format short 2>/dev/null | grep 'sec' | head -1 | sed 's/.*\///' | awk '{print $1}')
           echo "GPG_KEYNAME=$GPG_KEYNAME" >> $GITHUB_ENV
 
-      # TODO: Remove this dry-run step and uncomment the deploy step below once verified
-      - name: Verify credentials and GPG signing (dry run)
+      - name: Deploy to Maven Central (staging)
         run: |
-          # Verify env vars are set
-          [ -n "$OSSRH_USERNAME" ] && echo "✓ OSSRH_USERNAME set" || echo "✗ OSSRH_USERNAME missing"
-          [ -n "$OSSRH_PASSWORD" ] && echo "✓ OSSRH_PASSWORD set" || echo "✗ OSSRH_PASSWORD missing"
-          [ -n "$GPG_PASSPHRASE" ] && echo "✓ GPG_PASSPHRASE set" || echo "✗ GPG_PASSPHRASE missing"
-          [ -n "$GPG_KEYNAME" ] && echo "✓ GPG_KEYNAME set ($GPG_KEYNAME)" || echo "✗ GPG_KEYNAME missing"
-
-          # Verify GPG key import and signing
-          gpg --list-secret-keys --keyid-format short
-          echo "test" | gpg --batch --yes --passphrase "$GPG_PASSPHRASE" --pinentry-mode loopback --clearsign
-
-          # Verify Maven Central credentials authenticate
-          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-            -u "$OSSRH_USERNAME:$OSSRH_PASSWORD" \
-            "https://ossrh-staging-api.central.sonatype.com/service/local/staging/profiles")
-          if [ "$HTTP_STATUS" = "200" ]; then
-            echo "✓ Maven Central authentication successful"
-          else
-            echo "✗ Maven Central authentication failed (HTTP $HTTP_STATUS)"
-            exit 1
-          fi
-
-      # - name: Deploy to Maven Central (staging)
-      #   run: |
-      #     ./mvnw -s settings.xml \
-      #       -Ddevelocity.storage.directory=$HOME/.develocity-root \
-      #       -Dmaven.repo.local=$HOME/.m2/spring-data-valkey \
-      #       deploy -DskipTests \
-      #       -pl spring-data-valkey,spring-boot-starter-data-valkey \
-      #       -Dmaven.deploy.skip=false \
-      #       -U -B
+          ./mvnw -s settings.xml \
+            -Ddevelocity.storage.directory=$HOME/.develocity-root \
+            -Dmaven.repo.local=$HOME/.m2/spring-data-valkey \
+            deploy -DskipTests \
+            -pl spring-data-valkey,spring-boot-starter-data-valkey \
+            -Dmaven.deploy.skip=false \
+            -U -B

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,31 +134,61 @@ jobs:
           SECRET=$(aws secretsmanager get-secret-value \
             --secret-id spring-data-valkey-maven-token \
             --query SecretString --output text)
-          echo "OSSRH_USERNAME=$(echo "$SECRET" | jq -r '.["maven-central-username"]')" >> $GITHUB_ENV
-          echo "OSSRH_PASSWORD=$(echo "$SECRET" | jq -r '.["maven-central-password"]')" >> $GITHUB_ENV
+          OSSRH_USERNAME=$(echo "$SECRET" | jq -r '.["maven-central-username"]')
+          OSSRH_PASSWORD=$(echo "$SECRET" | jq -r '.["maven-central-password"]')
+          echo "::add-mask::$OSSRH_USERNAME"
+          echo "::add-mask::$OSSRH_PASSWORD"
+          echo "OSSRH_USERNAME=$OSSRH_USERNAME" >> $GITHUB_ENV
+          echo "OSSRH_PASSWORD=$OSSRH_PASSWORD" >> $GITHUB_ENV
 
       - name: Fetch GPG passphrase
         run: |
-          GPG_PASSPHRASE=$(aws secretsmanager get-secret-value \
+          SECRET=$(aws secretsmanager get-secret-value \
             --secret-id GPGPassword \
             --query SecretString --output text)
+          GPG_PASSPHRASE=$(echo "$SECRET" | jq -r '.["GPG Password"]')
+          echo "::add-mask::$GPG_PASSPHRASE"
           echo "GPG_PASSPHRASE=$GPG_PASSPHRASE" >> $GITHUB_ENV
 
       - name: Import GPG private key
         run: |
           SECRET=$(aws secretsmanager get-secret-value \
-            --secret-id PGPASCFile \
+            --secret-id PGPPrivateKey \
             --query SecretString --output text)
-          echo "$SECRET" | jq -r '.PGP_SECRET_KEY' | gpg --batch --import
+          echo "$SECRET" | jq -r '.PGP_SECRET_KEY' | tr ' ' '\n' | base64 -d | gpg --batch --import
           GPG_KEYNAME=$(gpg --list-secret-keys --keyid-format short 2>/dev/null | grep 'sec' | head -1 | sed 's/.*\///' | awk '{print $1}')
           echo "GPG_KEYNAME=$GPG_KEYNAME" >> $GITHUB_ENV
 
-      - name: Deploy to Maven Central (staging)
+      # TODO: Remove this dry-run step and uncomment the deploy step below once verified
+      - name: Verify credentials and GPG signing (dry run)
         run: |
-          ./mvnw -s settings.xml \
-            -Ddevelocity.storage.directory=$HOME/.develocity-root \
-            -Dmaven.repo.local=$HOME/.m2/spring-data-valkey \
-            deploy -DskipTests \
-            -pl spring-data-valkey,spring-boot-starter-data-valkey \
-            -Dmaven.deploy.skip=false \
-            -U -B
+          # Verify env vars are set
+          [ -n "$OSSRH_USERNAME" ] && echo "✓ OSSRH_USERNAME set" || echo "✗ OSSRH_USERNAME missing"
+          [ -n "$OSSRH_PASSWORD" ] && echo "✓ OSSRH_PASSWORD set" || echo "✗ OSSRH_PASSWORD missing"
+          [ -n "$GPG_PASSPHRASE" ] && echo "✓ GPG_PASSPHRASE set" || echo "✗ GPG_PASSPHRASE missing"
+          [ -n "$GPG_KEYNAME" ] && echo "✓ GPG_KEYNAME set ($GPG_KEYNAME)" || echo "✗ GPG_KEYNAME missing"
+
+          # Verify GPG key import and signing
+          gpg --list-secret-keys --keyid-format short
+          echo "test" | gpg --batch --yes --passphrase "$GPG_PASSPHRASE" --pinentry-mode loopback --clearsign
+
+          # Verify Maven Central credentials authenticate
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            -u "$OSSRH_USERNAME:$OSSRH_PASSWORD" \
+            "https://ossrh-staging-api.central.sonatype.com/service/local/staging/profiles")
+          if [ "$HTTP_STATUS" = "200" ]; then
+            echo "✓ Maven Central authentication successful"
+          else
+            echo "✗ Maven Central authentication failed (HTTP $HTTP_STATUS)"
+            exit 1
+          fi
+
+      # - name: Deploy to Maven Central (staging)
+      #   run: |
+      #     ./mvnw -s settings.xml \
+      #       -Ddevelocity.storage.directory=$HOME/.develocity-root \
+      #       -Dmaven.repo.local=$HOME/.m2/spring-data-valkey \
+      #       deploy -DskipTests \
+      #       -pl spring-data-valkey,spring-boot-starter-data-valkey \
+      #       -Dmaven.deploy.skip=false \
+      #       -U -B

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     tags: ["v*"]
 
+permissions:
+  contents: write
+  id-token: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -87,3 +91,74 @@ jobs:
             spring-data-valkey/target/*.jar
             spring-boot-starter-data-valkey/target/*.jar
           generate_release_notes: true
+
+  publish:
+    needs: release
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: maven-publish
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: "temurin"
+
+      - name: Cache Maven dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/spring-data-valkey
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Configure GPG for non-interactive signing
+        run: |
+          mkdir -p ~/.gnupg
+          echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf
+          echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
+          chmod 700 ~/.gnupg
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Fetch Maven Central credentials
+        run: |
+          SECRET=$(aws secretsmanager get-secret-value \
+            --secret-id spring-data-valkey-maven-token \
+            --query SecretString --output text)
+          echo "OSSRH_USERNAME=$(echo "$SECRET" | jq -r '.["maven-central-username"]')" >> $GITHUB_ENV
+          echo "OSSRH_PASSWORD=$(echo "$SECRET" | jq -r '.["maven-central-password"]')" >> $GITHUB_ENV
+
+      - name: Fetch GPG passphrase
+        run: |
+          GPG_PASSPHRASE=$(aws secretsmanager get-secret-value \
+            --secret-id GPGPassword \
+            --query SecretString --output text)
+          echo "GPG_PASSPHRASE=$GPG_PASSPHRASE" >> $GITHUB_ENV
+
+      - name: Import GPG private key
+        run: |
+          SECRET=$(aws secretsmanager get-secret-value \
+            --secret-id PGPASCFile \
+            --query SecretString --output text)
+          echo "$SECRET" | jq -r '.PGP_SECRET_KEY' | gpg --batch --import
+          GPG_KEYNAME=$(gpg --list-secret-keys --keyid-format short 2>/dev/null | grep 'sec' | head -1 | sed 's/.*\///' | awk '{print $1}')
+          echo "GPG_KEYNAME=$GPG_KEYNAME" >> $GITHUB_ENV
+
+      - name: Deploy to Maven Central (staging)
+        run: |
+          ./mvnw -s settings.xml \
+            -Ddevelocity.storage.directory=$HOME/.develocity-root \
+            -Dmaven.repo.local=$HOME/.m2/spring-data-valkey \
+            deploy -DskipTests \
+            -pl spring-data-valkey,spring-boot-starter-data-valkey \
+            -Dmaven.deploy.skip=false \
+            -U -B

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,33 +175,52 @@ jobs:
             exit 1
           fi
 
-      - name: Deploy and release to Maven Central
-        id: deploy
+      # TODO: Remove dry-run step and uncomment deploy steps below once verified
+      - name: Verify credentials and GPG signing (dry run)
         run: |
-          ./mvnw -s settings.xml \
-            -Ddevelocity.storage.directory=$HOME/.develocity-root \
-            -Dmaven.repo.local=$HOME/.m2/spring-data-valkey \
-            deploy -DskipTests \
-            -pl spring-data-valkey,spring-boot-starter-data-valkey \
-            -Dmaven.deploy.skip=false \
-            -DautoReleaseAfterClose=true \
-            -U -B
-
-      - name: Drop staging repository on failure
-        if: failure() && steps.deploy.outcome == 'failure'
-        run: |
-          echo "Deploy failed - attempting to drop staging repository..."
+          [ -n "$OSSRH_USERNAME" ] && echo "OSSRH_USERNAME set" || echo "OSSRH_USERNAME missing"
+          [ -n "$OSSRH_PASSWORD" ] && echo "OSSRH_PASSWORD set" || echo "OSSRH_PASSWORD missing"
+          [ -n "$GPG_PASSPHRASE" ] && echo "GPG_PASSPHRASE set" || echo "GPG_PASSPHRASE missing"
+          [ -n "$GPG_KEYNAME" ] && echo "GPG_KEYNAME set ($GPG_KEYNAME)" || echo "GPG_KEYNAME missing"
+          gpg --list-secret-keys --keyid-format short
+          echo "test" | gpg --batch --yes --passphrase "$GPG_PASSPHRASE" --pinentry-mode loopback --clearsign
           AUTH_HEADER="Bearer $(echo -n "${OSSRH_USERNAME}:${OSSRH_PASSWORD}" | base64)"
-          # Find any open repositories for our namespace
-          REPOS=$(curl -s --header "Authorization: ${AUTH_HEADER}" \
-            "https://ossrh-staging-api.central.sonatype.com/manual/search/repositories?profile_id=io.valkey.springframework&state=open")
-          REPO_KEY=$(echo "$REPOS" | jq -r '.repositories[0].key // empty')
-          if [ -n "$REPO_KEY" ]; then
-            echo "Dropping repository: $REPO_KEY"
-            curl --fail --request DELETE \
-              --header "Authorization: ${AUTH_HEADER}" \
-              "https://ossrh-staging-api.central.sonatype.com/manual/drop/repository/${REPO_KEY}"
-            echo "Staging repository dropped - safe to retry"
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            --header "Authorization: ${AUTH_HEADER}" \
+            "https://central.sonatype.com/api/v1/publisher/deployments")
+          if [ "$HTTP_STATUS" = "200" ]; then
+            echo "Maven Central authentication successful"
           else
-            echo "No open staging repository found - nothing to clean up"
+            echo "Maven Central authentication failed (HTTP $HTTP_STATUS)"
+            exit 1
           fi
+
+      # - name: Deploy and release to Maven Central
+      #   id: deploy
+      #   run: |
+      #     ./mvnw -s settings.xml \
+      #       -Ddevelocity.storage.directory=$HOME/.develocity-root \
+      #       -Dmaven.repo.local=$HOME/.m2/spring-data-valkey \
+      #       deploy -DskipTests \
+      #       -pl spring-data-valkey,spring-boot-starter-data-valkey \
+      #       -Dmaven.deploy.skip=false \
+      #       -DautoReleaseAfterClose=true \
+      #       -U -B
+      #
+      # - name: Drop staging repository on failure
+      #   if: failure() && steps.deploy.outcome == 'failure'
+      #   run: |
+      #     echo "Deploy failed - attempting to drop staging repository..."
+      #     AUTH_HEADER="Bearer $(echo -n "${OSSRH_USERNAME}:${OSSRH_PASSWORD}" | base64)"
+      #     REPOS=$(curl -s --header "Authorization: ${AUTH_HEADER}" \
+      #       "https://ossrh-staging-api.central.sonatype.com/manual/search/repositories?profile_id=io.valkey.springframework&state=open")
+      #     REPO_KEY=$(echo "$REPOS" | jq -r '.repositories[0].key // empty')
+      #     if [ -n "$REPO_KEY" ]; then
+      #       echo "Dropping repository: $REPO_KEY"
+      #       curl --fail --request DELETE \
+      #         --header "Authorization: ${AUTH_HEADER}" \
+      #         "https://ossrh-staging-api.central.sonatype.com/manual/drop/repository/${REPO_KEY}"
+      #       echo "Staging repository dropped - safe to retry"
+      #     else
+      #       echo "No open staging repository found - nothing to clean up"
+      #     fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,52 +175,32 @@ jobs:
             exit 1
           fi
 
-      # TODO: Remove dry-run step and uncomment deploy steps below once verified
-      - name: Verify credentials and GPG signing (dry run)
+      - name: Deploy and release to Maven Central
+        id: deploy
         run: |
-          [ -n "$OSSRH_USERNAME" ] && echo "OSSRH_USERNAME set" || echo "OSSRH_USERNAME missing"
-          [ -n "$OSSRH_PASSWORD" ] && echo "OSSRH_PASSWORD set" || echo "OSSRH_PASSWORD missing"
-          [ -n "$GPG_PASSPHRASE" ] && echo "GPG_PASSPHRASE set" || echo "GPG_PASSPHRASE missing"
-          [ -n "$GPG_KEYNAME" ] && echo "GPG_KEYNAME set ($GPG_KEYNAME)" || echo "GPG_KEYNAME missing"
-          gpg --list-secret-keys --keyid-format short
-          echo "test" | gpg --batch --yes --passphrase "$GPG_PASSPHRASE" --pinentry-mode loopback --clearsign
-          AUTH_HEADER="Bearer $(echo -n "${OSSRH_USERNAME}:${OSSRH_PASSWORD}" | base64)"
-          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-            --header "Authorization: ${AUTH_HEADER}" \
-            "https://central.sonatype.com/api/v1/publisher/deployments")
-          if [ "$HTTP_STATUS" = "200" ]; then
-            echo "Maven Central authentication successful"
-          else
-            echo "Maven Central authentication failed (HTTP $HTTP_STATUS)"
-            exit 1
-          fi
+          ./mvnw -s settings.xml \
+            -Ddevelocity.storage.directory=$HOME/.develocity-root \
+            -Dmaven.repo.local=$HOME/.m2/spring-data-valkey \
+            deploy -DskipTests \
+            -pl spring-data-valkey,spring-boot-starter-data-valkey \
+            -Dmaven.deploy.skip=false \
+            -DautoReleaseAfterClose=true \
+            -U -B
 
-      # - name: Deploy and release to Maven Central
-      #   id: deploy
-      #   run: |
-      #     ./mvnw -s settings.xml \
-      #       -Ddevelocity.storage.directory=$HOME/.develocity-root \
-      #       -Dmaven.repo.local=$HOME/.m2/spring-data-valkey \
-      #       deploy -DskipTests \
-      #       -pl spring-data-valkey,spring-boot-starter-data-valkey \
-      #       -Dmaven.deploy.skip=false \
-      #       -DautoReleaseAfterClose=true \
-      #       -U -B
-      #
-      # - name: Drop staging repository on failure
-      #   if: failure() && steps.deploy.outcome == 'failure'
-      #   run: |
-      #     echo "Deploy failed - attempting to drop staging repository..."
-      #     AUTH_HEADER="Bearer $(echo -n "${OSSRH_USERNAME}:${OSSRH_PASSWORD}" | base64)"
-      #     REPOS=$(curl -s --header "Authorization: ${AUTH_HEADER}" \
-      #       "https://ossrh-staging-api.central.sonatype.com/manual/search/repositories?profile_id=io.valkey.springframework&state=open")
-      #     REPO_KEY=$(echo "$REPOS" | jq -r '.repositories[0].key // empty')
-      #     if [ -n "$REPO_KEY" ]; then
-      #       echo "Dropping repository: $REPO_KEY"
-      #       curl --fail --request DELETE \
-      #         --header "Authorization: ${AUTH_HEADER}" \
-      #         "https://ossrh-staging-api.central.sonatype.com/manual/drop/repository/${REPO_KEY}"
-      #       echo "Staging repository dropped - safe to retry"
-      #     else
-      #       echo "No open staging repository found - nothing to clean up"
-      #     fi
+      - name: Drop staging repository on failure
+        if: failure() && steps.deploy.outcome == 'failure'
+        run: |
+          echo "Deploy failed - attempting to drop staging repository..."
+          AUTH_HEADER="Bearer $(echo -n "${OSSRH_USERNAME}:${OSSRH_PASSWORD}" | base64)"
+          REPOS=$(curl -s --header "Authorization: ${AUTH_HEADER}" \
+            "https://ossrh-staging-api.central.sonatype.com/manual/search/repositories?profile_id=io.valkey.springframework&state=open")
+          REPO_KEY=$(echo "$REPOS" | jq -r '.repositories[0].key // empty')
+          if [ -n "$REPO_KEY" ]; then
+            echo "Dropping repository: $REPO_KEY"
+            curl --fail --request DELETE \
+              --header "Authorization: ${AUTH_HEADER}" \
+              "https://ossrh-staging-api.central.sonatype.com/manual/drop/repository/${REPO_KEY}"
+            echo "Staging repository dropped - safe to retry"
+          else
+            echo "No open staging repository found - nothing to clean up"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,14 +4,12 @@ on:
   push:
     tags: ["v*"]
 
-permissions:
-  contents: write
-  id-token: write
-
 jobs:
   release:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout
@@ -97,6 +95,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: maven-publish
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up JDK
         uses: actions/setup-java@v4
@@ -194,13 +196,17 @@ jobs:
           AUTH_HEADER="Bearer $(echo -n "${OSSRH_USERNAME}:${OSSRH_PASSWORD}" | base64)"
           REPOS=$(curl -s --header "Authorization: ${AUTH_HEADER}" \
             "https://ossrh-staging-api.central.sonatype.com/manual/search/repositories?profile_id=io.valkey.springframework&state=open")
-          REPO_KEY=$(echo "$REPOS" | jq -r '.repositories[0].key // empty')
-          if [ -n "$REPO_KEY" ]; then
+          REPO_COUNT=$(echo "$REPOS" | jq '.repositories | length')
+          if [ "$REPO_COUNT" = "1" ]; then
+            REPO_KEY=$(echo "$REPOS" | jq -r '.repositories[0].key')
             echo "Dropping repository: $REPO_KEY"
             curl --fail --request DELETE \
               --header "Authorization: ${AUTH_HEADER}" \
               "https://ossrh-staging-api.central.sonatype.com/manual/drop/repository/${REPO_KEY}"
             echo "Staging repository dropped - safe to retry"
-          else
+          elif [ "$REPO_COUNT" = "0" ]; then
             echo "No open staging repository found - nothing to clean up"
+          else
+            echo "Multiple open staging repositories found ($REPO_COUNT) - skipping automatic cleanup to avoid dropping wrong repo"
+            echo "$REPOS" | jq '.repositories'
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,6 +136,10 @@ jobs:
             --query SecretString --output text)
           OSSRH_USERNAME=$(echo "$SECRET" | jq -r '.["maven-central-username"]')
           OSSRH_PASSWORD=$(echo "$SECRET" | jq -r '.["maven-central-password"]')
+          if [ -z "$OSSRH_USERNAME" ] || [ "$OSSRH_USERNAME" = "null" ] || [ -z "$OSSRH_PASSWORD" ] || [ "$OSSRH_PASSWORD" = "null" ]; then
+            echo "ERROR: Failed to extract Maven credentials from secret"
+            exit 1
+          fi
           echo "::add-mask::$OSSRH_USERNAME"
           echo "::add-mask::$OSSRH_PASSWORD"
           echo "OSSRH_USERNAME=$OSSRH_USERNAME" >> $GITHUB_ENV
@@ -147,6 +151,10 @@ jobs:
             --secret-id GPGPassword \
             --query SecretString --output text)
           GPG_PASSPHRASE=$(echo "$SECRET" | jq -r '.["GPG Password"]')
+          if [ -z "$GPG_PASSPHRASE" ] || [ "$GPG_PASSPHRASE" = "null" ]; then
+            echo "ERROR: Failed to extract GPG passphrase from secret"
+            exit 1
+          fi
           echo "::add-mask::$GPG_PASSPHRASE"
           echo "GPG_PASSPHRASE=$GPG_PASSPHRASE" >> $GITHUB_ENV
 
@@ -157,9 +165,14 @@ jobs:
             --query SecretString --output text)
           echo "$SECRET" | jq -r '.PGP_SECRET_KEY' | tr ' ' '\n' | base64 -d | gpg --batch --import
           GPG_KEYNAME=$(gpg --list-secret-keys --keyid-format short 2>/dev/null | grep 'sec' | head -1 | sed 's/.*\///' | awk '{print $1}')
+          if [ -z "$GPG_KEYNAME" ]; then
+            echo "ERROR: Failed to determine GPG key ID after import"
+            exit 1
+          fi
           echo "GPG_KEYNAME=$GPG_KEYNAME" >> $GITHUB_ENV
 
-      - name: Deploy to Maven Central (staging)
+      - name: Deploy and release to Maven Central
+        id: deploy
         run: |
           ./mvnw -s settings.xml \
             -Ddevelocity.storage.directory=$HOME/.develocity-root \
@@ -167,4 +180,24 @@ jobs:
             deploy -DskipTests \
             -pl spring-data-valkey,spring-boot-starter-data-valkey \
             -Dmaven.deploy.skip=false \
+            -DautoReleaseAfterClose=true \
             -U -B
+
+      - name: Drop staging repository on failure
+        if: failure() && steps.deploy.outcome == 'failure'
+        run: |
+          echo "Deploy failed - attempting to drop staging repository..."
+          AUTH_HEADER="Bearer $(echo -n "${OSSRH_USERNAME}:${OSSRH_PASSWORD}" | base64)"
+          # Find any open repositories for our namespace
+          REPOS=$(curl -s --header "Authorization: ${AUTH_HEADER}" \
+            "https://ossrh-staging-api.central.sonatype.com/manual/search/repositories?profile_id=io.valkey.springframework&state=open")
+          REPO_KEY=$(echo "$REPOS" | jq -r '.repositories[0].key // empty')
+          if [ -n "$REPO_KEY" ]; then
+            echo "Dropping repository: $REPO_KEY"
+            curl --fail --request DELETE \
+              --header "Authorization: ${AUTH_HEADER}" \
+              "https://ossrh-staging-api.central.sonatype.com/manual/drop/repository/${REPO_KEY}"
+            echo "Staging repository dropped - safe to retry"
+          else
+            echo "No open staging repository found - nothing to clean up"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,47 +129,51 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
-      - name: Fetch Maven Central credentials
+      - name: Fetch release credentials
         run: |
           SECRET=$(aws secretsmanager get-secret-value \
             --secret-id spring-data-valkey-maven-token \
             --query SecretString --output text)
           OSSRH_USERNAME=$(echo "$SECRET" | jq -r '.["maven-central-username"]')
           OSSRH_PASSWORD=$(echo "$SECRET" | jq -r '.["maven-central-password"]')
+          GPG_PASSPHRASE=$(echo "$SECRET" | jq -r '.["gpg-passphrase"]')
+          GPG_KEYNAME=$(echo "$SECRET" | jq -r '.["gpg-key-id"]')
           if [ -z "$OSSRH_USERNAME" ] || [ "$OSSRH_USERNAME" = "null" ] || [ -z "$OSSRH_PASSWORD" ] || [ "$OSSRH_PASSWORD" = "null" ]; then
             echo "ERROR: Failed to extract Maven credentials from secret"
             exit 1
           fi
-          echo "::add-mask::$OSSRH_USERNAME"
-          echo "::add-mask::$OSSRH_PASSWORD"
-          echo "OSSRH_USERNAME=$OSSRH_USERNAME" >> $GITHUB_ENV
-          echo "OSSRH_PASSWORD=$OSSRH_PASSWORD" >> $GITHUB_ENV
-
-      - name: Fetch GPG passphrase
-        run: |
-          SECRET=$(aws secretsmanager get-secret-value \
-            --secret-id GPGPassword \
-            --query SecretString --output text)
-          GPG_PASSPHRASE=$(echo "$SECRET" | jq -r '.["GPG Password"]')
           if [ -z "$GPG_PASSPHRASE" ] || [ "$GPG_PASSPHRASE" = "null" ]; then
             echo "ERROR: Failed to extract GPG passphrase from secret"
             exit 1
           fi
+          if [ -z "$GPG_KEYNAME" ] || [ "$GPG_KEYNAME" = "null" ]; then
+            echo "ERROR: Failed to extract GPG key ID from secret"
+            exit 1
+          fi
+          echo "::add-mask::$OSSRH_USERNAME"
+          echo "::add-mask::$OSSRH_PASSWORD"
           echo "::add-mask::$GPG_PASSPHRASE"
+          echo "OSSRH_USERNAME=$OSSRH_USERNAME" >> $GITHUB_ENV
+          echo "OSSRH_PASSWORD=$OSSRH_PASSWORD" >> $GITHUB_ENV
           echo "GPG_PASSPHRASE=$GPG_PASSPHRASE" >> $GITHUB_ENV
+          echo "GPG_KEYNAME=$GPG_KEYNAME" >> $GITHUB_ENV
 
       - name: Import GPG private key
         run: |
           SECRET=$(aws secretsmanager get-secret-value \
-            --secret-id PGPPrivateKey \
+            --secret-id spring-data-valkey-maven-token \
             --query SecretString --output text)
-          echo "$SECRET" | jq -r '.PGP_SECRET_KEY' | tr ' ' '\n' | base64 -d | gpg --batch --import
-          GPG_KEYNAME=$(gpg --list-secret-keys --keyid-format short 2>/dev/null | grep 'sec' | head -1 | sed 's/.*\///' | awk '{print $1}')
-          if [ -z "$GPG_KEYNAME" ]; then
-            echo "ERROR: Failed to determine GPG key ID after import"
+          GPG_KEY=$(echo "$SECRET" | jq -r '.["gpg-private-key"]')
+          if [ -z "$GPG_KEY" ] || [ "$GPG_KEY" = "null" ]; then
+            echo "ERROR: Failed to extract GPG private key from secret"
             exit 1
           fi
-          echo "GPG_KEYNAME=$GPG_KEYNAME" >> $GITHUB_ENV
+          echo "::add-mask::$GPG_KEY"
+          echo "$GPG_KEY" | tr ' ' '\n' | base64 -d | gpg --batch --import
+          if ! gpg --list-secret-keys --keyid-format short 2>/dev/null | grep -q 'sec'; then
+            echo "ERROR: GPG key import failed"
+            exit 1
+          fi
 
       - name: Deploy and release to Maven Central
         id: deploy


### PR DESCRIPTION
## Summary

Adds a publish job to the release workflow that signs and deploys artifacts to Maven Central (staging) after the existing build/test/release steps complete.

Closes #85

## Changes

- New publish job gated by maven-publish environment approval
- Uses OIDC to assume AWS IAM role (no static credentials in GitHub)
- Fetches Maven and GPG credentials from AWS Secrets Manager
- Configures GPG for non-interactive signing
- Deploys spring-data-valkey and spring-boot-starter-data-valkey to Sonatype staging

## Prerequisites

- AWS IAM role with OIDC trust policy
- Secrets in AWS Secrets Manager for Maven credentials and GPG key/passphrase
- GitHub environment with required reviewers and AWS_ROLE_ARN variable

## Testing

- Tested by adding a temporary dry-run step to validate fetching and use of the Maven credentials and signing of the artifacts with a GPG private key